### PR TITLE
adding agent name feature to help monitor traces in LLMOps tools

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -24,10 +24,7 @@ from crewai.agents import CacheHandler, CrewAgentExecutor, CrewAgentParser, Tool
 from crewai.memory.contextual.contextual_memory import ContextualMemory
 from crewai.utilities import I18N, Logger, Prompts, RPMController
 from crewai.utilities.token_counter_callback import TokenCalcHandler, TokenProcess
-from agentops.agent import track_agent
 
-
-@track_agent()
 class Agent(BaseModel):
     """Represents an agent in a system.
 

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -50,6 +50,7 @@ class Agent(BaseModel):
             tools: Tools at agents disposal
             step_callback: Callback to be executed after each step of the agent execution.
             callbacks: A list of callback functions from the langchain library that are triggered during the agent's execution process
+            agent_name: The Name of the agent
     """
 
     __hash__ = object.__hash__  # type: ignore
@@ -124,6 +125,9 @@ class Agent(BaseModel):
     )
     callbacks: Optional[List[InstanceOf[BaseCallbackHandler]]] = Field(
         default=None, description="Callback to be executed"
+    )
+    agent_name: Optional[str] = Field(
+        default=None, description="The Name of the Agent"
     )
 
     _original_role: str | None = None
@@ -232,7 +236,7 @@ class Agent(BaseModel):
                 "input": task_prompt,
                 "tool_names": self.agent_executor.tools_names,
                 "tools": self.agent_executor.tools_description,
-            }
+            },{"run_name":self.agent_name}
         )["output"]
 
         if self.max_rpm:

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -24,7 +24,10 @@ from crewai.agents import CacheHandler, CrewAgentExecutor, CrewAgentParser, Tool
 from crewai.memory.contextual.contextual_memory import ContextualMemory
 from crewai.utilities import I18N, Logger, Prompts, RPMController
 from crewai.utilities.token_counter_callback import TokenCalcHandler, TokenProcess
+from agentops.agent import track_agent
 
+
+@track_agent()
 class Agent(BaseModel):
     """Represents an agent in a system.
 

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -50,7 +50,6 @@ class Agent(BaseModel):
             tools: Tools at agents disposal
             step_callback: Callback to be executed after each step of the agent execution.
             callbacks: A list of callback functions from the langchain library that are triggered during the agent's execution process
-            agent_name: The Name of the agent
     """
 
     __hash__ = object.__hash__  # type: ignore
@@ -125,9 +124,6 @@ class Agent(BaseModel):
     )
     callbacks: Optional[List[InstanceOf[BaseCallbackHandler]]] = Field(
         default=None, description="Callback to be executed"
-    )
-    agent_name: Optional[str] = Field(
-        default=None, description="The Name of the Agent"
     )
 
     _original_role: str | None = None
@@ -236,7 +232,7 @@ class Agent(BaseModel):
                 "input": task_prompt,
                 "tool_names": self.agent_executor.tools_names,
                 "tools": self.agent_executor.tools_description,
-            },{"run_name":self.agent_name}
+            },{"run_name":self.role}
         )["output"]
 
         if self.max_rpm:


### PR DESCRIPTION
Hello,

I have been using various LLM monitoring tools and I noticed that the Trace Name appears as "CrewAgentExecutor" by default in monitoring tools

below image for reference
![image](https://github.com/joaomdmoura/crewAI/assets/11057669/0e6cb3df-4f9d-442c-b873-09f5e0f547e1)


It can be helpful for developers if we add a name to the Agent so that the traces have these names
Below image for reference


![image](https://github.com/joaomdmoura/crewAI/assets/11057669/27ca5650-a4c0-4cd5-b70a-686cf8fe678b)


This helps in filtering and easy monitoring of traces in any LLMOps tool.