### PR TITLE
Clarify text in docstring

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -39,7 +39,7 @@ class Agent(BaseModel):
             backstory: The backstory of the agent.
             config: Dict representation of agent configuration.
             llm: The language model that will run the agent.
-            function_calling_llm: The language model that will the tool calling for this agent, it overrides the crew function_calling_llm.
+            function_calling_llm: The language model that will handle the tool calling for this agent, it overrides the crew function_calling_llm.
             max_iter: Maximum number of iterations for an agent to execute a task.
             memory: Whether the agent should have memory or not.
             max_rpm: Maximum number of requests per minute for the agent execution to be respected.


### PR DESCRIPTION
In reading this docstring I couldn't make sense of it because it looked like it was missing a word. I looked it up in the docs online and matched the wording here to that.