### PR TITLE
Fix broken link to the installation guide

### DIFF
--- a/docs/how-to/Start-a-New-CrewAI-Project.md
+++ b/docs/how-to/Start-a-New-CrewAI-Project.md
@@ -9,7 +9,7 @@ Welcome to the ultimate guide for starting a new CrewAI project. This document w
 
 ## Prerequisites
 
-We assume you have already installed CrewAI. If not, please refer to the [installation guide](how-to/Installing-CrewAI.md) to install CrewAI and its dependencies.
+We assume you have already installed CrewAI. If not, please refer to the [installation guide](https://docs.crewai.com/how-to/Installing-CrewAI/) to install CrewAI and its dependencies.
 
 ## Creating a New Project
 


### PR DESCRIPTION
Updated the installation guide link to use the absolute URL instead of a relative path, ensuring it correctly points to 'https://docs.crewai.com/how-to/Installing-CrewAI/'.

Reproduce by:

- Go to https://docs.crewai.com/how-to/Start-a-New-CrewAI-Project/ 
- Click on "installation guide"
- Current flow goes to https://docs.crewai.com/how-to/Start-a-New-CrewAI-Project/how-to/Installing-CrewAI.md which gives a 404.

Expected: As far as I can tell, the how to is located at `https://docs.crewai.com/how-to/Installing-CrewAI/`