### PR TITLE
Properly capture result from max retry recursive call

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -181,7 +181,6 @@ class Agent(BaseAgent):
         self.agent_executor.tools = parsed_tools
         self.agent_executor.task = task
 
-        # TODO: COMPARE WITH ARGS AND WITHOUT ARGS
         self.agent_executor.tools_description = self._render_text_description_and_args(
             parsed_tools
         )
@@ -204,7 +203,7 @@ class Agent(BaseAgent):
             self._times_executed += 1
             if self._times_executed > self.max_retry_limit:
                 raise e
-            self.execute_task(task, context, tools)
+            return self.execute_task(task, context, tools)
 
         if self.max_rpm:
             self._rpm_controller.stop_rpm_counter()

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -203,7 +203,7 @@ class Agent(BaseAgent):
             self._times_executed += 1
             if self._times_executed > self.max_retry_limit:
                 raise e
-            return self.execute_task(task, context, tools)
+            result = self.execute_task(task, context, tools)
 
         if self.max_rpm:
             self._rpm_controller.stop_rpm_counter()


### PR DESCRIPTION
There is a super tiny issue with our recursive `self.execute_task` calls not properly returning the results. 

Here's how the current issue occurs:
- The first `execute_task` 1 call fails and recursively calls `execute_task` agains.
- `execute_task` 2 succeeds and return results
- The first `execute_task` get's the result back from the recursive call. Once we get the result back, we aren't assigning it to `result` which causes issues when the first `execute_task` tries to return result.