### PR TITLE
Update Force-Tool-Ouput-as-Result.md

### DIFF
--- a/docs/how-to/Force-Tool-Ouput-as-Result.md
+++ b/docs/how-to/Force-Tool-Ouput-as-Result.md
@@ -7,7 +7,7 @@ description: Learn how to force tool output as the result in of an Agent's task 
 In CrewAI, you can force the output of a tool as the result of an agent's task. This feature is useful when you want to ensure that the tool output is captured and returned as the task result, and avoid the agent modifying the output during the task execution.
 
 ## Forcing Tool Output as Result
-To force the tool output as the result of an agent's task, you can set the `force_tool_output` parameter to `True` when creating the task. This parameter ensures that the tool output is captured and returned as the task result, without any modifications by the agent.
+To force the tool output as the result of an agent's task, you can set the `result_as_answer` parameter to `True` when creating the agent. This parameter ensures that the tool output is captured and returned as the task result, without any modifications by the agent.
 
 Here's an example of how to force the tool output as the result of an agent's task:
 


### PR DESCRIPTION
I think there is some mistake, because there is no such parameter as `force_output_result`, and as the code shows, the correct parameter `result_as_answer` is set during agent creation, not task.