### PR TITLE
remove API key from codeblock

### DIFF
--- a/docs/core-concepts/Tools.md
+++ b/docs/core-concepts/Tools.md
@@ -39,10 +39,6 @@ from crewai_tools import (
     WebsiteSearchTool
 )
 
-# Set up API keys
-os.environ["SERPER_API_KEY"] = "Your Key" # serper.dev API key
-os.environ["OPENAI_API_KEY"] = "Your Key"
-
 # Instantiate tools
 docs_tool = DirectoryReadTool(directory='./blog-posts')
 file_tool = FileReadTool()


### PR DESCRIPTION
the API keys for serper and openai were setup, in a awkward fashion, but were never used and are not needed here.