### PR TITLE
Fix getting started section links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,11 @@ Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By 
     <div style="width:25%">
         <h2>Getting Started</h2>
         <ul>
-            <li><a href='./getting-started/Installing-CrewAI.md'>
+            <li><a href='./getting-started/Installing-CrewAI'>
                    Installing CrewAI
                  </a>
             </li>
-            <li><a href='./getting-started/Start-a-New-CrewAI-Project-Template-Method.md'>
+            <li><a href='./getting-started/Start-a-New-CrewAI-Project-Template-Method'>
                    Start a New CrewAI Project: Template Method
                  </a>
             </li>


### PR DESCRIPTION
Fixes documentation links for the `Getting Started` section

Installing CrewAI `https://docs.crewai.com/getting-started/Installing-CrewAI.md` to `https://docs.crewai.com/getting-started/Installing-CrewAI `

Start a New CrewAI Project: Template Method `https://docs.crewai.com/getting-started/Start-a-New-CrewAI-Project-Template-Method.md` => `https://docs.crewai.com/getting-started/Start-a-New-CrewAI-Project-Template-Method`