### PR TITLE
Fixed package name typo in pip install command

### DIFF
--- a/docs/getting-started/Start-a-New-CrewAI-Project-Template-Method.md
+++ b/docs/getting-started/Start-a-New-CrewAI-Project-Template-Method.md
@@ -17,7 +17,7 @@ Beforre we start there are a couple of things to note:
 Before getting started with CrewAI, make sure that you have installed it via pip:
 
 ```shell
-$ pip install crewai crewi-tools
+$ pip install crewai crewai-tools
 ```
 
 ### Virtual Environemnts


### PR DESCRIPTION
Changed `pip install crewi-tools` to `pip install crewai-tools`