### PR TITLE
Sanitize agent roles to ensure valid directory names (Windows)

### DIFF
--- a/src/crewai/memory/storage/rag_storage.py
+++ b/src/crewai/memory/storage/rag_storage.py
@@ -47,7 +47,7 @@ class RAGStorage(Storage):
             os.environ["OPENAI_API_KEY"] = "fake"
 
         agents = crew.agents if crew else []
-        agents = [agent.role for agent in agents]
+        agents = [self._sanitize_role(agent.role) for agent in agents]
         agents = "_".join(agents)
 
         config = {
@@ -77,6 +77,12 @@ class RAGStorage(Storage):
         self.app.llm = FakeLLM()
         if allow_reset:
             self.app.reset()
+            
+    def _sanitize_role(self, role: str) -> str:
+        """
+        Sanitizes agent roles to ensure valid directory names.
+        """
+        return role.replace('\n', '').replace(' ', '_').replace('/', '_')
 
     def save(self, value: Any, metadata: Dict[str, Any]) -> None:
         self._generate_embedding(value, metadata)


### PR DESCRIPTION
This pull request addresses an issue with path construction in the RAGStorage class, specifically how agent roles are concatenated and used to create the directory path.

### Issue:

When agent roles contain spaces or newline characters, it results in an invalid directory name, leading to the following error:
`OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Users\\user\\AppData\\Local\\CrewAI\\my_crew_name/short_term/Agent A\n_Agent B\n_Agent C\n_Agent D\n'
`

### Solution:

To resolve this, I've added a method to sanitize the agent roles, replacing newline characters, spaces, and slashes with underscores. This ensures that the constructed directory paths are valid.

### Changes Made:

Added a` _sanitize_role` method to `RAGStorage` in `src/crewai/memory/storage/rag_storage.py` to replace invalid characters.
Applied this sanitization method when creating the agents string for the directory path.

### Example Code Changes:

```
def _sanitize_role(self, role: str) -> str:
    """
    Sanitizes agent roles to ensure valid directory names.
    """
    return role.replace('\n', '').replace(' ', '_').replace('/', '_')

agents = [self._sanitize_role(agent.role) for agent in agents]
```

This change ensures that all agent roles form valid directory names, preventing the `WinError 123`.

### Testing:

I have tested this change locally and it resolved the path construction issue, allowing the CrewAI application to run without errors.