### PR TITLE
Remove broken sidebar navigation links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,9 +136,6 @@ nav:
     - Using LangChain Tools: 'core-concepts/Using-LangChain-Tools.md'
     - Using LlamaIndex Tools: 'core-concepts/Using-LlamaIndex-Tools.md'
   - How to Guides:
-    - Starting Your crewAI Project: 'how-to/Start-a-New-CrewAI-Project.md'
-    - Installing CrewAI: 'how-to/Installing-CrewAI.md'
-    - Getting Started: 'how-to/Creating-a-Crew-and-kick-it-off.md'
     - Create Custom Tools: 'how-to/Create-Custom-Tools.md'
     - Using Sequential Process: 'how-to/Sequential.md'
     - Using Hierarchical Process: 'how-to/Hierarchical.md'


### PR DESCRIPTION
Currently the first 3 links in the how-to section lead to 404 
<img width="599" alt="image" src="https://github.com/user-attachments/assets/def644f7-5a09-443e-83ee-c1a5e6154dca">

These links seem to be accounted for here:
https://github.com/crewAIInc/crewAI/blob/767f2a5fca90d0b13b6a1bbf76d11ccf619f1c69/mkdocs.yml#L122-L124