### PR TITLE
Fix grammatical errors in config template

### DIFF
--- a/src/crewai/cli/templates/config/tasks.yaml
+++ b/src/crewai/cli/templates/config/tasks.yaml
@@ -12,6 +12,6 @@ reporting_task:
     Review the context you got and expand each topic into a full section for a report.
     Make sure the report is detailed and contains any and all relevant information.
   expected_output: >
-    A fully fledge reports with the mains topics, each with a full section of information.
+    A fully fledged report with the main topics, each with a full section of information.
     Formatted as markdown without '```'
   agent: reporting_analyst


### PR DESCRIPTION
This commit fixes a few small grammatical errors in the `config/tasks` template.