### PR TITLE
Remove orphan links in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,9 +136,6 @@ nav:
     - Using LangChain Tools: 'core-concepts/Using-LangChain-Tools.md'
     - Using LlamaIndex Tools: 'core-concepts/Using-LlamaIndex-Tools.md'
   - How to Guides:
-    - Starting Your crewAI Project: 'how-to/Start-a-New-CrewAI-Project.md'
-    - Installing CrewAI: 'how-to/Installing-CrewAI.md'
-    - Getting Started: 'how-to/Creating-a-Crew-and-kick-it-off.md'
     - Create Custom Tools: 'how-to/Create-Custom-Tools.md'
     - Using Sequential Process: 'how-to/Sequential.md'
     - Using Hierarchical Process: 'how-to/Hierarchical.md'


### PR DESCRIPTION
Remove deprecated links, related to #1019

Currently, 3 links under "How to Guides" are inaccessible in the docs

1. https://docs.crewai.com/how-to/Start-a-New-CrewAI-Project.md , replaced with https://docs.crewai.com/getting-started/Start-a-New-CrewAI-Project-Template-Method/ under "Getting Started"
2. https://docs.crewai.com/how-to/Installing-CrewAI.md , replaced with https://docs.crewai.com/getting-started/Installing-CrewAI/
3. https://docs.crewai.com/how-to/Creating-a-Crew-and-kick-it-off.md 

<img width="697" alt="Screenshot 2024-08-09 at 21 12 41" src="https://github.com/user-attachments/assets/63207a16-3cc6-4b4c-935f-7f5a64175cf5">



