### PR TITLE
Attempt to decode tool_input as a JSON

### DIFF
--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -1,4 +1,5 @@
 import ast
+import json
 from difflib import SequenceMatcher
 import os
 from textwrap import dedent
@@ -344,7 +345,10 @@ class ToolUsage:
                 tool = self._select_tool(tool_name)
                 try:
                     tool_input = self._validate_tool_input(self.action.tool_input)
-                    arguments = ast.literal_eval(tool_input)
+                    try:
+                        arguments = ast.literal_eval(tool_input)
+                    except Exception:
+                        arguments = json.loads(tool_input)
                 except Exception:
                     return ToolUsageErrorException(  # type: ignore # Incompatible return value type (got "ToolUsageErrorException", expected "ToolCalling | InstructorToolCalling")
                         f'{self._i18n.errors("tool_arguments_error")}'


### PR DESCRIPTION
We currently evaluate tool_input as a Python object. However, self._validate_tool_input may return a JSON string instead. This causes an error when tool_input contains lowercase true/false, which are valid JSON values but not valid Python (True/False).

As a result, the agent could enter an infinite loop if tool_input keeps resolving to a JSON string like:

```
{"timeMin": "2024-08-12T00:00:00Z", "timeMax": "2024-08-13T00:00:00Z", "single_events": true, "order_by": "startTime", "calendar_id": "primary"}
```

This commit addresses the issue by ensuring that tool_input is correctly parsed as JSON when necessary, preventing the infinite loop.