### PR TITLE
♻️ refactor (cli): creating a new project

### DIFF
--- a/docs/getting-started/Start-a-New-CrewAI-Project-Template-Method.md
+++ b/docs/getting-started/Start-a-New-CrewAI-Project-Template-Method.md
@@ -54,7 +54,7 @@ To set up a virtual environment, run the following CLI command:
 To create a new CrewAI project, run the following CLI command:
 
 ```shell
-$ crewai create crew <project_name>
+$ crewai create <project_name>
 ```
 
 This command will create a new project folder with the following structure:


### PR DESCRIPTION
> Correction of `crewai create` command in documentation

**PR Description:**

Hello,

I propose a correction in the documentation regarding the `crewai create` command for creating a new project. The current documentation mentions:

```shell
$ crewai create crew <project_name>
```

However, after executing this command, I received the following error message:

```
Usage: crewai create [OPTIONS] PROJECT_NAME
Try 'crewai create --help' for help.
```

Upon investigation, I found that the correct command is:

```shell
$ crewai create <project_name>
```

This correction prevents the error and allows the project to be created correctly.

**Changes Made:**
- Corrected the `crewai create` command in the documentation.

**Justification:**
The current command causes an error and does not allow a new project to be created correctly. By correcting this command, we improve the user experience and avoid confusion for new users of CrewAI.

**Section Modified:**
- docs/getting-started/Start-a-New-CrewAI-Project-Template-Method.md

Thank you for considering this modification.