### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,4 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open for 45 days with no activity.'
         days-before-pr-stale: 45
         days-before-pr-close: -1
+        operations-per-run: 500


### PR DESCRIPTION
Added  
operations-per-run: 500

The core issue here is that the default for  `operations-per-run` is set to 30 meaning the first 30 issues get processed only.

We can set it to 500 to cover all issues and once they have all been processed we can revert back to 30 as there will be no need for a high number of 'operations-per-run`