### PR TITLE
feat: Add only on release to deploy docs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,10 +1,8 @@
 name: Deploy MkDocs
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR intends to change the way we deploy docs, instead of right after merging to main is now when a new release happens