### PR TITLE
Update operations-per-run to a higher value

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,4 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open for 45 days with no activity.'
         days-before-pr-stale: 45
         days-before-pr-close: -1
-        operations-per-run: 500
+        operations-per-run: 1200


### PR DESCRIPTION
This PR updates the operations-per-run setting to 1200 because each single issue / PR thats processed by the stale issues action takes up 2-3 operations, meaning that we need to set the number higher to accommodate this