### PR TITLE
Fixed version conflict for regex package due to full year in version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ opentelemetry-api = "^1.22.0"
 opentelemetry-sdk = "^1.22.0"
 opentelemetry-exporter-otlp-proto-http = "^1.22.0"
 instructor = "1.3.3"
-regex = "^2023.12.25"
+regex = ">=2023.12.25"
 crewai-tools = { version = "^0.8.3", optional = true }
 click = "^8.1.7"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION


As a result it will be compatible with installations / projects using a 2024.x.x version of the regex package

Fixes #1004

p.s.
Alternativly the project maintainers could decide to update the package to a 2024.x.x version
=> https://pypi.org/project/regex/2024.4.16/#history