### PR TITLE
bug: fix incorrect mkdocs site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: crewAI
 site_author: crewAI, Inc
 site_description: Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks.
 repo_name: crewAI
-repo_url: https://github.com/joaomdmoura/crewai/
+repo_url: https://github.com/crewAIInc/crewAI
 site_url: https://docs.crewai.com
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2024 crewAI, Inc

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_author: crewAI, Inc
 site_description: Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks.
 repo_name: crewAI
 repo_url: https://github.com/joaomdmoura/crewai/
-site_url: https://crewai.com
+site_url: https://docs.crewai.com
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2024 crewAI, Inc
 


### PR DESCRIPTION
I noticed that your site_url is pointing to the wrong domain for your docs. This will cause a few issues, such as your sitemap.xml pointing to the wrong domain. Eg this entry in your docs site sitemap.xml. Definitely not helping your SEO.

```xml
<url>
<loc>https://crewai.com/core-concepts/Using-LlamaIndex-Tools/</loc>
<lastmod>2024-08-17</lastmod>
<changefreq>daily</changefreq>
</url>
```