### PR TITLE
Add py 3.10 support back to CLI + fixes

### DIFF
--- a/src/crewai/cli/deploy/api.py
+++ b/src/crewai/cli/deploy/api.py
@@ -2,6 +2,8 @@ from os import getenv
 
 import requests
 
+from crewai.cli.deploy.utils import get_crewai_version
+
 
 class CrewAPI:
     """
@@ -13,6 +15,7 @@ class CrewAPI:
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            "User-Agent": f"CrewAI-CLI/{get_crewai_version()}",
         }
         self.base_url = getenv(
             "CREWAI_BASE_URL", "https://dev.crewai.com/crewai_plus/api/v1/crews"

--- a/src/crewai/cli/deploy/main.py
+++ b/src/crewai/cli/deploy/main.py
@@ -113,6 +113,11 @@ class DeployCommand:
         env_vars = fetch_and_json_env_file()
         remote_repo_url = get_git_remote_url()
 
+        if remote_repo_url is None:
+            console.print("No remote repository URL found.", style="bold red")
+            console.print("Please ensure your project has a valid remote repository.", style="yellow")
+            return
+
         self._confirm_input(env_vars, remote_repo_url)
         payload = self._create_payload(env_vars, remote_repo_url)
 

--- a/src/crewai/cli/deploy/main.py
+++ b/src/crewai/cli/deploy/main.py
@@ -33,6 +33,10 @@ class DeployCommand:
             raise SystemExit
 
         self.project_name = get_project_name()
+        if self.project_name is None:
+            console.print("No project name found. Please ensure your project has a valid pyproject.toml file.", style="bold red")
+            raise SystemExit
+
         self.client = CrewAPI(api_key=access_token)
 
     def _handle_error(self, json_response: Dict[str, Any]) -> None:

--- a/src/crewai/cli/deploy/utils.py
+++ b/src/crewai/cli/deploy/utils.py
@@ -66,11 +66,11 @@ def get_git_remote_url() -> str | None:
     return None
 
 
-def get_project_name(pyproject_path: str = "pyproject.toml"):
+def get_project_name(pyproject_path: str = "pyproject.toml") -> str | None:
     """Get the project name from the pyproject.toml file."""
     try:
         # Read the pyproject.toml file
-        with open(pyproject_path, "rb") as f:
+        with open(pyproject_path, "r") as f:
             pyproject_content = parse_toml(f.read())
 
         # Extract the project name

--- a/src/crewai/cli/deploy/utils.py
+++ b/src/crewai/cli/deploy/utils.py
@@ -1,9 +1,12 @@
 import sys
 import re
 import subprocess
-import ast
+
+from rich.console import Console
 
 from ..authentication.utils import TokenManager
+
+console = Console()
 
 
 if sys.version_info >= (3, 11):
@@ -53,13 +56,12 @@ def get_git_remote_url() -> str:
         if matches:
             return matches[0]  # Return the first match (origin URL)
         else:
-            print("No origin remote found.")
-            return "No remote URL found"
+            console.print("No origin remote found.", style="bold red")
 
     except subprocess.CalledProcessError as e:
-        return f"Error running trying to fetch the Git Repository: {e}"
+        console.print(f"Error running trying to fetch the Git Repository: {e}", style="bold red")
     except FileNotFoundError:
-        return "Git command not found. Make sure Git is installed and in your PATH."
+        console.print("Git command not found. Make sure Git is installed and in your PATH.", style="bold red")
 
 
 def get_project_name(pyproject_path: str = "pyproject.toml"):

--- a/src/crewai/cli/deploy/utils.py
+++ b/src/crewai/cli/deploy/utils.py
@@ -39,7 +39,7 @@ def parse_toml(content):
         return simple_toml_parser(content)
 
 
-def get_git_remote_url() -> str:
+def get_git_remote_url() -> str | None:
     """Get the Git repository's remote URL."""
     try:
         # Run the git remote -v command
@@ -63,6 +63,8 @@ def get_git_remote_url() -> str:
     except FileNotFoundError:
         console.print("Git command not found. Make sure Git is installed and in your PATH.", style="bold red")
 
+    return None
+
 
 def get_project_name(pyproject_path: str = "pyproject.toml"):
     """Get the project name from the pyproject.toml file."""
@@ -83,7 +85,7 @@ def get_project_name(pyproject_path: str = "pyproject.toml"):
         print(f"Error: {pyproject_path} not found.")
     except KeyError:
         print(f"Error: {pyproject_path} is not a valid pyproject.toml file.")
-    except tomllib.TOMLDecodeError if sys.version_info >= (3, 11) else Exception as e:
+    except tomllib.TOMLDecodeError if sys.version_info >= (3, 11) else Exception as e:  # type: ignore
         print(
             f"Error: {pyproject_path} is not a valid TOML file."
             if sys.version_info >= (3, 11)

--- a/src/crewai/cli/deploy/utils.py
+++ b/src/crewai/cli/deploy/utils.py
@@ -13,6 +13,7 @@ if sys.version_info >= (3, 11):
     import tomllib
 
 
+# Drop the simple_toml_parser when we move to python3.11
 def simple_toml_parser(content):
     result = {}
     current_section = result

--- a/tests/cli/deploy/test_api.py
+++ b/tests/cli/deploy/test_api.py
@@ -17,6 +17,7 @@ class TestCrewAPI(unittest.TestCase):
             {
                 "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
+                "User-Agent": "CrewAI-CLI/no-version-found"
             },
         )
 

--- a/tests/cli/deploy/test_deploy_main.py
+++ b/tests/cli/deploy/test_deploy_main.py
@@ -1,9 +1,10 @@
 import unittest
 from io import StringIO
 from unittest.mock import MagicMock, patch
+import sys
 
 from crewai.cli.deploy.main import DeployCommand
-
+from crewai.cli.deploy.utils import parse_toml
 
 class TestDeployCommand(unittest.TestCase):
     @patch("crewai.cli.deploy.main.get_auth_token")
@@ -151,3 +152,62 @@ class TestDeployCommand(unittest.TestCase):
             self.assertIn(
                 "Crew 'test_project' removed successfully", fake_out.getvalue()
             )
+
+    @patch('crewai.cli.deploy.utils.sys.version_info', (3, 10))
+    def test_parse_toml_python_310(self):
+        toml_content = """
+        [tool.poetry]
+        name = "test_project"
+        version = "0.1.0"
+
+        [tool.poetry.dependencies]
+        python = "^3.10"
+        crewai = "^0.1.0"
+        """
+        parsed = parse_toml(toml_content)
+        self.assertEqual(parsed['tool']['poetry']['name'], 'test_project')
+        self.assertEqual(parsed['tool']['poetry']['dependencies']['crewai'], '^0.1.0')
+
+    @unittest.skipIf(sys.version_info < (3, 11), "Requires Python 3.11+")
+    def test_parse_toml_python_311_plus(self):
+        toml_content = """
+        [tool.poetry]
+        name = "test_project"
+        version = "0.1.0"
+
+        [tool.poetry.dependencies]
+        python = "^3.11"
+        crewai = "^0.1.0"
+        """
+        parsed = parse_toml(toml_content)
+        self.assertEqual(parsed['tool']['poetry']['name'], 'test_project')
+        self.assertEqual(parsed['tool']['poetry']['dependencies']['crewai'], '^0.1.0')
+
+    @patch('builtins.open', new_callable=unittest.mock.mock_open, read_data="""
+    [tool.poetry]
+    name = "test_project"
+    version = "0.1.0"
+
+    [tool.poetry.dependencies]
+    python = "^3.10"
+    crewai = "^0.1.0"
+    """)
+    def test_get_project_name_python_310(self, mock_open):
+        from crewai.cli.deploy.utils import get_project_name
+        project_name = get_project_name()
+        self.assertEqual(project_name, 'test_project')
+
+    @unittest.skipIf(sys.version_info < (3, 11), "Requires Python 3.11+")
+    @patch('builtins.open', new_callable=unittest.mock.mock_open, read_data="""
+    [tool.poetry]
+    name = "test_project"
+    version = "0.1.0"
+
+    [tool.poetry.dependencies]
+    python = "^3.11"
+    crewai = "^0.1.0"
+    """)
+    def test_get_project_name_python_311_plus(self, mock_open):
+        from crewai.cli.deploy.utils import get_project_name
+        project_name = get_project_name()
+        self.assertEqual(project_name, 'test_project')


### PR DESCRIPTION
* Fallback to simple parser to get project name when running Python 3.10.
* Get crewai version from poetry.lock.
* Send locked crewai version as User-Agent header.