### PR TITLE
Added a new feature to log the final thoughts of each agent 🚀

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -101,13 +101,14 @@ class Crew(BaseModel):
     _task_output_handler: TaskOutputStorageHandler = PrivateAttr(
         default_factory=TaskOutputStorageHandler
     )
-
+    
     name: Optional[str] = Field(default=None)
     cache: bool = Field(default=True)
     tasks: List[Task] = Field(default_factory=list)
     agents: List[BaseAgent] = Field(default_factory=list)
     process: Process = Field(default=Process.sequential)
     verbose: bool = Field(default=False)
+    logs: ClassVar[Dict[int, List[TaskOutput]]] = {}
     memory: bool = Field(
         default=False,
         description="Whether the crew should use memory to store memories of it's execution",
@@ -667,7 +668,7 @@ class Crew(BaseModel):
                 task_outputs = [task_output]
                 self._process_task_result(task, task_output)
                 self._store_execution_log(task, task_output, task_index, was_replayed)
-
+                self.logs[task_index] = task_outputs
         if futures:
             task_outputs = self._process_async_tasks(futures, was_replayed)
 


### PR DESCRIPTION
A really helpful feature to have is that we know what each agent produced as their final answer (**not** the entire chain of thought) which was fed to the next agent in line in a sequential system.
For example, one agent `X` writes code and another agent `Y` explains that code. Then instead of having just the final explanation, it would be nice to retrieve what code was actually written by `X`. See my project on this [here](https://github.com/shiladityasarkar/LeetCoder).

![Screenshot (325)](https://github.com/user-attachments/assets/f6ff69be-89ce-4eee-a89d-9cfb2dc326a0)

I have added a class variable called `logs` in the `Crew` class. Every time `_execute_tasks()` is called, `logs` is updated (overwritten) with the latest thoughts of the current agent. The idea is - for each `task_index` the last update will always be the agent's final thought - which is the final answer (see `translations/en.json` for more clarity).

Thus, after `kickoff()` completes execution, `logs` has the final answer of each intermediate agent stored as a dictionary with the integer keys denoting the order of execution of tasks starting from `0`.

If somebody wants just the raw output and not the entire mess of TaskOutput, then just write -

`logs[<task_number>][0].raw`

Hope this helps 😀
