### PR TITLE
feat(memory): adds support for customizable memory interface

### DIFF
--- a/docs/core-concepts/Memory.md
+++ b/docs/core-concepts/Memory.md
@@ -28,7 +28,7 @@ description: Leveraging memory systems in the crewAI framework to enhance agent 
 ## Implementing Memory in Your Crew
 
 When configuring a crew, you can enable and customize each memory component to suit the crew's objectives and the nature of tasks it will perform.
-By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration. The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model.
+By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration. The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model. It's also possible to initialize the memory instance with your own instance.
 
 The 'embedder' only applies to **Short-Term Memory** which uses Chroma for RAG using the EmbedChain package.
 The **Long-Term Memory** uses SQLite3 to store task results. Currently, there is no way to override these storage implementations.
@@ -49,6 +49,45 @@ my_crew = Crew(
     verbose=True
 )
 ```
+
+### Example: Use Custom Memory Instances e.g FAISS as the VectorDB
+
+```python
+from crewai import Crew, Agent, Task, Process
+
+# Assemble your crew with memory capabilities
+my_crew = Crew(
+    agents=[...],
+    tasks=[...],
+    process="Process.sequential",
+    memory=True,
+    long_term_memory=EnhanceLongTermMemory(
+        storage=LTMSQLiteStorage(
+            db_path="/my_data_dir/my_crew1/long_term_memory_storage.db"
+        )
+    ),
+    short_term_memory=EnhanceShortTermMemory(
+        storage=CustomRAGStorage(
+            crew_name="my_crew",
+            storage_type="short_term",
+            data_dir="//my_data_dir",
+            model=embedder["model"],
+            dimension=embedder["dimension"],
+        ),
+    ),
+    entity_memory=EnhanceEntityMemory(
+        storage=CustomRAGStorage(
+            crew_name="my_crew",
+            storage_type="entities",
+            data_dir="//my_data_dir",
+            model=embedder["model"],
+            dimension=embedder["dimension"],
+        ),
+    ),
+    verbose=True,
+)
+```
+
 
 ## Additional Embedding Providers
 

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -944,7 +944,7 @@ class Crew(BaseModel):
     def test(
         self,
         n_iterations: int,
-        openai_model_name: str = "",
+        openai_model_name: Optional[str] = None,
         inputs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Test and evaluate the Crew with the given inputs for n iterations concurrently using concurrent.futures."""

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -110,6 +110,18 @@ class Crew(BaseModel):
         default=False,
         description="Whether the crew should use memory to store memories of it's execution",
     )
+    short_term_memory: Optional[InstanceOf[ShortTermMemory]] = Field(
+        default=None,
+        description="An Instance of the ShortTermMemory to be used by the Crew",
+    )
+    long_term_memory: Optional[InstanceOf[LongTermMemory]] = Field(
+        default=None,
+        description="An Instance of the LongTermMemory to be used by the Crew",
+    )
+    entity_memory: Optional[InstanceOf[EntityMemory]] = Field(
+        default=None,
+        description="An Instance of the EntityMemory to be used by the Crew",
+    )
     embedder: Optional[dict] = Field(
         default={"provider": "openai"},
         description="Configuration for the embedder to be used for the crew.",
@@ -212,11 +224,11 @@ class Crew(BaseModel):
     def create_crew_memory(self) -> "Crew":
         """Set private attributes."""
         if self.memory:
-            self._long_term_memory = LongTermMemory()
-            self._short_term_memory = ShortTermMemory(
+            self._long_term_memory = self.long_term_memory if self.long_term_memory else LongTermMemory()
+            self._short_term_memory = self.short_term_memory if self.short_term_memory else ShortTermMemory(
                 crew=self, embedder_config=self.embedder
             )
-            self._entity_memory = EntityMemory(crew=self, embedder_config=self.embedder)
+            self._entity_memory = self.entity_memory if self.entity_memory else EntityMemory(crew=self, embedder_config=self.embedder)
         return self
 
     @model_validator(mode="after")

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -944,7 +944,7 @@ class Crew(BaseModel):
     def test(
         self,
         n_iterations: int,
-        openai_model_name: Optional[str] = None,
+        openai_model_name: str = "",
         inputs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Test and evaluate the Crew with the given inputs for n iterations concurrently using concurrent.futures."""

--- a/src/crewai/memory/entity/entity_memory.py
+++ b/src/crewai/memory/entity/entity_memory.py
@@ -1,6 +1,5 @@
 from crewai.memory.entity.entity_memory_item import EntityMemoryItem
 from crewai.memory.memory import Memory
-from crewai.memory.storage.interface import Storage
 from crewai.memory.storage.rag_storage import RAGStorage
 
 
@@ -11,7 +10,7 @@ class EntityMemory(Memory):
     Inherits from the Memory class.
     """
 
-    def __init__(self, crew=None, embedder_config=None, storage: Storage | None=None):
+    def __init__(self, crew=None, embedder_config=None, storage=None):
         storage = (
             storage
             if storage

--- a/src/crewai/memory/entity/entity_memory.py
+++ b/src/crewai/memory/entity/entity_memory.py
@@ -1,5 +1,6 @@
 from crewai.memory.entity.entity_memory_item import EntityMemoryItem
 from crewai.memory.memory import Memory
+from crewai.memory.storage.interface import Storage
 from crewai.memory.storage.rag_storage import RAGStorage
 
 
@@ -10,12 +11,13 @@ class EntityMemory(Memory):
     Inherits from the Memory class.
     """
 
-    def __init__(self, crew=None, embedder_config=None):
-        storage = RAGStorage(
-            type="entities",
-            allow_reset=False,
-            embedder_config=embedder_config,
-            crew=crew,
+    def __init__(self, crew=None, embedder_config=None, storage: Storage=None):
+        storage = (
+            storage
+            if storage
+            else RAGStorage(
+                type="entities", allow_reset=False, embedder_config=embedder_config, crew=crew
+            )
         )
         super().__init__(storage)
 

--- a/src/crewai/memory/entity/entity_memory.py
+++ b/src/crewai/memory/entity/entity_memory.py
@@ -11,7 +11,7 @@ class EntityMemory(Memory):
     Inherits from the Memory class.
     """
 
-    def __init__(self, crew=None, embedder_config=None, storage: Storage=None):
+    def __init__(self, crew=None, embedder_config=None, storage: Storage | None=None):
         storage = (
             storage
             if storage

--- a/src/crewai/memory/long_term/long_term_memory.py
+++ b/src/crewai/memory/long_term/long_term_memory.py
@@ -16,7 +16,7 @@ class LongTermMemory(Memory):
     """
 
     def __init__(self, storage: Storage=None):
-        storage = storage if storage esle LTMSQLiteStorage()
+        storage = storage if storage else LTMSQLiteStorage()
         super().__init__(storage)
 
     def save(self, item: LongTermMemoryItem) -> None:  # type: ignore # BUG?: Signature of "save" incompatible with supertype "Memory"

--- a/src/crewai/memory/long_term/long_term_memory.py
+++ b/src/crewai/memory/long_term/long_term_memory.py
@@ -15,7 +15,7 @@ class LongTermMemory(Memory):
     LongTermMemoryItem instances.
     """
 
-    def __init__(self, storage: Storage=None):
+    def __init__(self, storage: Storage: Storage | None=None):
         storage = storage if storage else LTMSQLiteStorage()
         super().__init__(storage)
 

--- a/src/crewai/memory/long_term/long_term_memory.py
+++ b/src/crewai/memory/long_term/long_term_memory.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 from crewai.memory.long_term.long_term_memory_item import LongTermMemoryItem
 from crewai.memory.memory import Memory
-from crewai.memory.storage.interface import Storage
 from crewai.memory.storage.ltm_sqlite_storage import LTMSQLiteStorage
 
 
@@ -15,7 +14,7 @@ class LongTermMemory(Memory):
     LongTermMemoryItem instances.
     """
 
-    def __init__(self, storage: Storage: Storage | None=None):
+    def __init__(self, storage=None):
         storage = storage if storage else LTMSQLiteStorage()
         super().__init__(storage)
 

--- a/src/crewai/memory/long_term/long_term_memory.py
+++ b/src/crewai/memory/long_term/long_term_memory.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from crewai.memory.long_term.long_term_memory_item import LongTermMemoryItem
 from crewai.memory.memory import Memory
+from crewai.memory.storage.interface import Storage
 from crewai.memory.storage.ltm_sqlite_storage import LTMSQLiteStorage
 
 
@@ -14,8 +15,8 @@ class LongTermMemory(Memory):
     LongTermMemoryItem instances.
     """
 
-    def __init__(self):
-        storage = LTMSQLiteStorage()
+    def __init__(self, storage: Storage=None):
+        storage = storage if storage esle LTMSQLiteStorage()
         super().__init__(storage)
 
     def save(self, item: LongTermMemoryItem) -> None:  # type: ignore # BUG?: Signature of "save" incompatible with supertype "Memory"

--- a/src/crewai/memory/short_term/short_term_memory.py
+++ b/src/crewai/memory/short_term/short_term_memory.py
@@ -14,7 +14,7 @@ class ShortTermMemory(Memory):
     MemoryItem instances.
     """
 
-    def __init__(self, crew=None, embedder_config=None, storage: Storage=None):
+    def __init__(self, crew=None, embedder_config=None, storage: Storage | None=None):
         storage = (
             storage
             if storage

--- a/src/crewai/memory/short_term/short_term_memory.py
+++ b/src/crewai/memory/short_term/short_term_memory.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 from crewai.memory.memory import Memory
-from crewai.memory.storage.interface import Storage
 from crewai.memory.short_term.short_term_memory_item import ShortTermMemoryItem
 from crewai.memory.storage.rag_storage import RAGStorage
 
@@ -14,7 +13,7 @@ class ShortTermMemory(Memory):
     MemoryItem instances.
     """
 
-    def __init__(self, crew=None, embedder_config=None, storage: Storage | None=None):
+    def __init__(self, crew=None, embedder_config=None, storage=None):
         storage = (
             storage
             if storage

--- a/src/crewai/memory/short_term/short_term_memory.py
+++ b/src/crewai/memory/short_term/short_term_memory.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 from crewai.memory.memory import Memory
+from crewai.memory.storage.interface import Storage
 from crewai.memory.short_term.short_term_memory_item import ShortTermMemoryItem
 from crewai.memory.storage.rag_storage import RAGStorage
 
@@ -13,9 +14,13 @@ class ShortTermMemory(Memory):
     MemoryItem instances.
     """
 
-    def __init__(self, crew=None, embedder_config=None):
-        storage = RAGStorage(
-            type="short_term", embedder_config=embedder_config, crew=crew
+    def __init__(self, crew=None, embedder_config=None, storage: Storage=None):
+        storage = (
+            storage
+            if storage
+            else RAGStorage(
+                type="short_term", embedder_config=embedder_config, crew=crew
+            )
         )
         super().__init__(storage)
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -27,7 +27,7 @@ def test_agent_creation():
 
 def test_agent_default_values():
     agent = Agent(role="test role", goal="test goal", backstory="test backstory")
-    assert agent.llm == "gpt-4o"
+    assert agent.llm == "gpt-4o-mini"
     assert agent.allow_delegation is False
 
 


### PR DESCRIPTION
This PR adds support to be able to use custom memory/storage interface for the Crew. A use case for this if the user wants to use some totally different embedding model, or some custom setup aside from the one provided by embeddchain - This is one step in removing the hard dependency on the embeddchain library.

Here is a sample storage interface - https://github.com/thehapyone/Sage/blob/7b24cedcc4cc0f90ed5c15949a63f13e6e966b5c/sage/agent/memory.py#L46

Others:
 - Address a previous failing test due to https://github.com/crewAIInc/crewAI/commit/c055c35361a58d6e5875d43dee79da17c30e367a#diff-5ccf1187d87635b000d9364216215d7d04dace4197c62219b3d875920f4cff2cR85
 - Address a type checker error due to - https://github.com/crewAIInc/crewAI/commit/2787c9b0ef60fa5f2c8250fde4c76fd850468b98
