### PR TITLE
docs: update "LLM-Connections" import and "Tasks" formatting

### DIFF
--- a/docs/core-concepts/Tasks.md
+++ b/docs/core-concepts/Tasks.md
@@ -1,4 +1,3 @@
-```markdown
 ---
 title: crewAI Tasks
 description: Detailed guide on managing and creating tasks within the crewAI framework, reflecting the latest codebase updates.

--- a/docs/how-to/LLM-Connections.md
+++ b/docs/how-to/LLM-Connections.md
@@ -66,7 +66,8 @@ claude_agent = Agent(
 For more detailed configuration, use the LLM class:
 
 ```python
-from crewai import Agent, LLM
+from crewai import Agent
+from crewai.llm import LLM
 
 llm = LLM(
     model="gpt-4",


### PR DESCRIPTION
- The import of LLM has been changed from `from crewai import LLM` to `from crewai.llm import LLM`, which has been affected the latest version.
- The current formatting of "Tasks" page is incorrect, see [the current page](https://docs.crewai.com/core-concepts/Tasks/).