### PR TITLE
docs: fix misspelling of "EXA Search" in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,7 +162,7 @@ nav:
     - Directory RAG Search: 'tools/DirectorySearchTool.md'
     - Directory Read: 'tools/DirectoryReadTool.md'
     - Docx Rag Search: 'tools/DOCXSearchTool.md'
-    - EXA Serch Web Loader: 'tools/EXASearchTool.md'
+    - EXA Search Web Loader: 'tools/EXASearchTool.md'
     - File Read: 'tools/FileReadTool.md'
     - File Write: 'tools/FileWriteTool.md'
     - Firecrawl Crawl Website Tool: 'tools/FirecrawlCrawlWebsiteTool.md'


### PR DESCRIPTION
- In the documentation sidebar "Exa Search" is misspelled as "Exa Serch": [https://docs.crewai.com/tools/EXASearchTool/](https://docs.crewai.com/tools/EXASearchTool/)
- Spelling has been corrected in`mkdocs.yml`