### PR TITLE
[Docs] Point footer socials to crewAIInc accounts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,6 @@ extra:
     property: G-N3Q505TMQ6
   social:
     - icon: fontawesome/brands/twitter
-      link: https://twitter.com/joaomdmoura
+      link: https://x.com/crewAIInc
     - icon: fontawesome/brands/github
-      link: https://github.com/joaomdmoura/crewAI
+      link: https://github.com/crewAIInc/crewAI


### PR DESCRIPTION
*Nit picky* - Point footer socials to `crewAIInc` accounts instead of `joaomdmoura` 😅 

Feel free to close.