### PR TITLE
[Docs] Update twitter logo to use x-twiiter icon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,7 +209,7 @@ extra:
     provider: google
     property: G-N3Q505TMQ6
   social:
-    - icon: fontawesome/brands/twitter
+    - icon: fontawesome/brands/x-twitter
       link: https://x.com/crewAIInc
     - icon: fontawesome/brands/github
       link: https://github.com/crewAIInc/crewAI


### PR DESCRIPTION
Update the footer icon to use `x-twitter` instead of just `twitter`.

<img width="340" alt="Screenshot 2024-10-07 at 10 41 42" src="https://github.com/user-attachments/assets/d07d48d8-52b1-4b5e-a617-78448c16e5fc">
