### PR TITLE
Fixing context of tasks when running pipeline

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -902,6 +902,15 @@ class Crew(BaseModel):
         cloned_agents = [agent.copy() for agent in self.agents]
         cloned_tasks = [task.copy(cloned_agents) for task in self.tasks]
 
+        for cloned_task in cloned_tasks:
+            cloned_task.context = [
+                next(
+                    (reference for reference in cloned_tasks if reference.key == context_task.key),
+                    None
+                )
+                for context_task in cloned_task.context
+            ] if cloned_task.context else None
+
         copied_data = self.model_dump(exclude=exclude)
         copied_data = {k: v for k, v in copied_data.items() if v is not None}
 


### PR DESCRIPTION
## Fixes #1410
I noticed the agents ignore the context tasks given to them in the `context` field. 
After thorough debugging I fund that the problem lays in the deep copy in `crew.py` (`def copy(self)` function) . 
The problem was that when running the pipeline, it first copies the crews and then runs the copied crews.
When deep-copying the crew, the tasks are being copied, but they create another instance of the task in the context. That instance's output is not updated when the real task completes and therefore the tasks in the context always have an empty output field.

To solve it, I compared the keys of the original copied tasks with the tasks in the context of each task, and  if they were the same, I replaced the context task with the original one. That way the context points to the task that is being run. It works perfectly now. 

## Proof it works: 
Now the example in #1410 gives the correct answer: 
![image](https://github.com/user-attachments/assets/c2f1adb4-cf20-468a-bc32-16d044501993)

