### PR TITLE
Fix incorrect parameter name in Vision tool docs page

### DIFF
--- a/docs/tools/visiontool.mdx
+++ b/docs/tools/visiontool.mdx
@@ -8,13 +8,13 @@ icon: eye
 
 ## Description
 
-This tool is used to extract text from images. When passed to the agent it will extract the text from the image and then use it to generate a response, report or any other output. 
+This tool is used to extract text from images. When passed to the agent it will extract the text from the image and then use it to generate a response, report or any other output.
 The URL or the PATH of the image should be passed to the Agent.
-
 
 ## Installation
 
 Install the crewai_tools package
+
 ```shell
 pip install 'crewai[tools]'
 ```
@@ -44,7 +44,6 @@ def researcher(self) -> Agent:
 
 The VisionTool requires the following arguments:
 
-| Argument       | Type     | Description                                                                                                                         |
-|:---------------|:---------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| **image_path** | `string` | **Mandatory**. The path to the image file from which text needs to be extracted.                                                |
-
+| Argument           | Type     | Description                                                                      |
+| :----------------- | :------- | :------------------------------------------------------------------------------- |
+| **image_path_url** | `string` | **Mandatory**. The path to the image file from which text needs to be extracted. |


### PR DESCRIPTION
According to the [source code](https://github.com/crewAIInc/crewAI-tools/blob/main/crewai_tools/tools/vision_tool/vision_tool.py), the [Vision tool docs](https://docs.crewai.com/tools/visiontool) are not updated. The parameter is incorrect, which gives the following error: `Tool Vision Tool accepts these inputs: Vision Tool(image_path_url: ‘string’) - This tool uses OpenAI’s Vision API to describe the contents of an image.`

Current docs:

| Argument           | Type     | Description                                                                      |
| :----------------- | :------- | :------------------------------------------------------------------------------- |
| **image_path** | `string` | **Mandatory**. The path to the image file from which text needs to be extracted. |

Should be:

| Argument           | Type     | Description                                                                      |
| :----------------- | :------- | :------------------------------------------------------------------------------- |
| **image_path_url** | `string` | **Mandatory**. The path to the image file from which text needs to be extracted. |