### PR TITLE
chore(readme): fixing step for 'running tests' in the contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ pre-commit install
 ### Running Tests
 
 ```bash
-uvx pytest
+uv run pytest .
 ```
 
 ### Running static type checks


### PR DESCRIPTION
For the correct "running tests" from a raw environment perspective in the section "Contribution", it's necessary to use the `uv run pytest /` instead of the alias `uvx`, as shown in the documentation of uv.

![image](https://github.com/user-attachments/assets/d36e7f7a-2513-4624-ac35-ce0a253dc3c1)

[Source](https://docs.astral.sh/uv/guides/tools/#running-tools)