### PR TITLE
Forward install command options to `uv sync`

### DIFF
--- a/src/crewai/cli/cli.py
+++ b/src/crewai/cli/cli.py
@@ -178,10 +178,14 @@ def test(n_iterations: int, model: str):
     evaluate_crew(n_iterations, model)
 
 
-@crewai.command()
-def install():
+@crewai.command(context_settings=dict(
+    ignore_unknown_options=True,
+    allow_extra_args=True,
+))
+@click.pass_context
+def install(context):
     """Install the Crew."""
-    install_crew()
+    install_crew(context.args)
 
 
 @crewai.command()

--- a/src/crewai/cli/install_crew.py
+++ b/src/crewai/cli/install_crew.py
@@ -3,12 +3,13 @@ import subprocess
 import click
 
 
-def install_crew() -> None:
+def install_crew(proxy_options: list[str]) -> None:
     """
     Install the crew by running the UV command to lock and install.
     """
     try:
-        subprocess.run(["uv", "sync"], check=True, capture_output=False, text=True)
+        command = ["uv", "sync"] + proxy_options
+        subprocess.run(command, check=True, capture_output=False, text=True)
 
     except subprocess.CalledProcessError as e:
         click.echo(f"An error occurred while running the crew: {e}", err=True)


### PR DESCRIPTION
Allow passing additional options from `crewai install` directly to `uv sync`. This enables commands like `crewai install --locked` to work as expected by forwarding all flags and options to the underlying uv command.