### PR TITLE
improve tool text description and args

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -392,6 +392,16 @@ class Agent(BaseAgent):
         return description
 
     def _render_text_description_and_args(self, tools: List[Any]) -> str:
+        """Render the tool name, description, and args in plain text.
+
+            Output will be in the format of:
+
+            .. code-block:: markdown
+
+            search: This tool is used for search, args: {"query": {"type": "string"}}
+            calculator: This tool is used for math, \
+            args: {"expression": {"type": "string"}}
+        """
         tool_strings = []
         for tool in tools:
             args_schema = {

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -406,8 +406,6 @@ class Agent(BaseAgent):
             )
             tool_strings.append(f"{description}\nTool Arguments: {args_schema}")
 
-        print("TOOL STRINGS:", "\n".join(tool_strings))
-
         return "\n".join(tool_strings)
 
     def _validate_docker_installation(self) -> None:

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -393,29 +393,21 @@ class Agent(BaseAgent):
         return description
 
     def _render_text_description_and_args(self, tools: List[Any]) -> str:
-        """Render the tool name, description, and args in plain text.
-
-        Output will be in the format of:
-
-        .. code-block:: markdown
-
-            search: This tool is used for search, args: {"query": {"type": "string"}}
-            calculator: This tool is used for math, \
-    args: {"expression": {"type": "string"}}
-        """
         tool_strings = []
         for tool in tools:
-            args_schema = str(tool.model_fields)
-            if hasattr(tool, "func") and tool.func:
-                sig = signature(tool.func)
-                description = (
-                    f"Tool Name: {tool.name}{sig}\nTool Description: {tool.description}"
-                )
-            else:
-                description = (
-                    f"Tool Name: {tool.name}\nTool Description: {tool.description}"
-                )
+            args_schema = {
+                name: {
+                    "description": field.description,
+                    "type": field.annotation.__name__,
+                }
+                for name, field in tool.args_schema.model_fields.items()
+            }
+            description = (
+                f"Tool Name: {tool.name}\nTool Description: {tool.description}"
+            )
             tool_strings.append(f"{description}\nTool Arguments: {args_schema}")
+
+        print("TOOL STRINGS:", "\n".join(tool_strings))
 
         return "\n".join(tool_strings)
 

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import subprocess
-from inspect import signature
 from typing import Any, List, Literal, Optional, Union
 
 from pydantic import Field, InstanceOf, PrivateAttr, model_validator


### PR DESCRIPTION
Simplify tools for LLMs to better understand what they need to pass to tools.

**Before**
```
Tool Name: Read website content(**kwargs: Any) -> Any
Tool Description: Read website content(website_url: 'string') - A tool that can be used to read a website content. website_url: 'Mandatory website url to read the file'
Tool Arguments: {'name': FieldInfo(annotation=str, required=True), 'description': FieldInfo(annotation=str, required=False, default=''), 'args_schema': FieldInfo(annotation=type[BaseModel], required=True, description='The tool schema.', metadata=[SkipValidation()]), 'return_direct': FieldInfo(annotation=bool, required=False, default=False), 'verbose': FieldInfo(annotation=bool, required=False, default=False), 'callbacks': FieldInfo(annotation=Union[list[BaseCallbackHandler], BaseCallbackManager, NoneType], required=False, default=None, exclude=True), 'callback_manager': FieldInfo(annotation=Union[BaseCallbackManager, NoneType], required=False, default=None, description='.. deprecated:: 0.1.7 Use :meth:`~callbacks` instead.\n\nCallback manager to add to the run trace.', exclude=True), 'tags': FieldInfo(annotation=Union[list[str], NoneType], required=False, default=None), 'metadata': FieldInfo(annotation=Union[dict[str, Any], NoneType], required=False, default=None), 'handle_tool_error': FieldInfo(annotation=Union[bool, str, Callable[list, str], NoneType], required=False, default=False), 'handle_validation_error': FieldInfo(annotation=Union[bool, str, Callable[list, str], NoneType], required=False, default=False), 'response_format': FieldInfo(annotation=Literal['content', 'content_and_artifact'], required=False, default='content'), 'func': FieldInfo(annotation=Union[Callable[..., Any], NoneType], required=False, default=None), 'coroutine': FieldInfo(annotation=Union[Callable[..., Awaitable[Any]], NoneType], required=False, default=None)}
Tool Name: Search the internet(**kwargs: Any) -> Any
Tool Description: Search the internet(search_query: 'string') - A tool that can be used to search the internet with a search_query. search_query: 'Mandatory search query you want to use to search the internet'
Tool Arguments: {'name': FieldInfo(annotation=str, required=True), 'description': FieldInfo(annotation=str, required=False, default=''), 'args_schema': FieldInfo(annotation=type[BaseModel], required=True, description='The tool schema.', metadata=[SkipValidation()]), 'return_direct': FieldInfo(annotation=bool, required=False, default=False), 'verbose': FieldInfo(annotation=bool, required=False, default=False), 'callbacks': FieldInfo(annotation=Union[list[BaseCallbackHandler], BaseCallbackManager, NoneType], required=False, default=None, exclude=True), 'callback_manager': FieldInfo(annotation=Union[BaseCallbackManager, NoneType], required=False, default=None, description='.. deprecated:: 0.1.7 Use :meth:`~callbacks` instead.\n\nCallback manager to add to the run trace.', exclude=True), 'tags': FieldInfo(annotation=Union[list[str], NoneType], required=False, default=None), 'metadata': FieldInfo(annotation=Union[dict[str, Any], NoneType], required=False, default=None), 'handle_tool_error': FieldInfo(annotation=Union[bool, str, Callable[list, str], NoneType], required=False, default=False), 'handle_validation_error': FieldInfo(annotation=Union[bool, str, Callable[list, str], NoneType], required=False, default=False), 'response_format': FieldInfo(annotation=Literal['content', 'content_and_artifact'], required=False, default='content'), 'func': FieldInfo(annotation=Union[Callable[..., Any], NoneType], required=False, default=None), 'coroutine': FieldInfo(annotation=Union[Callable[..., Awaitable[Any]], NoneType], required=False, default=None)}
```

**After**
```
Tool Name: Search the internet
Tool Description: Search the internet(search_query: 'string') - A tool that can be used to search the internet with a search_query. search_query: 'Mandatory search query you want to use to search the internet'
Tool Arguments: {'search_query': {'description': 'Mandatory search query you want to use to search the internet', 'type': 'str'}}
Tool Name: Read website content
Tool Description: Read website content(website_url: 'string') - A tool that can be used to read a website content. website_url: 'Mandatory website url to read the file'
Tool Arguments: {'website_url': {'description': 'Mandatory website url to read the file', 'type': 'str'}}
```

Closes #1511 

Thank you @c0dezli