### PR TITLE
refactor: Move BaseTool to main package and centralize tool description generation

### DIFF
--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -5,13 +5,13 @@ icon: screwdriver-wrench
 ---
 
 ## Introduction
-CrewAI tools empower agents with capabilities ranging from web searching and data analysis to collaboration and delegating tasks among coworkers. 
+CrewAI tools empower agents with capabilities ranging from web searching and data analysis to collaboration and delegating tasks among coworkers.
 This documentation outlines how to create, integrate, and leverage these tools within the CrewAI framework, including a new focus on collaboration tools.
 
 ## What is a Tool?
 
-A tool in CrewAI is a skill or function that agents can utilize to perform various actions. 
-This includes tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools), 
+A tool in CrewAI is a skill or function that agents can utilize to perform various actions.
+This includes tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools),
 enabling everything from simple searches to complex interactions and effective teamwork among agents.
 
 ## Key Characteristics of Tools
@@ -103,57 +103,53 @@ crew.kickoff()
 
 Here is a list of the available tools and their descriptions:
 
-| Tool                        | Description                                                                                   |
-| :-------------------------- | :-------------------------------------------------------------------------------------------- |
-| **BrowserbaseLoadTool**     | A tool for interacting with and extracting data from web browsers.                            |
-| **CodeDocsSearchTool**      | A RAG tool optimized for searching through code documentation and related technical documents. |
-| **CodeInterpreterTool**     | A tool for interpreting python code.                                                          |
-| **ComposioTool**            | Enables use of Composio tools.                                                                |
-| **CSVSearchTool**           | A RAG tool designed for searching within CSV files, tailored to handle structured data.       |
-| **DALL-E Tool**             | A tool for generating images using the DALL-E API.                                            |
-| **DirectorySearchTool**     | A RAG tool for searching within directories, useful for navigating through file systems.      |
-| **DOCXSearchTool**          | A RAG tool aimed at searching within DOCX documents, ideal for processing Word files.         |
-| **DirectoryReadTool**       | Facilitates reading and processing of directory structures and their contents.                |
-| **EXASearchTool**           | A tool designed for performing exhaustive searches across various data sources.               |
-| **FileReadTool**            | Enables reading and extracting data from files, supporting various file formats.              |
-| **FirecrawlSearchTool**     | A tool to search webpages using Firecrawl and return the results.                             |
-| **FirecrawlCrawlWebsiteTool** | A tool for crawling webpages using Firecrawl.                                               |
-| **FirecrawlScrapeWebsiteTool** | A tool for scraping webpages URL using Firecrawl and returning its contents.              |
-| **GithubSearchTool**        | A RAG tool for searching within GitHub repositories, useful for code and documentation search.|
-| **SerperDevTool**           | A specialized tool for development purposes, with specific functionalities under development. |
-| **TXTSearchTool**           | A RAG tool focused on searching within text (.txt) files, suitable for unstructured data.     |
-| **JSONSearchTool**          | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
-| **LlamaIndexTool**          | Enables the use of LlamaIndex tools.                                                          |
-| **MDXSearchTool**           | A RAG tool tailored for searching within Markdown (MDX) files, useful for documentation.      |
-| **PDFSearchTool**           | A RAG tool aimed at searching within PDF documents, ideal for processing scanned documents.    |
-| **PGSearchTool**            | A RAG tool optimized for searching within PostgreSQL databases, suitable for database queries. |
-| **Vision Tool**             | A tool for generating images using the DALL-E API.                                            |
-| **RagTool**                 | A general-purpose RAG tool capable of handling various data sources and types.                |
-| **ScrapeElementFromWebsiteTool** | Enables scraping specific elements from websites, useful for targeted data extraction.   |
-| **ScrapeWebsiteTool**       | Facilitates scraping entire websites, ideal for comprehensive data collection.                |
-| **WebsiteSearchTool**       | A RAG tool for searching website content, optimized for web data extraction.                  |
-| **XMLSearchTool**           | A RAG tool designed for searching within XML files, suitable for structured data formats.     |
-| **YoutubeChannelSearchTool**| A RAG tool for searching within YouTube channels, useful for video content analysis.          |
-| **YoutubeVideoSearchTool**  | A RAG tool aimed at searching within YouTube videos, ideal for video data extraction.         |
+| Tool                             | Description                                                                                    |
+| :------------------------------- | :--------------------------------------------------------------------------------------------- |
+| **BrowserbaseLoadTool**          | A tool for interacting with and extracting data from web browsers.                             |
+| **CodeDocsSearchTool**           | A RAG tool optimized for searching through code documentation and related technical documents. |
+| **CodeInterpreterTool**          | A tool for interpreting python code.                                                           |
+| **ComposioTool**                 | Enables use of Composio tools.                                                                 |
+| **CSVSearchTool**                | A RAG tool designed for searching within CSV files, tailored to handle structured data.        |
+| **DALL-E Tool**                  | A tool for generating images using the DALL-E API.                                             |
+| **DirectorySearchTool**          | A RAG tool for searching within directories, useful for navigating through file systems.       |
+| **DOCXSearchTool**               | A RAG tool aimed at searching within DOCX documents, ideal for processing Word files.          |
+| **DirectoryReadTool**            | Facilitates reading and processing of directory structures and their contents.                 |
+| **EXASearchTool**                | A tool designed for performing exhaustive searches across various data sources.                |
+| **FileReadTool**                 | Enables reading and extracting data from files, supporting various file formats.               |
+| **FirecrawlSearchTool**          | A tool to search webpages using Firecrawl and return the results.                              |
+| **FirecrawlCrawlWebsiteTool**    | A tool for crawling webpages using Firecrawl.                                                  |
+| **FirecrawlScrapeWebsiteTool**   | A tool for scraping webpages URL using Firecrawl and returning its contents.                   |
+| **GithubSearchTool**             | A RAG tool for searching within GitHub repositories, useful for code and documentation search. |
+| **SerperDevTool**                | A specialized tool for development purposes, with specific functionalities under development.  |
+| **TXTSearchTool**                | A RAG tool focused on searching within text (.txt) files, suitable for unstructured data.      |
+| **JSONSearchTool**               | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
+| **LlamaIndexTool**               | Enables the use of LlamaIndex tools.                                                           |
+| **MDXSearchTool**                | A RAG tool tailored for searching within Markdown (MDX) files, useful for documentation.       |
+| **PDFSearchTool**                | A RAG tool aimed at searching within PDF documents, ideal for processing scanned documents.    |
+| **PGSearchTool**                 | A RAG tool optimized for searching within PostgreSQL databases, suitable for database queries. |
+| **Vision Tool**                  | A tool for generating images using the DALL-E API.                                             |
+| **RagTool**                      | A general-purpose RAG tool capable of handling various data sources and types.                 |
+| **ScrapeElementFromWebsiteTool** | Enables scraping specific elements from websites, useful for targeted data extraction.         |
+| **ScrapeWebsiteTool**            | Facilitates scraping entire websites, ideal for comprehensive data collection.                 |
+| **WebsiteSearchTool**            | A RAG tool for searching website content, optimized for web data extraction.                   |
+| **XMLSearchTool**                | A RAG tool designed for searching within XML files, suitable for structured data formats.      |
+| **YoutubeChannelSearchTool**     | A RAG tool for searching within YouTube channels, useful for video content analysis.           |
+| **YoutubeVideoSearchTool**       | A RAG tool aimed at searching within YouTube videos, ideal for video data extraction.          |
 
 ## Creating your own Tools
 
 <Tip>
-  Developers can craft `custom tools` tailored for their agent’s needs or utilize pre-built options.
+  Developers can craft `custom tools` tailored for their agent’s needs or
+  utilize pre-built options.
 </Tip>
 
-To create your own CrewAI tools you will need to install our extra tools package:
-
-```bash
-pip install 'crewai[tools]'
-```
-
-Once you do that there are two main ways for one to create a CrewAI tool:
+There are two main ways for one to create a CrewAI tool:
 
 ### Subclassing `BaseTool`
 
 ```python Code
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
+
 
 class MyCustomTool(BaseTool):
     name: str = "Name of my tool"
@@ -167,7 +163,7 @@ class MyCustomTool(BaseTool):
 ### Utilizing the `tool` Decorator
 
 ```python Code
-from crewai_tools import tool
+from crewai.tools.base_tool import tool
 @tool("Name of my tool")
 def my_tool(question: str) -> str:
     """Clear description for what this tool is useful for, your agent will need this information to use it."""
@@ -178,11 +174,13 @@ def my_tool(question: str) -> str:
 ### Custom Caching Mechanism
 
 <Tip>
-  Tools can optionally implement a `cache_function` to fine-tune caching behavior. This function determines when to cache results based on specific conditions, offering granular control over caching logic.
+  Tools can optionally implement a `cache_function` to fine-tune caching
+  behavior. This function determines when to cache results based on specific
+  conditions, offering granular control over caching logic.
 </Tip>
 
 ```python Code
-from crewai_tools import tool
+from crewai.tools.base_tool import tool
 
 @tool
 def multiplication_tool(first_number: int, second_number: int) -> str:
@@ -208,6 +206,6 @@ writer1 = Agent(
 
 ## Conclusion
 
-Tools are pivotal in extending the capabilities of CrewAI agents, enabling them to undertake a broad spectrum of tasks and collaborate effectively. 
-When building solutions with CrewAI, leverage both custom and existing tools to empower your agents and enhance the AI ecosystem. Consider utilizing error handling, 
+Tools are pivotal in extending the capabilities of CrewAI agents, enabling them to undertake a broad spectrum of tasks and collaborate effectively.
+When building solutions with CrewAI, leverage both custom and existing tools to empower your agents and enhance the AI ecosystem. Consider utilizing error handling,
 caching mechanisms, and the flexibility of tool arguments to optimize your agents' performance and capabilities.

--- a/docs/how-to/create-custom-tools.mdx
+++ b/docs/how-to/create-custom-tools.mdx
@@ -6,24 +6,17 @@ icon: hammer
 
 ## Creating and Utilizing Tools in CrewAI
 
-This guide provides detailed instructions on creating custom tools for the CrewAI framework and how to efficiently manage and utilize these tools, 
-incorporating the latest functionalities such as tool delegation, error handling, and dynamic tool calling. It also highlights the importance of collaboration tools, 
+This guide provides detailed instructions on creating custom tools for the CrewAI framework and how to efficiently manage and utilize these tools,
+incorporating the latest functionalities such as tool delegation, error handling, and dynamic tool calling. It also highlights the importance of collaboration tools,
 enabling agents to perform a wide range of actions.
-
-### Prerequisites
-
-Before creating your own tools, ensure you have the crewAI extra tools package installed:
-
-```bash
-pip install 'crewai[tools]'
-```
 
 ### Subclassing `BaseTool`
 
 To create a personalized tool, inherit from `BaseTool` and define the necessary attributes and the `_run` method.
 
 ```python Code
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
+
 
 class MyCustomTool(BaseTool):
     name: str = "Name of my tool"
@@ -40,7 +33,7 @@ Alternatively, you can use the tool decorator `@tool`. This approach allows you 
 offering a concise and efficient way to create specialized tools tailored to your needs.
 
 ```python Code
-from crewai_tools import tool
+from crewai.tools.base_tool import tool
 
 @tool("Tool Name")
 def my_simple_tool(question: str) -> str:
@@ -66,5 +59,5 @@ def my_cache_strategy(arguments: dict, result: str) -> bool:
 cached_tool.cache_function = my_cache_strategy
 ```
 
-By adhering to these guidelines and incorporating new functionalities and collaboration tools into your tool creation and management processes, 
+By adhering to these guidelines and incorporating new functionalities and collaboration tools into your tool creation and management processes,
 you can leverage the full capabilities of the CrewAI framework, enhancing both the development experience and the efficiency of your AI agents.

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -11,6 +11,7 @@ from crewai.agents.crew_agent_executor import CrewAgentExecutor
 from crewai.llm import LLM
 from crewai.memory.contextual.contextual_memory import ContextualMemory
 from crewai.tools.agent_tools import AgentTools
+from crewai.tools.base_tool import BaseTool
 from crewai.utilities import Converter, Prompts
 from crewai.utilities.constants import TRAINED_AGENTS_DATA_FILE, TRAINING_DATA_FILE
 from crewai.utilities.token_counter_callback import TokenCalcHandler
@@ -192,7 +193,7 @@ class Agent(BaseAgent):
         self,
         task: Any,
         context: Optional[str] = None,
-        tools: Optional[List[Any]] = None,
+        tools: Optional[List[BaseTool]] = None,
     ) -> str:
         """Execute a task with the agent.
 
@@ -259,7 +260,9 @@ class Agent(BaseAgent):
 
         return result
 
-    def create_agent_executor(self, tools=None, task=None) -> None:
+    def create_agent_executor(
+        self, tools: Optional[List[BaseTool]] = None, task=None
+    ) -> None:
         """Create an agent executor for the agent.
 
         Returns:
@@ -332,7 +335,7 @@ class Agent(BaseAgent):
         tools_list = []
         try:
             # tentatively try to import from crewai_tools import BaseTool as CrewAITool
-            from crewai_tools import BaseTool as CrewAITool
+            from crewai.tools.base_tool import BaseTool as CrewAITool
 
             for tool in tools:
                 if isinstance(tool, CrewAITool):
@@ -391,7 +394,7 @@ class Agent(BaseAgent):
 
         return description
 
-    def _render_text_description_and_args(self, tools: List[Any]) -> str:
+    def _render_text_description_and_args(self, tools: List[BaseTool]) -> str:
         """Render the tool name, description, and args in plain text.
 
             Output will be in the format of:
@@ -404,17 +407,7 @@ class Agent(BaseAgent):
         """
         tool_strings = []
         for tool in tools:
-            args_schema = {
-                name: {
-                    "description": field.description,
-                    "type": field.annotation.__name__,
-                }
-                for name, field in tool.args_schema.model_fields.items()
-            }
-            description = (
-                f"Tool Name: {tool.name}\nTool Description: {tool.description}"
-            )
-            tool_strings.append(f"{description}\nTool Arguments: {args_schema}")
+            tool_strings.append(tool.description)
 
         return "\n".join(tool_strings)
 

--- a/src/crewai/agents/agent_builder/base_agent.py
+++ b/src/crewai/agents/agent_builder/base_agent.py
@@ -18,6 +18,7 @@ from pydantic_core import PydanticCustomError
 from crewai.agents.agent_builder.utilities.base_token_process import TokenProcess
 from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.agents.tools_handler import ToolsHandler
+from crewai.tools.base_tool import BaseTool
 from crewai.utilities import I18N, Logger, RPMController
 from crewai.utilities.config import process_config
 
@@ -105,7 +106,7 @@ class BaseAgent(ABC, BaseModel):
         default=False,
         description="Enable agent to delegate and ask questions among each other.",
     )
-    tools: Optional[List[Any]] = Field(
+    tools: Optional[List[BaseTool]] = Field(
         default_factory=list, description="Tools at agents' disposal"
     )
     max_iter: Optional[int] = Field(
@@ -188,7 +189,7 @@ class BaseAgent(ABC, BaseModel):
         self,
         task: Any,
         context: Optional[str] = None,
-        tools: Optional[List[Any]] = None,
+        tools: Optional[List[BaseTool]] = None,
     ) -> str:
         pass
 
@@ -197,11 +198,11 @@ class BaseAgent(ABC, BaseModel):
         pass
 
     @abstractmethod
-    def _parse_tools(self, tools: List[Any]) -> List[Any]:
+    def _parse_tools(self, tools: List[BaseTool]) -> List[BaseTool]:
         pass
 
     @abstractmethod
-    def get_delegation_tools(self, agents: List["BaseAgent"]) -> List[Any]:
+    def get_delegation_tools(self, agents: List["BaseAgent"]) -> List[BaseTool]:
         """Set the task tools that init BaseAgenTools class."""
         pass
 

--- a/src/crewai/cli/templates/crew/tools/custom_tool.py
+++ b/src/crewai/cli/templates/crew/tools/custom_tool.py
@@ -1,4 +1,4 @@
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
 
 
 class MyCustomTool(BaseTool):

--- a/src/crewai/cli/templates/flow/tools/custom_tool.py
+++ b/src/crewai/cli/templates/flow/tools/custom_tool.py
@@ -1,4 +1,4 @@
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
 
 
 class MyCustomTool(BaseTool):

--- a/src/crewai/cli/templates/pipeline/tools/custom_tool.py
+++ b/src/crewai/cli/templates/pipeline/tools/custom_tool.py
@@ -1,4 +1,5 @@
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
+
 
 
 class MyCustomTool(BaseTool):

--- a/src/crewai/cli/templates/pipeline_router/tools/custom_tool.py
+++ b/src/crewai/cli/templates/pipeline_router/tools/custom_tool.py
@@ -1,4 +1,5 @@
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
+
 
 
 class MyCustomTool(BaseTool):

--- a/src/crewai/cli/templates/tool/src/{{folder_name}}/tool.py
+++ b/src/crewai/cli/templates/tool/src/{{folder_name}}/tool.py
@@ -1,4 +1,5 @@
-from crewai_tools import BaseTool
+from crewai.tools.base_tool import BaseTool
+
 
 class {{class_name}}(BaseTool):
     name: str = "Name of my tool"

--- a/src/crewai/tools/base_tool.py
+++ b/src/crewai/tools/base_tool.py
@@ -1,0 +1,171 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional, Type, get_args, get_origin
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, ConfigDict, Field, validator
+from pydantic import BaseModel as PydanticBaseModel
+
+
+class BaseTool(BaseModel, ABC):
+    class _ArgsSchemaPlaceholder(PydanticBaseModel):
+        pass
+
+    model_config = ConfigDict()
+
+    name: str
+    """The unique name of the tool that clearly communicates its purpose."""
+    description: str
+    """Used to tell the model how/when/why to use the tool."""
+    args_schema: Type[PydanticBaseModel] = Field(default_factory=_ArgsSchemaPlaceholder)
+    """The schema for the arguments that the tool accepts."""
+    description_updated: bool = False
+    """Flag to check if the description has been updated."""
+    cache_function: Optional[Callable] = lambda _args, _result: True
+    """Function that will be used to determine if the tool should be cached, should return a boolean. If None, the tool will be cached."""
+    result_as_answer: bool = False
+    """Flag to check if the tool should be the final agent answer."""
+
+    @validator("args_schema", always=True, pre=True)
+    def _default_args_schema(
+        cls, v: Type[PydanticBaseModel]
+    ) -> Type[PydanticBaseModel]:
+        if not isinstance(v, cls._ArgsSchemaPlaceholder):
+            return v
+
+        return type(
+            f"{cls.__name__}Schema",
+            (PydanticBaseModel,),
+            {
+                "__annotations__": {
+                    k: v for k, v in cls._run.__annotations__.items() if k != "return"
+                },
+            },
+        )
+
+    def model_post_init(self, __context: Any) -> None:
+        self._generate_description()
+
+        super().model_post_init(__context)
+
+    def run(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        print(f"Using Tool: {self.name}")
+        return self._run(*args, **kwargs)
+
+    @abstractmethod
+    def _run(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Here goes the actual implementation of the tool."""
+
+    def to_langchain(self) -> StructuredTool:
+        self._set_args_schema()
+        return StructuredTool(
+            name=self.name,
+            description=self.description,
+            args_schema=self.args_schema,
+            func=self._run,
+        )
+
+    def _set_args_schema(self):
+        if self.args_schema is None:
+            class_name = f"{self.__class__.__name__}Schema"
+            self.args_schema = type(
+                class_name,
+                (PydanticBaseModel,),
+                {
+                    "__annotations__": {
+                        k: v
+                        for k, v in self._run.__annotations__.items()
+                        if k != "return"
+                    },
+                },
+            )
+
+    def _generate_description(self):
+        args_schema = {
+            name: {
+                "description": field.description,
+                "type": BaseTool._get_arg_annotations(field.annotation),
+            }
+            for name, field in self.args_schema.model_fields.items()
+        }
+
+        description = self.description.replace("\n", " ")
+        self.description = f"Tool Name: {self.name}\nTool Arguments: {args_schema}\nTool Description: {description}"
+
+    @staticmethod
+    def _get_arg_annotations(annotation: type[Any] | None) -> str:
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+        if origin is None:
+            return (
+                annotation.__name__
+                if hasattr(annotation, "__name__")
+                else str(annotation)
+            )
+
+        if args:
+            args_str = ", ".join(BaseTool._get_arg_annotations(arg) for arg in args)
+            return f"{origin.__name__}[{args_str}]"
+
+        return origin.__name__
+
+
+class Tool(BaseTool):
+    func: Callable
+    """The function that will be executed when the tool is called."""
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        return self.func(*args, **kwargs)
+
+
+def to_langchain(
+    tools: list[BaseTool | StructuredTool],
+) -> list[StructuredTool]:
+    return [t.to_langchain() if isinstance(t, BaseTool) else t for t in tools]
+
+
+def tool(*args):
+    """
+    Decorator to create a tool from a function.
+    """
+
+    def _make_with_name(tool_name: str) -> Callable:
+        def _make_tool(f: Callable) -> BaseTool:
+            if f.__doc__ is None:
+                raise ValueError("Function must have a docstring")
+            if f.__annotations__ is None:
+                raise ValueError("Function must have type annotations")
+
+            class_name = "".join(tool_name.split()).title()
+            args_schema = type(
+                class_name,
+                (PydanticBaseModel,),
+                {
+                    "__annotations__": {
+                        k: v for k, v in f.__annotations__.items() if k != "return"
+                    },
+                },
+            )
+
+            return Tool(
+                name=tool_name,
+                description=f.__doc__,
+                func=f,
+                args_schema=args_schema,
+            )
+
+        return _make_tool
+
+    if len(args) == 1 and callable(args[0]):
+        return _make_with_name(args[0].__name__)(args[0])
+    if len(args) == 1 and isinstance(args[0], str):
+        return _make_with_name(args[0])
+    raise ValueError("Invalid arguments")

--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -10,6 +10,7 @@ import crewai.utilities.events as events
 from crewai.agents.tools_handler import ToolsHandler
 from crewai.task import Task
 from crewai.telemetry import Telemetry
+from crewai.tools.base_tool import BaseTool
 from crewai.tools.tool_calling import InstructorToolCalling, ToolCalling
 from crewai.tools.tool_usage_events import ToolUsageError, ToolUsageFinished
 from crewai.utilities import I18N, Converter, ConverterError, Printer
@@ -49,7 +50,7 @@ class ToolUsage:
     def __init__(
         self,
         tools_handler: ToolsHandler,
-        tools: List[Any],
+        tools: List[BaseTool],
         original_tools: List[Any],
         tools_description: str,
         tools_names: str,
@@ -298,22 +299,7 @@ class ToolUsage:
         """Render the tool name and description in plain text."""
         descriptions = []
         for tool in self.tools:
-            args = {
-                name: {
-                    "description": field.description,
-                    "type": field.annotation.__name__,
-                }
-                for name, field in tool.args_schema.model_fields.items()
-            }
-            descriptions.append(
-                "\n".join(
-                    [
-                        f"Tool Name: {tool.name.lower()}",
-                        f"Tool Description: {tool.description}",
-                        f"Tool Arguments: {args}",
-                    ]
-                )
-            )
+            descriptions.append(tool.description)
         return "\n--\n".join(descriptions)
 
     def _function_calling(self, tool_string: str):

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -5,7 +5,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from crewai_tools import tool
 
 from crewai import Agent, Crew, Task
 from crewai.agents.cache import CacheHandler
@@ -14,6 +13,7 @@ from crewai.agents.parser import AgentAction, CrewAgentParser, OutputParserExcep
 from crewai.llm import LLM
 from crewai.tools.tool_calling import InstructorToolCalling
 from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.base_tool import tool
 from crewai.tools.tool_usage_events import ToolUsageFinished
 from crewai.utilities import RPMController
 from crewai.utilities.events import Emitter
@@ -277,9 +277,10 @@ def test_cache_hitting():
         "multiplier-{'first_number': 12, 'second_number': 3}": 36,
     }
 
-    with patch.object(CacheHandler, "read") as read, patch.object(
-        Emitter, "emit"
-    ) as emit:
+    with (
+        patch.object(CacheHandler, "read") as read,
+        patch.object(Emitter, "emit") as emit,
+    ):
         read.return_value = "0"
         task = Task(
             description="What is 2 times 6? Ignore correctness and just return the result of the multiplication tool, you must use the tool.",
@@ -604,7 +605,7 @@ def test_agent_respect_the_max_rpm_set(capsys):
 def test_agent_respect_the_max_rpm_set_over_crew_rpm(capsys):
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def get_final_answer() -> float:
@@ -642,7 +643,7 @@ def test_agent_respect_the_max_rpm_set_over_crew_rpm(capsys):
 def test_agent_without_max_rpm_respet_crew_rpm(capsys):
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def get_final_answer() -> float:
@@ -696,7 +697,7 @@ def test_agent_without_max_rpm_respet_crew_rpm(capsys):
 def test_agent_error_on_parsing_tool(capsys):
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def get_final_answer() -> float:
@@ -739,7 +740,7 @@ def test_agent_error_on_parsing_tool(capsys):
 def test_agent_remembers_output_format_after_using_tools_too_many_times():
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def get_final_answer() -> float:
@@ -863,11 +864,16 @@ def test_agent_function_calling_llm():
 
     from crewai.tools.tool_usage import ToolUsage
 
-    with patch.object(
-        instructor, "from_litellm", wraps=instructor.from_litellm
-    ) as mock_from_litellm, patch.object(
-        ToolUsage, "_original_tool_calling", side_effect=Exception("Forced exception")
-    ) as mock_original_tool_calling:
+    with (
+        patch.object(
+            instructor, "from_litellm", wraps=instructor.from_litellm
+        ) as mock_from_litellm,
+        patch.object(
+            ToolUsage,
+            "_original_tool_calling",
+            side_effect=Exception("Forced exception"),
+        ) as mock_original_tool_calling,
+    ):
         crew.kickoff()
         mock_from_litellm.assert_called()
         mock_original_tool_calling.assert_called()
@@ -894,7 +900,7 @@ def test_agent_count_formatting_error():
 
 @pytest.mark.vcr(filter_headers=["authorization"])
 def test_tool_result_as_answer_is_the_final_answer_for_the_agent():
-    from crewai_tools import BaseTool
+    from crewai.tools.base_tool import BaseTool
 
     class MyCustomTool(BaseTool):
         name: str = "Get Greetings"
@@ -924,7 +930,7 @@ def test_tool_result_as_answer_is_the_final_answer_for_the_agent():
 
 @pytest.mark.vcr(filter_headers=["authorization"])
 def test_tool_usage_information_is_appended_to_agent():
-    from crewai_tools import BaseTool
+    from crewai.tools.base_tool import BaseTool
 
     class MyCustomTool(BaseTool):
         name: str = "Decide Greetings"

--- a/tests/crew_test.py
+++ b/tests/crew_test.py
@@ -456,7 +456,7 @@ def test_crew_verbose_output(capsys):
 def test_cache_hitting_between_agents():
     from unittest.mock import call, patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def multiplier(first_number: int, second_number: int) -> float:
@@ -499,7 +499,7 @@ def test_cache_hitting_between_agents():
 def test_api_calls_throttling(capsys):
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def get_final_answer() -> float:
@@ -1111,7 +1111,7 @@ def test_dont_set_agents_step_callback_if_already_set():
 def test_crew_function_calling_llm():
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     llm = "gpt-4o"
 
@@ -1146,7 +1146,7 @@ def test_crew_function_calling_llm():
 
 @pytest.mark.vcr(filter_headers=["authorization"])
 def test_task_with_no_arguments():
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def return_data() -> str:
@@ -1494,7 +1494,7 @@ def test_task_callback_on_crew():
 def test_tools_with_custom_caching():
     from unittest.mock import patch
 
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def multiplcation_tool(first_number: int, second_number: int) -> int:
@@ -1696,7 +1696,7 @@ def test_manager_agent_in_agents_raises_exception():
 
 
 def test_manager_agent_with_tools_raises_exception():
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def testing_tool(first_number: int, second_number: int) -> int:

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -15,7 +15,7 @@ from pydantic_core import ValidationError
 
 
 def test_task_tool_reflect_agent_tools():
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def fake_tool() -> None:
@@ -39,7 +39,7 @@ def test_task_tool_reflect_agent_tools():
 
 
 def test_task_tool_takes_precedence_over_agent_tools():
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def fake_tool() -> None:
@@ -656,7 +656,7 @@ def test_increment_delegations_for_sequential_process():
 
 @pytest.mark.vcr(filter_headers=["authorization"])
 def test_increment_tool_errors():
-    from crewai_tools import tool
+    from crewai.tools.base_tool import tool
 
     @tool
     def scoring_examples() -> None:

--- a/tests/tools/test_tool_usage.py
+++ b/tests/tools/test_tool_usage.py
@@ -3,11 +3,11 @@ import random
 from unittest.mock import MagicMock
 
 import pytest
-from crewai_tools import BaseTool
 from pydantic import BaseModel, Field
 
 from crewai import Agent, Task
 from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.base_tool import BaseTool
 
 
 class RandomNumberToolInput(BaseModel):


### PR DESCRIPTION
Here's a draft PR for implementing the suggested changes:

Title:
```
refactor: Move BaseTool to main package and centralize tool description generation
```

Description:

## Problem
Currently, we have:
1. The `BaseTool` definition in crewai-tools package, which should focus on tool implementations rather than core definitions
2. Duplicated tool description generation logic across three locations:
   - agent.py: `_render_text_description_and_args()`
   - tool_usage.py: `_render()`
   - base_tool.py: `_generate_description()`

## Proposed Changes

1. Move `BaseTool` class from crewai-tools to the main crewai package
   - This establishes crewai as the source of core tool abstractions
   - Allows crewai-tools to focus purely on tool implementations

2. Create a centralized tool description generator in the moved base_tool.py:
```python
    def _generate_description(self):
        args_schema = {
            name: {
                "description": field.description,
                "type": BaseTool._get_arg_annotations(field.annotation),
            }
            for name, field in self.args_schema.model_fields.items()
        }

        description = self.description.replace("\n", " ")
        self.description = f"Tool Name: {self.name}\nTool Arguments: {args_schema}\nTool Description: {description}"

    @staticmethod
    def _get_arg_annotations(annotation: type[Any] | None) -> str:
        origin = get_origin(annotation)
        args = get_args(annotation)

        if origin is None:
            return (
                annotation.__name__
                if hasattr(annotation, "__name__")
                else str(annotation)
            )

        if args:
            args_str = ", ".join(BaseTool._get_arg_annotations(arg) for arg in args)
            return f"{origin.__name__}[{args_str}]"

        return origin.__name__

```

3. Update all existing implementations to use this centralized function
   - Replace `_render_text_description_and_args()` in agent.py
   - Replace `_render()` in tool_usage.py
   - Remove duplicated code from crewai-tools

## Benefits
- Proper separation of concerns between packages
  - crewai: core abstractions and interfaces
  - crewai-tools: implementations and utilities
- Single source of truth for tool descriptions
- Improved maintainability
- Consistent tool description format across the system

## Breaking Changes
- Projects directly importing BaseTool from crewai-tools will need to update their imports
- Will require a major version bump for crewai-tools

## Migration Guide
For users importing from crewai-tools:
```python
# Old
from crewai_tools import BaseTool

# New
from crewai.tools.base_tool import BaseTool
```

Related Issues: #1511 


Let me know if you'd like me to adjust or expand any part of the PR description.