### PR TITLE
Fix issue when streaming LLM response

### DIFF
--- a/src/crewai/llm.py
+++ b/src/crewai/llm.py
@@ -153,7 +153,13 @@ class LLM:
                 params = {k: v for k, v in params.items() if v is not None}
 
                 response = litellm.completion(**params)
-                return response["choices"][0]["message"]["content"]
+                if params.get("stream", False):
+                    content = ""
+                    for chunk in response:
+                        content += chunk.choices[0].delta.content or ""
+                    return content
+                else:
+                    return response["choices"][0]["message"]["content"]
             except Exception as e:
                 if not LLMContextLengthExceededException(
                     str(e)


### PR DESCRIPTION
## Problem
Currently, if `stream` flag is set to True in the LLM params, there will be an exception raised from`llm.py`. The reason is that litellm will return an instance of litellm's `CustomStreamWrapper` which cannot be accessed in the current way. This is a real issue for our use case where we stream LLM response for special handling of lengthy content as well as optimizing application performance.

## Proposed Change
To solve this, we can check the `stream` flag when calling `litellm.completion` and have a separated handling for streaming mode.

## Test Case
The following sample code fails due to `TypeError: 'CustomStreamWrapper' object is not subscriptable` and succeeds after the PR. 
```
from crewai import Agent, Task, LLM
from crewai import Crew, Process


api_key = "my_key"
my_llm = LLM(model="gpt-4o-mini", api_key=api_key, stream=True)

# Create a researcher agent
researcher = Agent(
    role='Senior Researcher',
    goal='Discover groundbreaking technologies',
    verbose=True,
    llm=my_llm,
    backstory='A curious mind fascinated by cutting-edge innovation and the potential to change the world, you know everything about tech.'
)

# Task for the researcher
research_task = Task(
    description='Identify the next big trend in AI',
    expected_output="A single short sentence.",
    async_execution=False,
    agent=researcher  # Assigning the task to the researcher
)

# Instantiate your crew
crew = Crew(
    agents=[researcher],
    tasks=[research_task],
    process=Process.sequential  # Tasks will be executed one after the other
)

# Begin the task execution
crew.kickoff()
```
