### PR TITLE
Enhance log storage to support more data types

### DIFF
--- a/src/crewai/memory/storage/kickoff_task_outputs_storage.py
+++ b/src/crewai/memory/storage/kickoff_task_outputs_storage.py
@@ -70,7 +70,7 @@ class KickoffTaskOutputsSQLiteStorage:
                         task.expected_output,
                         json.dumps(output, cls=CrewJSONEncoder),
                         task_index,
-                        json.dumps(inputs),
+                        json.dumps(inputs, cls=CrewJSONEncoder),
                         was_replayed,
                     ),
                 )

--- a/src/crewai/utilities/crew_json_encoder.py
+++ b/src/crewai/utilities/crew_json_encoder.py
@@ -2,13 +2,14 @@ from datetime import datetime, date
 import json
 from uuid import UUID
 from pydantic import BaseModel
+from decimal import Decimal
 
 
 class CrewJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, BaseModel):
             return self._handle_pydantic_model(obj)
-        elif isinstance(obj, UUID):
+        elif isinstance(obj, UUID) or isinstance(obj, Decimal):
             return str(obj)
 
         elif isinstance(obj, datetime) or isinstance(obj, date):


### PR DESCRIPTION
## Problem
Our team is using crewAI for financial applications where non-basic data types like date, datetime and Decimal are heavily used. Input data to the crew contains such non-basic types which are usually retrieved from upstreaming data source.

After upgrading crewAI, the code execution failed because such data types in crew inputs are not handled during log storage inside crewAI. This has been a blocking issue for us and we would like to propose change to solve this and enhance the log storage.

## Proposed Change
Manage encoding for different data types in `CrewJSONEncoder` and use `CrewJSONEncoder` when seralizing the crew inputs during log storage.

## Test Case
The following sample code fails due to errors like `TypeError: Object of type {type} is not JSON serializable` where `type` in the error message can be date, datetime, Decimal, etc. After applying the proposed change, the crew inputs can be successfully encoded and saved as defined and managed in `CrewJSONEncoder`.
```python
from datetime import date
from decimal import Decimal

from crewai import Agent, Task
from crewai import Crew, Process


salesperson = Agent(
    role='Salesperson',
    goal='Describe the products to the customer',
    verbose=True,
    llm="gpt-4o-mini",
    backstory="A salesperson who recommends and sells product to customers"
)

introduce_product = Task(
    description='Given the product name: {name}, begin date: {begin_date} and total funds {total_funds}, '
                'write a short introduction to the product',
    expected_output="Several sentences",
    async_execution=False,
    agent=salesperson
)

crew = Crew(
    agents=[salesperson],
    tasks=[introduce_product],
    process=Process.sequential
)

product_data = {
    'name': 'product A',
    'total_funds': Decimal("123456789.12"),
    'begin_date': date(2023, 1, 1)
}

crew.kickoff(inputs=product_data)

```