### PR TITLE
BUG - fixes ollama key_name to address key_name error when running Ol…

### DIFF
--- a/src/crewai/cli/constants.py
+++ b/src/crewai/cli/constants.py
@@ -41,6 +41,7 @@ ENV_VARS = {
         {
             "default": True,
             "API_BASE": "http://localhost:11434",
+            "key_name": "model",
         }
     ],
     "bedrock": [

--- a/src/crewai/cli/constants.py
+++ b/src/crewai/cli/constants.py
@@ -41,7 +41,8 @@ ENV_VARS = {
         {
             "default": True,
             "API_BASE": "http://localhost:11434",
-            "key_name": "model",
+            "prompt": "Enter your Ollama model name (must start with 'ollama/')",
+            "key_name": "MODEL",
         }
     ],
     "bedrock": [


### PR DESCRIPTION
…lama models

## Issue
If you use the CrewAI CLI to create a project, and then run your LLM locally with Ollama, you get a a `key_name` error, since there is no key_name in the `ENV_VARS` object.

### Shell Example
```shell
➜ crewai run
Running the Crew
Traceback (most recent call last):
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/bin/run_crew", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/src/web_developers_crew/main.py", line 20, in run
    WebDevelopersCrew().crew().kickoff(inputs=inputs)
    ^^^^^^^^^^^^^^^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 35, in __init__
    self.map_all_task_variables()
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 145, in map_all_task_variables
    self._map_task_variables(
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 178, in _map_task_variables
    self.tasks_config[task_name]["agent"] = agents[agent_name]()
                                            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/crewai/project/utils.py", line 7, in memoized_func
    cache[key] = func(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/src/web_developers_crew/crew.py", line 20, in researcher
    return Agent(
           ^^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/toupsi/Development/AI/crew-ai/web_developers_crew/.venv/lib/python3.12/site-packages/crewai/agent.py", line 160, in post_init_setup
    if env_var["key_name"] in unnacepted_attributes:
       ~~~~~~~^^^^^^^^^^^^
KeyError: 'key_name'
An error occurred while running the crew: Command '['uv', 'run', 'run_crew']' returned non-zero exit status 1.
```

## Solution
I added the key_name `MODEL`, and it fixed the issue.

> I can imagine anyone **using the CLI** and running **Ollama models locally** will run into this, so hopefully this can make it into the next release.

## Not sure how to test 2nd Commit
I added a prompt to ask the user to enter their model if they are using Ollama. I entered that as a 2nd commit, so I can drop it if necessary.

## Demos & Screenshots
### Bug
![ ollama-constants-bug](https://github.com/user-attachments/assets/bffca16e-eaca-4bf5-b39e-c37efe867a2d)

![ ollama-constants-bug](https://github.com/user-attachments/assets/593dd1f2-4f29-4a3e-a13a-e4b54718d9c9)

### Solution
![ ollama-constants-solution](https://github.com/user-attachments/assets/32e5da83-0042-4c0f-ac80-1f6a8f13828f)

