### PR TITLE
fix: Correct order of checks for environment variable keys, enabling Ollama defaults to work

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -157,10 +157,10 @@ class Agent(BaseAgent):
             for provider, env_vars in ENV_VARS.items():
                 if provider == set_provider:
                     for env_var in env_vars:
-                        if env_var["key_name"] in unnacepted_attributes:
-                            continue
                         # Check if the environment variable is set
                         if "key_name" in env_var:
+                            if env_var["key_name"] in unnacepted_attributes:
+                                continue
                             env_value = os.environ.get(env_var["key_name"])
                             if env_value:
                                 # Map key names containing "API_KEY" to "api_key"


### PR DESCRIPTION
This addresses #1584 
- Moved the check for `unnacepted_attributes` to ensure it is evaluated after confirming the presence of `key_name` in the environment variable.
- This change improves the clarity and correctness of the environment variable handling logic, allowing the Ollama default env API_BASE to be handled in the Agent setup