### PR TITLE
Fix KeyError: 'key_name' in agent.py

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -157,7 +157,7 @@ class Agent(BaseAgent):
             for provider, env_vars in ENV_VARS.items():
                 if provider == set_provider:
                     for env_var in env_vars:
-                        if env_var["key_name"] in unnacepted_attributes:
+                        if "key_name" in env_var and env_var["key_name"] in unnacepted_attributes:
                             continue
                         # Check if the environment variable is set
                         if "key_name" in env_var:


### PR DESCRIPTION
**Problem**:
When running crewai run, a KeyError: 'key_name' occurs if the key_name attribute is missing in the environment variables.

```
(latest-ai-development) userk@mycelium:~/development/git/vanto_ai_agents_cornerstone/cre
wai/latest_ai_development$ crewai run                                                   
Running the Crew                                                                        
Traceback (most recent call last):                                                      
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/bin/run_crew", line 8, in <module>                                           
    sys.exit(run())                                                                     
             ^^^^^                                                                      
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/src/latest_ai_development/main.py", line 13, in run                                
    LatestAiDevelopmentCrew().crew().kickoff(inputs=inputs)                             
    ^^^^^^^^^^^^^^^^^^^^^^^^^                                                           
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 35, in __init
__                                                                                      
    self.map_all_task_variables()                                                       
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 145, in map_a
ll_task_variables                                                                       
    self._map_task_variables(                                                           
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/crewai/project/crew_base.py", line 178, in _map_
task_variables                                                                          
    self.tasks_config[task_name]["agent"] = agents[agent_name]()                        
                                            ^^^^^^^^^^^^^^^^^^^^                        
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/crewai/project/utils.py", line 7, in memoized_fu
nc                                                                                      
    cache[key] = func(*args, **kwargs)                                                  
                 ^^^^^^^^^^^^^^^^^^^^^                                                  
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/src/latest_ai_development/crew.py", line 12, in researcher                         
    return Agent(                                                                       
           ^^^^^^                                                                       
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__        
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=sel
f)                                                                                      
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^
  File "/home/userk/development/git/vanto_ai_agents_cornerstone/crewai/latest_ai_develop
ment/.venv/lib/python3.12/site-packages/crewai/agent.py", line 160, in post_init_setup
    if env_var["key_name"] in unnacepted_attributes:
       ~~~~~~~^^^^^^^^^^^^
KeyError: 'key_name'
An error occurred while running the crew: Command '['uv', 'run', 'run_crew']' returned n
on-zero exit status 1.
```


**Solution**:
Added a conditional check in agent.py to skip processing key_name unless it exists. This prevents the error and ensures compatibility for setups where key_name is not required.

**Proposed Fix**: A conditional check can be added in agent.py to skip processing key_name unless it's present and valid:

if "key_name" in env_var and env_var["key_name"] in unnacepted_attributes:
    continue

This ensures the error doesn’t occur when key_name is absent but unnecessary for the task.

Environment:

-   Python version: 3.12.3
-   CrewAI version: 0.80.0
-   CrewAI Tools: 0.14.0
-   Environment: Virtualenv

Files Modified:

    agent.py

Testing:
Validated the fix without setting key_name as environment variable.

To test:
    
-  With key_name present.
-  With conflicting or unrelated environment variables.