### PR TITLE
Update Perplexity example in documentation

### DIFF
--- a/docs/concepts/llms.mdx
+++ b/docs/concepts/llms.mdx
@@ -308,8 +308,8 @@ These are examples of how to configure LLMs for your agent.
     from crewai import LLM
 
     llm = LLM(
-        model="perplexity/mistral-7b-instruct",
-        base_url="https://api.perplexity.ai/v1",
+        model="llama-3.1-sonar-large-128k-online",
+        base_url="https://api.perplexity.ai/",
         api_key="your-api-key-here"
     )
     agent = Agent(llm=llm, ...)


### PR DESCRIPTION
The example in the documentation wasn't working for me. After looking at Perplexity's docs, I found that the base URL should not have `/v1` on it. After removing that from my code, I was able to get it to function.

While I was in there, I also updated the example model to one that Perplexity currently supports. 