### PR TITLE
Remove markdown code block markers from LLM's response

### DIFF
--- a/src/crewai/utilities/converter.py
+++ b/src/crewai/utilities/converter.py
@@ -97,6 +97,8 @@ def convert_to_model(
     if model is None:
         return result
     try:
+        # Sanitize the result by removing any markdown code block markers added by the LLM.
+        result = result = result.replace('```json', '').replace('```', '').strip()
         escaped_result = json.dumps(json.loads(result, strict=False))
         return validate_model(escaped_result, model, bool(output_json))
     except json.JSONDecodeError:

--- a/src/crewai/utilities/converter.py
+++ b/src/crewai/utilities/converter.py
@@ -98,7 +98,7 @@ def convert_to_model(
         return result
     try:
         # Sanitize the result by removing any markdown code block markers added by the LLM.
-        result = result = result.replace('```json', '').replace('```', '').strip()
+        result = result.replace("```json", "").replace("```", "").strip()
         escaped_result = json.dumps(json.loads(result, strict=False))
         return validate_model(escaped_result, model, bool(output_json))
     except json.JSONDecodeError:

--- a/tests/utilities/test_converter.py
+++ b/tests/utilities/test_converter.py
@@ -142,6 +142,13 @@ def test_validate_model_json_output():
     assert output == {"name": "Bob", "age": 40}
 
 
+def test_validate_model_remove_code_block_markers():
+    result = '```json {"name": "Charlie", "age": 35}```'
+    output = validate_model(result, SimpleModel, True, None)
+    assert isinstance(output, dict)
+    assert output == {"name": "Charlie", "age": 35}
+
+
 # Tests for handle_partial_json
 def test_handle_partial_json_with_valid_partial():
     result = 'Some text {"name": "Charlie", "age": 35} more text'

--- a/tests/utilities/test_converter.py
+++ b/tests/utilities/test_converter.py
@@ -126,6 +126,14 @@ def test_convert_to_model_with_multiple_special_characters():
     )
 
 
+def test_convert_to_model_remove_code_block_markers():
+    result = '```json {"name": "Charlie", "age": 35}```'
+    output = convert_to_model(result, SimpleModel, None, None)
+    assert isinstance(output, SimpleModel)
+    assert output.age == 35
+    assert output.name == "Charlie"
+
+
 # Tests for validate_model
 def test_validate_model_pydantic_output():
     result = '{"name": "Alice", "age": 25}'
@@ -140,13 +148,6 @@ def test_validate_model_json_output():
     output = validate_model(result, SimpleModel, True)
     assert isinstance(output, dict)
     assert output == {"name": "Bob", "age": 40}
-
-
-def test_validate_model_remove_code_block_markers():
-    result = '```json {"name": "Charlie", "age": 35}```'
-    output = validate_model(result, SimpleModel, True, None)
-    assert isinstance(output, dict)
-    assert output == {"name": "Charlie", "age": 35}
 
 
 # Tests for handle_partial_json


### PR DESCRIPTION
@roribio and I debugged today why it takes so long (`60s+`) for a task to complete when using `output_pydantic` .

It turns out that it was caused by `gpt-4o` insisting to respond with block code markers when returning the JSON.

We tracked down the fix to the `Converter` throwing `JSONDecodeError` Error and going down the path of `handle_partial_json` , which, for a simple JSON (`120` lines, `7KB`) it takes `60s+` to complete.   