### PR TITLE
fix spelling issue found by @Jacques-Murray

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -126,7 +126,7 @@ class Agent(BaseAgent):
     @model_validator(mode="after")
     def post_init_setup(self):
         self.agent_ops_agent_name = self.role
-        unnacepted_attributes = [
+        unaccepted_attributes = [
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
             "AWS_REGION_NAME",
@@ -162,7 +162,7 @@ class Agent(BaseAgent):
                     for env_var in env_vars:
                         # Check if the environment variable is set
                         key_name = env_var.get("key_name")
-                        if key_name and key_name not in unnacepted_attributes:
+                        if key_name and key_name not in unaccepted_attributes:
                             env_value = os.environ.get(key_name)
                             if env_value:
                                 # Map key names containing "API_KEY" to "api_key"


### PR DESCRIPTION
Fix spelling issue with `unaccepted_attributes`.

Thank you @Jacques-Murray for finding this error. Because of a few changes that were just made, yours had a merge conflict so I just opened a new PR to fix the issue.

Closes #1626 