### PR TITLE
Improve Quickstart Documentation: Update CrewAI Reset Command for Accuracy

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -349,7 +349,7 @@ Replace `<task_id>` with the ID of the task you want to replay.
 If you need to reset the memory of your crew before running it again, you can do so by calling the reset memory feature:
 
 ```shell
-crewai reset-memory
+crewai reset-memories --all
 ```
 
 This will clear the crew's memory, allowing for a fresh start.


### PR DESCRIPTION
This pull request includes a change to the `docs/quickstart.mdx` file to improve the clarity and accuracy of the documentation.

Documentation improvement:

* [`docs/quickstart.mdx`](diffhunk://#diff-f1db7c587c0fc6ae7a362a3b0b9bd308c4b8efa4687f14f248abd72b09ebd58bL352-R352): Updated the command to reset the memory of the crew from `crewai reset-memory` to `crewai reset-memories --all` for better accuracy and functionality.