### PR TITLE
_execute_tool_and_check_finality 结果给回调参数，这样就可以提前拿到结果信息，去做数据解析判断做预判

### DIFF
--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -143,6 +143,9 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                         tool_result = self._execute_tool_and_check_finality(
                             formatted_answer
                         )
+                        if self.step_callback:
+                          self.step_callback(tool_result)
+
                         formatted_answer.text += f"\nObservation: {tool_result.result}"
                         formatted_answer.result = tool_result.result
                         if tool_result.result_as_answer:


### PR DESCRIPTION
_execute_tool_and_check_finality 结果给回调参数，比如做ws或者其他的情况的时候，就比较灵活的可以提前处理，在多个agent执行的情况下，不需要等到 crew_cli.kickoff_async 返回结果在处理