### PR TITLE
revise the model description for OpenAI-like APIs

### DIFF
--- a/docs/how-to/llm-connections.mdx
+++ b/docs/how-to/llm-connections.mdx
@@ -120,7 +120,7 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
 
         os.environ["OPENAI_API_KEY"] = "your-api-key"
         os.environ["OPENAI_API_BASE"] = "https://api.your-provider.com/v1"
-        os.environ["OPENAI_MODEL_NAME"] = "your-model-name"
+        os.environ["OPENAI_MODEL_NAME"] = "openai/your-model-name"
         ```
         </CodeGroup>
     </Tab>
@@ -128,7 +128,7 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
         <CodeGroup>
             ```python Code
             llm = LLM(
-                model="custom-model-name",
+                model="openai/custom-model-name",
                 api_key="your-api-key",
                 base_url="https://api.your-provider.com/v1"
             )


### PR DESCRIPTION
Based on the documentation for liteLLM, it is necessary to add a prefix to the model description in order for it to be properly recognized by the API.

===
https://docs.litellm.ai/docs/providers/openai_compatible
For /chat/completions: Put openai/ in front of your model name, so litellm knows you're trying to call an openai /chat/completions endpoint.