### PR TITLE
Fix API Key Behavior and Entity Handling in Mem0 Integration

### DIFF
--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -6,8 +6,8 @@ icon: database
 
 ## Introduction to Memory Systems in CrewAI
 
-The crewAI framework introduces a sophisticated memory system designed to significantly enhance the capabilities of AI agents.
-This system comprises `short-term memory`, `long-term memory`, `entity memory`, and `contextual memory`, each serving a unique purpose in aiding agents to remember,
+The crewAI framework introduces a sophisticated memory system designed to significantly enhance the capabilities of AI agents. 
+This system comprises `short-term memory`, `long-term memory`, `entity memory`, and `contextual memory`, each serving a unique purpose in aiding agents to remember, 
 reason, and learn from past interactions.
 
 ## Memory System Components
@@ -31,8 +31,8 @@ reason, and learn from past interactions.
 ## Implementing Memory in Your Crew
 
 When configuring a crew, you can enable and customize each memory component to suit the crew's objectives and the nature of tasks it will perform.
-By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration.
-The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model.
+By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration. 
+The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model. 
 It's also possible to initialize the memory instance with your own instance.
 
 The 'embedder' only applies to **Short-Term Memory** which uses Chroma for RAG.
@@ -95,7 +95,7 @@ my_crew = Crew(
 
 ## Integrating Mem0 for Enhanced User Memory
 
-[Mem0](https://mem0.ai/) is a self-improving memory layer for LLM applications, enabling personalized AI experiences.
+[Mem0](https://mem0.ai/) is a self-improving memory layer for LLM applications, enabling personalized AI experiences. 
 
 To include user-specific memory you can get your API key [here](https://app.mem0.ai/dashboard/api-keys) and refer the [docs](https://docs.mem0.ai/platform/quickstart#4-1-create-memories) for adding user preferences.
 
@@ -363,5 +363,5 @@ crewai reset-memories [OPTIONS]
 
 ## Conclusion
 
-Integrating CrewAI's memory system into your projects is straightforward. By leveraging the provided memory components and configurations,
+Integrating CrewAI's memory system into your projects is straightforward. By leveraging the provided memory components and configurations, 
 you can quickly empower your agents with the ability to remember, reason, and learn from their interactions, unlocking new levels of intelligence and capability.

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -6,8 +6,8 @@ icon: database
 
 ## Introduction to Memory Systems in CrewAI
 
-The crewAI framework introduces a sophisticated memory system designed to significantly enhance the capabilities of AI agents. 
-This system comprises `short-term memory`, `long-term memory`, `entity memory`, and `contextual memory`, each serving a unique purpose in aiding agents to remember, 
+The crewAI framework introduces a sophisticated memory system designed to significantly enhance the capabilities of AI agents.
+This system comprises `short-term memory`, `long-term memory`, `entity memory`, and `contextual memory`, each serving a unique purpose in aiding agents to remember,
 reason, and learn from past interactions.
 
 ## Memory System Components
@@ -31,8 +31,8 @@ reason, and learn from past interactions.
 ## Implementing Memory in Your Crew
 
 When configuring a crew, you can enable and customize each memory component to suit the crew's objectives and the nature of tasks it will perform.
-By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration. 
-The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model. 
+By default, the memory system is disabled, and you can ensure it is active by setting `memory=True` in the crew configuration.
+The memory will use OpenAI embeddings by default, but you can change it by setting `embedder` to a different model.
 It's also possible to initialize the memory instance with your own instance.
 
 The 'embedder' only applies to **Short-Term Memory** which uses Chroma for RAG.
@@ -95,7 +95,7 @@ my_crew = Crew(
 
 ## Integrating Mem0 for Enhanced User Memory
 
-[Mem0](https://mem0.ai/) is a self-improving memory layer for LLM applications, enabling personalized AI experiences. 
+[Mem0](https://mem0.ai/) is a self-improving memory layer for LLM applications, enabling personalized AI experiences.
 
 To include user-specific memory you can get your API key [here](https://app.mem0.ai/dashboard/api-keys) and refer the [docs](https://docs.mem0.ai/platform/quickstart#4-1-create-memories) for adding user preferences.
 
@@ -134,6 +134,23 @@ crew = Crew(
 )
 ```
 
+## Memory Configuration Options
+If you want to access a specific organization and project, you can set the `org_id` and `project_id` parameters in the memory configuration.
+
+```python Code
+from crewai import Crew
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    verbose=True,
+    memory=True,
+    memory_config={
+        "provider": "mem0",
+        "config": {"user_id": "john", "org_id": "my_org_id", "project_id": "my_project_id"},
+    },
+)
+```
 
 ## Additional Embedding Providers
 
@@ -346,5 +363,5 @@ crewai reset-memories [OPTIONS]
 
 ## Conclusion
 
-Integrating CrewAI's memory system into your projects is straightforward. By leveraging the provided memory components and configurations, 
+Integrating CrewAI's memory system into your projects is straightforward. By leveraging the provided memory components and configurations,
 you can quickly empower your agents with the ability to remember, reason, and learn from their interactions, unlocking new levels of intelligence and capability.


### PR DESCRIPTION
**Issue with API Key:**
Previously, if the Mem0 API key was not associated with the default project, the integration would fail. This fix ensures that users can explicitly specify org_id and project_id to properly authenticate and interact with the API.

**Entity Handling Fix:**
There was an issue where entity_id was not correctly set for memory type "entities". To address this, the agent_id is now assigned when working with entities, ensuring compliance with API requirements.