### PR TITLE
chore: Update date to current year in template

### DIFF
--- a/src/crewai/cli/templates/crew/config/tasks.yaml
+++ b/src/crewai/cli/templates/crew/config/tasks.yaml
@@ -2,7 +2,7 @@ research_task:
   description: >
     Conduct a thorough research about {topic}
     Make sure you find any interesting and relevant information given
-    the current year is 2024.
+    the current year is 2025.
   expected_output: >
     A list with 10 bullet points of the most relevant information about {topic}
   agent: researcher

--- a/src/crewai/cli/templates/crew/config/tasks.yaml
+++ b/src/crewai/cli/templates/crew/config/tasks.yaml
@@ -2,7 +2,7 @@ research_task:
   description: >
     Conduct a thorough research about {topic}
     Make sure you find any interesting and relevant information given
-    the current year is 2025.
+    the current year is {current_year}.
   expected_output: >
     A list with 10 bullet points of the most relevant information about {topic}
   agent: researcher

--- a/src/crewai/cli/templates/crew/main.py
+++ b/src/crewai/cli/templates/crew/main.py
@@ -2,6 +2,8 @@
 import sys
 import warnings
 
+from datetime import datetime
+
 from {{folder_name}}.crew import {{crew_name}}
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
@@ -16,7 +18,8 @@ def run():
     Run the crew.
     """
     inputs = {
-        'topic': 'AI LLMs'
+        'topic': 'AI LLMs',
+        'current_year': str(datetime.now().year)
     }
     
     try:


### PR DESCRIPTION
The example task template states "given the current year is 2024". This PR updates the date to 2025--it is a very small change.

An alternative to this PR would be to just keep the date at 2024, but the example will show more relevant results for people if this is updated to 2025.