### PR TITLE
Support LLM managers that use `model` instead of `model_name`

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -674,6 +674,7 @@ class Crew(BaseModel):
         else:
             self.manager_llm = (
                 getattr(self.manager_llm, "model_name", None)
+                or getattr(self.manager_llm, "model", None)
                 or getattr(self.manager_llm, "deployment_name", None)
                 or self.manager_llm
             )


### PR DESCRIPTION
When trying to use a hierarchical process with `ChatOllama` from `langchain_ollama` as `manager_llm` I get this error: `litellm.exceptions.BadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=model='ollama/llama3'`.

`ChatOllama` requires to pass the model using the [param `model`](https://python.langchain.com/api_reference/ollama/chat_models/langchain_ollama.chat_models.ChatOllama.html#langchain_ollama.chat_models.ChatOllama.model), while [`_create_manager_agent` expects a `model_name`](https://github.com/crewAIInc/crewAI/blob/main/src/crewai/crew.py#L676). As a result, all the param, included the `model=` part is passed as a provider.

This PR adds the options to get the model if the name of the param used is `model`