### PR TITLE
Bugfix/litellm plus generic exceptions

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -2,7 +2,6 @@ import shutil
 import subprocess
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from pydantic import Field, InstanceOf, PrivateAttr, model_validator
 
 from crewai.agents import CacheHandler
@@ -260,7 +259,7 @@ class Agent(BaseAgent):
                 }
             )["output"]
         except Exception as e:
-            if isinstance(e, BaseLLMException):
+            if e.__class__.__module__.startswith("litellm"):
                 # Do not retry on litellm errors
                 raise e
             self._times_executed += 1

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -262,8 +262,8 @@ class Agent(BaseAgent):
                 }
             )["output"]
         except Exception as e:
-            if isinstance(e, LiteLLMAuthenticationError):
-                # Do not retry on authentication errors
+            if e.__class__.__module__.startswith("litellm.exceptions"):
+                # Do not retry on litellm errors
                 raise e
             self._times_executed += 1
             if self._times_executed > self.max_retry_limit:

--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -1,15 +1,13 @@
-import os
 import shutil
 import subprocess
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from litellm import AuthenticationError as LiteLLMAuthenticationError
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from pydantic import Field, InstanceOf, PrivateAttr, model_validator
 
 from crewai.agents import CacheHandler
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.crew_agent_executor import CrewAgentExecutor
-from crewai.cli.constants import ENV_VARS, LITELLM_PARAMS
 from crewai.knowledge.knowledge import Knowledge
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.knowledge.utils.knowledge_utils import extract_knowledge_context
@@ -262,7 +260,7 @@ class Agent(BaseAgent):
                 }
             )["output"]
         except Exception as e:
-            if e.__class__.__module__.startswith("litellm.exceptions"):
+            if isinstance(e, BaseLLMException):
                 # Do not retry on litellm errors
                 raise e
             self._times_executed += 1

--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -3,9 +3,6 @@ import re
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from litellm.exceptions import AuthenticationError as LiteLLMAuthenticationError
-from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.agent_builder.base_agent_executor_mixin import CrewAgentExecutorMixin
 from crewai.agents.parser import (
@@ -104,7 +101,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         try:
             formatted_answer = self._invoke_loop()
         except Exception as e:
-            raise e
+            if e.__class__.__module__.startswith("litellm"):
+                # Do not retry on litellm errors
+                raise e
+            else:
+                self._handle_unknown_error(e)
+                raise e
 
         if self.ask_for_human_input:
             formatted_answer = self._handle_human_feedback(formatted_answer)
@@ -143,9 +145,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 self._invoke_step_callback(formatted_answer)
                 self._append_message(formatted_answer.text, role="assistant")
 
+            except OutputParserException as e:
+                formatted_answer = self._handle_output_parser_exception(e)
+
             except Exception as e:
-                if isinstance(e, BaseLLMException):
-                    # Stop execution on litellm errors
+                if e.__class__.__module__.startswith("litellm"):
+                    # Do not retry on litellm errors
                     raise e
                 if self._is_context_length_exceeded(e):
                     self._handle_context_length()

--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from litellm.exceptions import AuthenticationError as LiteLLMAuthenticationError
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.agent_builder.base_agent_executor_mixin import CrewAgentExecutorMixin
@@ -142,10 +143,10 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 self._invoke_step_callback(formatted_answer)
                 self._append_message(formatted_answer.text, role="assistant")
 
-            except OutputParserException as e:
-                formatted_answer = self._handle_output_parser_exception(e)
-
             except Exception as e:
+                if isinstance(e, BaseLLMException):
+                    # Stop execution on litellm errors
+                    raise e
                 if self._is_context_length_exceeded(e):
                     self._handle_context_length()
                     continue

--- a/src/crewai/cli/cli.py
+++ b/src/crewai/cli/cli.py
@@ -350,7 +350,10 @@ def chat():
     Start a conversation with the Crew, collecting user-supplied inputs,
     and using the Chat LLM to generate responses.
     """
-    click.echo("Starting a conversation with the Crew")
+    click.secho(
+        "\nStarting a conversation with the Crew\n" "Type 'exit' or Ctrl+C to quit.\n",
+    )
+
     run_chat()
 
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1705,11 +1705,6 @@ def test_crew_agent_executor_litellm_auth_error():
     assert exc_info.value.llm_provider == "openai"
     assert exc_info.value.model == "gpt-4"
 
-    # Optionally, assert that the exception is an instance of BaseLLMException
-    from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-    assert isinstance(exc_info.value, BaseLLMException)
-
 
 def test_litellm_anthropic_error_handling():
     """Test that AnthropicError from LiteLLM is handled correctly and not retried."""

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1623,7 +1623,7 @@ def test_litellm_auth_error_handling():
         agent=agent,
     )
 
-    # Mock the LLM call to raise LiteLLMAuthenticationError
+    # Mock the LLM call to raise AuthenticationError
     with (
         patch.object(LLM, "call") as mock_llm_call,
         pytest.raises(LiteLLMAuthenticationError, match="Invalid API key"),
@@ -1639,7 +1639,7 @@ def test_litellm_auth_error_handling():
 
 def test_crew_agent_executor_litellm_auth_error():
     """Test that CrewAgentExecutor handles LiteLLM authentication errors by raising them."""
-    from litellm import AuthenticationError as LiteLLMAuthenticationError
+    from litellm.exceptions import AuthenticationError
 
     from crewai.agents.tools_handler import ToolsHandler
     from crewai.utilities import Printer
@@ -1672,13 +1672,13 @@ def test_crew_agent_executor_litellm_auth_error():
         tools_handler=ToolsHandler(),
     )
 
-    # Mock the LLM call to raise LiteLLMAuthenticationError
+    # Mock the LLM call to raise AuthenticationError
     with (
         patch.object(LLM, "call") as mock_llm_call,
         patch.object(Printer, "print") as mock_printer,
-        pytest.raises(LiteLLMAuthenticationError, match="Invalid API key"),
+        pytest.raises(AuthenticationError, match="Invalid API key"),
     ):
-        mock_llm_call.side_effect = LiteLLMAuthenticationError(
+        mock_llm_call.side_effect = AuthenticationError(
             message="Invalid API key", llm_provider="openai", model="gpt-4"
         )
         executor.invoke(
@@ -1711,7 +1711,7 @@ def test_litellm_anthropic_error_handling():
         role="test role",
         goal="test goal",
         backstory="test backstory",
-        llm=LLM(model="claude-3.5-sonnet-20240620"), 
+        llm=LLM(model="claude-3.5-sonnet-20240620"),
         max_retry_limit=0,
     )
 


### PR DESCRIPTION
Issue:
- We updated our agent and crew_agent_executor to track when LiteLLM threw an error. Originally, I thought there was only one type of error - BaseLLMException. However, different models throw different errors.
- Because we weren't properly catching errors from Anthropic and other models, our invoke_loop logic ends up in a loop where it's making many LLM calls that are all breaking.

Solution:
- Update exception handling to look for litellm in the exception and then abort loop gracefully.
- Added 2 different types of failing operations, one from OpenAI and another from Anthropic, to prove this works.

Result:
- We now exit our loops gracefully for all LiteLLM errors.


----

This also fixes the additional warnings because we were importing litellm in agent and litellm is the library throwing all the warnings.