### PR TITLE
FIX: correctly initialize embedder for crew knowledge

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -293,7 +293,7 @@ class Crew(BaseModel):
                 ):
                     self.knowledge = Knowledge(
                         sources=self.knowledge_sources,
-                        embedder_config=self.embedder,
+                        embedder=self.embedder,
                         collection_name="crew",
                     )
 


### PR DESCRIPTION
embedder_config doesn't exist in Knowledge and should be replaced with embedder as it's done in the agent.py file.

It's fixing part of #2033 and #2023.