### PR TITLE
agent: improve knowledge naming

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 import subprocess
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -153,7 +154,8 @@ class Agent(BaseAgent):
     def _set_knowledge(self):
         try:
             if self.knowledge_sources:
-                knowledge_agent_name = f"{self.role.replace(' ', '_')}"
+                full_pattern = re.compile(r'[^a-zA-Z0-9\-_\r\n]|(\.\.)')
+                knowledge_agent_name = f"{re.sub(full_pattern, '_', self.role)}"
                 if isinstance(self.knowledge_sources, list) and all(
                     isinstance(k, BaseKnowledgeSource) for k in self.knowledge_sources
                 ):


### PR DESCRIPTION
Using the example, creating knowledge in the agent failled beacause it tries ro create the knowledge including "{" character in the name.

This first proposal drops more characters than before and ensure creation in more case.