### PR TITLE
Ensure `@start` methods emit `MethodExecutionStartedEvent`

### DIFF
--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import inspect
 import logging
 from typing import (
@@ -568,27 +569,8 @@ class Flow(Generic[T], metaclass=FlowMeta):
             f"Initial state must be dict or BaseModel, got {type(self.initial_state)}"
         )
 
-    def _dump_state(self) -> Optional[Dict[str, Any]]:
-        """
-        Dumps the current flow state as a dictionary.
-
-        This method converts the internal state into a serializable dictionary format,
-        ensuring compatibility with both dictionary and Pydantic BaseModel states.
-
-        Returns:
-            Optional[Dict[str, Any]]: The serialized state dictionary, or None if state is not available.
-        """
-        if self._state is None:
-            return None
-
-        if isinstance(self._state, dict):
-            return self._state.copy()
-
-        if isinstance(self._state, BaseModel):
-            return self._state.model_dump()
-
-        logger.warning("Unsupported flow state type for dumping.")
-        return None
+    def _copy_state(self) -> T:
+        return copy.deepcopy(self._state)
 
     @property
     def state(self) -> T:
@@ -833,7 +815,7 @@ class Flow(Generic[T], metaclass=FlowMeta):
                 method_name=method_name,
                 flow_name=self.__class__.__name__,
                 params=dumped_params,
-                state=self._dump_state(),
+                state=self._copy_state(),
             ),
         )
 
@@ -853,7 +835,7 @@ class Flow(Generic[T], metaclass=FlowMeta):
                 type="method_execution_finished",
                 method_name=method_name,
                 flow_name=self.__class__.__name__,
-                state=self._dump_state(),
+                state=self._copy_state(),
                 result=result,
             ),
         )

--- a/src/crewai/flow/flow_events.py
+++ b/src/crewai/flow/flow_events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -15,17 +15,21 @@ class Event:
 
 @dataclass
 class FlowStartedEvent(Event):
-    pass
+    inputs: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class MethodExecutionStartedEvent(Event):
     method_name: str
+    params: Optional[Dict[str, Any]] = None
+    state: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class MethodExecutionFinishedEvent(Event):
     method_name: str
+    result: Any = None
+    state: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/src/crewai/flow/flow_events.py
+++ b/src/crewai/flow/flow_events.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
+
+from pydantic import BaseModel
 
 
 @dataclass
@@ -21,15 +23,15 @@ class FlowStartedEvent(Event):
 @dataclass
 class MethodExecutionStartedEvent(Event):
     method_name: str
+    state: Union[Dict[str, Any], BaseModel]
     params: Optional[Dict[str, Any]] = None
-    state: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class MethodExecutionFinishedEvent(Event):
     method_name: str
+    state: Union[Dict[str, Any], BaseModel]
     result: Any = None
-    state: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/tests/flow_test.py
+++ b/tests/flow_test.py
@@ -460,21 +460,21 @@ def test_unstructured_flow_event_emission():
         if event.method_name == "prepare_flower":
             if isinstance(event, MethodExecutionStartedEvent):
                 assert event.params == {}
-                assert event.state.get("separator") == ", "
+                assert event.state["separator"] == ", "
             elif isinstance(event, MethodExecutionFinishedEvent):
                 assert event.result == "foo"
-                assert event.state.get("flower") == "roses"
-                assert event.state.get("separator") == ", "
+                assert event.state["flower"] == "roses"
+                assert event.state["separator"] == ", "
             else:
                 assert False, "Unexpected event type for prepare_flower"
         elif event.method_name == "prepare_color":
             if isinstance(event, MethodExecutionStartedEvent):
                 assert event.params == {}
-                assert event.state.get("separator") == ", "
+                assert event.state["separator"] == ", "
             elif isinstance(event, MethodExecutionFinishedEvent):
                 assert event.result == "bar"
-                assert event.state.get("color") == "red"
-                assert event.state.get("separator") == ", "
+                assert event.state["color"] == "red"
+                assert event.state["separator"] == ", "
             else:
                 assert False, "Unexpected event type for prepare_color"
         else:
@@ -484,9 +484,9 @@ def test_unstructured_flow_event_emission():
     assert event_log[5].method_name == "write_first_sentence"
     assert event_log[5].params == {}
     assert isinstance(event_log[5].state, dict)
-    assert event_log[5].state.get("flower") == "roses"
-    assert event_log[5].state.get("color") == "red"
-    assert event_log[5].state.get("separator") == ", "
+    assert event_log[5].state["flower"] == "roses"
+    assert event_log[5].state["color"] == "red"
+    assert event_log[5].state["separator"] == ", "
 
     assert isinstance(event_log[6], MethodExecutionFinishedEvent)
     assert event_log[6].method_name == "write_first_sentence"
@@ -496,8 +496,8 @@ def test_unstructured_flow_event_emission():
     assert event_log[7].method_name == "finish_poem"
     assert event_log[7].params == {"_0": "roses are red"}
     assert isinstance(event_log[7].state, dict)
-    assert event_log[7].state.get("flower") == "roses"
-    assert event_log[7].state.get("color") == "red"
+    assert event_log[7].state["flower"] == "roses"
+    assert event_log[7].state["color"] == "red"
 
     assert isinstance(event_log[8], MethodExecutionFinishedEvent)
     assert event_log[8].method_name == "finish_poem"
@@ -507,8 +507,8 @@ def test_unstructured_flow_event_emission():
     assert event_log[9].method_name == "save_poem_to_database"
     assert event_log[9].params == {}
     assert isinstance(event_log[9].state, dict)
-    assert event_log[9].state.get("flower") == "roses"
-    assert event_log[9].state.get("color") == "red"
+    assert event_log[9].state["flower"] == "roses"
+    assert event_log[9].state["color"] == "red"
 
     assert isinstance(event_log[10], MethodExecutionFinishedEvent)
     assert event_log[10].method_name == "save_poem_to_database"
@@ -561,13 +561,11 @@ def test_structured_flow_event_emission():
     assert isinstance(event_log[3], MethodExecutionStartedEvent)
     assert event_log[3].method_name == "send_welcome_message"
     assert event_log[3].params == {}
-    assert isinstance(event_log[3].state, dict)
-    assert event_log[3].state.get("sent") == False
+    assert getattr(event_log[3].state, "sent") == False
 
     assert isinstance(event_log[4], MethodExecutionFinishedEvent)
     assert event_log[4].method_name == "send_welcome_message"
-    assert isinstance(event_log[4].state, dict)
-    assert event_log[4].state.get("sent") == True
+    assert getattr(event_log[4].state, "sent") == True
     assert event_log[4].result == "Welcome, Anakin!"
 
     assert isinstance(event_log[5], FlowFinishedEvent)

--- a/tests/flow_test.py
+++ b/tests/flow_test.py
@@ -1,11 +1,18 @@
 """Test Flow creation and execution basic functionality."""
 
 import asyncio
+from datetime import datetime
 
 import pytest
 from pydantic import BaseModel
 
 from crewai.flow.flow import Flow, and_, listen, or_, router, start
+from crewai.flow.flow_events import (
+    FlowFinishedEvent,
+    FlowStartedEvent,
+    MethodExecutionFinishedEvent,
+    MethodExecutionStartedEvent,
+)
 
 
 def test_simple_sequential_flow():
@@ -398,3 +405,220 @@ def test_router_with_multiple_conditions():
 
     # final_step should run after router_and
     assert execution_order.index("log_final_step") > execution_order.index("router_and")
+
+
+def test_unstructured_flow_event_emission():
+    """Test that the correct events are emitted during unstructured flow
+    execution with all fields validated."""
+
+    class PoemFlow(Flow):
+        @start()
+        def prepare_flower(self):
+            self.state["flower"] = "roses"
+            return "foo"
+
+        @start()
+        def prepare_color(self):
+            self.state["color"] = "red"
+            return "bar"
+
+        @listen(prepare_color)
+        def write_first_sentence(self):
+            return f"{self.state["flower"]} are {self.state["color"]}"
+
+        @listen(write_first_sentence)
+        def finish_poem(self, first_sentence):
+            separator = self.state.get("separator", "\n")
+            return separator.join([first_sentence, "violets are blue"])
+
+        @listen(finish_poem)
+        def save_poem_to_database(self):
+            # A method without args/kwargs to ensure events are sent correctly
+            pass
+
+    event_log = []
+
+    def handle_event(_, event):
+        event_log.append(event)
+
+    flow = PoemFlow()
+    flow.event_emitter.connect(handle_event)
+    flow.kickoff(inputs={"separator": ", "})
+
+    assert isinstance(event_log[0], FlowStartedEvent)
+    assert event_log[0].flow_name == "PoemFlow"
+    assert event_log[0].inputs == {"separator": ", "}
+    assert isinstance(event_log[0].timestamp, datetime)
+
+    # Asserting for concurrent start method executions in a for loop as you
+    # can't guarantee ordering in asynchronous executions
+    for i in range(1, 5):
+        event = event_log[i]
+        assert isinstance(event.state, dict)
+        assert isinstance(event.state["id"], str)
+
+        if event.method_name == "prepare_flower":
+            if isinstance(event, MethodExecutionStartedEvent):
+                assert event.params == {}
+                assert event.state.get("separator") == ", "
+            elif isinstance(event, MethodExecutionFinishedEvent):
+                assert event.result == "foo"
+                assert event.state.get("flower") == "roses"
+                assert event.state.get("separator") == ", "
+            else:
+                assert False, "Unexpected event type for prepare_flower"
+        elif event.method_name == "prepare_color":
+            if isinstance(event, MethodExecutionStartedEvent):
+                assert event.params == {}
+                assert event.state.get("separator") == ", "
+            elif isinstance(event, MethodExecutionFinishedEvent):
+                assert event.result == "bar"
+                assert event.state.get("color") == "red"
+                assert event.state.get("separator") == ", "
+            else:
+                assert False, "Unexpected event type for prepare_color"
+        else:
+            assert False, f"Unexpected method {event.method_name} in prepare events"
+
+    assert isinstance(event_log[5], MethodExecutionStartedEvent)
+    assert event_log[5].method_name == "write_first_sentence"
+    assert event_log[5].params == {}
+    assert isinstance(event_log[5].state, dict)
+    assert event_log[5].state.get("flower") == "roses"
+    assert event_log[5].state.get("color") == "red"
+    assert event_log[5].state.get("separator") == ", "
+
+    assert isinstance(event_log[6], MethodExecutionFinishedEvent)
+    assert event_log[6].method_name == "write_first_sentence"
+    assert event_log[6].result == "roses are red"
+
+    assert isinstance(event_log[7], MethodExecutionStartedEvent)
+    assert event_log[7].method_name == "finish_poem"
+    assert event_log[7].params == {"_0": "roses are red"}
+    assert isinstance(event_log[7].state, dict)
+    assert event_log[7].state.get("flower") == "roses"
+    assert event_log[7].state.get("color") == "red"
+
+    assert isinstance(event_log[8], MethodExecutionFinishedEvent)
+    assert event_log[8].method_name == "finish_poem"
+    assert event_log[8].result == "roses are red, violets are blue"
+
+    assert isinstance(event_log[9], MethodExecutionStartedEvent)
+    assert event_log[9].method_name == "save_poem_to_database"
+    assert event_log[9].params == {}
+    assert isinstance(event_log[9].state, dict)
+    assert event_log[9].state.get("flower") == "roses"
+    assert event_log[9].state.get("color") == "red"
+
+    assert isinstance(event_log[10], MethodExecutionFinishedEvent)
+    assert event_log[10].method_name == "save_poem_to_database"
+    assert event_log[10].result is None
+
+    assert isinstance(event_log[11], FlowFinishedEvent)
+    assert event_log[11].flow_name == "PoemFlow"
+    assert event_log[11].result is None
+    assert isinstance(event_log[11].timestamp, datetime)
+
+
+def test_structured_flow_event_emission():
+    """Test that the correct events are emitted during structured flow
+    execution with all fields validated."""
+
+    class OnboardingState(BaseModel):
+        name: str = ""
+        sent: bool = False
+
+    class OnboardingFlow(Flow[OnboardingState]):
+        @start()
+        def user_signs_up(self):
+            self.state.sent = False
+
+        @listen(user_signs_up)
+        def send_welcome_message(self):
+            self.state.sent = True
+            return f"Welcome, {self.state.name}!"
+
+    event_log = []
+
+    def handle_event(_, event):
+        event_log.append(event)
+
+    flow = OnboardingFlow()
+    flow.event_emitter.connect(handle_event)
+    flow.kickoff(inputs={"name": "Anakin"})
+
+    assert isinstance(event_log[0], FlowStartedEvent)
+    assert event_log[0].flow_name == "OnboardingFlow"
+    assert event_log[0].inputs == {"name": "Anakin"}
+    assert isinstance(event_log[0].timestamp, datetime)
+
+    assert isinstance(event_log[1], MethodExecutionStartedEvent)
+    assert event_log[1].method_name == "user_signs_up"
+
+    assert isinstance(event_log[2], MethodExecutionFinishedEvent)
+    assert event_log[2].method_name == "user_signs_up"
+
+    assert isinstance(event_log[3], MethodExecutionStartedEvent)
+    assert event_log[3].method_name == "send_welcome_message"
+    assert event_log[3].params == {}
+    assert isinstance(event_log[3].state, dict)
+    assert event_log[3].state.get("sent") == False
+
+    assert isinstance(event_log[4], MethodExecutionFinishedEvent)
+    assert event_log[4].method_name == "send_welcome_message"
+    assert isinstance(event_log[4].state, dict)
+    assert event_log[4].state.get("sent") == True
+    assert event_log[4].result == "Welcome, Anakin!"
+
+    assert isinstance(event_log[5], FlowFinishedEvent)
+    assert event_log[5].flow_name == "OnboardingFlow"
+    assert event_log[5].result == "Welcome, Anakin!"
+    assert isinstance(event_log[5].timestamp, datetime)
+
+
+def test_stateless_flow_event_emission():
+    """Test that the correct events are emitted stateless during flow execution
+    with all fields validated."""
+
+    class StatelessFlow(Flow):
+        @start()
+        def init(self):
+            pass
+
+        @listen(init)
+        def process(self):
+            return "Deeds will not be less valiant because they are unpraised."
+
+    event_log = []
+
+    def handle_event(_, event):
+        event_log.append(event)
+
+    flow = StatelessFlow()
+    flow.event_emitter.connect(handle_event)
+    flow.kickoff()
+
+    assert isinstance(event_log[0], FlowStartedEvent)
+    assert event_log[0].flow_name == "StatelessFlow"
+    assert event_log[0].inputs is None
+    assert isinstance(event_log[0].timestamp, datetime)
+
+    assert isinstance(event_log[1], MethodExecutionStartedEvent)
+    assert event_log[1].method_name == "init"
+
+    assert isinstance(event_log[2], MethodExecutionFinishedEvent)
+    assert event_log[2].method_name == "init"
+
+    assert isinstance(event_log[3], MethodExecutionStartedEvent)
+    assert event_log[3].method_name == "process"
+
+    assert isinstance(event_log[4], MethodExecutionFinishedEvent)
+    assert event_log[4].method_name == "process"
+
+    assert isinstance(event_log[5], FlowFinishedEvent)
+    assert event_log[5].flow_name == "StatelessFlow"
+    assert (
+        event_log[5].result
+        == "Deeds will not be less valiant because they are unpraised."
+    )
+    assert isinstance(event_log[5].timestamp, datetime)


### PR DESCRIPTION
Previously, `@start` methods triggered a `FlowStartedEvent` but did not emit a `MethodExecutionStartedEvent`. This was fine for a single entry point but caused ambiguity when multiple `@start` methods existed.

This commit (1) emits events for starting points, (2) adds tests ensuring ordering, (3) adds more fields to events.