### PR TITLE
fix: typo in 'delegate_work' and 'ask_question' promps

### DIFF
--- a/src/crewai/translations/en.json
+++ b/src/crewai/translations/en.json
@@ -40,8 +40,8 @@
     "validation_error": "### Previous attempt failed validation: {guardrail_result_error}\n\n\n### Previous result:\n{task_output}\n\n\nTry again, making sure to address the validation error."
   },
   "tools": {
-    "delegate_work": "Delegate a specific task to one of the following coworkers: {coworkers}\nThe input to this tool should be the coworker, the task you want them to do, and ALL necessary context to execute the task, they know nothing about the task, so share absolute everything you know, don't reference things but instead explain them.",
-    "ask_question": "Ask a specific question to one of the following coworkers: {coworkers}\nThe input to this tool should be the coworker, the question you have for them, and ALL necessary context to ask the question properly, they know nothing about the question, so share absolute everything you know, don't reference things but instead explain them.",
+    "delegate_work": "Delegate a specific task to one of the following coworkers: {coworkers}\nThe input to this tool should be the coworker, the task you want them to do, and ALL necessary context to execute the task, they know nothing about the task, so share absolutely everything you know, don't reference things but instead explain them.",
+    "ask_question": "Ask a specific question to one of the following coworkers: {coworkers}\nThe input to this tool should be the coworker, the question you have for them, and ALL necessary context to ask the question properly, they know nothing about the question, so share absolutely everything you know, don't reference things but instead explain them.",
     "add_image": {
       "name": "Add image to content",
       "description": "See image to understand its content, you can optionally ask a question about the image",


### PR DESCRIPTION
"so share **absolute** everything you know" -> "so share **absolutely** everything you know"

Many cassettes also have the typo but I am not sure what to do with them since I am guessing they are generated and I don't know how to re-generate them.
Guidance appreciated :)