### PR TITLE
fix token calculate error,if cached_tokens is None

### DIFF
--- a/src/crewai/utilities/token_counter_callback.py
+++ b/src/crewai/utilities/token_counter_callback.py
@@ -31,7 +31,7 @@ class TokenCalcHandler(CustomLogger):
                         self.token_cost_process.sum_prompt_tokens(usage.prompt_tokens)
                     if hasattr(usage, "completion_tokens"):
                         self.token_cost_process.sum_completion_tokens(usage.completion_tokens)
-                    if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
+                    if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens:
                         self.token_cost_process.sum_cached_prompt_tokens(
                             usage.prompt_tokens_details.cached_tokens
                         )


### PR DESCRIPTION
when i use crewAi，find the bug ，if cached_tokens is None，sum_cached_prompt_tokens will error