### PR TITLE
Detect if run is a flow and kick it off properly

### DIFF
--- a/src/crewai/cli/run_crew.py
+++ b/src/crewai/cli/run_crew.py
@@ -26,6 +26,9 @@ def run_crew() -> None:
             fg="red",
         )
 
+    if pyproject_data.get("tool", {}).get("crewai", {}).get("type") == "flow":
+        command = ["uv", "run", "kickoff"]
+    
     try:
         subprocess.run(command, capture_output=False, text=True, check=True)
 


### PR DESCRIPTION
I had this situation several times now when I am working on a flow and run `crewai run` only to find that it fails. Today I was debugging for 20 minutes because I didn't drink my coffee.

The correct way to run flows is `crewai flow kickoff`.

This code serves as a fallback. It detects if you defined the flow in `pyproject.toml` and nicely runs flow kickoff even if you don't have your coffee ;)