### PR TITLE
Fix #2171 require-python version to import UTC from datetime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "crewai"
 version = "0.102.0"
 description = "Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks."
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.11,<3.13"
 authors = [
     { name = "Joao Moura", email = "joao@crewai.com" }
 ]


### PR DESCRIPTION
### Fix `requires-python` version to import `UTC` from `datetime`  
[Fix #2171](https://github.com/crewAIInc/crewAI/issues/2171)

#### Summary  
This PR updates the `requires-python` version in `pyproject.toml` from `>=3.10,<3.13` to `>=3.11,<3.13` to ensure compatibility with the `datetime.UTC` import.  

#### Changes  
- Updated `requires-python` to `>=3.11,<3.13` in `pyproject.toml`.  

#### Reason  
Python 3.11 introduced `datetime.UTC`, which is not available in Python 3.10. This change prevents compatibility issues for users running an unsupported Python version, which requires in

- crewAI\src\crewai\tools\tool_usage.py
- crewAI\src\crewai\traces\unified_trace_controller.py
- crewAI\tests\agent_test.py
- crewAI\tests\traces\test_unified_trace_controller.py


![image](https://github.com/user-attachments/assets/c8c0ea8a-427a-44cf-808a-365107cb37af)

#### Impact  
- Ensures that the package runs with the correct Python version.  
- Avoids import errors related to `datetime.UTC`.  

#### Checklist  
- [x] Updated `pyproject.toml`  
- [x] Verified compatibility with Python 3.11+  

---

Would you like any modifications or additional details? 🚀
