### PR TITLE
fix(agents): Align tool reuse check with caching behavior

### DIFF
--- a/src/crewai/agents/tools_handler.py
+++ b/src/crewai/agents/tools_handler.py
@@ -23,7 +23,11 @@ class ToolsHandler:
         should_cache: bool = True,
     ) -> Any:
         """Run when tool ends running."""
-        self.last_used_tool = calling  # type: ignore # BUG?: Incompatible types in assignment (expression has type "Union[ToolCalling, InstructorToolCalling]", variable has type "ToolCalling")
+        if should_cache:
+            self.last_used_tool = calling  # type: ignore # BUG?: Incompatible types in assignment (expression has type "Union[ToolCalling, InstructorToolCalling]", variable has type "ToolCalling")
+        else:
+            self.last_used_tool = {}
+
         if self.cache and should_cache and calling.tool_name != CacheTools().name:
             self.cache.add(
                 tool=calling.tool_name,


### PR DESCRIPTION
This change updates the logic in the ToolsHandler so that when a tool call is not meant to be cached (using should_cache = false), the tool reuse check is bypassed by resetting the last used tool to an empty state instead of storing the tool call. When caching is enabled, the last used tool is recorded as before.

The update helps ensure that tools with non-deterministic behavior—like those that increment a counter on each call—can be run multiple times in a row without being blocked by the reuse check.