### PR TITLE
Adds Task key to the output to back ref to it on callbacks/webhooks

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -373,6 +373,7 @@ class Task(BaseModel):
 
             pydantic_output, json_output = self._export_output(result)
             task_output = TaskOutput(
+                key=self.key,
                 name=self.name,
                 description=self.description,
                 expected_output=self.expected_output,

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -9,6 +9,7 @@ from crewai.tasks.output_format import OutputFormat
 class TaskOutput(BaseModel):
     """Class that represents the result of a task."""
 
+    key: Optional[str] = Field(description="Key of the task", default=None)
     description: str = Field(description="Description of the task")
     name: Optional[str] = Field(description="Name of the task", default=None)
     expected_output: Optional[str] = Field(

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -111,6 +111,7 @@ def test_task_callback():
         task.execute_sync(agent=researcher)
         task_completed.assert_called_once_with(task.output)
 
+        assert task.output.key == task.key
         assert task.output.description == task.description
         assert task.output.expected_output == task.expected_output
         assert task.output.name == task.name
@@ -149,6 +150,7 @@ def test_task_callback_returns_task_output():
         assert isinstance(callback_data, str)
         output_dict = json.loads(callback_data)
         expected_output = {
+            "key": task.key,
             "description": task.description,
             "raw": "exported_ok",
             "pydantic": None,


### PR DESCRIPTION
This PR adds the task's key to the TaskOutput which is used not only but on callbacks too. Having the key is interesting to properly identify the task since the description included is already interpolated with the input values.