### PR TITLE
Fix minor typo in installation document

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -58,7 +58,7 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
 
       - To verify that `crewai` is installed, run:
         ```shell
-        uv tools list
+        uv tool list
         ```
       - You should see something like:
         ```markdown
@@ -67,6 +67,7 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
         ```
       <Check>Installation successful! You're ready to create your first crew! 🎉</Check>
     </Step>
+
 </Steps>
 
 # Creating a CrewAI Project
@@ -102,6 +103,7 @@ We recommend using the `YAML` template scaffolding for a structured approach to 
                   └── tasks.yaml
       ```
       </Frame>
+
   </Step>
 
   <Step title="Customize Your Project">
@@ -118,6 +120,7 @@ We recommend using the `YAML` template scaffolding for a structured approach to 
 
     - Start by editing `agents.yaml` and `tasks.yaml` to define your crew's behavior.
     - Keep sensitive information like API keys in `.env`.
+
   </Step>
 
   <Step title="Run your Crew">
@@ -139,12 +142,9 @@ We recommend using the `YAML` template scaffolding for a structured approach to 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card
-    title="Build Your First Agent"
-    icon="code"
-    href="/quickstart"
-  >
-    Follow our quickstart guide to create your first CrewAI agent and get hands-on experience.
+  <Card title="Build Your First Agent" icon="code" href="/quickstart">
+    Follow our quickstart guide to create your first CrewAI agent and get
+    hands-on experience.
   </Card>
   <Card
     title="Join the Community"


### PR DESCRIPTION
The installation document contained an incorrect command, using "tools" instead of "tool." This has been corrected to ensure proper execution.
- No functional change
- Only documentation

Why this change?
- Prevents confusion for users following the setup guide.
- Ensures the correct command is provided for smooth installation.
