### PR TITLE
Fixed 'tools' to 'tool' typo in the installation file

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -58,7 +58,7 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
 
       - To verify that `crewai` is installed, run:
         ```shell
-        uv tools list
+        uv tool list
         ```
       - You should see something like:
         ```markdown


### PR DESCRIPTION
Fixed the typo present in the docs/installation file associated with the issue #2303 