### PR TITLE
fix: wrong command on listing tools

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -58,7 +58,7 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
 
       - To verify that `crewai` is installed, run:
         ```shell
-        uv tools list
+        uv tool list
         ```
       - You should see something like:
         ```markdown


### PR DESCRIPTION
The command `uv tools list` is unrecognized by uv, instead we need to use `uv tool list`

Error on terminal:
![image](https://github.com/user-attachments/assets/0c680206-dba2-4a38-b1ca-a03f0478f699)

Command that works:
![image](https://github.com/user-attachments/assets/c537b4ee-a40c-4c4b-b763-aa513aa7efa4)

Reference from uv docs:
https://docs.astral.sh/uv/getting-started/features/#tools

![image](https://github.com/user-attachments/assets/746a5d36-faa9-435b-9560-a949804a4c68)
