### PR TITLE
docs: add instructions for upgrading crewAI with uv tool

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -58,12 +58,16 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
 
       - To verify that `crewai` is installed, run:
         ```shell
-        uv tools list
+        uv tool list
         ```
       - You should see something like:
-        ```markdown
+        ```shell
         crewai v0.102.0
         - crewai
+        ```
+      - If you need to update `crewai`, run:
+        ```shell
+        uv tool install crewai --upgrade
         ```
       <Check>Installation successful! You're ready to create your first crew! 🎉</Check>
     </Step>


### PR DESCRIPTION
## Description

This PR makes two important updates to the installation documentation:

1. Fixes a typo in the command: changed `uv tools list` to the correct command `uv tool list`

2. Adds instructions for upgrading crewAI using `uv tool install crewai --upgrade`

## Why this is important

When trying to upgrade crewAI using `uv tool upgrade crewai` (even with the `--upgrade` flag), the command doesn't actually upgrade to the latest version and shows "Nothing to upgrade" even when a newer version is available.

Through testing, I discovered that the proper way to upgrade packages with uv is to use `uv tool install [package] --upgrade` instead. This successfully upgraded crewAI from version 0.100.0 to 0.105.0 in my testing.

This documentation update will help users correctly upgrade their crewAI installation when new versions are released.

## Screenshot
![Screenshot 2025-03-13 at 10 34 37 AM](https://github.com/user-attachments/assets/85db62a6-bc3f-4a4c-a8fb-3d5eb092d1cb)