### PR TITLE
Support wildcard handling in `emit()`

### DIFF
--- a/src/crewai/utilities/events/crewai_event_bus.py
+++ b/src/crewai/utilities/events/crewai_event_bus.py
@@ -67,7 +67,6 @@ class CrewAIEventsBus:
             source: The object emitting the event
             event: The event instance to emit
         """
-        event_type = type(event)
         for event_type, handlers in self._handlers.items():
             if isinstance(event, event_type):
                 for handler in handlers:

--- a/src/crewai/utilities/events/crewai_event_bus.py
+++ b/src/crewai/utilities/events/crewai_event_bus.py
@@ -9,7 +9,6 @@ from crewai.utilities.events.event_types import EventTypes
 
 EventT = TypeVar("EventT", bound=CrewEvent)
 
-
 class CrewAIEventsBus:
     """
     A singleton event bus that uses blinker signals for event handling.
@@ -68,9 +67,11 @@ class CrewAIEventsBus:
             event: The event instance to emit
         """
         event_type = type(event)
-        if event_type in self._handlers:
-            for handler in self._handlers[event_type]:
-                handler(source, event)
+        for event_type, handlers in self._handlers.items():
+            if isinstance(event, event_type):
+                for handler in handlers:
+                    handler(source, event)
+
         self._signal.send(source, event=event)
 
     def clear_handlers(self) -> None:

--- a/src/crewai/utilities/events/crewai_event_bus.py
+++ b/src/crewai/utilities/events/crewai_event_bus.py
@@ -9,6 +9,7 @@ from crewai.utilities.events.event_types import EventTypes
 
 EventT = TypeVar("EventT", bound=CrewEvent)
 
+
 class CrewAIEventsBus:
     """
     A singleton event bus that uses blinker signals for event handling.
@@ -73,10 +74,6 @@ class CrewAIEventsBus:
                     handler(source, event)
 
         self._signal.send(source, event=event)
-
-    def clear_handlers(self) -> None:
-        """Clear all registered event handlers - useful for testing"""
-        self._handlers.clear()
 
     def register_handler(
         self, event_type: Type[EventTypes], handler: Callable[[Any, EventTypes], None]

--- a/tests/utilities/events/test_crewai_event_bus.py
+++ b/tests/utilities/events/test_crewai_event_bus.py
@@ -1,40 +1,34 @@
 from unittest.mock import Mock
 
-import pytest
-
 from crewai.utilities.events.base_events import CrewEvent
-from crewai.utilities.events.crewai_event_bus import CrewAIEventsBus
+from crewai.utilities.events.crewai_event_bus import crewai_event_bus
 
 
 class TestEvent(CrewEvent):
     pass
 
-@pytest.fixture
-def event_bus():
-    bus = CrewAIEventsBus()
-    bus.clear_handlers()
-    return bus
 
-def test_specific_event_handler(event_bus):
+def test_specific_event_handler():
     mock_handler = Mock()
 
-    @event_bus.on(TestEvent)
+    @crewai_event_bus.on(TestEvent)
     def handler(source, event):
         mock_handler(source, event)
 
     event = TestEvent(type="test_event")
-    event_bus.emit("source_object", event)
+    crewai_event_bus.emit("source_object", event)
 
     mock_handler.assert_called_once_with("source_object", event)
 
-def test_wildcard_event_handler(event_bus):
+
+def test_wildcard_event_handler():
     mock_handler = Mock()
 
-    @event_bus.on(CrewEvent)
+    @crewai_event_bus.on(CrewEvent)
     def handler(source, event):
         mock_handler(source, event)
 
     event = TestEvent(type="test_event")
-    event_bus.emit("source_object", event)
+    crewai_event_bus.emit("source_object", event)
 
     mock_handler.assert_called_once_with("source_object", event)

--- a/tests/utilities/events/test_crewai_event_bus.py
+++ b/tests/utilities/events/test_crewai_event_bus.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+import pytest
+
+from crewai.utilities.events.base_events import CrewEvent
+from crewai.utilities.events.crewai_event_bus import CrewAIEventsBus
+
+
+class TestEvent(CrewEvent):
+    pass
+
+@pytest.fixture
+def event_bus():
+    bus = CrewAIEventsBus()
+    bus.clear_handlers()
+    return bus
+
+def test_specific_event_handler(event_bus):
+    mock_handler = Mock()
+
+    @event_bus.on(TestEvent)
+    def handler(source, event):
+        mock_handler(source, event)
+
+    event = TestEvent(type="test_event")
+    event_bus.emit("source_object", event)
+
+    mock_handler.assert_called_once_with("source_object", event)
+
+def test_wildcard_event_handler(event_bus):
+    mock_handler = Mock()
+
+    @event_bus.on(CrewEvent)
+    def handler(source, event):
+        mock_handler(source, event)
+
+    event = TestEvent(type="test_event")
+    event_bus.emit("source_object", event)
+
+    mock_handler.assert_called_once_with("source_object", event)


### PR DESCRIPTION
Change `emit()` to call handlers registered for parent classes using `isinstance()`. Ensures that base event handlers receive derived events.