### PR TITLE
feat: Add result parameter to ToolUsage and ToolUsageFinishedEvent

### DIFF
--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -493,10 +493,14 @@ class ToolUsage:
         crewai_event_bus.emit(self, ToolUsageErrorEvent(**{**event_data, "error": e}))
 
     def on_tool_use_finished(
-        self, tool: Any, tool_calling: ToolCalling, from_cache: bool, started_at: float, result: Any = None
+        self, tool: Any, tool_calling: ToolCalling, from_cache: bool, started_at: float, result: Optional[Any] = None
     ) -> None:
         finished_at = time.time()
         event_data = self._prepare_event_data(tool, tool_calling)
+        
+        if result is not None and not isinstance(result, (str, int, float, bool, dict, list)):
+            self._logger.warning(f"Unexpected result type for tool {tool.name}: {type(result)}")
+        
         event_data.update(
             {
                 "started_at": datetime.datetime.fromtimestamp(started_at),

--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -244,6 +244,7 @@ class ToolUsage:
             tool_calling=calling,
             from_cache=from_cache,
             started_at=started_at,
+            result=result,
         )
 
         if (
@@ -492,7 +493,7 @@ class ToolUsage:
         crewai_event_bus.emit(self, ToolUsageErrorEvent(**{**event_data, "error": e}))
 
     def on_tool_use_finished(
-        self, tool: Any, tool_calling: ToolCalling, from_cache: bool, started_at: float
+        self, tool: Any, tool_calling: ToolCalling, from_cache: bool, started_at: float, result: Any = None
     ) -> None:
         finished_at = time.time()
         event_data = self._prepare_event_data(tool, tool_calling)
@@ -501,6 +502,7 @@ class ToolUsage:
                 "started_at": datetime.datetime.fromtimestamp(started_at),
                 "finished_at": datetime.datetime.fromtimestamp(finished_at),
                 "from_cache": from_cache,
+                "result": result,
             }
         )
         crewai_event_bus.emit(self, ToolUsageFinishedEvent(**event_data))

--- a/src/crewai/utilities/events/tool_usage_events.py
+++ b/src/crewai/utilities/events/tool_usage_events.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from .base_events import CrewEvent
 
@@ -30,7 +30,7 @@ class ToolUsageFinishedEvent(ToolUsageEvent):
     started_at: datetime
     finished_at: datetime
     from_cache: bool = False
-    result: Any = None
+    result: Optional[Any] = None
     type: str = "tool_usage_finished"
 
 

--- a/src/crewai/utilities/events/tool_usage_events.py
+++ b/src/crewai/utilities/events/tool_usage_events.py
@@ -30,6 +30,7 @@ class ToolUsageFinishedEvent(ToolUsageEvent):
     started_at: datetime
     finished_at: datetime
     from_cache: bool = False
+    result: Any = None
     type: str = "tool_usage_finished"
 
 

--- a/tests/utilities/test_events.py
+++ b/tests/utilities/test_events.py
@@ -357,6 +357,7 @@ def test_tools_emits_finished_events():
     assert received_events[0].tool_name == SayHiTool().name
     assert received_events[0].tool_args == {}
     assert received_events[0].type == "tool_usage_finished"
+    assert received_events[0].result == "hi" 
     assert isinstance(received_events[0].timestamp, datetime)
 
 


### PR DESCRIPTION
### Problem

Currently, listeners for ToolUsageFinishedEvent don't have direct access to the tool execution result, requiring complex workarounds to access this crucial information.


### Solution 

Add the tool result directly to the event, making it easily accessible to all event listeners.

### Benefits

Improved developer experience when working with tool execution events
Reduced coupling between event listeners and the internal CrewAI structure
More complete event information, following the principle that events should contain all relevant data

### Related Issues


#2440 [[FEATURE] Add tool execution result to ToolUsageFinishedEvent](https://github.com/crewAIInc/crewAI/issues/2440)