### PR TITLE
Crewai_tools is an absolute dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "tomli>=2.0.2",
     "blinker>=1.9.0",
     "json5>=0.10.0",
+    # CrewAI Tools
+    "crewai-tools>=0.37.0"
 ]
 
 [project.urls]
@@ -45,7 +47,6 @@ Documentation = "https://docs.crewai.com"
 Repository = "https://github.com/crewAIInc/crewAI"
 
 [project.optional-dependencies]
-tools = ["crewai-tools>=0.37.0"]
 embeddings = [
     "tiktoken~=0.7.0"
 ]


### PR DESCRIPTION
Fixes #2361 

Issue: Whenever any tools is being used inside a crew with cli command `crewai run`.
This creates a virtual environment, which consider `crewai_tools` as an option dependency.

`crewai_tools` should be installed regardless of tools are used or not.
