### PR TITLE
Propagating Agent I18n to CrewAgentParser

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -340,6 +340,7 @@ class Agent(BaseAgent):
                 self._rpm_controller.check_or_wait if self._rpm_controller else None
             ),
             callbacks=[TokenCalcHandler(self._token_process)],
+            i18n=self.i18n,
         )
 
     def get_delegation_tools(self, agents: List[BaseAgent]):

--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -59,8 +59,9 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         respect_context_window: bool = False,
         request_within_rpm_limit: Optional[Callable[[], bool]] = None,
         callbacks: List[Any] = [],
+        i18n: I18N = I18N()
     ):
-        self._i18n: I18N = I18N()
+        self._i18n = i18n
         self.llm: BaseLLM = llm
         self.task = task
         self.agent = agent
@@ -524,7 +525,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         return prompt
 
     def _format_answer(self, answer: str) -> Union[AgentAction, AgentFinish]:
-        return CrewAgentParser(agent=self.agent).parse(answer)
+        return CrewAgentParser(agent=self.agent, i18n=self._i18n).parse(answer)
 
     def _format_msg(self, prompt: str, role: str = "user") -> Dict[str, str]:
         prompt = prompt.rstrip()

--- a/src/crewai/agents/parser.py
+++ b/src/crewai/agents/parser.py
@@ -64,11 +64,12 @@ class CrewAgentParser:
     Final Answer: The temperature is 100 degrees
     """
 
-    _i18n: I18N = I18N()
+    _i18n: I18N = None
     agent: Any = None
 
-    def __init__(self, agent: Any):
+    def __init__(self, agent: Any, i18n: I18N = I18N()):
         self.agent = agent
+        self._i18n = i18n
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         thought = self._extract_thought(text)


### PR DESCRIPTION
Currently the I18n object is not being passed on through `CrewAgentParser`. This leads to prompt slices like `final_answer_format` not being able to be overridden using `prompt_file` on the Crew level. As a result of this, prompts like how to recover from output format mishaps can't be customized.

Specific example that lead to this discover:
* Add a `output_json` model to your Task
* Agent gets a Thought, Answer pair in the chain of thought wrong, get's asked to retry
* Agent tries again, gets the Thought, Answer right, but due to the `final_answer_prompt` being overly restrictive, it doesn't adhere to the JSON format specified in the initial prompt.

Will add some unit tests once I got the okay that this is a change we want.