### PR TITLE
fix: correct parameter name in crew template test function

### DIFF
--- a/src/crewai/cli/templates/crew/main.py
+++ b/src/crewai/cli/templates/crew/main.py
@@ -60,7 +60,7 @@ def test():
         "current_year": str(datetime.now().year)
     }
     try:
-        {{crew_name}}().crew().test(n_iterations=int(sys.argv[1]), openai_model_name=sys.argv[2], inputs=inputs)
+        {{crew_name}}().crew().test(n_iterations=int(sys.argv[1]), eval_llm=sys.argv[2], inputs=inputs)
 
     except Exception as e:
         raise Exception(f"An error occurred while testing the crew: {e}")


### PR DESCRIPTION
This commit resolves an issue in the crew template generator where the test()  function incorrectly uses 'openai_model_name' as a parameter name when calling  Crew.test(), while the actual implementation expects 'eval_llm'.

The mismatch causes a TypeError when users run the generated test command: "Crew.test() got an unexpected keyword argument 'openai_model_name'"

This change ensures that templates generated with 'crewai create crew' will  produce code that aligns with the framework's API.