### PR TITLE
fix(llm): add fallback to non-streaming mode when content extraction fails

### DIFF
--- a/src/crewai/utilities/events/llm_events.py
+++ b/src/crewai/utilities/events/llm_events.py
@@ -46,3 +46,4 @@ class LLMStreamChunkEvent(BaseEvent):
 
     type: str = "llm_stream_chunk"
     chunk: str
+    tool_call: Optional[dict] = None


### PR DESCRIPTION

When streaming responses don't contain extractable content, the code now falls back to non-streaming mode instead of raising an exception. This creates a more resilient system that can handle a wider variety of response formats from different LLM providers, preventing crashes in the agent flow.

The key changes:
- Add fallback to non-streaming call when content extraction fails
- Simplify error handling logic
- Keep stream_options for usage metrics collection