### PR TITLE
refactor: create constants.py & use in telemetry

### DIFF
--- a/src/crewai/telemetry/constants.py
+++ b/src/crewai/telemetry/constants.py
@@ -1,0 +1,2 @@
+CREWAI_TELEMETRY_BASE_URL: str = "https://telemetry.crewai.com:4319"
+CREWAI_TELEMETRY_SERVICE_NAME: str = "crewAI-telemetry"

--- a/src/crewai/telemetry/telemetry.py
+++ b/src/crewai/telemetry/telemetry.py
@@ -9,6 +9,11 @@ from contextlib import contextmanager
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional
 
+from crewai.telemetry.constants import (
+    CREWAI_TELEMETRY_BASE_URL, 
+    CREWAI_TELEMETRY_SERVICE_NAME,
+)
+
 
 @contextmanager
 def suppress_warnings():
@@ -52,16 +57,15 @@ class Telemetry:
             return
 
         try:
-            telemetry_endpoint = "https://telemetry.crewai.com:4319"
             self.resource = Resource(
-                attributes={SERVICE_NAME: "crewAI-telemetry"},
+                attributes={SERVICE_NAME: CREWAI_TELEMETRY_SERVICE_NAME},
             )
             with suppress_warnings():
                 self.provider = TracerProvider(resource=self.resource)
 
             processor = BatchSpanProcessor(
                 OTLPSpanExporter(
-                    endpoint=f"{telemetry_endpoint}/v1/traces",
+                    endpoint=f"{CREWAI_TELEMETRY_BASE_URL}/v1/traces",
                     timeout=30,
                 )
             )

--- a/src/crewai/telemetry/telemetry.py
+++ b/src/crewai/telemetry/telemetry.py
@@ -10,7 +10,7 @@ from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional
 
 from crewai.telemetry.constants import (
-    CREWAI_TELEMETRY_BASE_URL, 
+    CREWAI_TELEMETRY_BASE_URL,
     CREWAI_TELEMETRY_SERVICE_NAME,
 )
 
@@ -79,12 +79,12 @@ class Telemetry:
             ):
                 raise  # Re-raise the exception to not interfere with system signals
             self.ready = False
-            
+
     def _is_telemetry_disabled(self) -> bool:
         """Check if telemetry should be disabled based on environment variables."""
         return (
-            os.getenv("OTEL_SDK_DISABLED", "false").lower() == "true" or
-            os.getenv("CREWAI_DISABLE_TELEMETRY", "false").lower() == "true"
+            os.getenv("OTEL_SDK_DISABLED", "false").lower() == "true"
+            or os.getenv("CREWAI_DISABLE_TELEMETRY", "false").lower() == "true"
         )
 
     def set_tracer(self):


### PR DESCRIPTION
Improved telemetry module maintainability + readability by separating out and centralizing constants

- created `constants.py` for telemetry base url and service name
- updated `telemetry.py` to reflect changes