### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Watch this video tutorial for a step-by-step demonstration of the installation p
 <Note>
   **Python Version Requirements**
 
-  CrewAI requires `Python >=3.10 and <3.13`. Here's how to check your version:
+  CrewAI requires `Python >=3.11 and <3.13`. Here's how to check your version:
   ```bash
   python3 --version
   ```


### PR DESCRIPTION
Update minimum Python version to 3.11 due to Self import error in 3.10

Installing crewai with Python 3.10 fails due to:

ImportError: cannot import name 'Self' from 'typing'

The Self type hint was introduced in Python 3.11, which is now the minimum recommended version. Installation with 3.11 works correctly.