### PR TITLE
fix: update OpenInference SDK link for Arize Phoenix integration

### DIFF
--- a/docs/how-to/arize-phoenix-observability.mdx
+++ b/docs/how-to/arize-phoenix-observability.mdx
@@ -6,7 +6,7 @@ icon: magnifying-glass-chart
 
 # Arize Phoenix Integration
 
-This guide demonstrates how to integrate **Arize Phoenix** with **CrewAI** using OpenTelemetry via the [OpenInference](https://github.com/openinference/openinference) SDK. By the end of this guide, you will be able to trace your CrewAI agents and easily debug your agents.
+This guide demonstrates how to integrate **Arize Phoenix** with **CrewAI** using OpenTelemetry via the [OpenInference](https://github.com/Arize-ai/openinference) SDK. By the end of this guide, you will be able to trace your CrewAI agents and easily debug your agents.
 
 > **What is Arize Phoenix?** [Arize Phoenix](https://phoenix.arize.com) is an LLM observability platform that provides tracing and evaluation for AI applications.
 


### PR DESCRIPTION
I updated the outdated OpenInference SDK link from https://github.com/openinference/openinference to https://github.com/Arize-ai/openinference to reflect the current repository location.
If you have a better or more accurate source for the OpenInference SDK, please feel free to suggest it, and I will update it accordingly.

