### PR TITLE
Remove logging setting from global context

### DIFF
--- a/src/crewai/project/crew_base.py
+++ b/src/crewai/project/crew_base.py
@@ -8,8 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-logging.basicConfig(level=logging.WARNING)
-
 T = TypeVar("T", bound=type)
 
 """Base decorator for creating crew classes with configuration and function management."""


### PR DESCRIPTION
This commit fixes a bug where changing logging level would be overriden by `src/crewai/project/crew_base.py`. For example, the following snippet on top of a crew or flow would not work:

```python
logging.basicConfig(
    level=logging.INFO,
    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
)
logger = logging.getLogger(__name__)
```

Crews and flows should be able to set their own log level, without being overriden by CrewAI library code.
