### PR TITLE
docs: added Windows bug solving to docs

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -71,6 +71,10 @@ If you haven't installed `uv` yet, follow **step 1** to quickly get it set up on
             ```
           </Warning>
 
+          <Warning>
+            If you encounter the `chroma-hnswlib==0.7.6` build error (`fatal error C1083: Cannot open include file: 'float.h'`) on Windows, install (Visual Studio Build Tools)[https://visualstudio.microsoft.com/downloads/] with *Desktop development with C++*.
+          </Warning>
+
       - To verify that `crewai` is installed, run:
         ```shell
         uv tool list


### PR DESCRIPTION
This pull request adds a troubleshooting note to the installation documentation to help users resolve a specific build error on Windows, pointed at https://github.com/crewAIInc/crewAI/issues/2694

It added a warning in `docs/installation.mdx` to guide users encountering the `chroma-hnswlib==0.7.6` build error (`fatal error C1083: Cannot open include file: 'float.h'`) on Windows. The note advises installing Visual Studio Build Tools with the *Desktop development with C++* workload.