### PR TITLE
Update internal_instructor.py MISSING API_KEY issue

### DIFF
--- a/src/crewai/utilities/internal_instructor.py
+++ b/src/crewai/utilities/internal_instructor.py
@@ -38,6 +38,6 @@ class InternalInstructor:
     def to_pydantic(self):
         messages = [{"role": "user", "content": self.content}]
         model = self._client.chat.completions.create(
-            model=self.llm.model, response_model=self.model, messages=messages
+            model=self.llm.model, response_model=self.model, messages=messages, api_key=self.llm.api_key
         )
         return model


### PR DESCRIPTION
In case when we do not add API KEY in env and pass it manually from LLM object, it fails to convert the output data to pydantic mode.

Error:
```
Failed to convert text into a Pydantic model due to error: litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` in your environment vars
```