### PR TITLE
Fix encoding error when creating tools

### DIFF
--- a/src/crewai/cli/utils.py
+++ b/src/crewai/cli/utils.py
@@ -161,7 +161,7 @@ def tree_find_and_replace(directory, find, replace):
         for filename in files:
             filepath = os.path.join(path, filename)
 
-            with open(filepath, "r") as file:
+            with open(filepath, "r", encoding="utf-8", errors="ignore") as file:
                 contents = file.read()
             with open(filepath, "w") as file:
                 file.write(contents.replace(find, replace))


### PR DESCRIPTION
This commit fixes a `UnicodeDecodeError` when creating tools. This was caused when reading template files.