### PR TITLE
fix: remove duplicated message about Tool result

### DIFF
--- a/src/crewai/utilities/agent_utils.py
+++ b/src/crewai/utilities/agent_utils.py
@@ -215,9 +215,6 @@ def handle_agent_action_core(
     if show_logs:
         show_logs(formatted_answer)
 
-    if messages is not None:
-        messages.append({"role": "assistant", "content": tool_result.result})
-
     return formatted_answer
 
 


### PR DESCRIPTION
We are currently inserting tool results into LLM messages twice, which may unnecessarily increase processing costs, especially for longer outputs.

As you can see in this screnshoot the tool result is being added duplicated
<img width="1722" alt="Screenshot 2025-06-05 at 10 12 12 AM" src="https://github.com/user-attachments/assets/f036fbc2-2dce-4cf9-9149-707cbbf7e161" />
