### PR TITLE
docs: improve hallucination guardrail examples

### DIFF
--- a/docs/enterprise/features/hallucination-guardrail.mdx
+++ b/docs/enterprise/features/hallucination-guardrail.mdx
@@ -25,8 +25,13 @@ AI hallucinations occur when language models generate content that appears plaus
 from crewai.tasks.hallucination_guardrail import HallucinationGuardrail
 from crewai import LLM
 
-# Initialize the guardrail with reference context
+# Basic usage - will use task's expected_output as context
 guardrail = HallucinationGuardrail(
+    llm=LLM(model="gpt-4o-mini")
+)
+
+# With explicit reference context
+context_guardrail = HallucinationGuardrail(
     context="AI helps with various tasks including analysis and generation.",
     llm=LLM(model="gpt-4o-mini")
 )


### PR DESCRIPTION
## Summary
- Add basic usage example showing guardrail uses task's expected_output as default context
- Add explicit context example for custom reference content