### PR TITLE
docs: update Python version requirement from <=3.13 to <3.14

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Watch this video tutorial for a step-by-step demonstration of the installation p
 <Note>
   **Python Version Requirements**
 
-  CrewAI requires `Python >=3.10 and <=3.13`. Here's how to check your version:
+  CrewAI requires `Python >=3.10 and <3.14`. Here's how to check your version:
   ```bash
   python3 --version
   ```


### PR DESCRIPTION
This correctly reflects support for all 3.13.x patch version