### PR TITLE
fix: SSL error while getting LLM data from GH

### DIFF
--- a/src/crewai/cli/provider.py
+++ b/src/crewai/cli/provider.py
@@ -1,3 +1,5 @@
+import os
+import certifi
 import json
 import time
 from collections import defaultdict
@@ -163,8 +165,10 @@ def fetch_provider_data(cache_file):
     Returns:
     - dict or None: The fetched provider data or None if the operation fails.
     """
+    ssl_config = os.environ['SSL_CERT_FILE'] = certifi.where()
+
     try:
-        response = requests.get(JSON_URL, stream=True, timeout=60)
+        response = requests.get(JSON_URL, stream=True, timeout=60, verify=ssl_config)
         response.raise_for_status()
         data = download_data(response)
         with open(cache_file, "w") as f:


### PR DESCRIPTION
Closes: https://github.com/crewAIInc/crewAI/issues/2978

When running behind cloud-based security users are struggling to donwload LLM data from Github. Usually the following error is raised

```
SSL certificate verification failed: HTTPSConnectionPool(host='raw.githubusercontent.com', port=443): Max retries exceeded with url: /BerriAI/litellm/main/model_prices_and_context_window.json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)')))
Current CA bundle path: /usr/local/etc///.pem
```

This commit ensures the SSL config is beign provided while requesting data