### PR TITLE
fix: ensure compatibility with Pydantic 2.7.x

### DIFF
--- a/src/crewai/flow/flow_trackable.py
+++ b/src/crewai/flow/flow_trackable.py
@@ -20,7 +20,8 @@ class FlowTrackable(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _set_parent_flow(self, max_depth: int = 5) -> "FlowTrackable":
+    def _set_parent_flow(self) -> "FlowTrackable":
+        max_depth = 5
         frame = inspect.currentframe()
 
         try:


### PR DESCRIPTION
Closes: https://github.com/crewAIInc/crewAI/issues/3011#issuecomment-2977898479

Pydantic 2.7.x does not support model validators with a second parameter when using mode="after". 