### PR TITLE
Updated LiteLLM dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # Core Dependencies
     "pydantic>=2.4.2",
     "openai>=1.13.3",
-    "litellm==1.72.0",
+    "litellm==1.72.6",
     "instructor>=1.3.3",
     # Text Processing
     "pdfplumber>=0.11.4",


### PR DESCRIPTION
This moves to the latest stable release. Critically, this includes a fix from https://github.com/BerriAI/litellm/pull/11563 which is required to use grok-3-mini with crewAI.