### PR TITLE
feat: Add Flow-level RPM control for global rate limiting

### DIFF
--- a/docs/features/flow_rpm_control.md
+++ b/docs/features/flow_rpm_control.md
@@ -1,0 +1,392 @@
+# Flow-Level RPM Control
+
+CrewAI now supports global RPM (Requests Per Minute) control at the Flow level, allowing you to set a single rate limit that applies across all Crews within a Flow. This feature is essential for complex applications that orchestrate multiple Crews and need precise control over API usage rates.
+
+## Overview
+
+Previously, CrewAI provided RPM control at the Agent and Crew levels independently. When working with Flows that coordinate multiple Crews, there was no mechanism to control the overall request rate across all Crews within a Flow. This could lead to exceeding API rate limits when multiple Crews executed simultaneously.
+
+With Flow-level RPM control, you can now:
+
+- Set a global RPM limit for all Crews in a Flow
+- Prevent API rate limit errors in complex multi-Crew workflows
+- Simplify rate management across multiple Crews
+- Better control API costs in production applications
+
+## Key Features
+
+- **Global Rate Limiting**: One RPM limit applies to all Crews within the Flow
+- **Automatic Configuration**: Crews created within Flow methods are automatically configured
+- **Thread-Safe**: Handles concurrent Crew execution safely
+- **Override Behavior**: Flow-level limits override individual Crew and Agent RPM settings
+- **Backward Compatible**: Existing Flows without RPM limits work unchanged
+
+## Usage
+
+### Basic Flow with RPM Control
+
+```python
+from crewai import Agent, Crew, Task
+from crewai.flow.flow import Flow, start, listen
+
+class AnalysisFlow(Flow):
+    def __init__(self):
+        # Set global RPM limit of 10 requests per minute for entire Flow
+        super().__init__(max_rpm=10, verbose=True)
+
+    @start()
+    def initialize_analysis(self):
+        return {"status": "initialized"}
+
+    @listen(initialize_analysis)
+    def run_data_collection_crew(self, context):
+        # Create agents
+        data_analyst = Agent(
+            role="Data Analyst",
+            goal="Collect and validate data",
+            backstory="Expert in data extraction",
+            max_rpm=20  # This will be overridden by Flow's 10 RPM limit
+        )
+
+        # Create tasks
+        collect_task = Task(
+            description="Collect data from sources",
+            agent=data_analyst,
+            expected_output="Clean dataset"
+        )
+
+        # Create crew - automatically uses Flow's RPM limit
+        data_crew = Crew(
+            agents=[data_analyst],
+            tasks=[collect_task],
+            max_rpm=15  # This will be overridden by Flow's 10 RPM limit
+        )
+
+        return data_crew.kickoff()
+
+    @listen(run_data_collection_crew)
+    def run_analysis_crew(self, context):
+        # This crew will also be limited to Flow's 10 RPM
+        analysis_agent = Agent(
+            role="Data Analyst",
+            goal="Analyze collected data",
+            backstory="Expert in data analysis"
+        )
+
+        analysis_task = Task(
+            description="Analyze the data",
+            agent=analysis_agent,
+            expected_output="Analysis report"
+        )
+
+        analysis_crew = Crew(
+            agents=[analysis_agent],
+            tasks=[analysis_task]
+        )
+
+        return analysis_crew.kickoff()
+
+# Execute the flow
+flow = AnalysisFlow()
+result = flow.kickoff()
+```
+
+### Flow Without RPM Control
+
+```python
+class UnlimitedFlow(Flow):
+    @start()
+    def process_data(self):
+        agent = Agent(
+            role="Data Processor",
+            goal="Process data quickly",
+            backstory="High-performance specialist"
+        )
+
+        task = Task(
+            description="Process dataset",
+            agent=agent,
+            expected_output="Processed data"
+        )
+
+        # This crew uses its own RPM settings
+        crew = Crew(
+            agents=[agent],
+            tasks=[task],
+            max_rpm=50  # This will be respected
+        )
+
+        return crew.kickoff()
+
+# No global RPM limit
+flow = UnlimitedFlow()
+result = flow.kickoff()
+```
+
+### Manual Crew Configuration
+
+```python
+# Create flow with RPM control
+flow = AnalysisFlow()
+
+# Create crew manually outside of flow methods
+agent = Agent(role="Manual Agent", goal="Test", backstory="Test agent")
+task = Task(description="Test task", agent=agent, expected_output="Result")
+crew = Crew(agents=[agent], tasks=[task], max_rpm=25)
+
+# Manually apply flow's RPM controller
+flow.set_crew_rpm_controller(crew)
+
+# Now crew uses flow's RPM limit
+crew.kickoff()
+```
+
+## API Reference
+
+### Flow Class
+
+#### Constructor Parameters
+
+```python
+Flow(
+    persistence: Optional[FlowPersistence] = None,
+    max_rpm: Optional[int] = None,
+    verbose: bool = False,
+    **kwargs: Any
+)
+```
+
+- **`max_rpm`**: Maximum requests per minute for all Crews in this Flow
+- **`verbose`**: Enable verbose logging for RPM operations
+- **`persistence`**: Optional persistence backend
+- **`**kwargs`**: Additional state initialization values
+
+#### Methods
+
+##### `get_flow_rpm_controller() -> Optional[RPMController]`
+
+Returns the Flow's global RPM controller, or `None` if no RPM limit is set.
+
+```python
+flow = AnalysisFlow()
+controller = flow.get_flow_rpm_controller()
+if controller:
+    print(f"Flow RPM limit: {controller.max_rpm}")
+```
+
+##### `set_crew_rpm_controller(crew: Crew) -> None`
+
+Manually configure a Crew to use the Flow's global RPM controller.
+
+```python
+flow.set_crew_rpm_controller(my_crew)
+```
+
+### Crew Class
+
+#### New Method
+
+##### `set_flow_rpm_controller(rpm_controller: RPMController) -> None`
+
+Set an external RPM controller (typically from a Flow) on this Crew.
+
+```python
+crew = Crew(agents=[agent], tasks=[task])
+crew.set_flow_rpm_controller(flow_controller)
+```
+
+## How It Works
+
+### Automatic Configuration
+
+When a Flow method returns a Crew instance (or data structure containing Crews), the Flow automatically configures those Crews to use its global RPM controller:
+
+1. **Method Execution**: Flow executes a method decorated with `@start()` or `@listen()`
+2. **Result Processing**: Flow inspects the returned result for Crew instances
+3. **Auto-Configuration**: Any found Crews are configured with the Flow's RPM controller
+4. **Agent Updates**: All agents within configured Crews are also updated
+
+### Override Behavior
+
+When a Flow has a global RPM limit:
+
+- **Crew RPM Settings**: Individual Crew `max_rpm` settings are overridden
+- **Agent RPM Settings**: Individual Agent `max_rpm` settings are overridden
+- **Shared Rate Limiting**: All Crews and Agents share the same RPM controller instance
+
+### Thread Safety
+
+The RPM controller uses thread-safe mechanisms:
+
+- **Locking**: Thread locks prevent race conditions during rate limit checks
+- **Atomic Operations**: Request counting and timing operations are atomic
+- **Concurrent Crews**: Multiple Crews can execute concurrently while respecting the global limit
+
+## Best Practices
+
+### 1. Choose Appropriate RPM Limits
+
+```python
+# For development/testing
+class DevFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=5)  # Conservative limit
+
+# For production with higher requirements
+class ProdFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=60)  # Higher limit for production
+```
+
+### 2. Monitor RPM Usage
+
+```python
+class MonitoredFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=20, verbose=True)  # Enable logging
+
+    @start()
+    def monitored_process(self):
+        controller = self.get_flow_rpm_controller()
+        if controller:
+            print(f"Current RPM limit: {controller.max_rpm}")
+        # ... rest of method
+```
+
+### 3. Handle Rate Limiting Gracefully
+
+```python
+@listen(some_method)
+def rate_limited_process(self, context):
+    try:
+        # Create and execute crew
+        crew = Crew(agents=[agent], tasks=[task])
+        result = crew.kickoff()
+        return result
+    except Exception as e:
+        if "RPM" in str(e):
+            print("Rate limit reached, will retry after delay")
+            # Handle rate limiting appropriately
+        raise
+```
+
+### 4. Design for Scalability
+
+```python
+class ScalableFlow(Flow):
+    def __init__(self, environment="dev"):
+        # Adjust RPM based on environment
+        rpm_limits = {
+            "dev": 10,
+            "staging": 30,
+            "prod": 100
+        }
+        super().__init__(max_rpm=rpm_limits.get(environment, 10))
+```
+
+## Migration Guide
+
+### From Individual Crew RPM to Flow RPM
+
+**Before:**
+```python
+# Manual coordination of RPM across crews
+crew1 = Crew(agents=[agent1], tasks=[task1], max_rpm=5)
+crew2 = Crew(agents=[agent2], tasks=[task2], max_rpm=5)
+# Total: 10 RPM, but no coordination between crews
+```
+
+**After:**
+```python
+class CoordinatedFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=10)  # Global limit for both crews
+
+    @start()
+    def run_crew1(self):
+        crew1 = Crew(agents=[agent1], tasks=[task1])  # Uses global limit
+        return crew1.kickoff()
+
+    @listen(run_crew1)
+    def run_crew2(self, context):
+        crew2 = Crew(agents=[agent2], tasks=[task2])  # Uses global limit
+        return crew2.kickoff()
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Crews Not Using Flow RPM Limit
+
+**Problem**: Manually created Crews aren't using the Flow's RPM limit.
+
+**Solution**: Use `set_crew_rpm_controller()` for manual configuration:
+
+```python
+flow = MyFlow()
+crew = Crew(agents=[agent], tasks=[task])
+flow.set_crew_rpm_controller(crew)  # Apply Flow's RPM limit
+```
+
+#### 2. Rate Limits Still Being Exceeded
+
+**Problem**: API rate limits are still being hit despite setting Flow RPM.
+
+**Solution**: Check that the Flow RPM limit is appropriate for your API provider:
+
+```python
+# Check your API provider's rate limits
+# OpenAI: typically 3-60 RPM depending on tier
+# Anthropic: varies by plan
+# Adjust Flow RPM accordingly
+class ConservativeFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=3)  # Very conservative
+```
+
+#### 3. Flows Running Slower Than Expected
+
+**Problem**: Flow execution is slower after adding RPM control.
+
+**Solution**: The RPM limit may be too restrictive. Monitor and adjust:
+
+```python
+class OptimizedFlow(Flow):
+    def __init__(self):
+        # Start conservative, then increase based on monitoring
+        super().__init__(max_rpm=30, verbose=True)
+```
+
+### Debug Mode
+
+Enable verbose logging to debug RPM issues:
+
+```python
+class DebugFlow(Flow):
+    def __init__(self):
+        super().__init__(max_rpm=10, verbose=True)
+
+    @start()
+    def debug_method(self):
+        print(f"Flow RPM controller: {self.get_flow_rpm_controller()}")
+        # Create crew and check its controller
+        crew = Crew(agents=[agent], tasks=[task])
+        print(f"Crew RPM controller: {crew._rpm_controller}")
+        return crew.kickoff()
+```
+
+## Examples Repository
+
+Find more examples in the `examples/` directory:
+
+- `flow_rpm_control_example.py`: Complete working example
+- `flow_rpm_migration_example.py`: Migration from individual to Flow RPM
+- `flow_rpm_production_example.py`: Production-ready implementation
+
+## Related Documentation
+
+- [Flow Basics](./flows.md)
+- [RPM Controller](./rpm_controller.md)
+- [Crew Configuration](./crews.md)
+- [Agent Configuration](./agents.md)

--- a/examples/flow_rpm_control_example.py
+++ b/examples/flow_rpm_control_example.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating Flow-level RPM control in CrewAI.
+
+This example shows how to use the new max_rpm parameter at the Flow level
+to control the global request rate across all Crews within a Flow.
+"""
+
+from crewai import Agent, Crew, Task
+from crewai.flow.flow import Flow, start, listen
+
+
+class AnalysisFlow(Flow):
+    """Example flow with global RPM control."""
+
+    def __init__(self):
+        # Initialize Flow with global RPM limit of 10 requests per minute
+        # This limit will be applied across ALL crews in this flow
+        super().__init__(max_rpm=10, verbose=True)
+
+    @start()
+    def initialize_analysis(self):
+        """Initialize the analysis process."""
+        print("🚀 Starting analysis flow with global RPM limit of 10 RPM")
+        return {"status": "initialized", "data_source": "production_db"}
+
+    @listen(initialize_analysis)
+    def run_data_collection_crew(self, context):
+        """Run the data collection crew."""
+        print("📊 Running data collection crew")
+
+        # Create agents for data collection
+        data_analyst = Agent(
+            role="Data Analyst",
+            goal="Collect and validate data from various sources",
+            backstory="Expert in data extraction and validation",
+            max_rpm=20  # This will be overridden by Flow's global limit of 10
+        )
+
+        data_validator = Agent(
+            role="Data Validator",
+            goal="Ensure data quality and completeness",
+            backstory="Specialist in data quality assurance"
+        )
+
+        # Create tasks
+        collect_task = Task(
+            description="Collect data from the production database",
+            agent=data_analyst,
+            expected_output="Clean dataset with validation report"
+        )
+
+        validate_task = Task(
+            description="Validate data quality and completeness",
+            agent=data_validator,
+            expected_output="Data quality report with metrics"
+        )
+
+        # Create crew - this will automatically use Flow's global RPM limit
+        data_crew = Crew(
+            agents=[data_analyst, data_validator],
+            tasks=[collect_task, validate_task],
+            max_rpm=15  # This will be overridden by Flow's global limit of 10
+        )
+
+        # Execute the crew
+        result = data_crew.kickoff()
+        return result
+
+    @listen(run_data_collection_crew)
+    def run_analysis_crew(self, context):
+        """Run the analysis crew."""
+        print("🔍 Running analysis crew")
+
+        # Create agents for analysis
+        senior_analyst = Agent(
+            role="Senior Data Analyst",
+            goal="Perform comprehensive data analysis",
+            backstory="Senior analyst with expertise in statistical analysis"
+        )
+
+        insights_specialist = Agent(
+            role="Insights Specialist",
+            goal="Extract actionable insights from analysis",
+            backstory="Expert in translating data into business insights"
+        )
+
+        # Create tasks
+        analyze_task = Task(
+            description="Perform statistical analysis on the validated data",
+            agent=senior_analyst,
+            expected_output="Statistical analysis report with findings"
+        )
+
+        insights_task = Task(
+            description="Extract key insights and recommendations",
+            agent=insights_specialist,
+            expected_output="Business insights report with recommendations"
+        )
+
+        # Create crew - this will also use Flow's global RPM limit
+        analysis_crew = Crew(
+            agents=[senior_analyst, insights_specialist],
+            tasks=[analyze_task, insights_task],
+            max_rpm=8  # This will be overridden by Flow's global limit of 10
+        )
+
+        # Execute the crew
+        result = analysis_crew.kickoff()
+        return result
+
+    @listen(run_analysis_crew)
+    def finalize_report(self, context):
+        """Finalize the analysis report."""
+        print("📋 Finalizing analysis report")
+        return {"status": "completed", "report": "final_analysis_report.pdf"}
+
+
+# Example of Flow without RPM control for comparison
+class UnlimitedFlow(Flow):
+    """Example flow without RPM control."""
+
+    @start()
+    def process_data(self):
+        """Process data without RPM limits."""
+        print("🏃‍♂️ Running unlimited flow")
+
+        agent = Agent(
+            role="Data Processor",
+            goal="Process large volumes of data quickly",
+            backstory="High-performance data processing specialist"
+        )
+
+        task = Task(
+            description="Process large dataset",
+            agent=agent,
+            expected_output="Processed data"
+        )
+
+        # This crew will use its own RPM settings (or no limits)
+        crew = Crew(
+            agents=[agent],
+            tasks=[task],
+            max_rpm=50  # This will be respected since Flow has no global limit
+        )
+
+        return crew.kickoff()
+
+
+def main():
+    """Run the example flows."""
+    print("=" * 60)
+    print("CrewAI Flow-Level RPM Control Example")
+    print("=" * 60)
+
+    # Example 1: Flow with global RPM control
+    print("\n🔒 Example 1: Flow with Global RPM Control (10 RPM)")
+    print("-" * 50)
+
+    analysis_flow = AnalysisFlow()
+
+    # Show the Flow's RPM controller
+    if analysis_flow.get_flow_rpm_controller():
+        print(f"✅ Flow has global RPM controller: {analysis_flow.max_rpm} RPM")
+    else:
+        print("❌ Flow has no RPM controller")
+
+    # Execute the flow
+    try:
+        result = analysis_flow.kickoff()
+        print(f"✅ Flow completed successfully: {result}")
+    except Exception as e:
+        print(f"❌ Flow failed: {e}")
+
+    print("\n" + "=" * 60)
+
+    # Example 2: Flow without RPM control
+    print("\n🚀 Example 2: Flow without RPM Control")
+    print("-" * 50)
+
+    unlimited_flow = UnlimitedFlow()
+
+    # Show the Flow's RPM controller status
+    if unlimited_flow.get_flow_rpm_controller():
+        print(f"✅ Flow has global RPM controller: {unlimited_flow.max_rpm} RPM")
+    else:
+        print("❌ Flow has no global RPM controller - crews use individual limits")
+
+    # Execute the flow
+    try:
+        result = unlimited_flow.kickoff()
+        print(f"✅ Flow completed successfully: {result}")
+    except Exception as e:
+        print(f"❌ Flow failed: {e}")
+
+    print("\n" + "=" * 60)
+    print("Example completed!")
+
+    # Demonstrate manual crew configuration
+    print("\n🔧 Example 3: Manual Crew Configuration")
+    print("-" * 50)
+
+    # Create a flow with RPM control
+    flow_with_rpm = AnalysisFlow()
+
+    # Create a crew manually
+    manual_agent = Agent(
+        role="Manual Agent",
+        goal="Test manual configuration",
+        backstory="Agent for testing manual RPM configuration"
+    )
+
+    manual_task = Task(
+        description="Test manual crew configuration",
+        agent=manual_agent,
+        expected_output="Configuration test result"
+    )
+
+    manual_crew = Crew(
+        agents=[manual_agent],
+        tasks=[manual_task],
+        max_rpm=25  # This will be overridden
+    )
+
+    print(f"Before configuration: Crew RPM = {manual_crew.max_rpm}")
+
+    # Manually configure the crew with flow's RPM controller
+    flow_with_rpm.set_crew_rpm_controller(manual_crew)
+
+    print(f"After configuration: Crew now uses Flow's global RPM limit")
+    print(f"Flow RPM limit: {flow_with_rpm.max_rpm}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flow_rpm_control_example.py
+++ b/examples/flow_rpm_control_example.py
@@ -6,28 +6,43 @@ This example shows how to use the new max_rpm parameter at the Flow level
 to control the global request rate across all Crews within a Flow.
 """
 
+import logging
+from typing import Dict, Any, Optional
+
 from crewai import Agent, Crew, Task
 from crewai.flow.flow import Flow, start, listen
+
+# Configuration constants
+FLOW_GLOBAL_RPM = 10
+UNLIMITED_CREW_RPM = 50
+MANUAL_CREW_RPM = 25
+
+# Set up structured logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
 
 
 class AnalysisFlow(Flow):
     """Example flow with global RPM control."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Initialize Flow with global RPM limit of 10 requests per minute
         # This limit will be applied across ALL crews in this flow
-        super().__init__(max_rpm=10, verbose=True)
+        super().__init__(max_rpm=FLOW_GLOBAL_RPM, verbose=True)
 
     @start()
-    def initialize_analysis(self):
+    def initialize_analysis(self) -> Dict[str, str]:
         """Initialize the analysis process."""
-        print("🚀 Starting analysis flow with global RPM limit of 10 RPM")
+        logger.info(f"🚀 Starting analysis flow with global RPM limit of {FLOW_GLOBAL_RPM} RPM")
         return {"status": "initialized", "data_source": "production_db"}
 
     @listen(initialize_analysis)
-    def run_data_collection_crew(self, context):
+    def run_data_collection_crew(self, context: Dict[str, str]) -> Any:
         """Run the data collection crew."""
-        print("📊 Running data collection crew")
+        logger.info("📊 Running data collection crew")
 
         # Create agents for data collection
         data_analyst = Agent(
@@ -60,7 +75,7 @@ class AnalysisFlow(Flow):
         data_crew = Crew(
             agents=[data_analyst, data_validator],
             tasks=[collect_task, validate_task],
-            max_rpm=15  # This will be overridden by Flow's global limit of 10
+            max_rpm=15  # This will be overridden by Flow's global limit
         )
 
         # Execute the crew
@@ -68,9 +83,9 @@ class AnalysisFlow(Flow):
         return result
 
     @listen(run_data_collection_crew)
-    def run_analysis_crew(self, context):
+    def run_analysis_crew(self, context: Any) -> Any:
         """Run the analysis crew."""
-        print("🔍 Running analysis crew")
+        logger.info("🔍 Running analysis crew")
 
         # Create agents for analysis
         senior_analyst = Agent(
@@ -102,7 +117,7 @@ class AnalysisFlow(Flow):
         analysis_crew = Crew(
             agents=[senior_analyst, insights_specialist],
             tasks=[analyze_task, insights_task],
-            max_rpm=8  # This will be overridden by Flow's global limit of 10
+            max_rpm=8  # This will be overridden by Flow's global limit
         )
 
         # Execute the crew
@@ -110,9 +125,9 @@ class AnalysisFlow(Flow):
         return result
 
     @listen(run_analysis_crew)
-    def finalize_report(self, context):
+    def finalize_report(self, context: Any) -> Dict[str, str]:
         """Finalize the analysis report."""
-        print("📋 Finalizing analysis report")
+        logger.info("📋 Finalizing analysis report")
         return {"status": "completed", "report": "final_analysis_report.pdf"}
 
 
@@ -121,9 +136,9 @@ class UnlimitedFlow(Flow):
     """Example flow without RPM control."""
 
     @start()
-    def process_data(self):
+    def process_data(self) -> Any:
         """Process data without RPM limits."""
-        print("🏃‍♂️ Running unlimited flow")
+        logger.info("🏃‍♂️ Running unlimited flow")
 
         agent = Agent(
             role="Data Processor",
@@ -141,94 +156,129 @@ class UnlimitedFlow(Flow):
         crew = Crew(
             agents=[agent],
             tasks=[task],
-            max_rpm=50  # This will be respected since Flow has no global limit
+            max_rpm=UNLIMITED_CREW_RPM  # This will be respected since Flow has no global limit
         )
 
         return crew.kickoff()
 
 
-def main():
-    """Run the example flows."""
-    print("=" * 60)
-    print("CrewAI Flow-Level RPM Control Example")
-    print("=" * 60)
-
-    # Example 1: Flow with global RPM control
-    print("\n🔒 Example 1: Flow with Global RPM Control (10 RPM)")
-    print("-" * 50)
+def demonstrate_flow_rpm_control() -> None:
+    """Demonstrate Flow-level RPM control."""
+    logger.info("🔒 Example 1: Flow with Global RPM Control (%d RPM)", FLOW_GLOBAL_RPM)
+    logger.info("-" * 50)
 
     analysis_flow = AnalysisFlow()
 
     # Show the Flow's RPM controller
     if analysis_flow.get_flow_rpm_controller():
-        print(f"✅ Flow has global RPM controller: {analysis_flow.max_rpm} RPM")
+        logger.info("✅ Flow has global RPM controller: %d RPM", analysis_flow.max_rpm)
     else:
-        print("❌ Flow has no RPM controller")
+        logger.warning("❌ Flow has no RPM controller")
 
     # Execute the flow
     try:
         result = analysis_flow.kickoff()
-        print(f"✅ Flow completed successfully: {result}")
+        logger.info("✅ Flow completed successfully: %s", result)
     except Exception as e:
-        print(f"❌ Flow failed: {e}")
+        logger.error("❌ Flow failed: %s", e)
+        raise
+    finally:
+        # Clean up resources
+        analysis_flow.cleanup_resources()
 
-    print("\n" + "=" * 60)
 
-    # Example 2: Flow without RPM control
-    print("\n🚀 Example 2: Flow without RPM Control")
-    print("-" * 50)
+def demonstrate_unlimited_flow() -> None:
+    """Demonstrate Flow without RPM control."""
+    logger.info("🚀 Example 2: Flow without RPM Control")
+    logger.info("-" * 50)
 
     unlimited_flow = UnlimitedFlow()
 
     # Show the Flow's RPM controller status
     if unlimited_flow.get_flow_rpm_controller():
-        print(f"✅ Flow has global RPM controller: {unlimited_flow.max_rpm} RPM")
+        logger.info("✅ Flow has global RPM controller: %d RPM", unlimited_flow.max_rpm)
     else:
-        print("❌ Flow has no global RPM controller - crews use individual limits")
+        logger.info("❌ Flow has no global RPM controller - crews use individual limits")
 
     # Execute the flow
     try:
         result = unlimited_flow.kickoff()
-        print(f"✅ Flow completed successfully: {result}")
+        logger.info("✅ Flow completed successfully: %s", result)
     except Exception as e:
-        print(f"❌ Flow failed: {e}")
+        logger.error("❌ Flow failed: %s", e)
+        raise
+    finally:
+        # Clean up resources
+        unlimited_flow.cleanup_resources()
 
-    print("\n" + "=" * 60)
-    print("Example completed!")
 
-    # Demonstrate manual crew configuration
-    print("\n🔧 Example 3: Manual Crew Configuration")
-    print("-" * 50)
+def demonstrate_manual_configuration() -> None:
+    """Demonstrate manual crew configuration."""
+    logger.info("🔧 Example 3: Manual Crew Configuration")
+    logger.info("-" * 50)
 
     # Create a flow with RPM control
     flow_with_rpm = AnalysisFlow()
 
-    # Create a crew manually
-    manual_agent = Agent(
-        role="Manual Agent",
-        goal="Test manual configuration",
-        backstory="Agent for testing manual RPM configuration"
-    )
+    try:
+        # Create a crew manually
+        manual_agent = Agent(
+            role="Manual Agent",
+            goal="Test manual configuration",
+            backstory="Agent for testing manual RPM configuration"
+        )
 
-    manual_task = Task(
-        description="Test manual crew configuration",
-        agent=manual_agent,
-        expected_output="Configuration test result"
-    )
+        manual_task = Task(
+            description="Test manual crew configuration",
+            agent=manual_agent,
+            expected_output="Configuration test result"
+        )
 
-    manual_crew = Crew(
-        agents=[manual_agent],
-        tasks=[manual_task],
-        max_rpm=25  # This will be overridden
-    )
+        manual_crew = Crew(
+            agents=[manual_agent],
+            tasks=[manual_task],
+            max_rpm=MANUAL_CREW_RPM  # This will be overridden
+        )
 
-    print(f"Before configuration: Crew RPM = {manual_crew.max_rpm}")
+        logger.info("Before configuration: Crew RPM = %d", manual_crew.max_rpm)
 
-    # Manually configure the crew with flow's RPM controller
-    flow_with_rpm.set_crew_rpm_controller(manual_crew)
+        # Manually configure the crew with flow's RPM controller
+        flow_with_rpm.set_crew_rpm_controller(manual_crew)
 
-    print(f"After configuration: Crew now uses Flow's global RPM limit")
-    print(f"Flow RPM limit: {flow_with_rpm.max_rpm}")
+        logger.info("After configuration: Crew now uses Flow's global RPM limit")
+        logger.info("Flow RPM limit: %d", flow_with_rpm.max_rpm)
+
+    finally:
+        # Clean up resources
+        flow_with_rpm.cleanup_resources()
+
+
+def main() -> None:
+    """Run the example flows."""
+    try:
+        logger.info("=" * 60)
+        logger.info("CrewAI Flow-Level RPM Control Example")
+        logger.info("=" * 60)
+
+        # Example 1: Flow with global RPM control
+        demonstrate_flow_rpm_control()
+
+        logger.info("\n" + "=" * 60)
+
+        # Example 2: Flow without RPM control
+        demonstrate_unlimited_flow()
+
+        logger.info("\n" + "=" * 60)
+
+        # Example 3: Manual crew configuration
+        demonstrate_manual_configuration()
+
+        logger.info("\n" + "=" * 60)
+        logger.info("Example completed!")
+
+    except Exception as e:
+        logger.error("Unexpected error occurred: %s", e)
+        raise
 
 
 if __name__ == "__main__":

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -282,7 +282,7 @@ class Crew(FlowTrackable, BaseModel):
             self._file_handler = FileHandler(self.output_log_file)
 
         # Initialize RPM controller only if not already set by a Flow
-        if not hasattr(self, '_rpm_controller') or self._rpm_controller is None:
+        if getattr(self, '_rpm_controller', None) is None:
             self._rpm_controller = RPMController(max_rpm=self.max_rpm, logger=self._logger)
 
         if self.function_calling_llm and not isinstance(self.function_calling_llm, LLM):
@@ -1515,7 +1515,13 @@ class Crew(FlowTrackable, BaseModel):
 
         Args:
             rpm_controller: The RPMController instance to use for this crew
+
+        Raises:
+            TypeError: If rpm_controller is not an RPMController instance
         """
+        if not isinstance(rpm_controller, RPMController):
+            raise TypeError("rpm_controller must be an RPMController instance")
+
         # Set the external RPM controller
         self._rpm_controller = rpm_controller
 
@@ -1526,7 +1532,7 @@ class Crew(FlowTrackable, BaseModel):
         # Log the change for debugging purposes
         if hasattr(self, '_logger'):
             self._logger.log(
-                "info",
-                f"Crew RPM controller set to global flow limit: {rpm_controller.max_rpm} RPM",
+                level="info",
+                message=f"Crew RPM controller set to global flow limit: {rpm_controller.max_rpm} RPM",
                 color="blue"
             )

--- a/tests/flow_rpm_control_test.py
+++ b/tests/flow_rpm_control_test.py
@@ -3,6 +3,7 @@
 Tests for Flow-level RPM control functionality.
 """
 
+import gc
 import pytest
 from unittest.mock import Mock, patch
 
@@ -32,6 +33,30 @@ class TestFlowRPMControl:
         flow_without_rpm = TestFlow()
         assert flow_without_rpm.max_rpm is None
         assert flow_without_rpm._rpm_controller is None
+
+    def test_flow_initialization_invalid_rpm(self):
+        """Test Flow initialization with invalid RPM values."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Test negative RPM
+        with pytest.raises(ValueError, match="max_rpm must be a positive integer"):
+            TestFlow(max_rpm=-1)
+
+        # Test zero RPM
+        with pytest.raises(ValueError, match="max_rpm must be a positive integer"):
+            TestFlow(max_rpm=0)
+
+        # Test non-integer RPM
+        with pytest.raises(ValueError, match="max_rpm must be a positive integer"):
+            TestFlow(max_rpm=10.5)
+
+        # Test string RPM
+        with pytest.raises(ValueError, match="max_rpm must be a positive integer"):
+            TestFlow(max_rpm="10")
 
     def test_flow_initialization_with_verbose(self):
         """Test that Flow initializes correctly with verbose parameter."""

--- a/tests/flow_rpm_control_test.py
+++ b/tests/flow_rpm_control_test.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Tests for Flow-level RPM control functionality.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from crewai import Agent, Crew, Task
+from crewai.flow.flow import Flow, start, listen
+from crewai.utilities.rpm_controller import RPMController
+
+
+class TestFlowRPMControl:
+    """Test suite for Flow-level RPM control."""
+
+    def test_flow_initialization_with_rpm(self):
+        """Test that Flow initializes correctly with max_rpm parameter."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Test with RPM limit
+        flow_with_rpm = TestFlow(max_rpm=15)
+        assert flow_with_rpm.max_rpm == 15
+        assert flow_with_rpm._rpm_controller is not None
+        assert flow_with_rpm._rpm_controller.max_rpm == 15
+
+        # Test without RPM limit
+        flow_without_rpm = TestFlow()
+        assert flow_without_rpm.max_rpm is None
+        assert flow_without_rpm._rpm_controller is None
+
+    def test_flow_initialization_with_verbose(self):
+        """Test that Flow initializes correctly with verbose parameter."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        flow_verbose = TestFlow(max_rpm=10, verbose=True)
+        assert flow_verbose._logger.verbose is True
+
+        flow_not_verbose = TestFlow(max_rpm=10, verbose=False)
+        assert flow_not_verbose._logger.verbose is False
+
+    def test_get_flow_rpm_controller(self):
+        """Test the get_flow_rpm_controller method."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Flow with RPM
+        flow_with_rpm = TestFlow(max_rpm=20)
+        controller = flow_with_rpm.get_flow_rpm_controller()
+        assert controller is not None
+        assert isinstance(controller, RPMController)
+        assert controller.max_rpm == 20
+
+        # Flow without RPM
+        flow_without_rpm = TestFlow()
+        controller = flow_without_rpm.get_flow_rpm_controller()
+        assert controller is None
+
+    def test_crew_rpm_override_by_flow(self):
+        """Test that crew's RPM settings are overridden by Flow's global RPM."""
+
+        class TestFlow(Flow):
+            def __init__(self):
+                super().__init__(max_rpm=5)
+
+            @start()
+            def create_crew(self):
+                agent = Agent(
+                    role="Test Agent",
+                    goal="Test goal",
+                    backstory="Test backstory"
+                )
+
+                task = Task(
+                    description="Test task",
+                    agent=agent,
+                    expected_output="Test output"
+                )
+
+                # Create crew with different RPM limit
+                crew = Crew(
+                    agents=[agent],
+                    tasks=[task],
+                    max_rpm=30  # This should be overridden
+                )
+
+                return crew
+
+        flow = TestFlow()
+        # This would normally execute the flow, but for testing we'll mock the execution
+        # to avoid actually running the crew
+        with patch.object(flow, '_execute_method') as mock_execute:
+            # Mock the method to return a crew directly
+            agent = Agent(role="Test Agent", goal="Test goal", backstory="Test backstory")
+            task = Task(description="Test task", agent=agent, expected_output="Test output")
+            mock_crew = Crew(agents=[agent], tasks=[task], max_rpm=30)
+            mock_execute.return_value = mock_crew
+
+            # Configure the crew with flow's RPM controller
+            flow.set_crew_rpm_controller(mock_crew)
+
+            # Verify that the crew now uses the flow's RPM controller
+            assert mock_crew._rpm_controller is flow._rpm_controller
+            assert mock_crew._rpm_controller.max_rpm == 5
+
+    def test_set_crew_rpm_controller(self):
+        """Test the set_crew_rpm_controller method."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Create flow with RPM controller
+        flow = TestFlow(max_rpm=12)
+
+        # Create a crew
+        agent = Agent(role="Test Agent", goal="Test goal", backstory="Test backstory")
+        task = Task(description="Test task", agent=agent, expected_output="Test output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=25)
+
+        # Store original controllers for comparison
+        original_crew_controller = crew._rpm_controller
+        original_agent_controller = agent._rpm_controller
+
+        # Apply flow's RPM controller to crew
+        flow.set_crew_rpm_controller(crew)
+
+        # Verify that crew and its agents now use flow's controller
+        assert crew._rpm_controller is flow._rpm_controller
+        assert crew._rpm_controller is not original_crew_controller
+        assert agent._rpm_controller is flow._rpm_controller
+        assert agent._rpm_controller is not original_agent_controller
+
+    def test_set_crew_rpm_controller_no_flow_rpm(self):
+        """Test set_crew_rpm_controller when flow has no RPM limit."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Create flow without RPM controller
+        flow = TestFlow()
+
+        # Create a crew
+        agent = Agent(role="Test Agent", goal="Test goal", backstory="Test backstory")
+        task = Task(description="Test task", agent=agent, expected_output="Test output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=25)
+
+        # Store original controllers
+        original_crew_controller = crew._rpm_controller
+
+        # Try to apply flow's RPM controller (should do nothing)
+        flow.set_crew_rpm_controller(crew)
+
+        # Verify that crew keeps its original controller
+        assert crew._rpm_controller is original_crew_controller
+
+    def test_auto_configure_flow_crews_function(self):
+        """Test the auto_configure_flow_crews utility function."""
+        from crewai.flow.utils import auto_configure_flow_crews
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        # Create flow with RPM controller
+        flow = TestFlow(max_rpm=8)
+
+        # Create test crew
+        agent = Agent(role="Test Agent", goal="Test goal", backstory="Test backstory")
+        task = Task(description="Test task", agent=agent, expected_output="Test output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=20)
+
+        # Store original controller
+        original_controller = crew._rpm_controller
+
+        # Auto-configure crew
+        result = auto_configure_flow_crews(flow, crew)
+
+        # Verify crew was configured and returned
+        assert result is crew
+        assert crew._rpm_controller is flow._rpm_controller
+        assert crew._rpm_controller is not original_controller
+
+    def test_auto_configure_flow_crews_with_list(self):
+        """Test auto_configure_flow_crews with a list containing crews."""
+        from crewai.flow.utils import auto_configure_flow_crews
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        flow = TestFlow(max_rpm=6)
+
+        # Create test crews
+        agent1 = Agent(role="Agent 1", goal="Goal 1", backstory="Backstory 1")
+        task1 = Task(description="Task 1", agent=agent1, expected_output="Output 1")
+        crew1 = Crew(agents=[agent1], tasks=[task1], max_rpm=15)
+
+        agent2 = Agent(role="Agent 2", goal="Goal 2", backstory="Backstory 2")
+        task2 = Task(description="Task 2", agent=agent2, expected_output="Output 2")
+        crew2 = Crew(agents=[agent2], tasks=[task2], max_rpm=25)
+
+        test_list = [crew1, "not_a_crew", crew2]
+
+        # Auto-configure
+        result = auto_configure_flow_crews(flow, test_list)
+
+        # Verify both crews were configured
+        assert result is test_list
+        assert crew1._rpm_controller is flow._rpm_controller
+        assert crew2._rpm_controller is flow._rpm_controller
+
+    def test_auto_configure_flow_crews_with_dict(self):
+        """Test auto_configure_flow_crews with a dictionary containing crews."""
+        from crewai.flow.utils import auto_configure_flow_crews
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        flow = TestFlow(max_rpm=4)
+
+        # Create test crew
+        agent = Agent(role="Agent", goal="Goal", backstory="Backstory")
+        task = Task(description="Task", agent=agent, expected_output="Output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=18)
+
+        test_dict = {
+            "crew": crew,
+            "other": "not_a_crew"
+        }
+
+        # Auto-configure
+        result = auto_configure_flow_crews(flow, test_dict)
+
+        # Verify crew was configured
+        assert result is test_dict
+        assert crew._rpm_controller is flow._rpm_controller
+
+    def test_auto_configure_flow_crews_no_flow_rpm(self):
+        """Test auto_configure_flow_crews when flow has no RPM limit."""
+        from crewai.flow.utils import auto_configure_flow_crews
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        flow = TestFlow()  # No RPM limit
+
+        # Create test crew
+        agent = Agent(role="Agent", goal="Goal", backstory="Backstory")
+        task = Task(description="Task", agent=agent, expected_output="Output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=12)
+
+        original_controller = crew._rpm_controller
+
+        # Auto-configure (should do nothing)
+        result = auto_configure_flow_crews(flow, crew)
+
+        # Verify crew was not modified
+        assert result is crew
+        assert crew._rpm_controller is original_controller
+
+    def test_crew_set_flow_rpm_controller_method(self):
+        """Test the Crew.set_flow_rpm_controller method."""
+
+        # Create test crew
+        agent = Agent(role="Agent", goal="Goal", backstory="Backstory")
+        task = Task(description="Task", agent=agent, expected_output="Output")
+        crew = Crew(agents=[agent], tasks=[task], max_rpm=20)
+
+        # Create RPM controller
+        new_controller = RPMController(max_rpm=7)
+
+        # Store original controllers
+        original_crew_controller = crew._rpm_controller
+        original_agent_controller = agent._rpm_controller
+
+        # Set new controller
+        crew.set_flow_rpm_controller(new_controller)
+
+        # Verify changes
+        assert crew._rpm_controller is new_controller
+        assert crew._rpm_controller is not original_crew_controller
+        assert agent._rpm_controller is new_controller
+        assert agent._rpm_controller is not original_agent_controller
+
+    def test_flow_cleanup_on_deletion(self):
+        """Test that Flow properly cleans up RPM controller on deletion."""
+
+        class TestFlow(Flow):
+            @start()
+            def test_method(self):
+                return "test"
+
+        flow = TestFlow(max_rpm=10)
+        controller = flow._rpm_controller
+
+        # Mock the stop_rpm_counter method to verify it's called
+        with patch.object(controller, 'stop_rpm_counter') as mock_stop:
+            # Delete the flow
+            del flow
+
+            # Verify cleanup was attempted
+            mock_stop.assert_called_once()
+
+    @pytest.mark.integration
+    def test_integration_flow_with_rpm_control(self):
+        """Integration test for complete flow with RPM control."""
+
+        class IntegrationFlow(Flow):
+            def __init__(self):
+                super().__init__(max_rpm=3, verbose=True)
+
+            @start()
+            def create_and_run_crew(self):
+                agent = Agent(
+                    role="Integration Agent",
+                    goal="Test integration",
+                    backstory="Agent for integration testing"
+                )
+
+                task = Task(
+                    description="Integration test task",
+                    agent=agent,
+                    expected_output="Integration test result"
+                )
+
+                crew = Crew(
+                    agents=[agent],
+                    tasks=[task],
+                    max_rpm=50  # Should be overridden
+                )
+
+                return crew
+
+        flow = IntegrationFlow()
+
+        # Verify flow setup
+        assert flow.max_rpm == 3
+        assert flow._rpm_controller is not None
+        assert flow._rpm_controller.max_rpm == 3
+
+        # The actual crew execution would be tested in a full integration test
+        # For unit testing, we verify the setup is correct


### PR DESCRIPTION
- Add max_rpm parameter to Flow class initialization
- Implement global RPM controller that overrides individual Crew/Agent RPM settings
- Add automatic crew configuration when crews are returned from flow methods
- Add utility functions for detecting and configuring crews with flow RPM controllers
- Add set_flow_rpm_controller method to Crew class
- Ensure thread-safe operation for concurrent crew execution
- Add comprehensive test suite for Flow RPM control functionality
- Add detailed documentation and examples
- Maintain backward compatibility with existing flows

This feature allows Flows to set a global rate limit that applies across all Crews within the Flow, preventing API rate limit errors in complex multi-Crew workflows and enabling better cost control.

[FEATURE] Global RPM Control at Flow Level #2906
