### PR TITLE
feat: improve Crew search while resetting their memories

### DIFF
--- a/src/crewai/cli/utils.py
+++ b/src/crewai/cli/utils.py
@@ -94,17 +94,18 @@ def _get_project_attribute(
 
         attribute = _get_nested_value(pyproject_content, keys)
     except FileNotFoundError:
-        print(f"Error: {pyproject_path} not found.")
+        console.print(f"Error: {pyproject_path} not found.", style="bold red")
     except KeyError:
-        print(f"Error: {pyproject_path} is not a valid pyproject.toml file.")
+        console.print(f"Error: {pyproject_path} is not a valid pyproject.toml file.", style="bold red")
     except tomllib.TOMLDecodeError if sys.version_info >= (3, 11) else Exception as e:  # type: ignore
-        print(
+        console.print(
             f"Error: {pyproject_path} is not a valid TOML file."
             if sys.version_info >= (3, 11)
-            else f"Error reading the pyproject.toml file: {e}"
+            else f"Error reading the pyproject.toml file: {e}",
+            style="bold red",
         )
     except Exception as e:
-        print(f"Error reading the pyproject.toml file: {e}")
+        console.print(f"Error reading the pyproject.toml file: {e}", style="bold red")
 
     if require and not attribute:
         console.print(
@@ -137,9 +138,9 @@ def fetch_and_json_env_file(env_file_path: str = ".env") -> dict:
         return env_dict
 
     except FileNotFoundError:
-        print(f"Error: {env_file_path} not found.")
+        console.print(f"Error: {env_file_path} not found.", style="bold red")
     except Exception as e:
-        print(f"Error reading the .env file: {e}")
+        console.print(f"Error reading the .env file: {e}", style="bold red")
 
     return {}
 
@@ -295,7 +296,7 @@ def get_crews(crew_path: str = "crew.py", require: bool = False) -> list[Crew]:
                                 try:
                                     crew_instances.extend(fetch_crews(module_attr))
                                 except Exception as e:
-                                    print(f"Error processing attribute {attr_name}: {e}")
+                                    console.print(f"Error processing attribute {attr_name}: {e}", style="bold red")
                                     continue
 
                             # If we found crew instances, break out of the loop
@@ -303,7 +304,7 @@ def get_crews(crew_path: str = "crew.py", require: bool = False) -> list[Crew]:
                                 break
 
                         except Exception as exec_error:
-                            print(f"Error executing module: {exec_error}")
+                            console.print(f"Error executing module: {exec_error}", style="bold red")
 
                     except (ImportError, AttributeError) as e:
                         if require:
@@ -425,7 +426,8 @@ def _load_tools_from_init(init_file: Path) -> list[dict[str, Any]]:
 
         if not hasattr(module, "__all__"):
             console.print(
-                f"[bold yellow]Warning: No __all__ defined in {init_file}[/bold yellow]"
+                f"Warning: No __all__ defined in {init_file}",
+                style="bold yellow",
             )
             raise SystemExit(1)
 

--- a/src/crewai/cli/utils.py
+++ b/src/crewai/cli/utils.py
@@ -275,7 +275,7 @@ def get_crews(crew_path: str = "crew.py", require: bool = False) -> list[Crew]:
 
         for search_path in search_paths:
             for root, _, files in os.walk(search_path):
-                if crew_path in files:
+                if crew_path in files and "cli/templates" not in root:
                     crew_os_path = os.path.join(root, crew_path)
                     try:
                         spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
Closes https://github.com/crewAIInc/crewAI/issues/2899

Some memories couldn't be reset due to their reliance on relative external sources like `PDFKnowledge`. This was caused by the need to run the reset memories command from the `src` directory, which could break when external files weren't accessible from that path.

This commit allows the reset command to be executed from the root of the project — the same location typically used to run a crew — improving compatibility and reducing friction.

https://github.com/user-attachments/assets/73be0475-4a66-4fa9-b0e8-0840b6f3e594


