### PR TITLE
Fix: Add cache_function of a CrewStructuredTool

### DIFF
--- a/src/crewai/tools/base_tool.py
+++ b/src/crewai/tools/base_tool.py
@@ -116,6 +116,7 @@ class BaseTool(BaseModel, ABC):
             result_as_answer=self.result_as_answer,
             max_usage_count=self.max_usage_count,
             current_usage_count=self.current_usage_count,
+            cache_function=self.cache_function,
         )
 
     @classmethod

--- a/src/crewai/tools/structured_tool.py
+++ b/src/crewai/tools/structured_tool.py
@@ -27,6 +27,7 @@ class CrewStructuredTool:
         result_as_answer: bool = False,
         max_usage_count: int | None = None,
         current_usage_count: int = 0,
+        cache_function: Callable = None,
     ) -> None:
         """Initialize the structured tool.
 
@@ -38,6 +39,7 @@ class CrewStructuredTool:
             result_as_answer: Whether to return the output directly
             max_usage_count: Maximum number of times this tool can be used. None means unlimited usage.
             current_usage_count: Current number of times this tool has been used.
+            cache_function: Function that will be used to determine if the tool should be cached, should return a boolean. If None, the tool will be cached.
         """
         self.name = name
         self.description = description
@@ -47,6 +49,7 @@ class CrewStructuredTool:
         self.result_as_answer = result_as_answer
         self.max_usage_count = max_usage_count
         self.current_usage_count = current_usage_count
+        self.cache_function = cache_function
 
         # Validate the function signature matches the schema
         self._validate_function_signature()


### PR DESCRIPTION
### Problem

When tools are added, `cache_function` parameter is silently dropped. This is because `BaseTool` is converted to `CrewStructuredTool` and the latter does not contain `cache_function`. As a result, tools like `list_directory` appear to be permanently cached, regardless of configuration.

This is a huge problem to my flow because an agent verifies the existence of newly created files and directories. It calls `list_directory` tool with the same arguments at different points in time, expecting different results. Due to caching, the result never changes.

### Solution

Add `cache_function` to CrewStructuredTool.

### Test case

Tool:

```python
def no_cache_tool(arguments: dict, result: str) -> bool:
    return False

tool = Tool(
    # ...
    cache_function=no_cache_tool
)
```

Task:

```python
test_tools_task = Task(
    description="""
1. check that non_existent_directory not exist using list_directory tool
2. create non_existent_directory/.gitkeep file
3. check that non_existent_directory exist using list_directory tool
YOU MUST use exactly the same arguments when you run list_directory two times
"""
)
```

[before.log](https://github.com/user-attachments/files/20945308/before.log)
[after.log](https://github.com/user-attachments/files/20945278/after.log)
