### PR TITLE
Fix: Correct typo 'depployments' to 'deployments' in Installation docs

### DIFF
--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -172,7 +172,7 @@ For teams and organizations, CrewAI offers enterprise deployment options that el
 
 ### CrewAI Factory (Self-hosted)
 - Containerized deployment for your infrastructure
-- Supports any hyperscaler including on prem depployments
+- Supports any hyperscaler including on prem deployments
 - Integration with your existing security systems
 
 <Card title="Explore Enterprise Options" icon="building" href="https://crewai.com/enterprise">


### PR DESCRIPTION
### Description
This PR corrects a minor typo in the "Installation" section of the documentation.
The word "depployments" has been updated to "deployments" for accuracy.

### Location of fix
The typo was found at: [https://docs.crewai.com/en/installation](https://docs.crewai.com/en/installation)
