### PR TITLE
Fix: Add continue message at the end of a message sequence

### DIFF
--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -154,9 +154,13 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
 
                 enforce_rpm_limit(self.request_within_rpm_limit)
 
+                messages = self.messages.copy()
+                if len(messages) > 2:
+                    messages.append(self._continue_message())
+
                 answer = get_llm_response(
                     llm=self.llm,
-                    messages=self.messages,
+                    messages=messages,
                     callbacks=self.callbacks,
                     printer=self._printer,
                 )
@@ -460,3 +464,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             ),
             color="red",
         )
+
+    def _continue_message(self) -> Dict[str, str]:
+        content = self._i18n.slice("continue")
+        return {"role": "user", "content": content}

--- a/src/crewai/llm.py
+++ b/src/crewai/llm.py
@@ -1023,17 +1023,6 @@ class LLM(BaseLLM):
                     formatted_messages.append(msg)
             return formatted_messages
 
-        # Handle Mistral models - they require the last message to have a role of 'user' or 'tool'
-        if "mistral" in self.model.lower():
-            # Check if the last message has a role of 'assistant'
-            if messages and messages[-1]["role"] == "assistant":
-                # Add a dummy user message to ensure the last message has a role of 'user'
-                messages = (
-                    messages.copy()
-                )  # Create a copy to avoid modifying the original
-                messages.append({"role": "user", "content": "Please continue."})
-            return messages
-
         # Handle Anthropic models
         if not self.is_anthropic:
             return messages

--- a/src/crewai/translations/en.json
+++ b/src/crewai/translations/en.json
@@ -7,6 +7,7 @@
   "slices": {
     "observation": "\nObservation:",
     "task": "\nCurrent Task: {input}\n\nBegin! This is VERY important to you, use the tools available and give your best Final Answer, your job depends on it!\n\nThought:",
+    "continue": "Continue!\n\nThought:",
     "memory": "\n\n# Useful context: \n{memory}",
     "role_playing": "You are {role}. {backstory}\nYour personal goal is: {goal}",
     "tools": "\nYou ONLY have access to the following tools, and should NEVER make up tools that are not listed here:\n\n{tools}\n\nIMPORTANT: Use the following format in your response:\n\n```\nThought: you should always think about what to do\nAction: the action to take, only one name of [{tool_names}], just the name, exactly as it's written.\nAction Input: the input to the action, just a simple JSON object, enclosed in curly braces, using \" to wrap keys and values.\nObservation: the result of the action\n```\n\nOnce all necessary information is gathered, return the following format:\n\n```\nThought: I now know the final answer\nFinal Answer: the final answer to the original input question\n```",


### PR DESCRIPTION
## Problem

The latest text is crucially important to LLM. Currently this can be easily a random text that distracts model significantly.
For instance consider this message sequence:
```
Message 1 - system - <describing a persona>

Message 2 - user - <describing a task and tools>

Message 3 - assistant tool usage (read file)
Observation: <file content>
```

As you can see the latest text can be any random depending on what the file contains. This is applicable to any tool output: files, api calls, everything.

The problem is that most models **tend to continue the latest content in their immediate response**.

Request:
```
Message 1 - system - <describing a persona>

Message 2 - user - <describing a task and tools>

Message 3 - assistant tool usage (read file)
Observation:
...
...
...
These principles are important to our system:
- Single Responsibility Principle
- Open/Closed Principle
```

Response:
```
- Liskov Substitution Principle
- Interface Segregation Principle
- Dependency Inversion Principle

Thought: xxx
Action: xxx
Action Input: xxx
```

Note how LLM completed SOLID principles but it is NOT desirable.

In my case this was much worse, LLM completed file context with lots of unusable content that distracted the further conversation with LLM and lead to bad results.

## Solution

Simply add ephemeral user's input as a last message like so:

Request:
```
Message 1 - system - <describing a persona>

Message 2 - user - <describing a task and tools>

Message 3 - assistant tool usage (read file)
Observation:
...
...
...
These principles are important to our system:
- Single Responsibility Principle
- Open/Closed Principle

Message 4: user - Continue!

Thought:
```

Response:
```
Thought: xxx
Action: xxx
Action Input: xxx
```