### PR TITLE
Speed up GitHub Actions tests with parallelization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,17 @@ permissions:
 
 env:
   OPENAI_API_KEY: fake-api-key
+  PYTHONUNBUFFERED: 1
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: true
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
+        group: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,12 +26,34 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Cache Python packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.local/share/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+
       - name: Install the project
         run: uv sync --dev --all-extras
 
-      - name: Run tests
-        run: uv run pytest --block-network --timeout=60 -vv
+      - name: Run tests (group ${{ matrix.group }} of 4)
+        run: |
+          uv run pytest \
+            --block-network \
+            --timeout=60 \
+            -vv \
+            --splits 4 \
+            --group ${{ matrix.group }} \
+            --durations=10 \
+            -n auto \
+            --maxfail=3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ dev-dependencies = [
     "pytest-recording>=0.13.2",
     "pytest-randomly>=3.16.0",
     "pytest-timeout>=2.3.1",
+    "pytest-xdist>=3.6.1",
+    "pytest-split>=0.9.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Split tests across 4 parallel groups
- Add CPU-level parallelization with pytest-xdist
- Implement fail-fast strategy to stop on early failures

## Changes
- Add `pytest-xdist` and `pytest-split` to dev dependencies
- Update GitHub Actions workflow to run tests in parallel groups
- Add improved caching for Python packages