### PR TITLE
Fix score computation in knowledge_storage to return cosine similarity

### DIFF
--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -75,7 +75,7 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                         "id": fetched["ids"][0][i],  # type: ignore
                         "metadata": fetched["metadatas"][0][i],  # type: ignore
                         "context": fetched["documents"][0][i],  # type: ignore
-                        "score": fetched["distances"][0][i],  # type: ignore
+                        "score": 1 - fetched["distances"][0][i],  # type: ignore
                     }
                     if result["score"] >= score_threshold:
                         results.append(result)
@@ -102,6 +102,7 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                 self.collection = self.app.get_or_create_collection(
                     name=sanitize_collection_name(collection_name),
                     embedding_function=self.embedder,
+                    metadata={"hnsw:space": "cosine"},
                 )
             else:
                 raise Exception("Vector Database Client not initialized")

--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -19,6 +19,9 @@ from crewai.utilities.constants import KNOWLEDGE_DIRECTORY
 from crewai.utilities.logger import Logger
 from crewai.utilities.paths import db_storage_path
 
+# “cosine” is the only supported metric in CrewAI for now; do NOT change.
+_VECTOR_SPACE = "cosine"
+
 
 @contextlib.contextmanager
 def suppress_logging(
@@ -75,6 +78,7 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                         "id": fetched["ids"][0][i],  # type: ignore
                         "metadata": fetched["metadatas"][0][i],  # type: ignore
                         "context": fetched["documents"][0][i],  # type: ignore
+                        # Chroma returns cosine *distance* (0~1); convert to similarity via 1 - distance
                         "score": 1 - fetched["distances"][0][i],  # type: ignore
                     }
                     if result["score"] >= score_threshold:
@@ -102,7 +106,7 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                 self.collection = self.app.get_or_create_collection(
                     name=sanitize_collection_name(collection_name),
                     embedding_function=self.embedder,
-                    metadata={"hnsw:space": "cosine"},
+                    metadata={"hnsw:space": _VECTOR_SPACE},
                 )
             else:
                 raise Exception("Vector Database Client not initialized")


### PR DESCRIPTION
## What’s fixed

1. Collection space set to cosine

When initializing a collection we now explicitly pass `metadata={"hnsw:space": "cosine"}` .
This ensures Chroma computes cosine distance, as recommended in the docs.
``` python
            if self.app:
                self.collection = self.app.get_or_create_collection(
                    name=sanitize_collection_name(collection_name),
                    embedding_function=self.embedder,
                    metadata={"hnsw:space": "cosine"},
                )
```

2. KnowledgeStorage.search now converts the value that Chroma returns (cosine distance) into a true cosine similarity:
`"score": 1 - fetched["distances"][0][i]`
```python
               for i in range(len(fetched["ids"][0])):  # type: ignore
                    result = {
                        "id": fetched["ids"][0][i],  # type: ignore
                        "metadata": fetched["metadatas"][0][i],  # type: ignore
                        "context": fetched["documents"][0][i],  # type: ignore
                        "score": 1 - fetched["distances"][0][i],  # type: ignore
                    }
```

## Why
When a collection is created with metadata={"hnsw:space": "cosine"}, Chroma’s query API returns cosine distance (0 = identical, larger = less similar) rather than cosine similarity.
According to Chroma FAQ “Distances and Similarity” <https://cookbook.chromadb.dev/faq/#distances-and-similarity>, the correct mapping is
```text
similarity = 1 – distance
```

Down-stream code and tests expect a higher score to mean “more relevant”, so the conversion is necessary.

## Impact
+ Search results are now ranked by cosine similarity (0 – 1) instead of the raw distance value.
+ No breaking API changes.

Feel free to let me know if any additional changes are needed!
