### PR TITLE
Input a meaningless character on introductory_message

### DIFF
--- a/src/crewai/cli/crew_chat.py
+++ b/src/crewai/cli/crew_chat.py
@@ -83,8 +83,9 @@ def run_chat():
         system_message = build_system_message(crew_chat_inputs)
 
         # Call the LLM to generate the introductory message
+        # NOTE: Some model (e.g. Google Gemini) rejects empty content for user role, thus input a meaningless character
         introductory_message = chat_llm.call(
-            messages=[{"role": "system", "content": system_message}]
+            messages=[{"role": "system", "content": system_message}, {"role": "user", "content": "."}]
         )
     finally:
         # Stop loading indicator


### PR DESCRIPTION
```
$ crewai create crew mycrew # Set Gemini
$ cd mycrew
$ crewai chat
```

causes

```
.VertexAIError: {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.contents: contents is not specified\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

because the original `chat_llm.call()` for `introductory_message` generates empty `contents` field on its requesting body (json data) but only 'system_instruction':

```
{'contents': [], 'system_instruction': {'parts': [{'text': "You are a helpful AI assistant for the CrewAI platform. Your primary purpose is to assist users with the crew's specific tasks. You can answer general questions, but should guide users back to the crew's purpose afterward. For example, after answering a general question, remind the user of your main purpose, such as generating a research report, and prompt them to specify a topic or task related to the crew's purpose. You have a function (tool) you can call by name if you have all required inputs. Those required inputs are: topic (desc: A subject for comprehensive research, data analysis, and reporting.), current_year (desc: The current calendar year.). Once you have them, call the function. Please keep your responses concise and friendly. If a user asks a question outside the crew's scope, provide a brief answer and remind them of the crew's purpose. After calling the tool, be prepared to take user feedback and make adjustments as needed. If you are ever unsure about a user's request or need clarification, ask the user for more information. Before doing anything else, introduce yourself with a friendly message like: 'Hey! I'm here to help you with [crew's purpose]. Could you please provide me with [inputs] so we can get started?' For example: 'Hey! I'm here to help you with uncovering and reporting cutting-edge developments through thorough research and detailed analysis. Could you please provide me with a topic you're interested in? This will help us generate a comprehensive research report and detailed analysis.'\nCrew Name: Mycrew\nCrew Description: Uncover cutting-edge developments and produce detailed reports."}]}, 'generationConfig': {'stop_sequences': []}}
```

Since (at least) Gemini requires non-empty `contents`, and other models might requires same condition or they can ignore the meaningless ".", I proposed to input "." for all default `introductory_message`.

I modified only for chat CLI, but adding some conversions on https://github.com/crewAIInc/crewAI/blob/a6e60a5d4264b94dd13f2948e017acfb43681378/src/crewai/llm.py#L1007 could be better solution.