### PR TITLE
Skip checking docker installation if unsafe mode

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -187,8 +187,8 @@ class Agent(BaseAgent):
         if not self.agent_executor:
             self._setup_agent_executor()
 
-        if self.allow_code_execution:
-            self._validate_docker_installation()
+        if self.allow_code_execution and self.code_execution_mode == "safe":
+            self._validate_docker_installation()  # Docker is required if the code is executed in safe mode
 
         return self
 


### PR DESCRIPTION
When I ran crew in condition with

* `allow_code_execution=True`
* `code_execution_mode = "unsafe"`

following error was gotten:

```
RuntimeError: Docker is not installed. Please install Docker to use code execution with agent:
```

But as [the document](https://docs.crewai.com/en/concepts/agents#code-execution) said, docker is required only if with `code_execution_mode = "safe"`.

Thus, skipping this validation is the best way to solve this problem.