### PR TITLE
fix: prevent runtime errors for pydamic models with PEP 604 Union types

### DIFF
--- a/src/crewai/utilities/pydantic_schema_parser.py
+++ b/src/crewai/utilities/pydantic_schema_parser.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Type, Union, get_args, get_origin
+from types import UnionType
 
 from pydantic import BaseModel
 
@@ -34,7 +35,7 @@ class PydanticSchemaParser(BaseModel):
             key_type, value_type = get_args(field_type)
             return f"Dict[{key_type.__name__}, {value_type.__name__}]"
 
-        if origin is Union:
+        if origin in {Union, UnionType}:
             return self._format_union_type(field_type, depth)
 
         if isinstance(field_type, type) and issubclass(field_type, BaseModel):

--- a/tests/utilities/test_pydantic_schema_parser.py
+++ b/tests/utilities/test_pydantic_schema_parser.py
@@ -80,6 +80,18 @@ def test_model_with_union():
 }"""
     assert schema.strip() == expected_schema.strip()
 
+def test_model_with_new_union():
+    class UnionModel(BaseModel):
+        union_field: int | str
+
+    parser = PydanticSchemaParser(model=UnionModel)
+    schema = parser.get_schema()
+
+    expected_schema = """{
+    union_field: Union[int, str]
+}"""
+    assert schema.strip() == expected_schema.strip()
+
 
 def test_model_with_dict():
     class DictModel(BaseModel):


### PR DESCRIPTION
When the output model has UnionType [PEP-604](https://peps.python.org/604) style, we get an error message saying that there is no method `__name__` for `types.UnionType`.

Currently, unions are created through `typing.Union[A, B]` and through the [PEP-604](https://peps.python.org/604) syntax A | B are at runtime instances of entirely different types, and they differ in exactly what elements they accept.