### PR TITLE
docs: fix incorrect model naming in Google Vertex AI documentation

### DIFF
--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -270,7 +270,7 @@ In this section, you'll find detailed examples that help you select, configure, 
     from crewai import LLM
 
     llm = LLM(
-        model="gemini/gemini-1.5-pro-latest",
+        model="gemini-1.5-pro-latest", # or vertex_ai/gemini-1.5-pro-latest
         temperature=0.7,
         vertex_credentials=vertex_credentials_json
     )

--- a/docs/pt-BR/concepts/llms.mdx
+++ b/docs/pt-BR/concepts/llms.mdx
@@ -268,7 +268,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     from crewai import LLM
 
     llm = LLM(
-        model="gemini/gemini-1.5-pro-latest",
+        model="gemini-1.5-pro-latest", # or vertex_ai/gemini-1.5-pro-latest
         temperature=0.7,
         vertex_credentials=vertex_credentials_json
     )


### PR DESCRIPTION
# Fix Incorrect Model Naming in Google Vertex AI Documentation

## Problem
The Google Vertex AI section in the LLM documentation contains incorrect model naming format. The current examples show:
```python
model="gemini/gemini-1.5-pro-latest"
```

This format is incorrect for Vertex AI usage and cause confusion with the regular Gemini API. 
The correct format should be either:
- `gemini-1.5-pro-latest` (without provider prefix)
- `vertex_ai/gemini-1.5-pro-latest` (with provider prefix)

## Solution
Updated the model naming in both English and Portuguese documentation to use the correct format:
```python
model="gemini-1.5-pro-latest"
```

## Changes Made
- **docs/en/concepts/llms.mdx** (line 272): Fixed model format in English documentation
- **docs/pt-BR/concepts/llms.mdx** (line 270): Fixed model format in Portuguese documentation

## Why This Matters
- Ensures users can successfully use Google Vertex AI with CrewAI
- Maintains consistency with Vertex AI provider requirements
- Prevents confusion between Gemini API and Vertex AI usage patterns
- Improves documentation accuracy and reliability

## Testing
The changes are purely documentation fixes and don't affect functionality. The corrected format aligns with CrewAI's LLM provider conventions.

## Related
This fix addresses the same issue across both language versions of the documentation, ensuring consistency for all users.