### PR TITLE
Removing the e and just reraising the original exception

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -501,7 +501,7 @@ class Task(BaseModel):
         except Exception as e:
             self.end_time = datetime.datetime.now()
             crewai_event_bus.emit(self, TaskFailedEvent(error=str(e), task=self))
-            raise e  # Re-raise the exception after emitting the event
+            raise  # Re-raise the exception after emitting the event
 
     def _process_guardrail(self, task_output: TaskOutput) -> GuardrailResult:
         assert self._guardrail is not None


### PR DESCRIPTION
Removing the `e` and just reraising the original exception so we don't lose the original traceback, it's useful to have the original traceback when we are debugging the code.