### PR TITLE
refactor: simplify exception handling by removing redundant raises.

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -447,7 +447,7 @@ class Agent(BaseAgent):
                     error=str(e),
                 ),
             )
-            raise e
+            raise
         except Exception as e:
             if e.__class__.__module__.startswith("litellm"):
                 # Do not retry on litellm errors
@@ -459,7 +459,7 @@ class Agent(BaseAgent):
                         error=str(e),
                     ),
                 )
-                raise e
+                raise
             self._times_executed += 1
             if self._times_executed > self.max_retry_limit:
                 crewai_event_bus.emit(
@@ -470,7 +470,7 @@ class Agent(BaseAgent):
                         error=str(e),
                     ),
                 )
-                raise e
+                raise
             result = self.execute_task(task, context, tools)
 
         if self.max_rpm and self._rpm_controller:

--- a/src/crewai/agents/crew_agent_executor.py
+++ b/src/crewai/agents/crew_agent_executor.py
@@ -120,11 +120,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             raise
         except Exception as e:
             handle_unknown_error(self._printer, e)
-            if e.__class__.__module__.startswith("litellm"):
-                # Do not retry on litellm errors
-                raise e
-            else:
-                raise e
+            raise
 
         if self.ask_for_human_input:
             formatted_answer = self._handle_human_feedback(formatted_answer)
@@ -208,7 +204,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             except Exception as e:
                 if e.__class__.__module__.startswith("litellm"):
                     # Do not retry on litellm errors
-                    raise e
+                    raise
                 if is_context_length_exceeded(e):
                     handle_context_length(
                         respect_context_window=self.respect_context_window,
@@ -221,7 +217,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     continue
                 else:
                     handle_unknown_error(self._printer, e)
-                    raise e
+                    raise
             finally:
                 self.iterations += 1
 

--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -873,7 +873,7 @@ class Flow(Generic[T], metaclass=FlowMeta):
                     error=e,
                 ),
             )
-            raise e
+            raise
 
     async def _execute_listeners(self, trigger_method: str, result: Any) -> None:
         """

--- a/src/crewai/flow/flow_visualizer.py
+++ b/src/crewai/flow/flow_visualizer.py
@@ -40,7 +40,7 @@ class FlowPlot:
             raise ValueError("Invalid flow object: missing '_listeners' attribute")
         if not hasattr(flow, '_start_methods'):
             raise ValueError("Invalid flow object: missing '_start_methods' attribute")
-            
+
         self.flow = flow
         self.colors = COLORS
         self.node_styles = NODE_STYLES
@@ -65,7 +65,7 @@ class FlowPlot:
         """
         if not filename or not isinstance(filename, str):
             raise ValueError("Filename must be a non-empty string")
-            
+
         try:
             # Initialize network
             net = Network(
@@ -132,7 +132,7 @@ class FlowPlot:
                 raise IOError(f"Failed to save flow visualization to {filename}.html: {str(e)}")
 
         except (ValueError, RuntimeError, IOError) as e:
-            raise e
+            raise
         except Exception as e:
             raise RuntimeError(f"Unexpected error during flow visualization: {str(e)}")
         finally:

--- a/src/crewai/knowledge/knowledge.py
+++ b/src/crewai/knowledge/knowledge.py
@@ -68,7 +68,7 @@ class Knowledge(BaseModel):
                 source.storage = self.storage
                 source.add()
         except Exception as e:
-            raise e
+            raise
 
     def reset(self) -> None:
         if self.storage:

--- a/src/crewai/knowledge/source/crew_docling_source.py
+++ b/src/crewai/knowledge/source/crew_docling_source.py
@@ -75,10 +75,10 @@ class CrewDoclingSource(BaseKnowledgeSource):
                 f"Error loading content: {e}. Supported formats: {self.document_converter.allowed_formats}",
                 "red",
             )
-            raise e
+            raise
         except Exception as e:
             self._logger.log("error", f"Error loading content: {e}")
-            raise e
+            raise
 
     def add(self) -> None:
         if self.content is None:

--- a/src/crewai/lite_agent.py
+++ b/src/crewai/lite_agent.py
@@ -337,7 +337,7 @@ class LiteAgent(FlowTrackable, BaseModel):
                     error=str(e),
                 ),
             )
-            raise e
+            raise
 
     def _execute_core(self, agent_info: Dict[str, Any]) -> LiteAgentOutput:
         # Emit event for agent execution start
@@ -551,7 +551,7 @@ class LiteAgent(FlowTrackable, BaseModel):
                         self,
                         event=LLMCallFailedEvent(error=str(e), from_agent=self),
                     )
-                    raise e
+                    raise
 
                 formatted_answer = process_llm_response(answer, self.use_stop_words)
 
@@ -566,7 +566,7 @@ class LiteAgent(FlowTrackable, BaseModel):
                             agent=self.original_agent,
                         )
                     except Exception as e:
-                        raise e
+                        raise
 
                     formatted_answer = handle_agent_action_core(
                         formatted_answer=formatted_answer,
@@ -587,7 +587,7 @@ class LiteAgent(FlowTrackable, BaseModel):
             except Exception as e:
                 if e.__class__.__module__.startswith("litellm"):
                     # Do not retry on litellm errors
-                    raise e
+                    raise
                 if is_context_length_exceeded(e):
                     handle_context_length(
                         respect_context_window=self.respect_context_window,
@@ -600,7 +600,7 @@ class LiteAgent(FlowTrackable, BaseModel):
                     continue
                 else:
                     handle_unknown_error(self._printer, e)
-                    raise e
+                    raise
 
             finally:
                 self._iterations += 1

--- a/src/crewai/utilities/agent_utils.py
+++ b/src/crewai/utilities/agent_utils.py
@@ -161,7 +161,7 @@ def get_llm_response(
             content=f"Error during LLM call: {e}",
             color="red",
         )
-        raise e
+        raise
     if not answer:
         printer.print(
             content="Received None or empty response from LLM call.",

--- a/src/crewai/utilities/embedding_configurator.py
+++ b/src/crewai/utilities/embedding_configurator.py
@@ -206,7 +206,7 @@ class EmbeddingConfigurator:
                     return cast(Embeddings, embeddings)
                 except Exception as e:
                     print("Error during Watson embedding:", e)
-                    raise e
+                    raise
 
         return WatsonEmbeddingFunction()
 

--- a/src/crewai/utilities/tool_utils.py
+++ b/src/crewai/utilities/tool_utils.py
@@ -87,4 +87,4 @@ def execute_tool_and_check_finality(
         return ToolResult(tool_result, False)
 
     except Exception as e:
-        raise e
+        raise


### PR DESCRIPTION
Replacing `raise e` with simply `raise`. In Python 3, invoking `raise` inside an except block re-raises the caught exception, preserving its original traceback and full context. By contrast, using `raise e` resets the traceback, which can obscure the exception chain and make it harder to trace back to the root cause in earlier frames.