### PR TITLE
chore: add deprecation notices to UserMemory

### DIFF
--- a/docs/en/concepts/memory.mdx
+++ b/docs/en/concepts/memory.mdx
@@ -712,7 +712,7 @@ crew = Crew(
     memory_config={
         "provider": "mem0",
         "config": {"user_id": "john"},
-        "user_memory": {}  # Required - triggers user memory initialization
+        "user_memory": {}  # DEPRECATED: Will be removed in version 0.156.0 or on 2025-08-04, use external_memory instead
     },
     process=Process.sequential,
     verbose=True

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -161,7 +161,7 @@ class Crew(FlowTrackable, BaseModel):
     )
     user_memory: Optional[InstanceOf[UserMemory]] = Field(
         default=None,
-        description="An instance of the UserMemory to be used by the Crew to store/fetch memories of a specific user.",
+        description="DEPRECATED: Will be removed in version 0.156.0 or on 2025-08-04, whichever comes first. Use external_memory instead.",
     )
     external_memory: Optional[InstanceOf[ExternalMemory]] = Field(
         default=None,
@@ -327,7 +327,7 @@ class Crew(FlowTrackable, BaseModel):
         self._short_term_memory = self.short_term_memory
         self._entity_memory = self.entity_memory
 
-        # UserMemory is gonna to be deprecated in the future, but we have to initialize a default value for now
+        # UserMemory will be removed in version 0.156.0 or on 2025-08-04, whichever comes first
         self._user_memory = None
 
         if self.memory:
@@ -1255,6 +1255,7 @@ class Crew(FlowTrackable, BaseModel):
         if self.external_memory:
             copied_data["external_memory"] = self.external_memory.model_copy(deep=True)
         if self.user_memory:
+            # DEPRECATED: UserMemory will be removed in version 0.156.0 or on 2025-08-04
             copied_data["user_memory"] = self.user_memory.model_copy(deep=True)
 
         copied_data.pop("agents", None)

--- a/src/crewai/memory/contextual/contextual_memory.py
+++ b/src/crewai/memory/contextual/contextual_memory.py
@@ -108,6 +108,7 @@ class ContextualMemory:
 
     def _fetch_user_context(self, query: str) -> str:
         """
+        DEPRECATED: Will be removed in version 0.156.0 or on 2025-08-04, whichever comes first.
         Fetches and formats relevant user information from User Memory.
         Args:
             query (str): The search query to find relevant user memories.

--- a/src/crewai/memory/user/user_memory.py
+++ b/src/crewai/memory/user/user_memory.py
@@ -14,7 +14,8 @@ class UserMemory(Memory):
 
     def __init__(self, crew=None):
         warnings.warn(
-            "UserMemory is deprecated and will be removed in a future version. "
+            "UserMemory is deprecated and will be removed in version 0.156.0 "
+            "or on 2025-08-04, whichever comes first. "
             "Please use ExternalMemory instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/src/crewai/memory/user/user_memory_item.py
+++ b/src/crewai/memory/user/user_memory_item.py
@@ -1,8 +1,16 @@
+import warnings
 from typing import Any, Dict, Optional
 
 
 class UserMemoryItem:
     def __init__(self, data: Any, user: str, metadata: Optional[Dict[str, Any]] = None):
+        warnings.warn(
+            "UserMemoryItem is deprecated and will be removed in version 0.156.0 "
+            "or on 2025-08-04, whichever comes first. "
+            "Please use ExternalMemory instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.data = data
         self.user = user
         self.metadata = metadata if metadata is not None else {}


### PR DESCRIPTION
## Summary
- Add deprecation warnings to UserMemory and UserMemoryItem classes
- Mark for removal in v0.156.0 or 2025-08-04, whichever comes first
- Update documentation and code comments with deprecation notices

## Changes
- Added deprecation warnings in `__init__` methods
- Updated field descriptions and comments throughout codebase
- Users should migrate to ExternalMemory