### PR TITLE
fix(flow): Prevent initial_state BaseModel from being coerced to dict

### DIFF
--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -69,19 +69,6 @@ def ensure_state_type(state: Any, expected_type: Type[StateT]) -> StateT:
         TypeError: If state doesn't match expected type
         ValueError: If state validation fails
     """
-    """Ensure state matches expected type with proper validation.
-
-    Args:
-        state: State instance to validate
-        expected_type: Expected type for the state
-
-    Returns:
-        Validated state instance
-
-    Raises:
-        TypeError: If state doesn't match expected type
-        ValueError: If state validation fails
-    """
     if expected_type is dict:
         if not isinstance(state, dict):
             raise TypeError(f"Expected dict, got {type(state).__name__}")
@@ -446,15 +433,20 @@ class Flow(Generic[T], metaclass=FlowMeta):
 
     def __init__(
         self,
+        initial_state: Union[Type[T], T, None] = None,
         persistence: Optional[FlowPersistence] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a new Flow instance.
-
         Args:
+            initial_state: Initial state for the flow (BaseModel instance or dict)
             persistence: Optional persistence backend for storing flow states
             **kwargs: Additional state values to initialize or override
         """
+        # Set the initial_state for this instance
+        if initial_state is not None:
+            self.initial_state = initial_state
+
         # Initialize basic instance attributes
         self._methods: Dict[str, Callable] = {}
         self._method_execution_counts: Dict[str, int] = {}
@@ -555,22 +547,20 @@ class Flow(Generic[T], metaclass=FlowMeta):
             if not hasattr(model, "id"):
                 raise ValueError("Flow state model must have an 'id' field")
 
-            # Create new instance with same values to avoid mutations
-            if hasattr(model, "model_dump"):
+            # Create copy of the BaseModel to avoid mutations
+            if hasattr(model, "model_copy"):
                 # Pydantic v2
-                state_dict = model.model_dump()
-            elif hasattr(model, "dict"):
+                return cast(T, model.model_copy())
+            elif hasattr(model, "copy"):
                 # Pydantic v1
-                state_dict = model.dict()
+                return cast(T, model.copy())
             else:
-                # Fallback for other BaseModel implementations
+                # Fallback for other BaseModel implementations - preserve original logic
                 state_dict = {
                     k: v for k, v in model.__dict__.items() if not k.startswith("_")
                 }
-
-            # Create new instance of the same class
-            model_class = type(model)
-            return cast(T, model_class(**state_dict))
+                model_class = type(model)
+                return cast(T, model_class(**state_dict))
         raise TypeError(
             f"Initial state must be dict or BaseModel, got {type(self.initial_state)}"
         )
@@ -645,30 +635,25 @@ class Flow(Generic[T], metaclass=FlowMeta):
             # For BaseModel states, preserve existing fields unless overridden
             try:
                 model = cast(BaseModel, self._state)
-                # Get current state as dict
-                if hasattr(model, "model_dump"):
-                    current_state = model.model_dump()
-                elif hasattr(model, "dict"):
-                    current_state = model.dict()
+                if hasattr(model, "model_copy"):
+                    # Pydantic v2
+                    self._state = cast(T, model.model_copy(update=inputs))
+                elif hasattr(model, "copy"):
+                    # Pydantic v1
+                    self._state = cast(T, model.copy(update=inputs))
                 else:
+                    # Fallback for other BaseModel implementations - preserve original logic
                     current_state = {
                         k: v for k, v in model.__dict__.items() if not k.startswith("_")
                     }
-
-                # Create new state with preserved fields and updates
-                new_state = {**current_state, **inputs}
-
-                # Create new instance with merged state
-                model_class = type(model)
-                if hasattr(model_class, "model_validate"):
-                    # Pydantic v2
-                    self._state = cast(T, model_class.model_validate(new_state))
-                elif hasattr(model_class, "parse_obj"):
-                    # Pydantic v1
-                    self._state = cast(T, model_class.parse_obj(new_state))
-                else:
-                    # Fallback for other BaseModel implementations
-                    self._state = cast(T, model_class(**new_state))
+                    new_state = {**current_state, **inputs}
+                    model_class = type(model)
+                    if hasattr(model_class, "model_validate"):
+                        self._state = cast(T, model_class.model_validate(new_state))
+                    elif hasattr(model_class, "parse_obj"):
+                        self._state = cast(T, model_class.parse_obj(new_state))
+                    else:
+                        self._state = cast(T, model_class(**new_state))
             except ValidationError as e:
                 raise ValueError(f"Invalid inputs for structured state: {e}") from e
         else:
@@ -776,9 +761,6 @@ class Flow(Generic[T], metaclass=FlowMeta):
         self._log_flow_event(
             f"Flow started with ID: {self.flow_id}", color="bold_magenta"
         )
-
-        if inputs is not None and "id" not in inputs:
-            self._initialize_state(inputs)
 
         tasks = [
             self._execute_start_method(start_method)

--- a/tests/test_flow_initial_state_fix.py
+++ b/tests/test_flow_initial_state_fix.py
@@ -1,0 +1,99 @@
+"""Test Flow initial_state BaseModel dict coercion fix for issue #3147"""
+
+from crewai.flow.flow import Flow, FlowState
+
+
+# All test states now inherit from FlowState to include the mandatory 'id' field
+class StateWithItems(FlowState):
+    items: list = [1, 2, 3]
+    metadata: dict = {"x": 1}
+
+
+class StateWithKeys(FlowState):
+    keys: list = ["a", "b", "c"]
+    data: str = "test"
+
+
+class StateWithValues(FlowState):
+    values: list = [10, 20, 30]
+    name: str = "example"
+
+
+class StateWithGet(FlowState):
+    get: str = "method_name"
+    config: dict = {"enabled": True}
+
+
+def test_flow_initial_state_items_field() -> None:
+    """Test that BaseModel with 'items' field preserves structure and doesn't get dict coercion."""
+    flow = Flow(initial_state=StateWithItems())
+    flow.kickoff()
+
+    assert isinstance(flow.state, StateWithItems)
+    assert not isinstance(flow.state, dict)
+    assert isinstance(flow.state.items, list)
+    assert flow.state.items == [1, 2, 3]
+    assert len(flow.state.items) == 3
+    assert flow.state.metadata == {"x": 1}
+
+
+def test_flow_initial_state_keys_field():
+    """Test that BaseModel with 'keys' field preserves structure."""
+    flow = Flow(initial_state=StateWithKeys())
+    flow.kickoff()
+
+    assert isinstance(flow.state, StateWithKeys)
+    assert isinstance(flow.state.keys, list)
+    assert flow.state.keys == ["a", "b", "c"]
+
+
+def test_flow_initial_state_values_field():
+    """Test that BaseModel with 'values' field preserves structure."""
+    flow = Flow(initial_state=StateWithValues())
+    flow.kickoff()
+
+    assert isinstance(flow.state, StateWithValues)
+    assert isinstance(flow.state.values, list)
+    assert flow.state.values == [10, 20, 30]
+
+
+def test_flow_initial_state_get_field():
+    """Test that BaseModel with 'get' field preserves structure."""
+    flow = Flow(initial_state=StateWithGet())
+    flow.kickoff()
+
+    assert isinstance(flow.state, StateWithGet)
+    assert isinstance(flow.state.get, str)
+    assert flow.state.get == "method_name"
+
+
+def test_flow_with_inputs_preserves_basemodel():
+    """Test that providing inputs to flow preserves BaseModel structure."""
+
+    class InputState(FlowState):
+        items: list = []
+        name: str = ""
+
+    flow = Flow(initial_state=InputState())
+    flow.kickoff(inputs={"name": "test_flow", "items": [5, 6, 7]})
+
+    assert isinstance(flow.state, InputState)
+    assert not isinstance(flow.state, dict)
+    assert flow.state.name == "test_flow"
+    assert flow.state.items == [5, 6, 7]
+
+
+def test_reproduction_case_from_issue_3147():
+    """Test the exact reproduction case from GitHub issue #3147."""
+
+    class MyState(FlowState):
+        items: list = [1, 2, 3]
+        metadata: dict = {"x": 1}
+
+    flow = Flow(initial_state=MyState())
+    flow.kickoff()
+
+    assert isinstance(flow.state.items, list)
+    assert len(flow.state.items) == 3
+    assert flow.state.items == [1, 2, 3]
+    assert not callable(flow.state.items)


### PR DESCRIPTION
Fixes #3147

This PR resolves a critical bug where passing a Pydantic `BaseModel` as `initial_state` to a `Flow` would cause it to be silently coerced into a dictionary. This led to attribute collisions and runtime errors if the `BaseModel` contained fields with names matching dictionary methods (e.g., `items`, `keys`, `values`).

The fix ensures that the `BaseModel` type is preserved throughout the flow's lifecycle by using Pydantic's native copy methods and correcting the `Flow` constructor.

#### Key Changes & Fixes

1.  **Corrected `Flow` Constructor:** The `__init__` method in `src/crewai/flow/flow.py` was modified to properly accept the `initial_state` parameter. Previously, this parameter was being ignored and incorrectly handled, which was the root cause of the state being initialized as a dictionary.

2.  **Preserved `BaseModel` on Creation:** The `_create_initial_state` method was updated to use `model.model_copy()` (Pydantic v2) or `model.copy()` (Pydantic v1) instead of converting the model to a dictionary. This ensures the state is a `BaseModel` instance from the very beginning.

3.  **Safe `BaseModel` Updates:** The `_initialize_state` method was updated to use `model.copy(update=...)` for applying inputs. This is a much safer and more direct way to update Pydantic models than the previous dictionary-merging approach.

#### Changes to Tests

A new, comprehensive test suite was created in `tests/test_flow_initial_state_fix.py` to validate the fix and prevent regressions:

1.  **Reproduces the Bug:** The tests confirm the original bug by using state models with colliding attribute names like `items`, `keys`, `values`, and `get`.
2.  **Validates the Fix:** The assertions now pass, proving that `flow.state` remains a `BaseModel` instance and that attributes can be accessed correctly.
3.  **Corrected Test Models:** All Pydantic models used for testing were updated to inherit from `FlowState`. This was a necessary change because the fix correctly enforces the requirement that all state models must have an `id` field, a detail the initial automated PR's tests missed.

#### Comparison to Previous Automated PR
The initial automated PR (#3148) correctly identified the need for `model_copy()` but failed because it missed two critical issues that this PR addresses:
1.  It did not fix the `Flow` constructor, which was the primary source of the bug.
2.  Its tests were incomplete and failed because they did not account for the mandatory `id` field in state models.

#### Code Quality & Linting
All modified files (`src/crewai/flow/flow.py` and `tests/test_flow_initial_state_fix.py`) have been formatted with `ruff format` and checked with `ruff check --fix` to ensure they adhere to the project's coding standards.