### PR TITLE
Add timezone to event timestamps

### DIFF
--- a/src/crewai/utilities/events/base_events.py
+++ b/src/crewai/utilities/events/base_events.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
-
 from pydantic import BaseModel, Field
 
 from crewai.utilities.serialization import to_serializable
@@ -9,7 +8,7 @@ from crewai.utilities.serialization import to_serializable
 class BaseEvent(BaseModel):
     """Base class for all events"""
 
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     type: str
     source_fingerprint: Optional[str] = None  # UUID string of the source entity
     source_type: Optional[str] = None  # "agent", "task", "crew", "memory", "entity_memory", "short_term_memory", "long_term_memory", "external_memory"


### PR DESCRIPTION
Events were lacking timezone information, making them naive datetimes, which can be ambiguous.