### PR TITLE
fix: allow persist Flow state with BaseModel entries

### DIFF
--- a/src/crewai/flow/persistence/sqlite.py
+++ b/src/crewai/flow/persistence/sqlite.py
@@ -81,7 +81,7 @@ class SQLiteFlowPersistence(FlowPersistence):
         """
         # Convert state_data to dict, handling both Pydantic and dict cases
         if isinstance(state_data, BaseModel):
-            state_dict = dict(state_data)  # Use dict() for better type compatibility
+            state_dict = state_data.model_dump()
         elif isinstance(state_data, dict):
             state_dict = state_data
         else:


### PR DESCRIPTION
When trying to persist Flow state with BaseModel entries we got the following error

```
Failed to persist state for method execute_message: Object of type Message is not JSON serializable
```