### PR TITLE
fix: Fix Knowledge Base Mix-up Across Crews

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -331,7 +331,7 @@ class Crew(FlowTrackable, BaseModel):
                     self.knowledge = Knowledge(
                         sources=self.knowledge_sources,
                         embedder=self.embedder,
-                        collection_name="crew",
+                        collection_name=self.name,
                     )
                     self.knowledge.add_sources()
 


### PR DESCRIPTION
This PR fixes an issue where multiple crews shared the same knowledge base if they're running within the same project (see [discussion](https://community.crewai.com/t/how-to-use-multiple-independant-memory-and-rag-database-for-different-crews/494)).

Now, crews must have unique names to maintain separate memory/RAG. If the default name "crew" is used, they will continue to share the same knowledge base as before.