### PR TITLE
docs: fix recurring grammar in README and docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ reporting_task:
     Review the context you got and expand each topic into a full section for a report.
     Make sure the report is detailed and contains any and all relevant information.
   expected_output: >
-    A fully fledge reports with the mains topics, each with a full section of information.
+    A fully fledged report with the main topics, each with a full section of information.
     Formatted as markdown without '```'
   agent: reporting_analyst
   output_file: report.md

--- a/docs/en/concepts/tasks.mdx
+++ b/docs/en/concepts/tasks.mdx
@@ -94,7 +94,7 @@ reporting_task:
     Review the context you got and expand each topic into a full section for a report.
     Make sure the report is detailed and contains any and all relevant information.
   expected_output: >
-    A fully fledge reports with the mains topics, each with a full section of information.
+    A fully fledged report with the main topics, each with a full section of information.
     Formatted as markdown without '```'
   agent: reporting_analyst
   markdown: true
@@ -185,7 +185,7 @@ reporting_task = Task(
         Make sure the report is detailed and contains any and all relevant information.
     """,
     expected_output="""
-        A fully fledge reports with the mains topics, each with a full section of information.
+        A fully fledged report with the main topics, each with a full section of information.
     """,
     agent=reporting_analyst,
     markdown=True,  # Enable markdown formatting for the final output

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -75,7 +75,7 @@ Follow the steps below to get Crewing! 🚣‍♂️
         Review the context you got and expand each topic into a full section for a report.
         Make sure the report is detailed and contains any and all relevant information.
       expected_output: >
-        A fully fledge reports with the mains topics, each with a full section of information.
+        A fully fledged report with the main topics, each with a full section of information.
         Formatted as markdown without '```'
       agent: reporting_analyst
       output_file: report.md
@@ -122,7 +122,7 @@ Follow the steps below to get Crewing! 🚣‍♂️
       def reporting_task(self) -> Task:
         return Task(
           config=self.tasks_config['reporting_task'], # type: ignore[index]
-          output_file='output/report.md' # This is the file that will be contain the final report.
+          output_file='output/report.md' # This file will contain the final report.
         )
 
       @crew


### PR DESCRIPTION
- README.md: “fully fledge reports” → “fully fledged report”; “mains topics” → “main topics”
- docs/en/quickstart.mdx: same phrasing; “will be contain” → “will contain”
- docs/en/concepts/tasks.mdx: same phrasing (including code block example)