### PR TITLE
chore(docs): fix and update apify logo

### DIFF
--- a/docs/en/tools/automation/apifyactorstool.mdx
+++ b/docs/en/tools/automation/apifyactorstool.mdx
@@ -2,7 +2,7 @@
 title: Apify Actors
 description: "`ApifyActorsTool` lets you call Apify Actors to provide your CrewAI workflows with web scraping, crawling, data extraction, and web automation capabilities."
 # hack to use custom Apify icon
-icon: "); -webkit-mask-image: url('https://upload.wikimedia.org/wikipedia/commons/a/ae/Apify.svg');/*"
+icon: "); -webkit-mask-image: url('https://raw.githubusercontent.com/apify/actors-mcp-server/refs/heads/master/docs/apify-logo.svg'); -webkit-mask-size: 16px 16px; mask-size: 16px 16px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;/*"
 ---
 
 # `ApifyActorsTool`

--- a/docs/ko/tools/automation/apifyactorstool.mdx
+++ b/docs/ko/tools/automation/apifyactorstool.mdx
@@ -2,7 +2,7 @@
 title: Apify 액터
 description: "`ApifyActorsTool`을(를) 사용하면 Apify 액터를 호출하여 CrewAI 워크플로우에 웹 스크래핑, 크롤링, 데이터 추출 및 웹 자동화 기능을 제공할 수 있습니다."
 # hack to use custom Apify icon
-icon: "); -webkit-mask-image: url('https://upload.wikimedia.org/wikipedia/commons/a/ae/Apify.svg');/*"
+icon: "); -webkit-mask-image: url('https://raw.githubusercontent.com/apify/actors-mcp-server/refs/heads/master/docs/apify-logo.svg'); -webkit-mask-size: 16px 16px; mask-size: 16px 16px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;/*"
 ---
 
 # `ApifyActorsTool`

--- a/docs/pt-BR/tools/automation/apifyactorstool.mdx
+++ b/docs/pt-BR/tools/automation/apifyactorstool.mdx
@@ -2,7 +2,7 @@
 title: Apify Actors
 description: "`ApifyActorsTool` permite que você execute Apify Actors para adicionar recursos de raspagem de dados na web, coleta, extração de dados e automação web aos seus fluxos de trabalho CrewAI."
 # hack to use custom Apify icon
-icon: "); -webkit-mask-image: url('https://upload.wikimedia.org/wikipedia/commons/a/ae/Apify.svg');/*"
+icon: "); -webkit-mask-image: url('https://raw.githubusercontent.com/apify/actors-mcp-server/refs/heads/master/docs/apify-logo.svg'); -webkit-mask-size: 16px 16px; mask-size: 16px 16px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;/*"
 ---
 
 # `ApifyActorsTool`


### PR DESCRIPTION
closes https://github.com/apify/ai-team/issues/58

This fixes the broken Apify logo:
<img width="269" height="187" alt="image" src="https://github.com/user-attachments/assets/5b0b0549-b2d1-45a6-aa00-3dd25376f585" />

It was caused by the Mintlify icon being lowercase, while Wikimedia. where the logo was hosted, required the first letter of the filename to be capitalized to overcome CORS restrictions. In this PR, we switch to GitHub for hosting and update the icon definition.