### PR TITLE
refactor: streamline tracing condition checks and clean up deprecated…

### DIFF
--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -40,7 +40,6 @@ from crewai.utilities.events.listeners.tracing.trace_listener import (
 )
 from crewai.utilities.events.listeners.tracing.utils import (
     is_tracing_enabled,
-    on_first_execution_tracing_confirmation,
 )
 from crewai.utilities.printer import Printer
 
@@ -479,11 +478,7 @@ class Flow(Generic[T], metaclass=FlowMeta):
         # Initialize state with initial values
         self._state = self._create_initial_state()
         self.tracing = tracing
-        if (
-            on_first_execution_tracing_confirmation()
-            or is_tracing_enabled()
-            or self.tracing
-        ):
+        if is_tracing_enabled() or self.tracing:
             trace_listener = TraceCollectionListener()
             trace_listener.setup_listeners(crewai_event_bus)
         # Apply any additional kwargs

--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -11,7 +11,6 @@ import chromadb.errors
 from chromadb.api import ClientAPI
 from chromadb.api.types import OneOrMany
 from chromadb.config import Settings
-from pydantic.warnings import PydanticDeprecatedSince211
 import warnings
 
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
@@ -91,7 +90,6 @@ class KnowledgeStorage(BaseKnowledgeStorage):
         # TODO: Remove this once we upgrade chromadb to at least 1.0.8.
         warnings.filterwarnings(
             "ignore",
-            category=PydanticDeprecatedSince211,
             message=r".*'model_fields'.*is deprecated.*",
             module=r"^chromadb(\.|$)",
         )

--- a/src/crewai/memory/storage/rag_storage.py
+++ b/src/crewai/memory/storage/rag_storage.py
@@ -13,7 +13,6 @@ from crewai.utilities.chromadb import create_persistent_client
 from crewai.utilities.constants import MAX_FILE_NAME_LENGTH
 from crewai.utilities.paths import db_storage_path
 import warnings
-from pydantic.warnings import PydanticDeprecatedSince211
 
 
 @contextlib.contextmanager
@@ -68,7 +67,6 @@ class RAGStorage(BaseRAGStorage):
         # TODO: Remove this once we upgrade chromadb to at least 1.0.8.
         warnings.filterwarnings(
             "ignore",
-            category=PydanticDeprecatedSince211,
             message=r".*'model_fields'.*is deprecated.*",
             module=r"^chromadb(\.|$)",
         )


### PR DESCRIPTION
… warnings

This commit simplifies the conditions for enabling tracing in both the Crew and Flow classes by removing the redundant call to `on_first_execution_tracing_confirmation()`. Additionally, it removes deprecated warning filters related to Pydantic in the KnowledgeStorage and RAGStorage classes, improving code clarity and maintainability.