### PR TITLE
feat: llm  event include thought process

### DIFF
--- a/src/crewai/utilities/events/llm_events.py
+++ b/src/crewai/utilities/events/llm_events.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from token import OP
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
@@ -63,6 +64,7 @@ class LLMCallCompletedEvent(LLMEventBase):
     type: str = "llm_call_completed"
     messages: str | list[dict[str, Any]] | None = None
     response: Any
+    reason_response: Optional[Any]
     call_type: LLMCallType
     model: Optional[str] = None
 
@@ -91,4 +93,5 @@ class LLMStreamChunkEvent(LLMEventBase):
 
     type: str = "llm_stream_chunk"
     chunk: str
+    reason_chunk: Optional[str]=""
     tool_call: Optional[ToolCall] = None


### PR DESCRIPTION
- Add new 'reason_chunk' property to the LLMStreamChunkEvent payload.
- Emit LLMStreamChunkEvent for reasoning steps, making the thought process streamable

(cherry picked from commit ce782c15ce819cdbb790b80696a7384ad23e3267)