### PR TITLE
fix: update OpenInference GitHub link in Arize Phoenix documentation

### DIFF
--- a/docs/en/observability/arize-phoenix.mdx
+++ b/docs/en/observability/arize-phoenix.mdx
@@ -6,7 +6,7 @@ icon: magnifying-glass-chart
 
 # Arize Phoenix Integration
 
-This guide demonstrates how to integrate **Arize Phoenix** with **CrewAI** using OpenTelemetry via the [OpenInference](https://github.com/openinference/openinference) SDK. By the end of this guide, you will be able to trace your CrewAI agents and easily debug your agents.
+This guide demonstrates how to integrate **Arize Phoenix** with **CrewAI** using OpenTelemetry via the [OpenInference](https://github.com/Arize-ai/openinference) SDK. By the end of this guide, you will be able to trace your CrewAI agents and easily debug your agents.
 
 > **What is Arize Phoenix?** [Arize Phoenix](https://phoenix.arize.com) is an LLM observability platform that provides tracing and evaluation for AI applications.
 
@@ -42,7 +42,7 @@ OPENAI_API_KEY = getpass("🔑 Enter your OpenAI API key: ")
 SERPER_API_KEY = getpass("🔑 Enter your Serper API key: ")
 
 # Set environment variables
-os.environ["PHOENIX_CLIENT_HEADERS"] = f"api_key={PHOENIX_API_KEY}"
+os.environ["PHOENIX_API_KEY"] = f"{PHOENIX_API_KEY}"
 os.environ["PHOENIX_COLLECTOR_ENDPOINT"] = "https://app.phoenix.arize.com" # Phoenix Cloud, change this to your own endpoint if you are using a self-hosted instance
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 os.environ["SERPER_API_KEY"] = SERPER_API_KEY
@@ -148,4 +148,4 @@ Log into your Phoenix Cloud account and navigate to the project you specified in
 - [Phoenix Documentation](https://docs.arize.com/phoenix/) - Overview of the Phoenix platform.
 - [CrewAI Documentation](https://docs.crewai.com/) - Overview of the CrewAI framework.
 - [OpenTelemetry Docs](https://opentelemetry.io/docs/) - OpenTelemetry guide
-- [OpenInference GitHub](https://github.com/openinference/openinference) - Source code for OpenInference SDK.
+- [OpenInference GitHub](https://github.com/Arize-ai/openinference) - Source code for OpenInference SDK.

--- a/docs/ko/observability/arize-phoenix.mdx
+++ b/docs/ko/observability/arize-phoenix.mdx
@@ -6,7 +6,7 @@ icon: magnifying-glass-chart
 
 # Arize Phoenix 통합
 
-이 가이드는 [OpenInference](https://github.com/openinference/openinference) SDK를 통해 OpenTelemetry를 사용하여 **Arize Phoenix**를 **CrewAI**와 통합하는 방법을 보여줍니다. 이 가이드를 완료하면 CrewAI agent를 추적하고 agent를 쉽게 디버그할 수 있습니다.
+이 가이드는 [OpenInference](https://github.com/Arize-ai/openinference) SDK를 통해 OpenTelemetry를 사용하여 **Arize Phoenix**를 **CrewAI**와 통합하는 방법을 보여줍니다. 이 가이드를 완료하면 CrewAI agent를 추적하고 agent를 쉽게 디버그할 수 있습니다.
 
 > **Arize Phoenix란?** [Arize Phoenix](https://phoenix.arize.com)는 AI 애플리케이션을 위한 추적 및 평가 기능을 제공하는 LLM 가시성(observability) 플랫폼입니다.
 
@@ -42,7 +42,7 @@ OPENAI_API_KEY = getpass("🔑 Enter your OpenAI API key: ")
 SERPER_API_KEY = getpass("🔑 Enter your Serper API key: ")
 
 # Set environment variables
-os.environ["PHOENIX_CLIENT_HEADERS"] = f"api_key={PHOENIX_API_KEY}"
+os.environ["PHOENIX_API_KEY"] = f"{PHOENIX_API_KEY}"
 os.environ["PHOENIX_COLLECTOR_ENDPOINT"] = "https://app.phoenix.arize.com" # Phoenix Cloud, change this to your own endpoint if you are using a self-hosted instance
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 os.environ["SERPER_API_KEY"] = SERPER_API_KEY
@@ -146,4 +146,4 @@ Phoenix Cloud 계정에 로그인한 다음 `project_name` 파라미터에서 �
 - [Phoenix 문서](https://docs.arize.com/phoenix/) - Phoenix 플랫폼 개요.
 - [CrewAI 문서](https://docs.crewai.com/) - CrewAI 프레임워크 개요.
 - [OpenTelemetry 문서](https://opentelemetry.io/docs/) - OpenTelemetry 가이드
-- [OpenInference GitHub](https://github.com/openinference/openinference) - OpenInference SDK 소스 코드.
+- [OpenInference GitHub](https://github.com/Arize-ai/openinference) - OpenInference SDK 소스 코드.

--- a/docs/pt-BR/observability/arize-phoenix.mdx
+++ b/docs/pt-BR/observability/arize-phoenix.mdx
@@ -6,7 +6,7 @@ icon: magnifying-glass-chart
 
 # Integração com Arize Phoenix
 
-Este guia demonstra como integrar o **Arize Phoenix** ao **CrewAI** usando o OpenTelemetry através do [OpenInference](https://github.com/openinference/openinference) SDK. Ao final deste guia, você será capaz de rastrear seus agentes CrewAI e depurá-los com facilidade.
+Este guia demonstra como integrar o **Arize Phoenix** ao **CrewAI** usando o OpenTelemetry através do [OpenInference](https://github.com/Arize-ai/openinference) SDK. Ao final deste guia, você será capaz de rastrear seus agentes CrewAI e depurá-los com facilidade.
 
 > **O que é o Arize Phoenix?** O [Arize Phoenix](https://phoenix.arize.com) é uma plataforma de observabilidade de LLM que oferece rastreamento e avaliação para aplicações de IA.
 
@@ -42,7 +42,7 @@ OPENAI_API_KEY = getpass("🔑 Digite sua OpenAI API key: ")
 SERPER_API_KEY = getpass("🔑 Digite sua Serper API key: ")
 
 # Defina as variáveis de ambiente
-os.environ["PHOENIX_CLIENT_HEADERS"] = f"api_key={PHOENIX_API_KEY}"
+os.environ["PHOENIX_API_KEY"] = f"{PHOENIX_API_KEY}"
 os.environ["PHOENIX_COLLECTOR_ENDPOINT"] = "https://app.phoenix.arize.com" # Phoenix Cloud, altere para seu endpoint se estiver utilizando uma instância self-hosted
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 os.environ["SERPER_API_KEY"] = SERPER_API_KEY
@@ -141,4 +141,4 @@ Acesse sua conta Phoenix Cloud e navegue até o projeto que você especificou no
 - [Documentação do Phoenix](https://docs.arize.com/phoenix/) - Visão geral da plataforma Phoenix.
 - [Documentação do CrewAI](https://docs.crewai.com/) - Visão geral do framework CrewAI.
 - [Documentação do OpenTelemetry](https://opentelemetry.io/docs/) - Guia do OpenTelemetry
-- [OpenInference GitHub](https://github.com/openinference/openinference) - Código-fonte do SDK OpenInference.
+- [OpenInference GitHub](https://github.com/Arize-ai/openinference) - Código-fonte do SDK OpenInference.


### PR DESCRIPTION
- Change github repository link for [openinference](https://github.com/Arize-ai/openinference)
- Change arize phoenix integration code to [latest](https://arize.com/docs/phoenix/integrations/frameworks/crewai/crewai-tracing)