### PR TITLE
fix: improve CacheHandler type annotations and module imports

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -16,7 +16,7 @@ from typing import (
 
 from pydantic import Field, InstanceOf, PrivateAttr, model_validator
 
-from crewai.agents import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.crew_agent_executor import CrewAgentExecutor
 from crewai.knowledge.knowledge import Knowledge

--- a/src/crewai/agents/__init__.py
+++ b/src/crewai/agents/__init__.py
@@ -1,5 +1,10 @@
-from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.agents.parser import parse, AgentAction, AgentFinish, OutputParserException
 from crewai.agents.tools_handler import ToolsHandler
 
-__all__ = ["CacheHandler", "parse", "AgentAction", "AgentFinish", "OutputParserException", "ToolsHandler"]
+__all__ = [
+    "parse",
+    "AgentAction",
+    "AgentFinish",
+    "OutputParserException",
+    "ToolsHandler",
+]

--- a/src/crewai/agents/cache/__init__.py
+++ b/src/crewai/agents/cache/__init__.py
@@ -1,3 +1,5 @@
-from .cache_handler import CacheHandler
+"""Internal caching utilities for agent tool execution.
 
-__all__ = ["CacheHandler"]
+This package provides caching mechanisms for storing and retrieving
+tool execution results to avoid redundant operations.
+"""

--- a/src/crewai/agents/cache/cache_handler.py
+++ b/src/crewai/agents/cache/cache_handler.py
@@ -1,15 +1,50 @@
-from typing import Any, Dict, Optional
+"""Cache handler for storing and retrieving tool execution results.
+
+This module provides a caching mechanism for tool outputs in the CrewAI framework,
+allowing agents to reuse previous tool execution results when the same tool is
+called with identical arguments.
+
+Classes:
+    CacheHandler: Manages the caching of tool execution results using an in-memory
+        dictionary with serialized tool arguments as keys.
+"""
+
+import json
+from typing import Any
 
 from pydantic import BaseModel, PrivateAttr
 
 
 class CacheHandler(BaseModel):
-    """Callback handler for tool usage."""
+    """Callback handler for tool usage.
 
-    _cache: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
-    def add(self, tool, input, output):
-        self._cache[f"{tool}-{input}"] = output
+    Notes:
+        TODO: Make thread-safe, currently not thread-safe.
+    """
 
-    def read(self, tool, input) -> Optional[str]:
-        return self._cache.get(f"{tool}-{input}")
+    _cache: dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    def add(self, tool: str, input_data: dict[str, Any] | None, output: str) -> None:
+        """Add a tool execution result to the cache.
+
+        Args:
+            tool: The name of the tool.
+            input_data: The input arguments for the tool.
+            output: The output from the tool execution.
+        """
+        cache_key = json.dumps(input_data, sort_keys=True) if input_data else ""
+        self._cache[f"{tool}-{cache_key}"] = output
+
+    def read(self, tool: str, input_data: dict[str, Any] | None) -> str | None:
+        """Read a tool execution result from the cache.
+
+        Args:
+            tool: The name of the tool.
+            input_data: The input arguments for the tool.
+
+        Returns:
+            The cached output if found, None otherwise.
+        """
+        cache_key = json.dumps(input_data, sort_keys=True) if input_data else ""
+        return self._cache.get(f"{tool}-{cache_key}")

--- a/src/crewai/agents/parser.py
+++ b/src/crewai/agents/parser.py
@@ -7,18 +7,18 @@ AgentAction or AgentFinish objects.
 
 from dataclasses import dataclass
 
-from json_repair import repair_json
+from json_repair import repair_json  # type: ignore[import-untyped]
 
 from crewai.agents.constants import (
+    ACTION_INPUT_ONLY_REGEX,
     ACTION_INPUT_REGEX,
     ACTION_REGEX,
-    ACTION_INPUT_ONLY_REGEX,
     FINAL_ANSWER_ACTION,
     MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE,
     MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE,
     UNABLE_TO_REPAIR_JSON_RESULTS,
 )
-from crewai.utilities import I18N
+from crewai.utilities.i18n import I18N
 
 _I18N = I18N()
 

--- a/src/crewai/agents/tools_handler.py
+++ b/src/crewai/agents/tools_handler.py
@@ -1,8 +1,8 @@
 """Tools handler for managing tool execution and caching."""
 
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.tools.cache_tools.cache_tools import CacheTools
 from crewai.tools.tool_calling import InstructorToolCalling, ToolCalling
-from crewai.agents.cache.cache_handler import CacheHandler
 
 
 class ToolsHandler:
@@ -39,6 +39,6 @@ class ToolsHandler:
         if self.cache and should_cache and calling.tool_name != CacheTools().name:
             self.cache.add(
                 tool=calling.tool_name,
-                input=calling.arguments,
+                input_data=calling.arguments,
                 output=output,
             )

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -37,7 +37,7 @@ from pydantic_core import PydanticCustomError
 
 from crewai.agent import Agent
 from crewai.agents.agent_builder.base_agent import BaseAgent
-from crewai.agents.cache import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.crews.crew_output import CrewOutput
 from crewai.flow.flow_trackable import FlowTrackable
 from crewai.knowledge.knowledge import Knowledge

--- a/src/crewai/lite_agent.py
+++ b/src/crewai/lite_agent.py
@@ -33,7 +33,7 @@ from pydantic import (
 
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.agent_builder.utilities.base_token_process import TokenProcess
-from crewai.agents.cache import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.agents.parser import (
     AgentAction,
     AgentFinish,

--- a/src/crewai/tools/cache_tools/cache_tools.py
+++ b/src/crewai/tools/cache_tools/cache_tools.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-from crewai.agents.cache import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.tools.structured_tool import CrewStructuredTool
 
 

--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -189,7 +189,7 @@ class ToolUsage:
 
         if self.tools_handler and self.tools_handler.cache:
             result = self.tools_handler.cache.read(
-                tool=calling.tool_name, input=calling.arguments
+                tool=calling.tool_name, input_data=calling.arguments
             )  # type: ignore
             from_cache = result is not None
 

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from crewai import Agent, Crew, Task
-from crewai.agents.cache import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.agents.crew_agent_executor import AgentFinish, CrewAgentExecutor
 from crewai.knowledge.knowledge import Knowledge
 from crewai.knowledge.knowledge_config import KnowledgeConfig
@@ -559,9 +559,9 @@ def test_agent_repeated_tool_usage(capsys):
     expected_message = (
         "I tried reusing the same input, I must stop using this action input."
     )
-    assert (
-        expected_message in output
-    ), f"Expected message not found in output. Output was: {output}"
+    assert expected_message in output, (
+        f"Expected message not found in output. Output was: {output}"
+    )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -602,9 +602,9 @@ def test_agent_repeated_tool_usage_check_even_with_disabled_cache(capsys):
     has_max_iterations = "maximum iterations reached" in output_lower
     has_final_answer = "final answer" in output_lower or "42" in captured.out
 
-    assert (
-        has_repeated_usage_message or (has_max_iterations and has_final_answer)
-    ), f"Expected repeated tool usage handling or proper max iteration handling. Output was: {captured.out[:500]}..."
+    assert has_repeated_usage_message or (has_max_iterations and has_final_answer), (
+        f"Expected repeated tool usage handling or proper max iteration handling. Output was: {captured.out[:500]}..."
+    )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])

--- a/tests/test_crew.py
+++ b/tests/test_crew.py
@@ -11,7 +11,7 @@ import pydantic_core
 import pytest
 
 from crewai.agent import Agent
-from crewai.agents import CacheHandler
+from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.crew import Crew
 from crewai.crews.crew_output import CrewOutput
 from crewai.flow import Flow, start
@@ -622,12 +622,12 @@ def test_crew_with_delegating_agents_should_not_override_task_tools(ceo, writer)
         _, kwargs = mock_execute_sync.call_args
         tools = kwargs["tools"]
 
-        assert any(
-            isinstance(tool, TestTool) for tool in tools
-        ), "TestTool should be present"
-        assert any(
-            "delegate" in tool.name.lower() for tool in tools
-        ), "Delegation tool should be present"
+        assert any(isinstance(tool, TestTool) for tool in tools), (
+            "TestTool should be present"
+        )
+        assert any("delegate" in tool.name.lower() for tool in tools), (
+            "Delegation tool should be present"
+        )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -686,12 +686,12 @@ def test_crew_with_delegating_agents_should_not_override_agent_tools(ceo, writer
         _, kwargs = mock_execute_sync.call_args
         tools = kwargs["tools"]
 
-        assert any(
-            isinstance(tool, TestTool) for tool in new_ceo.tools
-        ), "TestTool should be present"
-        assert any(
-            "delegate" in tool.name.lower() for tool in tools
-        ), "Delegation tool should be present"
+        assert any(isinstance(tool, TestTool) for tool in new_ceo.tools), (
+            "TestTool should be present"
+        )
+        assert any("delegate" in tool.name.lower() for tool in tools), (
+            "Delegation tool should be present"
+        )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -815,17 +815,17 @@ def test_task_tools_override_agent_tools_with_allow_delegation(researcher, write
         used_tools = kwargs["tools"]
 
         # Confirm AnotherTestTool is present but TestTool is not
-        assert any(
-            isinstance(tool, AnotherTestTool) for tool in used_tools
-        ), "AnotherTestTool should be present"
-        assert not any(
-            isinstance(tool, TestTool) for tool in used_tools
-        ), "TestTool should not be present among used tools"
+        assert any(isinstance(tool, AnotherTestTool) for tool in used_tools), (
+            "AnotherTestTool should be present"
+        )
+        assert not any(isinstance(tool, TestTool) for tool in used_tools), (
+            "TestTool should not be present among used tools"
+        )
 
         # Confirm delegation tool(s) are present
-        assert any(
-            "delegate" in tool.name.lower() for tool in used_tools
-        ), "Delegation tool should be present"
+        assert any("delegate" in tool.name.lower() for tool in used_tools), (
+            "Delegation tool should be present"
+        )
 
     # Finally, make sure the agent's original tools remain unchanged
     assert len(researcher_with_delegation.tools) == 1
@@ -929,9 +929,9 @@ def test_cache_hitting_between_agents(researcher, writer, ceo):
             tool="multiplier", input={"first_number": 2, "second_number": 6}
         )
         assert cache_calls[0] == expected_call, f"First call mismatch: {cache_calls[0]}"
-        assert (
-            cache_calls[1] == expected_call
-        ), f"Second call mismatch: {cache_calls[1]}"
+        assert cache_calls[1] == expected_call, (
+            f"Second call mismatch: {cache_calls[1]}"
+        )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -1674,9 +1674,9 @@ def test_code_execution_flag_adds_code_tool_upon_kickoff():
 
             # Verify that exactly one tool was used and it was a CodeInterpreterTool
             assert len(used_tools) == 1, "Should have exactly one tool"
-            assert isinstance(
-                used_tools[0], CodeInterpreterTool
-            ), "Tool should be CodeInterpreterTool"
+            assert isinstance(used_tools[0], CodeInterpreterTool), (
+                "Tool should be CodeInterpreterTool"
+            )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -3815,9 +3815,9 @@ def test_fetch_inputs():
     expected_placeholders = {"role_detail", "topic", "field"}
     actual_placeholders = crew.fetch_inputs()
 
-    assert (
-        actual_placeholders == expected_placeholders
-    ), f"Expected {expected_placeholders}, but got {actual_placeholders}"
+    assert actual_placeholders == expected_placeholders, (
+        f"Expected {expected_placeholders}, but got {actual_placeholders}"
+    )
 
 
 def test_task_tools_preserve_code_execution_tools():
@@ -3892,20 +3892,20 @@ def test_task_tools_preserve_code_execution_tools():
         used_tools = kwargs["tools"]
 
         # Verify all expected tools are present
-        assert any(
-            isinstance(tool, TestTool) for tool in used_tools
-        ), "Task's TestTool should be present"
-        assert any(
-            isinstance(tool, CodeInterpreterTool) for tool in used_tools
-        ), "CodeInterpreterTool should be present"
-        assert any(
-            "delegate" in tool.name.lower() for tool in used_tools
-        ), "Delegation tool should be present"
+        assert any(isinstance(tool, TestTool) for tool in used_tools), (
+            "Task's TestTool should be present"
+        )
+        assert any(isinstance(tool, CodeInterpreterTool) for tool in used_tools), (
+            "CodeInterpreterTool should be present"
+        )
+        assert any("delegate" in tool.name.lower() for tool in used_tools), (
+            "Delegation tool should be present"
+        )
 
         # Verify the total number of tools (TestTool + CodeInterpreter + 2 delegation tools)
-        assert (
-            len(used_tools) == 4
-        ), "Should have TestTool, CodeInterpreter, and 2 delegation tools"
+        assert len(used_tools) == 4, (
+            "Should have TestTool, CodeInterpreter, and 2 delegation tools"
+        )
 
 
 @pytest.mark.vcr(filter_headers=["authorization"])
@@ -3949,9 +3949,9 @@ def test_multimodal_flag_adds_multimodal_tools():
         used_tools = kwargs["tools"]
 
         # Check that the multimodal tool was added
-        assert any(
-            isinstance(tool, AddImageTool) for tool in used_tools
-        ), "AddImageTool should be present when agent is multimodal"
+        assert any(isinstance(tool, AddImageTool) for tool in used_tools), (
+            "AddImageTool should be present when agent is multimodal"
+        )
 
         # Verify we have exactly one tool (just the AddImageTool)
         assert len(used_tools) == 1, "Should only have the AddImageTool"
@@ -4215,9 +4215,9 @@ def test_crew_guardrail_feedback_in_context():
     assert len(execution_contexts) > 1, "Task should have been executed multiple times"
 
     # Verify that the second execution included the guardrail feedback
-    assert (
-        "Output must contain the keyword 'IMPORTANT'" in execution_contexts[1]
-    ), "Guardrail feedback should be included in retry context"
+    assert "Output must contain the keyword 'IMPORTANT'" in execution_contexts[1], (
+        "Guardrail feedback should be included in retry context"
+    )
 
     # Verify final output meets guardrail requirements
     assert "IMPORTANT" in result.raw, "Final output should contain required keyword"
@@ -4433,46 +4433,46 @@ def test_crew_copy_with_memory():
     try:
         crew_copy = crew.copy()
 
-        assert hasattr(
-            crew_copy, "_short_term_memory"
-        ), "Copied crew should have _short_term_memory"
-        assert (
-            crew_copy._short_term_memory is not None
-        ), "Copied _short_term_memory should not be None"
-        assert (
-            id(crew_copy._short_term_memory) != original_short_term_id
-        ), "Copied _short_term_memory should be a new object"
+        assert hasattr(crew_copy, "_short_term_memory"), (
+            "Copied crew should have _short_term_memory"
+        )
+        assert crew_copy._short_term_memory is not None, (
+            "Copied _short_term_memory should not be None"
+        )
+        assert id(crew_copy._short_term_memory) != original_short_term_id, (
+            "Copied _short_term_memory should be a new object"
+        )
 
-        assert hasattr(
-            crew_copy, "_long_term_memory"
-        ), "Copied crew should have _long_term_memory"
-        assert (
-            crew_copy._long_term_memory is not None
-        ), "Copied _long_term_memory should not be None"
-        assert (
-            id(crew_copy._long_term_memory) != original_long_term_id
-        ), "Copied _long_term_memory should be a new object"
+        assert hasattr(crew_copy, "_long_term_memory"), (
+            "Copied crew should have _long_term_memory"
+        )
+        assert crew_copy._long_term_memory is not None, (
+            "Copied _long_term_memory should not be None"
+        )
+        assert id(crew_copy._long_term_memory) != original_long_term_id, (
+            "Copied _long_term_memory should be a new object"
+        )
 
-        assert hasattr(
-            crew_copy, "_entity_memory"
-        ), "Copied crew should have _entity_memory"
-        assert (
-            crew_copy._entity_memory is not None
-        ), "Copied _entity_memory should not be None"
-        assert (
-            id(crew_copy._entity_memory) != original_entity_id
-        ), "Copied _entity_memory should be a new object"
+        assert hasattr(crew_copy, "_entity_memory"), (
+            "Copied crew should have _entity_memory"
+        )
+        assert crew_copy._entity_memory is not None, (
+            "Copied _entity_memory should not be None"
+        )
+        assert id(crew_copy._entity_memory) != original_entity_id, (
+            "Copied _entity_memory should be a new object"
+        )
 
         if original_external_id:
-            assert hasattr(
-                crew_copy, "_external_memory"
-            ), "Copied crew should have _external_memory"
-            assert (
-                crew_copy._external_memory is not None
-            ), "Copied _external_memory should not be None"
-            assert (
-                id(crew_copy._external_memory) != original_external_id
-            ), "Copied _external_memory should be a new object"
+            assert hasattr(crew_copy, "_external_memory"), (
+                "Copied crew should have _external_memory"
+            )
+            assert crew_copy._external_memory is not None, (
+                "Copied _external_memory should not be None"
+            )
+            assert id(crew_copy._external_memory) != original_external_id, (
+                "Copied _external_memory should be a new object"
+            )
         else:
             assert (
                 not hasattr(crew_copy, "_external_memory")


### PR DESCRIPTION
## Summary

Add type annotations to CacheHandler and refactor module imports for better code organization.

## Changes

- Add type annotations to CacheHandler.add() and .read() methods
- Rename parameter from `input` to `input_data` to avoid shadowing built-in
- Update to modern union syntax (`| None`)
- Refactor imports to use direct paths
- Remove CacheHandler from public API exports