### PR TITLE
chore: relax mypy configuration and exclude tests from CI

### DIFF
--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -41,18 +41,18 @@ jobs:
           echo "Fetching changed files..."
           git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }}...HEAD -- '*.py' > changed_files.txt
 
-          # Filter for files in src/ and tests/ directories
-          grep -E "^(src/|tests/)" changed_files.txt > filtered_changed_files.txt || true
+          # Filter for files in src/ directory only (excluding tests/)
+          grep -E "^src/" changed_files.txt > filtered_changed_files.txt || true
 
           # Check if there are any changed files
           if [ -s filtered_changed_files.txt ]; then
-            echo "Changed Python files in src/ and tests/:"
+            echo "Changed Python files in src/:"
             cat filtered_changed_files.txt
             echo "has_changes=true" >> $GITHUB_OUTPUT
             # Convert newlines to spaces for mypy command
             echo "files=$(cat filtered_changed_files.txt | tr '\n' ' ')" >> $GITHUB_OUTPUT
           else
-            echo "No Python files changed in src/ or tests/"
+            echo "No Python files changed in src/"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: No files to check
         if: steps.changed-files.outputs.has_changes == 'false'
-        run: echo "No Python files in src/ or tests/ were modified - skipping type checks"
+        run: echo "No Python files in src/ were modified - skipping type checks"
 
   # Summary job to provide single status for branch protection
   type-checker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,7 @@ select = [
 ]
 
 [tool.mypy]
-strict = true
-exclude = ["src/crewai/cli/templates"]
+exclude = ["src/crewai/cli/templates", "tests"]
 
 [tool.bandit]
 exclude_dirs = ["src/crewai/cli/templates"]


### PR DESCRIPTION
Temporarily removes strict mypy mode and excludes tests from type checking in both local config and CI workflow.