### PR TITLE
fix: Remove unused imports from agent adapters and builders

### DIFF
--- a/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
+++ b/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, PrivateAttr
 
@@ -22,7 +22,6 @@ from crewai.utilities.events.agent_events import (
 )
 
 try:
-    from langchain_core.messages import ToolMessage
     from langgraph.checkpoint.memory import MemorySaver
     from langgraph.prebuilt import create_react_agent
 

--- a/src/crewai/agents/agent_builder/base_agent.py
+++ b/src/crewai/agents/agent_builder/base_agent.py
@@ -25,7 +25,6 @@ from crewai.security.security_config import SecurityConfig
 from crewai.tools.base_tool import BaseTool, Tool
 from crewai.utilities import I18N, Logger, RPMController
 from crewai.utilities.config import process_config
-from crewai.utilities.converter import Converter
 from crewai.utilities.string_utils import interpolate_only
 
 T = TypeVar("T", bound="BaseAgent")


### PR DESCRIPTION
## Summary
- Remove unused AsyncIterable and ToolMessage imports from langgraph_adapter.py
- Remove unused Converter import from base_agent.py  
- Improves code quality and reduces linting warnings
- All ruff checks now pass for these files

## Test plan
- [x] Verified imports are truly unused with static analysis
- [x] Confirmed ruff passes without warnings on both files
- [x] Tested that functionality remains intact after import removal
- [x] Validated that no other modules depend on these removed imports

🤖 Generated with [Claude Code](https://claude.ai/code)