### PR TITLE
fix: Remove unused imports from agent adapters and builders

### DIFF
--- a/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
+++ b/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, PrivateAttr
 
@@ -22,7 +22,6 @@ from crewai.utilities.events.agent_events import (
 )
 
 try:
-    from langchain_core.messages import ToolMessage
     from langgraph.checkpoint.memory import MemorySaver
     from langgraph.prebuilt import create_react_agent
 

--- a/src/crewai/agents/agent_builder/base_agent.py
+++ b/src/crewai/agents/agent_builder/base_agent.py
@@ -25,7 +25,6 @@ from crewai.security.security_config import SecurityConfig
 from crewai.tools.base_tool import BaseTool, Tool
 from crewai.utilities import I18N, Logger, RPMController
 from crewai.utilities.config import process_config
-from crewai.utilities.converter import Converter
 from crewai.utilities.string_utils import interpolate_only
 
 T = TypeVar("T", bound="BaseAgent")


### PR DESCRIPTION
## Summary
- Remove unused AsyncIterable and ToolMessage imports from langgraph_adapter.py
- Remove unused Converter import from base_agent.py  
- Clean up imports detected by ruff linting

## Testing Results
✅ **Python 3.10**: 138 passed  
✅ **Python 3.11**: 138 passed, 44 warnings  
✅ **Python 3.12**: 138 passed, 34 warnings  
⚠️  **Python 3.13**: 1 failed (unrelated test), 136 passed

The single Python 3.13 test failure (`test_agent_repeated_tool_usage`) is unrelated to import changes and appears to be due to iteration limit behavior differences in Python 3.13.

## Validation
- [x] Ruff linting passes
- [x] Type checking passes  
- [x] Security checks pass
- [x] All import removals confirmed unused via static analysis

🤖 Generated with [Claude Code](https://claude.ai/code)