### PR TITLE
fix: Remove unused imports from agent adapters and builders

### DIFF
--- a/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
+++ b/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, PrivateAttr
 
@@ -22,7 +22,6 @@ from crewai.utilities.events.agent_events import (
 )
 
 try:
-    from langchain_core.messages import ToolMessage
     from langgraph.checkpoint.memory import MemorySaver
     from langgraph.prebuilt import create_react_agent
 

--- a/src/crewai/agents/agent_builder/base_agent.py
+++ b/src/crewai/agents/agent_builder/base_agent.py
@@ -25,7 +25,6 @@ from crewai.security.security_config import SecurityConfig
 from crewai.tools.base_tool import BaseTool, Tool
 from crewai.utilities import I18N, Logger, RPMController
 from crewai.utilities.config import process_config
-from crewai.utilities.converter import Converter
 from crewai.utilities.string_utils import interpolate_only
 
 T = TypeVar("T", bound="BaseAgent")


### PR DESCRIPTION
## Summary

This PR removes unused imports that were detected by static analysis:

- **langgraph_adapter.py**: Remove unused  and  imports
- **base_agent.py**: Remove unused  import

## Changes Made

### src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
- Removed  from typing imports (unused)
- Removed  import (unused)

### src/crewai/agents/agent_builder/base_agent.py  
- Removed  import from utilities (unused)

## Validation

✅ **Static Analysis**: All imports confirmed unused via code analysis  
✅ **Linting**: Passes ruff checks  
✅ **Type Checking**: No type errors introduced  
✅ **Testing**: No functional impact on existing functionality  

## Impact

- **Risk Level**: Minimal - only removes genuinely unused code
- **Breaking Changes**: None
- **Performance**: Marginal improvement in import time
- **Maintainability**: Cleaner, more focused imports

🤖 Generated with [Claude Code](https://claude.ai/code)