### PR TITLE
ci: configure pre-commit hooks and github actions to use uv run

### DIFF
--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --dev --no-install-project
+        run: uv sync --dev --all-extras --no-install-project
 
       - name: Get changed Python files
         id: changed-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,18 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+  - repo: local
     hooks:
       - id: ruff
-        args: ["--config", "pyproject.toml"]
+        name: ruff
+        entry: uv run ruff check
+        language: system
+        types: [python]
       - id: ruff-format
-        args: ["--config", "pyproject.toml"]
-  
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
-    hooks:
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types: [python]
       - id: mypy
-        args: ["--config-file", "pyproject.toml"]
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]


### PR DESCRIPTION
Update pre-commit hooks and GitHub Actions type checker to use uv run for consistency.