### PR TITLE
docs: fix Integrations Overview links (Bedrock & CrewAI Automation)

### DIFF
--- a/docs/en/tools/tool-integrations/overview.mdx
+++ b/docs/en/tools/tool-integrations/overview.mdx
@@ -11,7 +11,7 @@ mode: "wide"
   <Card
     title="Bedrock Invoke Agent Tool"
     icon="cloud"
-    href="/en/tools/tool-integrations/bedrockinvokeagenttool"
+    href="/en/tools/integration/bedrockinvokeagenttool"
     color="#0891B2"
   >
     Invoke Amazon Bedrock Agents from CrewAI to orchestrate actions across AWS services.
@@ -20,7 +20,7 @@ mode: "wide"
   <Card
     title="CrewAI Automation Tool"
     icon="bolt"
-    href="/en/tools/tool-integrations/crewaiautomationtool"
+    href="/en/tools/integration/crewaiautomationtool"
     color="#7C3AED"
   >
     Automate deployment and operations by integrating CrewAI with external platforms and workflows.


### PR DESCRIPTION
### Summary
Manual fix for Integrations Overview links.

### What changed
- Updated **Bedrock Invoke Agent Tool** link → `/en/tools/integration/bedrockinvokeagenttool`
- Updated **CrewAI Automation Tool** link → `/en/tools/integration/crewaiautomationtool`

### Why
The bot-generated PR (#3517) attempted the same fix but failed checks.
This PR applies the fix cleanly so the links resolve correctly.

### Links
Fixes #3516
Supersedes #3517
