### PR TITLE
feat: add configurable search parameters for RAG, knowledge, and memory

### DIFF
--- a/src/crewai/knowledge/knowledge.py
+++ b/src/crewai/knowledge/knowledge.py
@@ -43,7 +43,7 @@ class Knowledge(BaseModel):
         self.sources = sources
 
     def query(
-        self, query: list[str], results_limit: int = 3, score_threshold: float = 0.35
+        self, query: list[str], results_limit: int = 5, score_threshold: float = 0.6
     ) -> list[SearchResult]:
         """
         Query across all knowledge sources to find the most relevant information.

--- a/src/crewai/knowledge/knowledge_config.py
+++ b/src/crewai/knowledge/knowledge_config.py
@@ -9,8 +9,8 @@ class KnowledgeConfig(BaseModel):
         score_threshold (float): The minimum score for a document to be considered relevant.
     """
 
-    results_limit: int = Field(default=3, description="The number of results to return")
+    results_limit: int = Field(default=5, description="The number of results to return")
     score_threshold: float = Field(
-        default=0.35,
+        default=0.6,
         description="The minimum score for a result to be considered relevant",
     )

--- a/src/crewai/knowledge/storage/base_knowledge_storage.py
+++ b/src/crewai/knowledge/storage/base_knowledge_storage.py
@@ -11,9 +11,9 @@ class BaseKnowledgeStorage(ABC):
     def search(
         self,
         query: list[str],
-        limit: int = 3,
+        limit: int = 5,
         metadata_filter: dict[str, Any] | None = None,
-        score_threshold: float = 0.35,
+        score_threshold: float = 0.6,
     ) -> list[SearchResult]:
         """Search for documents in the knowledge base."""
 

--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import warnings
 from typing import Any, cast
 
@@ -49,9 +50,9 @@ class KnowledgeStorage(BaseKnowledgeStorage):
     def search(
         self,
         query: list[str],
-        limit: int = 3,
+        limit: int = 5,
         metadata_filter: dict[str, Any] | None = None,
-        score_threshold: float = 0.35,
+        score_threshold: float = 0.6,
     ) -> list[SearchResult]:
         try:
             if not query:
@@ -73,7 +74,9 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                 score_threshold=score_threshold,
             )
         except Exception as e:
-            logging.error(f"Error during knowledge search: {e!s}")
+            logging.error(
+                f"Error during knowledge search: {e!s}\n{traceback.format_exc()}"
+            )
             return []
 
     def reset(self) -> None:
@@ -86,7 +89,9 @@ class KnowledgeStorage(BaseKnowledgeStorage):
             )
             client.delete_collection(collection_name=collection_name)
         except Exception as e:
-            logging.error(f"Error during knowledge reset: {e!s}")
+            logging.error(
+                f"Error during knowledge reset: {e!s}\n{traceback.format_exc()}"
+            )
 
     def save(self, documents: list[str]) -> None:
         try:

--- a/src/crewai/memory/external/external_memory.py
+++ b/src/crewai/memory/external/external_memory.py
@@ -1,41 +1,41 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
 import time
+from typing import TYPE_CHECKING, Any
 
+from crewai.events.event_bus import crewai_event_bus
+from crewai.events.types.memory_events import (
+    MemoryQueryCompletedEvent,
+    MemoryQueryFailedEvent,
+    MemoryQueryStartedEvent,
+    MemorySaveCompletedEvent,
+    MemorySaveFailedEvent,
+    MemorySaveStartedEvent,
+)
 from crewai.memory.external.external_memory_item import ExternalMemoryItem
 from crewai.memory.memory import Memory
 from crewai.memory.storage.interface import Storage
-from crewai.events.event_bus import crewai_event_bus
-from crewai.events.types.memory_events import (
-    MemoryQueryStartedEvent,
-    MemoryQueryCompletedEvent,
-    MemoryQueryFailedEvent,
-    MemorySaveStartedEvent,
-    MemorySaveCompletedEvent,
-    MemorySaveFailedEvent,
-)
 
 if TYPE_CHECKING:
     from crewai.memory.storage.mem0_storage import Mem0Storage
 
 
 class ExternalMemory(Memory):
-    def __init__(self, storage: Optional[Storage] = None, **data: Any):
+    def __init__(self, storage: Storage | None = None, **data: Any):
         super().__init__(storage=storage, **data)
 
     @staticmethod
-    def _configure_mem0(crew: Any, config: Dict[str, Any]) -> "Mem0Storage":
+    def _configure_mem0(crew: Any, config: dict[str, Any]) -> "Mem0Storage":
         from crewai.memory.storage.mem0_storage import Mem0Storage
 
         return Mem0Storage(type="external", crew=crew, config=config)
 
     @staticmethod
-    def external_supported_storages() -> Dict[str, Any]:
+    def external_supported_storages() -> dict[str, Any]:
         return {
             "mem0": ExternalMemory._configure_mem0,
         }
 
     @staticmethod
-    def create_storage(crew: Any, embedder_config: Optional[Dict[str, Any]]) -> Storage:
+    def create_storage(crew: Any, embedder_config: dict[str, Any] | None) -> Storage:
         if not embedder_config:
             raise ValueError("embedder_config is required")
 
@@ -52,7 +52,7 @@ class ExternalMemory(Memory):
     def save(
         self,
         value: Any,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Saves a value into the external storage."""
         crewai_event_bus.emit(
@@ -103,8 +103,8 @@ class ExternalMemory(Memory):
     def search(
         self,
         query: str,
-        limit: int = 3,
-        score_threshold: float = 0.35,
+        limit: int = 5,
+        score_threshold: float = 0.6,
     ):
         crewai_event_bus.emit(
             self,

--- a/src/crewai/memory/memory.py
+++ b/src/crewai/memory/memory.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel
 
@@ -12,8 +12,8 @@ class Memory(BaseModel):
     Base class for memory, now supporting agent tags and generic metadata.
     """
 
-    embedder_config: Optional[Dict[str, Any]] = None
-    crew: Optional[Any] = None
+    embedder_config: dict[str, Any] | None = None
+    crew: Any | None = None
 
     storage: Any
     _agent: Optional["Agent"] = None
@@ -45,7 +45,7 @@ class Memory(BaseModel):
     def save(
         self,
         value: Any,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         metadata = metadata or {}
 
@@ -54,9 +54,9 @@ class Memory(BaseModel):
     def search(
         self,
         query: str,
-        limit: int = 3,
-        score_threshold: float = 0.35,
-    ) -> List[Any]:
+        limit: int = 5,
+        score_threshold: float = 0.6,
+    ) -> list[Any]:
         return self.storage.search(
             query=query, limit=limit, score_threshold=score_threshold
         )

--- a/src/crewai/memory/storage/mem0_storage.py
+++ b/src/crewai/memory/storage/mem0_storage.py
@@ -151,7 +151,7 @@ class Mem0Storage(Storage):
         self.memory.add(conversations, **params)
 
     def search(
-        self, query: str, limit: int = 3, score_threshold: float = 0.35
+        self, query: str, limit: int = 5, score_threshold: float = 0.6
     ) -> list[Any]:
         params = {
             "query": query,

--- a/src/crewai/memory/storage/rag_storage.py
+++ b/src/crewai/memory/storage/rag_storage.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import warnings
 from typing import Any
 
@@ -86,14 +87,16 @@ class RAGStorage(BaseRAGStorage):
 
             client.add_documents(collection_name=collection_name, documents=[document])
         except Exception as e:
-            logging.error(f"Error during {self.type} save: {e!s}")
+            logging.error(
+                f"Error during {self.type} save: {e!s}\n{traceback.format_exc()}"
+            )
 
     def search(
         self,
         query: str,
-        limit: int = 3,
+        limit: int = 5,
         filter: dict[str, Any] | None = None,
-        score_threshold: float = 0.35,
+        score_threshold: float = 0.6,
     ) -> list[Any]:
         try:
             client = self._get_client()
@@ -110,7 +113,9 @@ class RAGStorage(BaseRAGStorage):
                 score_threshold=score_threshold,
             )
         except Exception as e:
-            logging.error(f"Error during {self.type} search: {e!s}")
+            logging.error(
+                f"Error during {self.type} search: {e!s}\n{traceback.format_exc()}"
+            )
             return []
 
     def reset(self) -> None:

--- a/src/crewai/rag/chromadb/factory.py
+++ b/src/crewai/rag/chromadb/factory.py
@@ -39,4 +39,6 @@ def create_client(config: ChromaDBConfig) -> ChromaDBClient:
     return ChromaDBClient(
         client=client,
         embedding_function=config.embedding_function,
+        default_limit=config.limit,
+        default_score_threshold=config.score_threshold,
     )

--- a/src/crewai/rag/config/base.py
+++ b/src/crewai/rag/config/base.py
@@ -14,3 +14,5 @@ class BaseRagConfig:
 
     provider: SupportedProvider = field(init=False)
     embedding_function: Any | None = field(default=None)
+    limit: int = field(default=5)
+    score_threshold: float = field(default=0.6)

--- a/src/crewai/rag/qdrant/factory.py
+++ b/src/crewai/rag/qdrant/factory.py
@@ -1,6 +1,7 @@
 """Factory functions for creating Qdrant clients from configuration."""
 
 from qdrant_client import QdrantClient as SyncQdrantClientBase
+
 from crewai.rag.qdrant.client import QdrantClient
 from crewai.rag.qdrant.config import QdrantConfig
 
@@ -17,5 +18,8 @@ def create_client(config: QdrantConfig) -> QdrantClient:
 
     qdrant_client = SyncQdrantClientBase(**config.options)
     return QdrantClient(
-        client=qdrant_client, embedding_function=config.embedding_function
+        client=qdrant_client,
+        embedding_function=config.embedding_function,
+        default_limit=config.limit,
+        default_score_threshold=config.score_threshold,
     )

--- a/src/crewai/rag/storage/base_rag_storage.py
+++ b/src/crewai/rag/storage/base_rag_storage.py
@@ -41,9 +41,9 @@ class BaseRAGStorage(ABC):
     def search(
         self,
         query: str,
-        limit: int = 3,
+        limit: int = 5,
         filter: dict[str, Any] | None = None,
-        score_threshold: float = 0.35,
+        score_threshold: float = 0.6,
     ) -> list[Any]:
         """Search for entries in the storage."""
 

--- a/tests/rag/chromadb/test_client.py
+++ b/tests/rag/chromadb/test_client.py
@@ -450,7 +450,7 @@ class TestChromaDBClient:
         )
         mock_collection.query.assert_called_once_with(
             query_texts=["test query"],
-            n_results=10,
+            n_results=5,
             where=None,
             where_document=None,
             include=["metadatas", "documents", "distances"],
@@ -521,7 +521,7 @@ class TestChromaDBClient:
         )
         mock_collection.query.assert_called_once_with(
             query_texts=["test query"],
-            n_results=10,
+            n_results=5,
             where=None,
             where_document=None,
             include=["metadatas", "documents", "distances"],

--- a/tests/rag/chromadb/test_client.py
+++ b/tests/rag/chromadb/test_client.py
@@ -236,7 +236,7 @@ class TestChromaDBClient:
     def test_add_documents(self, client, mock_chromadb_client) -> None:
         """Test that add_documents adds documents to collection."""
         mock_collection = Mock()
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
 
         documents: list[BaseRecord] = [
             {
@@ -247,7 +247,7 @@ class TestChromaDBClient:
 
         client.add_documents(collection_name="test_collection", documents=documents)
 
-        mock_chromadb_client.get_collection.assert_called_once_with(
+        mock_chromadb_client.get_or_create_collection.assert_called_once_with(
             name="test_collection",
             embedding_function=client.embedding_function,
         )
@@ -262,7 +262,7 @@ class TestChromaDBClient:
     def test_add_documents_with_custom_ids(self, client, mock_chromadb_client) -> None:
         """Test add_documents with custom document IDs."""
         mock_collection = Mock()
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
 
         documents: list[BaseRecord] = [
             {
@@ -288,7 +288,7 @@ class TestChromaDBClient:
     def test_add_documents_without_metadata(self, client, mock_chromadb_client) -> None:
         """Test add_documents with documents that have no metadata."""
         mock_collection = Mock()
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
 
         documents: list[BaseRecord] = [
             {"content": "Document without metadata"},
@@ -308,7 +308,7 @@ class TestChromaDBClient:
     ) -> None:
         """Test add_documents when all documents have no metadata."""
         mock_collection = Mock()
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
 
         documents: list[BaseRecord] = [
             {"content": "Document 1"},
@@ -335,7 +335,7 @@ class TestChromaDBClient:
     ) -> None:
         """Test that aadd_documents adds documents to collection asynchronously."""
         mock_collection = AsyncMock()
-        mock_async_chromadb_client.get_collection = AsyncMock(
+        mock_async_chromadb_client.get_or_create_collection = AsyncMock(
             return_value=mock_collection
         )
 
@@ -350,7 +350,7 @@ class TestChromaDBClient:
             collection_name="test_collection", documents=documents
         )
 
-        mock_async_chromadb_client.get_collection.assert_called_once_with(
+        mock_async_chromadb_client.get_or_create_collection.assert_called_once_with(
             name="test_collection",
             embedding_function=async_client.embedding_function,
         )
@@ -368,7 +368,7 @@ class TestChromaDBClient:
     ) -> None:
         """Test aadd_documents with custom document IDs."""
         mock_collection = AsyncMock()
-        mock_async_chromadb_client.get_collection = AsyncMock(
+        mock_async_chromadb_client.get_or_create_collection = AsyncMock(
             return_value=mock_collection
         )
 
@@ -401,7 +401,7 @@ class TestChromaDBClient:
     ) -> None:
         """Test aadd_documents with documents that have no metadata."""
         mock_collection = AsyncMock()
-        mock_async_chromadb_client.get_collection = AsyncMock(
+        mock_async_chromadb_client.get_or_create_collection = AsyncMock(
             return_value=mock_collection
         )
 
@@ -434,7 +434,7 @@ class TestChromaDBClient:
         """Test that search queries the collection correctly."""
         mock_collection = Mock()
         mock_collection.metadata = {"hnsw:space": "cosine"}
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
         mock_collection.query.return_value = {
             "ids": [["doc1", "doc2"]],
             "documents": [["Document 1", "Document 2"]],
@@ -444,7 +444,7 @@ class TestChromaDBClient:
 
         results = client.search(collection_name="test_collection", query="test query")
 
-        mock_chromadb_client.get_collection.assert_called_once_with(
+        mock_chromadb_client.get_or_create_collection.assert_called_once_with(
             name="test_collection",
             embedding_function=client.embedding_function,
         )
@@ -466,7 +466,7 @@ class TestChromaDBClient:
         """Test search with optional parameters."""
         mock_collection = Mock()
         mock_collection.metadata = {"hnsw:space": "cosine"}
-        mock_chromadb_client.get_collection.return_value = mock_collection
+        mock_chromadb_client.get_or_create_collection.return_value = mock_collection
         mock_collection.query.return_value = {
             "ids": [["doc1", "doc2", "doc3"]],
             "documents": [["Document 1", "Document 2", "Document 3"]],
@@ -499,7 +499,7 @@ class TestChromaDBClient:
         """Test that asearch queries the collection correctly."""
         mock_collection = AsyncMock()
         mock_collection.metadata = {"hnsw:space": "cosine"}
-        mock_async_chromadb_client.get_collection = AsyncMock(
+        mock_async_chromadb_client.get_or_create_collection = AsyncMock(
             return_value=mock_collection
         )
         mock_collection.query = AsyncMock(
@@ -515,7 +515,7 @@ class TestChromaDBClient:
             collection_name="test_collection", query="test query"
         )
 
-        mock_async_chromadb_client.get_collection.assert_called_once_with(
+        mock_async_chromadb_client.get_or_create_collection.assert_called_once_with(
             name="test_collection",
             embedding_function=async_client.embedding_function,
         )
@@ -540,7 +540,7 @@ class TestChromaDBClient:
         """Test asearch with optional parameters."""
         mock_collection = AsyncMock()
         mock_collection.metadata = {"hnsw:space": "cosine"}
-        mock_async_chromadb_client.get_collection = AsyncMock(
+        mock_async_chromadb_client.get_or_create_collection = AsyncMock(
             return_value=mock_collection
         )
         mock_collection.query = AsyncMock(

--- a/tests/rag/qdrant/test_client.py
+++ b/tests/rag/qdrant/test_client.py
@@ -3,7 +3,8 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from qdrant_client import AsyncQdrantClient, QdrantClient as SyncQdrantClient
+from qdrant_client import AsyncQdrantClient
+from qdrant_client import QdrantClient as SyncQdrantClient
 
 from crewai.rag.core.exceptions import ClientMethodMismatchError
 from crewai.rag.qdrant.client import QdrantClient
@@ -435,7 +436,7 @@ class TestQdrantClient:
         call_args = mock_qdrant_client.query_points.call_args
         assert call_args.kwargs["collection_name"] == "test_collection"
         assert call_args.kwargs["query"] == [0.1, 0.2, 0.3]
-        assert call_args.kwargs["limit"] == 10
+        assert call_args.kwargs["limit"] == 5
         assert call_args.kwargs["with_payload"] is True
         assert call_args.kwargs["with_vectors"] is False
 
@@ -540,7 +541,7 @@ class TestQdrantClient:
         call_args = mock_async_qdrant_client.query_points.call_args
         assert call_args.kwargs["collection_name"] == "test_collection"
         assert call_args.kwargs["query"] == [0.1, 0.2, 0.3]
-        assert call_args.kwargs["limit"] == 10
+        assert call_args.kwargs["limit"] == 5
         assert call_args.kwargs["with_payload"] is True
         assert call_args.kwargs["with_vectors"] is False
 


### PR DESCRIPTION
- Add `limit` and `score_threshold` fields to `BaseRagConfig` for configurable search parameters
- Update all RAG, knowledge, and memory modules to use new defaults (limit=5, threshold=0.6)
- Pass config values through client factories to enable runtime configuration
- Fix existing linting issues (B904, PERF203) and type annotations in memory module