### PR TITLE
fix: remove outdated ChromaDB model_fields deprecation warning suppre…

### DIFF
--- a/src/crewai/rag/chromadb/config.py
+++ b/src/crewai/rag/chromadb/config.py
@@ -23,11 +23,6 @@ warnings.filterwarnings(
     module="pydantic._internal._generate_schema",
 )
 
-warnings.filterwarnings(
-    "ignore",
-    message=r".*'model_fields'.*is deprecated.*",
-    module=r"^chromadb(\.|$)",
-)
 
 
 def _default_settings() -> Settings:


### PR DESCRIPTION
…ssions

- Remove deprecated warning filters for model_fields deprecation in ChromaDB
- ChromaDB 0.5.23 no longer emits these warnings
- Clean up unused warnings imports in affected files
- Fix exception handling to use 'raise ... from e' pattern
- Affects: rag_storage.py, knowledge_storage.py, chromadb/config.py

Resolves TODO comments about upgrading ChromaDB to 1.0.8+