### PR TITLE
fix: remove outdated ChromaDB model_fields deprecation warning suppre…

### DIFF
--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-import warnings
 from typing import Any, cast
 
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
@@ -27,12 +26,6 @@ class KnowledgeStorage(BaseKnowledgeStorage):
     ) -> None:
         self.collection_name = collection_name
         self._client: BaseClient | None = None
-
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*'model_fields'.*is deprecated.*",
-            module=r"^chromadb(\.|$)",
-        )
 
         if embedder:
             embedding_function = get_embedding_function(embedder)

--- a/src/crewai/memory/storage/rag_storage.py
+++ b/src/crewai/memory/storage/rag_storage.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-import warnings
 from typing import Any, cast
 
 from crewai.rag.chromadb.config import ChromaDBConfig
@@ -41,12 +40,6 @@ class RAGStorage(BaseRAGStorage):
 
         self.allow_reset = allow_reset
         self.path = path
-
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*'model_fields'.*is deprecated.*",
-            module=r"^chromadb(\.|$)",
-        )
 
         if self.embedder_config:
             embedding_function = get_embedding_function(self.embedder_config)

--- a/src/crewai/rag/chromadb/config.py
+++ b/src/crewai/rag/chromadb/config.py
@@ -23,12 +23,6 @@ warnings.filterwarnings(
     module="pydantic._internal._generate_schema",
 )
 
-warnings.filterwarnings(
-    "ignore",
-    message=r".*'model_fields'.*is deprecated.*",
-    module=r"^chromadb(\.|$)",
-)
-
 
 def _default_settings() -> Settings:
     """Create default ChromaDB settings.


### PR DESCRIPTION
…ssions

- Remove deprecated warning filters for model_fields deprecation in ChromaDB
- ChromaDB 0.5.23 no longer emits these warnings
- Clean up unused warnings imports in affected files
- Affects: rag_storage.py, knowledge_storage.py, chromadb/config.py

Resolves TODO comments about upgrading ChromaDB to 1.0.8+