### PR TITLE
Fix/memory leak crewbase

### DIFF
--- a/src/crewai/project/annotations.py
+++ b/src/crewai/project/annotations.py
@@ -1,5 +1,6 @@
+import weakref
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable
 
 from crewai import Crew
 from crewai.project.utils import memoize
@@ -36,15 +37,13 @@ def task(func):
 def agent(func):
     """Marks a method as a crew agent."""
     func.is_agent = True
-    func = memoize(func)
-    return func
+    return memoize(func)
 
 
 def llm(func):
     """Marks a method as an LLM provider."""
     func.is_llm = True
-    func = memoize(func)
-    return func
+    return memoize(func)
 
 
 def output_json(cls):
@@ -91,7 +90,7 @@ def crew(func) -> Callable[..., Crew]:
         agents = self._original_agents.items()
 
         # Instantiate tasks in order
-        for task_name, task_method in tasks:
+        for _task_name, task_method in tasks:
             task_instance = task_method(self)
             instantiated_tasks.append(task_instance)
             agent_instance = getattr(task_instance, "agent", None)
@@ -100,7 +99,7 @@ def crew(func) -> Callable[..., Crew]:
                 agent_roles.add(agent_instance.role)
 
         # Instantiate agents not included by tasks
-        for agent_name, agent_method in agents:
+        for _agent_name, agent_method in agents:
             agent_instance = agent_method(self)
             if agent_instance.role not in agent_roles:
                 instantiated_agents.append(agent_instance)
@@ -111,16 +110,27 @@ def crew(func) -> Callable[..., Crew]:
 
         crew = func(self, *args, **kwargs)
 
-        def callback_wrapper(callback, instance):
+        def callback_wrapper(callback, instance_ref):
             def wrapper(*args, **kwargs):
-                return callback(instance, *args, **kwargs)
+                # Get the instance from weak reference
+                instance = instance_ref()
+                if instance is not None:
+                    return callback(instance, *args, **kwargs)
+                # If instance was garbage collected, return None or handle gracefully
+                return None
 
             return wrapper
 
-        for _, callback in self._before_kickoff.items():
-            crew.before_kickoff_callbacks.append(callback_wrapper(callback, self))
-        for _, callback in self._after_kickoff.items():
-            crew.after_kickoff_callbacks.append(callback_wrapper(callback, self))
+        # Use weak reference to avoid circular reference
+        instance_ref = weakref.ref(self)
+        for callback in self._before_kickoff.values():
+            crew.before_kickoff_callbacks.append(
+                callback_wrapper(callback, instance_ref)
+            )
+        for callback in self._after_kickoff.values():
+            crew.after_kickoff_callbacks.append(
+                callback_wrapper(callback, instance_ref)
+            )
 
         return crew
 

--- a/src/crewai/project/utils.py
+++ b/src/crewai/project/utils.py
@@ -1,14 +1,60 @@
+import weakref
 from functools import wraps
 
 
 def memoize(func):
-    cache = {}
+    """
+    Memoization decorator that uses weak references to prevent memory leaks.
+
+    This implementation uses weak references for the first argument (typically 'self')
+    to allow proper garbage collection of instances while still providing caching
+    benefits for method calls.
+    """
+    # Use WeakKeyDictionary for instance-based caching
+    instance_caches: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
     @wraps(func)
     def memoized_func(*args, **kwargs):
-        key = (args, tuple(kwargs.items()))
+        if not args:
+            # No arguments, use simple caching
+            key = tuple(kwargs.items())
+            if not hasattr(memoized_func, "_simple_cache"):
+                memoized_func._simple_cache = {}
+            cache = memoized_func._simple_cache
+        else:
+            # First argument exists, check if it's an instance
+            first_arg = args[0]
+
+            # Try to use the first argument as a weak reference key
+            try:
+                # Get or create cache for this instance
+                if first_arg not in instance_caches:
+                    instance_caches[first_arg] = {}
+                cache = instance_caches[first_arg]
+
+                # Create key from remaining args and kwargs
+                key = (args[1:], tuple(kwargs.items()))
+
+            except TypeError:
+                # First argument is not hashable or cannot be weakly referenced
+                # Fall back to regular caching (for primitive types, etc.)
+                if not hasattr(memoized_func, "_fallback_cache"):
+                    memoized_func._fallback_cache = {}
+                cache = memoized_func._fallback_cache
+                key = (args, tuple(kwargs.items()))
+
+        # Check cache and return or compute result
         if key not in cache:
             cache[key] = func(*args, **kwargs)
         return cache[key]
 
+    # Add method to clear cache for debugging/testing
+    def clear_cache():
+        instance_caches.clear()
+        if hasattr(memoized_func, "_simple_cache"):
+            memoized_func._simple_cache.clear()
+        if hasattr(memoized_func, "_fallback_cache"):
+            memoized_func._fallback_cache.clear()
+
+    memoized_func.clear_cache = clear_cache
     return memoized_func

--- a/tests/cli/test_crew_discovery_fix.py
+++ b/tests/cli/test_crew_discovery_fix.py
@@ -1,0 +1,182 @@
+"""Tests for crew discovery bug fixes."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai.cli.crew_chat import load_crew_and_name
+from crewai.cli.utils import get_crews, normalize_project_name
+
+
+class TestNormalizeProjectName:
+    """Test project name normalization."""
+
+    def test_underscore_project_name(self):
+        """Test project name with underscores."""
+        module_name, class_name = normalize_project_name("my_project")
+        assert module_name == "my_project"
+        assert class_name == "MyProject"
+
+    def test_hyphen_project_name(self):
+        """Test project name with hyphens."""
+        module_name, class_name = normalize_project_name("my-project")
+        assert module_name == "my_project"
+        assert class_name == "MyProject"
+
+    def test_mixed_separators(self):
+        """Test project name with mixed separators."""
+        module_name, class_name = normalize_project_name("my-project_name")
+        assert module_name == "my_project_name"
+        assert class_name == "MyProjectName"
+
+    def test_complex_project_name(self):
+        """Test complex project name like the one in the issue."""
+        module_name, class_name = normalize_project_name(
+            "dropbox_to_rag_migration_system"
+        )
+        assert module_name == "dropbox_to_rag_migration_system"
+        assert class_name == "DropboxToRagMigrationSystem"
+
+    def test_hyphenated_complex_name(self):
+        """Test hyphenated complex project name."""
+        module_name, class_name = normalize_project_name(
+            "dropbox-to-rag-migration-system"
+        )
+        assert module_name == "dropbox_to_rag_migration_system"
+        assert class_name == "DropboxToRagMigrationSystem"
+
+
+class TestCrewDiscovery:
+    """Test crew discovery improvements."""
+
+    def test_get_crews_with_better_error_handling(self):
+        """Test that get_crews provides better error information."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a broken crew.py file
+            crew_file = Path(temp_dir) / "crew.py"
+            crew_file.write_text("""
+# Broken crew file
+import non_existent_module  # This will cause ImportError
+
+class TestCrew:
+    pass
+""")
+
+            # Change to temp directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+
+                # Should not raise exception when require=False
+                crews = get_crews(require=False)
+                assert crews == []
+
+                # Should provide detailed error when require=True
+                with pytest.raises(SystemExit):
+                    get_crews(require=True)
+
+            finally:
+                os.chdir(original_cwd)
+
+    def test_get_crews_finds_valid_crew(self):
+        """Test that get_crews can find a valid crew."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a valid crew.py file
+            crew_file = Path(temp_dir) / "crew.py"
+            crew_file.write_text("""
+# Simple test crew
+class TestCrew:
+    pass
+""")
+
+            # Change to temp directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+
+                # Mock the dependencies to avoid actual CrewAI imports
+                with patch("crewai.cli.utils.fetch_crews") as mock_fetch:
+                    # Return empty list for most calls, one crew for our test class
+                    def fetch_side_effect(attr):
+                        if hasattr(attr, "__name__") and attr.__name__ == "TestCrew":
+                            mock_crew = MagicMock()
+                            return [mock_crew]
+                        return []
+
+                    mock_fetch.side_effect = fetch_side_effect
+
+                    crews = get_crews(require=False)
+                    # Should find at least one crew (might find more due to other attributes)
+                    assert len(crews) >= 1
+
+            finally:
+                os.chdir(original_cwd)
+
+
+class TestLoadCrewAndName:
+    """Test the improved load_crew_and_name function."""
+
+    def test_load_crew_with_detailed_errors(self):
+        """Test that load_crew_and_name provides detailed error information."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create pyproject.toml
+            pyproject_file = Path(temp_dir) / "pyproject.toml"
+            pyproject_file.write_text("""
+[project]
+name = "test-project"
+version = "0.1.0"
+""")
+
+            # Change to temp directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+
+                # Should provide detailed error information
+                with pytest.raises(ImportError) as exc_info:
+                    load_crew_and_name()
+
+                error_message = str(exc_info.value)
+                assert (
+                    "Failed to import crew module using all strategies" in error_message
+                )
+                assert "Project name: test-project" in error_message
+                assert "Folder name: test_project" in error_message
+                assert "Expected crew class: TestProject" in error_message
+                assert "Debug info:" in error_message
+
+            finally:
+                os.chdir(original_cwd)
+
+    def test_load_crew_with_fallback_class_detection(self):
+        """Test that load_crew_and_name provides better error messages."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create pyproject.toml
+            pyproject_file = Path(temp_dir) / "pyproject.toml"
+            pyproject_file.write_text("""
+[project]
+name = "test-project"
+version = "0.1.0"
+""")
+
+            # Change to temp directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+
+                # Should provide detailed error information when no crew is found
+                with pytest.raises(ImportError) as exc_info:
+                    load_crew_and_name()
+
+                error_message = str(exc_info.value)
+                # Check that our improved error message includes debugging info
+                assert (
+                    "Failed to import crew module using all strategies" in error_message
+                )
+                assert "Debug info:" in error_message
+
+            finally:
+                os.chdir(original_cwd)

--- a/tests/project/test_memory_leak_fix.py
+++ b/tests/project/test_memory_leak_fix.py
@@ -1,0 +1,376 @@
+"""Tests for memory leak fixes in CrewBase decorator."""
+
+import gc
+import weakref
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+from crewai import Agent, Crew, Task
+from crewai.project import CrewBase, agent, crew, task
+from crewai.project.utils import memoize
+
+
+class TestMemoizeMemoryLeak:
+    """Test that the memoize decorator doesn't cause memory leaks."""
+
+    def test_memoize_allows_garbage_collection(self):
+        """Test that memoized methods don't prevent garbage collection."""
+
+        class TestClass:
+            def __init__(self, value):
+                self.value = value
+
+            @memoize
+            def get_value(self):
+                return self.value
+
+        # Create instance and get weak reference
+        instance = TestClass("test")
+        weak_ref = weakref.ref(instance)
+
+        # Call memoized method to populate cache
+        result = instance.get_value()
+        assert result == "test"
+
+        # Delete the instance
+        del instance
+
+        # Force garbage collection
+        gc.collect()
+
+        # The weak reference should be None (object was garbage collected)
+        assert weak_ref() is None
+
+    def test_memoize_cache_functionality(self):
+        """Test that memoization still works correctly."""
+        call_count = 0
+
+        class TestClass:
+            @memoize
+            def expensive_operation(self, x):
+                nonlocal call_count
+                call_count += 1
+                return x * 2
+
+        instance = TestClass()
+
+        # First call
+        result1 = instance.expensive_operation(5)
+        assert result1 == 10
+        assert call_count == 1
+
+        # Second call with same argument should use cache
+        result2 = instance.expensive_operation(5)
+        assert result2 == 10
+        assert call_count == 1  # Should not increment
+
+        # Different argument should call function again
+        result3 = instance.expensive_operation(10)
+        assert result3 == 20
+        assert call_count == 2
+
+    def test_memoize_clear_cache(self):
+        """Test that cache can be cleared."""
+        call_count = 0
+
+        class TestClass:
+            @memoize
+            def get_data(self):
+                nonlocal call_count
+                call_count += 1
+                return "data"
+
+        instance = TestClass()
+
+        # Call method
+        result1 = instance.get_data()
+        assert result1 == "data"
+        assert call_count == 1
+
+        # Call again, should use cache
+        result2 = instance.get_data()
+        assert result2 == "data"
+        assert call_count == 1
+
+        # Clear cache
+        instance.get_data.clear_cache()
+
+        # Call again, should execute function
+        result3 = instance.get_data()
+        assert result3 == "data"
+        assert call_count == 2
+
+
+class TestCrewBaseMemoryLeak:
+    """Test that CrewBase instances can be garbage collected."""
+
+    def test_crewbase_garbage_collection(self):
+        """Test that CrewBase instances can be garbage collected."""
+
+        def inner_test():
+            @CrewBase
+            class TestCrew:
+                @agent
+                def test_agent(self) -> Agent:
+                    return Agent(
+                        role="Test Agent", goal="Test goal", backstory="Test backstory"
+                    )
+
+                @task
+                def test_task(self) -> Task:
+                    return Task(
+                        description="Test task",
+                        expected_output="Test output",
+                        agent=self.test_agent(),
+                    )
+
+                @crew
+                def crew(self) -> Crew:
+                    return Crew(agents=[self.test_agent()], tasks=[self.test_task()])
+
+            # Create instance and weak reference
+            crew_instance = TestCrew()
+            weak_ref = weakref.ref(crew_instance)
+
+            # Use the crew to populate caches
+            crew_obj = crew_instance.crew()
+            assert crew_obj is not None
+
+            # Delete references
+            del crew_obj
+            del crew_instance
+
+            return weak_ref
+
+        # Run test in isolated scope
+        weak_ref = inner_test()
+
+        # Force garbage collection
+        gc.collect()
+
+        # The weak reference should be None (object was garbage collected)
+        assert weak_ref() is None
+
+    def test_crewbase_explicit_cleanup(self):
+        """Test that explicit cleanup works."""
+
+        def inner_test():
+            @CrewBase
+            class TestCrew:
+                @agent
+                def test_agent(self) -> Agent:
+                    return Agent(
+                        role="Test Agent", goal="Test goal", backstory="Test backstory"
+                    )
+
+                @task
+                def test_task(self) -> Task:
+                    return Task(
+                        description="Test task",
+                        expected_output="Test output",
+                        agent=self.test_agent(),
+                    )
+
+                @crew
+                def crew(self) -> Crew:
+                    return Crew(agents=[self.test_agent()], tasks=[self.test_task()])
+
+            # Create instance
+            crew_instance = TestCrew()
+            weak_ref = weakref.ref(crew_instance)
+
+            # Use the crew
+            crew_obj = crew_instance.crew()
+            assert crew_obj is not None
+
+            # Explicit cleanup
+            crew_instance.cleanup()
+
+            # Delete references
+            del crew_obj
+            del crew_instance
+
+            return weak_ref
+
+        # Run test in isolated scope
+        weak_ref = inner_test()
+
+        # Force garbage collection
+        gc.collect()
+
+        # Should be garbage collected
+        assert weak_ref() is None
+
+    def test_multiple_crewbase_instances(self):
+        """Test that multiple CrewBase instances don't interfere with each other's garbage collection."""
+
+        def inner_test():
+            @CrewBase
+            class TestCrew:
+                def __init__(self, name):
+                    super().__init__()
+                    self.name = name
+
+                @agent
+                def test_agent(self) -> Agent:
+                    return Agent(
+                        role=f"Test Agent {self.name}",
+                        goal="Test goal",
+                        backstory="Test backstory",
+                    )
+
+                @task
+                def test_task(self) -> Task:
+                    return Task(
+                        description=f"Test task for {self.name}",
+                        expected_output="Test output",
+                        agent=self.test_agent(),
+                    )
+
+                @crew
+                def crew(self) -> Crew:
+                    return Crew(agents=[self.test_agent()], tasks=[self.test_task()])
+
+            # Create multiple instances
+            instances = []
+            weak_refs = []
+
+            for i in range(5):
+                instance = TestCrew(f"crew_{i}")
+                instances.append(instance)
+                weak_refs.append(weakref.ref(instance))
+
+                # Use each crew
+                crew_obj = instance.crew()
+                assert crew_obj is not None
+                del crew_obj  # Clean up immediately
+
+            # Delete all instances
+            del instances
+
+            return weak_refs
+
+        # Run test in isolated scope
+        weak_refs = inner_test()
+
+        # Force garbage collection
+        gc.collect()
+
+        # All instances should be garbage collected
+        for weak_ref in weak_refs:
+            assert weak_ref() is None
+
+    def test_crewbase_with_mcp_adapter_cleanup(self):
+        """Test that MCP adapter is properly cleaned up."""
+
+        @CrewBase
+        class TestCrewWithMCP:
+            mcp_server_params: ClassVar[dict] = {"test": "params"}
+
+            @agent
+            def test_agent(self) -> Agent:
+                return Agent(
+                    role="Test Agent", goal="Test goal", backstory="Test backstory"
+                )
+
+            @crew
+            def crew(self) -> Crew:
+                return Crew(agents=[self.test_agent()], tasks=[])
+
+        # Create instance
+        crew_instance = TestCrewWithMCP()
+
+        # Mock MCP adapter
+        mock_adapter = MagicMock()
+        crew_instance._mcp_server_adapter = mock_adapter
+
+        # Create weak reference
+        weak_ref = weakref.ref(crew_instance)
+
+        # Cleanup
+        crew_instance.cleanup()
+
+        # Verify MCP adapter stop was called
+        mock_adapter.stop.assert_called_once()
+
+        # Delete instance
+        del crew_instance
+
+        # Force garbage collection
+        gc.collect()
+
+        # Should be garbage collected
+        assert weak_ref() is None
+
+
+class TestMemoryLeakRegression:
+    """Regression tests to ensure the original issue is fixed."""
+
+    def test_issue_3450_regression(self):
+        """
+        Regression test for issue #3450.
+
+        This test simulates the exact scenario from the GitHub issue
+        to ensure the memory leak is fixed.
+        """
+
+        def inner_test():
+            @CrewBase
+            class CrewAI:
+                @agent
+                def searcher(self) -> Agent:
+                    return Agent(
+                        role="Searcher",
+                        goal="Search for information",
+                        backstory="I am a search agent",
+                    )
+
+                @task
+                def searcher_task(self) -> Task:
+                    return Task(
+                        description="Search for information",
+                        expected_output="Search results",
+                        agent=self.searcher(),
+                    )
+
+                @crew
+                def crew(self) -> Crew:
+                    return Crew(
+                        agents=[self.searcher()],
+                        tasks=[self.searcher_task()],
+                        verbose=False,
+                        cache=True,
+                        memory=False,
+                    )
+
+            # Create multiple instances to simulate the issue
+            instances = []
+            weak_refs = []
+
+            for _ in range(10):
+                instance = CrewAI()
+                instances.append(instance)
+                weak_refs.append(weakref.ref(instance))
+
+                # Execute crew to populate caches
+                crew_obj = instance.crew()
+                assert crew_obj is not None
+                del crew_obj  # Clean up immediately
+
+            # Clear all references
+            del instances
+
+            return weak_refs
+
+        # Run test in isolated scope
+        weak_refs = inner_test()
+
+        # Force garbage collection multiple times
+        for _ in range(3):
+            gc.collect()
+
+        # Count how many instances are still alive
+        alive_count = sum(1 for ref in weak_refs if ref() is not None)
+
+        # All instances should be garbage collected
+        assert alive_count == 0, f"{alive_count} instances were not garbage collected"


### PR DESCRIPTION
Fixes issue #3450 - CrewBase objects cannot be garbage collected

## Root Cause Analysis:
The memory leak was caused by multiple circular references:
1. Memoize decorator holding strong references to 'self' in cache
2. Callback wrapper functions creating circular references 
3. MCP server method bound to instance preventing GC

## Solutions Implemented:

### 1. Weak Reference Memoization
- Replaced strong reference caching with WeakKeyDictionary
- Uses weak references for instance-based caching
- Allows proper garbage collection while maintaining cache benefits
- Added cache clearing functionality for debugging

### 2. Callback System Fix  
- Updated crew decorator to use weak references in callback wrappers
- Prevents circular references between crew and CrewBase instances
- Callbacks gracefully handle garbage collected instances

### 3. MCP Server Method Fix
- Replaced bound method with functools.partial + weak reference
- Eliminates circular reference from MCP server cleanup method
- Maintains functionality while allowing garbage collection

### 4. Enhanced Cleanup Methods
- Added __del__ method for automatic cleanup
- Added explicit cleanup() method for user control
- Proper resource management for MCP adapters and cached data

## Testing:
- Comprehensive test suite covering all scenarios
- Memory leak regression tests for issue #3450
- Tests for multiple instances and explicit cleanup
- Verified garbage collection works correctly

## Performance Impact:
- Maintains memoization performance benefits
- No breaking changes to existing API
- Memory usage now properly bounded
- Eliminates 