### PR TITLE
fix: correct directory name in quickstart documentation

### DIFF
--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -27,7 +27,7 @@ Follow the steps below to get Crewing! 🚣‍♂️
   <Step title="Navigate to your new crew project">
     <CodeGroup>
       ```shell Terminal
-      cd latest-ai-development
+      cd latest_ai_development
       ```
     </CodeGroup>
   </Step>

--- a/docs/ko/quickstart.mdx
+++ b/docs/ko/quickstart.mdx
@@ -27,7 +27,7 @@ mode: "wide"
   <Step title="새로운 crew 프로젝트로 이동하기">
     <CodeGroup>
       ```shell Terminal
-      cd latest-ai-development
+      cd latest_ai_development
       ```
     </CodeGroup>
   </Step>

--- a/docs/pt-BR/quickstart.mdx
+++ b/docs/pt-BR/quickstart.mdx
@@ -27,7 +27,7 @@ Siga os passos abaixo para começar a tripular! 🚣‍♂️
   <Step title="Navegue até o novo projeto da sua tripulação">
     <CodeGroup>
       ```shell Terminal
-      cd latest-ai-development
+      cd latest_ai_development
       ```
     </CodeGroup>
   </Step>


### PR DESCRIPTION
Fix directory name from latest-ai-development to latest_ai_development in quickstart docs