### PR TITLE
Fix no response / null response from LLM

### DIFF
--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent_executor_mixin.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent_executor_mixin.py
@@ -9,6 +9,7 @@ from crewai.memory.long_term.long_term_memory_item import LongTermMemoryItem
 from crewai.utilities.converter import ConverterError
 from crewai.utilities.evaluators.task_evaluator import TaskEvaluator
 from crewai.utilities.printer import Printer
+from crewai.utilities.types import LLMMessage
 
 
 if TYPE_CHECKING:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -39,6 +39,7 @@ from crewai.utilities.agent_utils import (
     handle_unknown_error,
     has_reached_max_iterations,
     is_context_length_exceeded,
+    is_null_response_because_context_length_exceeded,
     process_llm_response,
 )
 from crewai.utilities.constants import TRAINING_DATA_FILE
@@ -49,6 +50,7 @@ from crewai.utilities.tool_utils import (
     execute_tool_and_check_finality,
 )
 from crewai.utilities.training_handler import CrewTrainingHandler
+from crewai.utilities.types import LLMMessage
 
 
 if TYPE_CHECKING:
@@ -289,7 +291,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 if e.__class__.__module__.startswith("litellm"):
                     # Do not retry on litellm errors
                     raise e
-                if is_context_length_exceeded(e):
+                if is_context_length_exceeded(exception=e) or is_null_response_because_context_length_exceeded(exception=e, messages=self.messages, llm=self.llm):
                     handle_context_length(
                         respect_context_window=self.respect_context_window,
                         printer=self._printer,

--- a/lib/crewai/src/crewai/lite_agent.py
+++ b/lib/crewai/src/crewai/lite_agent.py
@@ -57,6 +57,7 @@ from crewai.utilities.agent_utils import (
     handle_unknown_error,
     has_reached_max_iterations,
     is_context_length_exceeded,
+    is_null_response_because_context_length_exceeded,
     parse_tools,
     process_llm_response,
     render_text_description_and_args,
@@ -600,7 +601,7 @@ class LiteAgent(FlowTrackable, BaseModel):
                 if e.__class__.__module__.startswith("litellm"):
                     # Do not retry on litellm errors
                     raise e
-                if is_context_length_exceeded(e):
+                if is_context_length_exceeded(exception=e) or is_null_response_because_context_length_exceeded(exception=e, messages=self.messages, llm=self.llm ):
                     handle_context_length(
                         respect_context_window=self.respect_context_window,
                         printer=self._printer,

--- a/lib/crewai/src/crewai/utilities/evaluators/task_evaluator.py
+++ b/lib/crewai/src/crewai/utilities/evaluators/task_evaluator.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel, Field
 
+from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.events.event_bus import crewai_event_bus
 from crewai.events.types.task_events import TaskEvaluationEvent
 from crewai.utilities.converter import Converter
@@ -14,7 +15,6 @@ from crewai.utilities.training_converter import TrainingConverter
 
 
 if TYPE_CHECKING:
-    from crewai.agent import Agent
     from crewai.task import Task
 
 
@@ -57,7 +57,7 @@ class TaskEvaluator:
         original_agent: The agent to evaluate.
     """
 
-    def __init__(self, original_agent: Agent) -> None:
+    def __init__(self, original_agent: BaseAgent) -> None:
         """Initializes the TaskEvaluator with the given LLM and agent.
 
         Args:

--- a/lib/crewai/src/crewai/utilities/tool_utils.py
+++ b/lib/crewai/src/crewai/utilities/tool_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.agents.parser import AgentAction
 from crewai.agents.tools_handler import ToolsHandler
 from crewai.hooks.tool_hooks import (

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import MagicMock
+from src.crewai.utilities.agent_utils import is_null_response_because_context_length_exceeded
+
+def test_is_null_response_because_context_length_exceeded_true():
+    """
+    Test that the function returns True when the exception is a ValueError
+    with 'None or empty' and there are messages.
+    """
+    # Arrange
+    mock_llm = MagicMock()
+    mock_llm.get_context_window_size.return_value = 10
+    exception = ValueError("Invalid response from LLM call - None or empty.")
+    messages = [{"content": "This is a test message."}]
+
+    # Act
+    result = is_null_response_because_context_length_exceeded(exception, messages, mock_llm)
+
+    # Assert
+    assert result is True
+
+
+def test_is_null_response_because_context_length_exceeded_false_wrong_exception():
+    """
+    Test that the function returns False when the exception is not a ValueError.
+    """
+    # Arrange
+    mock_llm = MagicMock()
+    mock_llm.get_context_window_size.return_value = 10
+    exception = TypeError("Some other error.")
+    messages = [{"content": "This is a test message."}]
+
+    # Act
+    result = is_null_response_because_context_length_exceeded(exception, messages, mock_llm)
+
+    # Assert
+    assert result is False
+
+
+def test_is_null_response_because_context_length_exceeded_false_wrong_message():
+    """
+    Test that the function returns False when the exception message does not
+    contain 'None or empty'.
+    """
+    # Arrange
+    mock_llm = MagicMock()
+    mock_llm.get_context_window_size.return_value = 10
+    exception = ValueError("Another value error.")
+    messages = [{"content": "This is a test message."}]
+
+    # Act
+    result = is_null_response_because_context_length_exceeded(exception, messages, mock_llm)
+
+    # Assert
+    assert result is False
+
+
+def test_is_null_response_because_context_length_exceeded_false_empty_messages():
+    """
+    Test that the function returns False when the messages list is empty.
+    """
+    # Arrange
+    mock_llm = MagicMock()
+    mock_llm.get_context_window_size.return_value = 10
+    exception = ValueError("Invalid response from LLM call - None or empty.")
+    messages = []
+
+    # Act
+    result = is_null_response_because_context_length_exceeded(exception, messages, mock_llm)
+
+    # Assert
+    assert result is False
+
+
+def test_is_null_response_because_context_length_exceeded_false():
+    """
+    Test that the function returns True when the exception is a ValueError
+    with 'None or empty' and there are messages.
+    """
+    # Arrange
+    mock_llm = MagicMock()
+    mock_llm.get_context_window_size.return_value = 50
+    exception = ValueError("Invalid response from LLM call - None or empty.")
+    messages = [{"content": "This is a test message."}]
+
+    # Act
+    result = is_null_response_because_context_length_exceeded(exception, messages, mock_llm)
+
+    # Assert
+    assert result is False
+
+


### PR DESCRIPTION
This is a try solution for None / Empty response from LLM.

This PR assumes that this might be because of context length exceeded at the server side, which is not returning an error, just an empty response.
This PR captures the ValueError which is being raised and try again with summarization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detect and handle null/empty LLM responses as context-window overflows, triggering summarization; update typings to `BaseAgent` and add focused tests.
> 
> - **Agents/Execution**:
>   - Treat null/empty LLM responses as potential context-window overflows via new `is_null_response_because_context_length_exceeded` and route to `handle_context_length` in `CrewAgentExecutor` and `LiteAgent`.
>   - Add `LLMMessage` typing where needed.
> - **Utilities**:
>   - Add `is_null_response_because_context_length_exceeded(exception, messages, llm)` in `utilities/agent_utils.py`.
>   - Broaden `is_context_length_exceeded` docstring/signature; no behavioral regression.
> - **Types/API**:
>   - Use `BaseAgent` in `TaskEvaluator` and update related imports/usages (e.g., tool utils typing).
> - **Tests**:
>   - Add unit tests for null/empty response handling and new utility, plus executor integration test ensuring summarization path and final answer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da3f1955dd46739eb33fd53ad08097a75fea2882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->