### PR TITLE
chore: update version and dependencies to 0.201.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,4 +196,3 @@ exclude = [
 "docs/**",
 "docs/",
 ]
-

--- a/src/crewai/__init__.py
+++ b/src/crewai/__init__.py
@@ -40,7 +40,7 @@ def _suppress_pydantic_deprecation_warnings() -> None:
 
 _suppress_pydantic_deprecation_warnings()
 
-__version__ = "0.193.2"
+__version__ = "0.201.0"
 _telemetry_submitted = False
 
 

--- a/src/crewai/cli/templates/crew/pyproject.toml
+++ b/src/crewai/cli/templates/crew/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]>=0.193.2,<1.0.0"
+    "crewai[tools]>=0.201.0,<1.0.0"
 ]
 
 [project.scripts]

--- a/src/crewai/cli/templates/flow/pyproject.toml
+++ b/src/crewai/cli/templates/flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]>=0.193.2,<1.0.0",
+    "crewai[tools]>=0.201.0,<1.0.0",
 ]
 
 [project.scripts]

--- a/src/crewai/cli/templates/tool/pyproject.toml
+++ b/src/crewai/cli/templates/tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]>=0.193.2"
+    "crewai[tools]>=0.201.0"
 ]
 
 [tool.crewai]


### PR DESCRIPTION
- Bump CrewAI version to 0.201.0 in __init__.py
- Update dependency versions in pyproject.toml for crew, flow, and tool templates to require CrewAI 0.201.0
- Remove unnecessary blank line in pyproject.toml