### PR TITLE
chore: bump version to 1.0.0a1 across all packages

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pytube>=15.0.0",
     "requests>=2.32.0",
     "docker>=7.1.0",
-    "crewai==1.0.0a0",
+    "crewai==1.0.0a1",
     "lancedb>=0.5.4",
     "tiktoken>=0.8.0",
     "stagehand>=0.4.1",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 from .adapters.enterprise_adapter import EnterpriseActionTool
 from .adapters.mcp_adapter import MCPServerAdapter
 from .adapters.zapier_adapter import ZapierActionTool
@@ -98,4 +99,4 @@ from .tools import (
 )
 
 
-__version__ = "1.0.0a0"
+__version__ = "1.0.0a1"

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -50,7 +50,7 @@ Repository = "https://github.com/crewAIInc/crewAI"
 
 [project.optional-dependencies]
 tools = [
-    "crewai-tools==1.0.0a0",
+    "crewai-tools==1.0.0a1",
 ]
 embeddings = [
     "tiktoken~=0.8.0"

--- a/lib/crewai/src/crewai/__init__.py
+++ b/lib/crewai/src/crewai/__init__.py
@@ -1,7 +1,7 @@
 import threading
+from typing import Any
 import urllib.request
 import warnings
-from typing import Any
 
 from crewai.agent import Agent
 from crewai.crew import Crew
@@ -40,7 +40,7 @@ def _suppress_pydantic_deprecation_warnings() -> None:
 
 _suppress_pydantic_deprecation_warnings()
 
-__version__ = "1.0.0a0"
+__version__ = "1.0.0a1"
 _telemetry_submitted = False
 
 


### PR DESCRIPTION
- Updated version to 1.0.0a1 in pyproject.toml for crewai and crewai-tools
- Adjusted version in __init__.py files for consistency