### PR TITLE
docs: add HITL webhook authentication examples

### DIFF
--- a/docs/en/learn/human-in-the-loop.mdx
+++ b/docs/en/learn/human-in-the-loop.mdx
@@ -25,7 +25,7 @@ Human-in-the-Loop (HITL) is a powerful approach that combines artificial intelli
 
         Example with Bearer authentication:
         ```bash
-        curl -X POST https://api.crewai.com/v1/crews/{crew_id}/kickoff \
+        curl -X POST {BASE_URL}/kickoff \
           -H "Authorization: Bearer YOUR_API_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{
@@ -44,7 +44,7 @@ Human-in-the-Loop (HITL) is a powerful approach that combines artificial intelli
 
         Or with Basic authentication:
         ```bash
-        curl -X POST https://api.crewai.com/v1/crews/{crew_id}/kickoff \
+        curl -X POST {BASE_URL}/kickoff \
           -H "Authorization: Bearer YOUR_API_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{
@@ -115,4 +115,4 @@ HITL workflows are particularly valuable for:
 - Complex decision-making scenarios
 - Sensitive or high-stakes operations
 - Creative tasks requiring human judgment
-- Compliance and regulatory reviews 
+- Compliance and regulatory reviews


### PR DESCRIPTION
Add curl examples for humanInputWebhook with Bearer and Basic auth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds curl examples for HITL webhook authentication (Bearer and Basic) in kickoff requests and fixes a list bullet formatting issue.
> 
> - **Docs (HITL)**:
>   - **Webhook auth examples**: Add `curl` snippets showing `humanInputWebhook.authentication` for `bearer` and `basic` strategies in kickoff requests.
>   - Minor: fix list bullet formatting for `Compliance and regulatory reviews`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862c85f283415913a033368b6c05fca2aafb4189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->