### PR TITLE
fix: repository public issue

### DIFF
--- a/src/crewai/cli/utils.py
+++ b/src/crewai/cli/utils.py
@@ -430,6 +430,10 @@ def build_env_with_tool_repository_credentials(repository_handle: str):
         settings.tool_repository_password or ""
     )
 
+    # Also provide PUBLIC alias to support projects that reference an index named "public"
+    env["UV_INDEX_PUBLIC_USERNAME"] = str(settings.tool_repository_username or "")
+    env["UV_INDEX_PUBLIC_PASSWORD"] = str(settings.tool_repository_password or "")
+
     return env
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose `UV_INDEX_PUBLIC_USERNAME` and `UV_INDEX_PUBLIC_PASSWORD` alongside repository-specific vars to support indexes named "public".
> 
> - **CLI utils**:
>   - In `build_env_with_tool_repository_credentials`, also set `UV_INDEX_PUBLIC_USERNAME` and `UV_INDEX_PUBLIC_PASSWORD` from `Settings` to support projects referencing a `public` index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c061252de759c094106b804223091d8b7287ffe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->