### PR TITLE
Allow Flow initialization with required BaseModel fields via kwargs

### DIFF
--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -465,7 +465,7 @@ class Flow(Generic[T], metaclass=FlowMeta):
         self._is_execution_resuming: bool = False
 
         # Initialize state with initial values
-        self._state = self._create_initial_state()
+        self._state = self._create_initial_state(kwargs)
         self.tracing = tracing
         if (
             is_tracing_enabled()
@@ -474,9 +474,6 @@ class Flow(Generic[T], metaclass=FlowMeta):
         ):
             trace_listener = TraceCollectionListener()
             trace_listener.setup_listeners(crewai_event_bus)
-        # Apply any additional kwargs
-        if kwargs:
-            self._initialize_state(kwargs)
 
         crewai_event_bus.emit(
             self,
@@ -502,23 +499,25 @@ class Flow(Generic[T], metaclass=FlowMeta):
                         method = method.__get__(self, self.__class__)
                     self._methods[method_name] = method
 
-    def _create_initial_state(self) -> T:
+    def _create_initial_state(self, kwargs: dict[str, Any] | None = None) -> T:
         """Create and initialize flow state with UUID and default values.
+        If kwargs are provided, use them to initialize the state.
 
-        Returns:
-            New state instance with UUID and default values initialized
+        Args:
+            kwargs: Dictionary of state values to set/update
 
         Raises:
             ValueError: If structured state model lacks 'id' field
             TypeError: If state is neither BaseModel nor dictionary
         """
+        kwargs = kwargs or {}
+
         # Handle case where initial_state is None but we have a type parameter
         if self.initial_state is None and hasattr(self, "_initial_state_t"):
             state_type = self._initial_state_t
             if isinstance(state_type, type):
                 if issubclass(state_type, FlowState):
-                    # Create instance without id, then set it
-                    instance = state_type()
+                    instance = state_type(**kwargs)
                     if not hasattr(instance, "id"):
                         instance.id = str(uuid4())
                     return cast(T, instance)
@@ -527,33 +526,38 @@ class Flow(Generic[T], metaclass=FlowMeta):
                     class StateWithId(state_type, FlowState):  # type: ignore
                         pass
 
-                    instance = StateWithId()
+                    instance = StateWithId(**kwargs)
                     if not hasattr(instance, "id"):
                         instance.id = str(uuid4())
                     return cast(T, instance)
                 if state_type is dict:
-                    return cast(T, {"id": str(uuid4())})
+                    return cast(T, {"id": str(uuid4()), **kwargs})
 
         # Handle case where no initial state is provided
         if self.initial_state is None:
-            return cast(T, {"id": str(uuid4())})
+            return cast(T, {"id": str(uuid4()), **kwargs})
 
         # Handle case where initial_state is a type (class)
         if isinstance(self.initial_state, type):
             if issubclass(self.initial_state, FlowState):
-                return cast(T, self.initial_state())  # Uses model defaults
+                # Uses model defaults + kwargs
+                return cast(T, self.initial_state(**kwargs))
             if issubclass(self.initial_state, BaseModel):
                 # Validate that the model has an id field
                 model_fields = getattr(self.initial_state, "model_fields", None)
                 if not model_fields or "id" not in model_fields:
                     raise ValueError("Flow state model must have an 'id' field")
-                return cast(T, self.initial_state())  # Uses model defaults
+                # Uses model defaults + kwargs
+                return cast(T, self.initial_state(**kwargs))
             if self.initial_state is dict:
-                return cast(T, {"id": str(uuid4())})
+                return cast(T, {"id": str(uuid4()), **kwargs})
 
         # Handle dictionary instance case
         if isinstance(self.initial_state, dict):
-            new_state = dict(self.initial_state)  # Copy to avoid mutations
+            # Copy to avoid mutations
+            new_state = dict(self.initial_state)
+            # Apply kwargs
+            new_state.update(kwargs)
             if "id" not in new_state:
                 new_state["id"] = str(uuid4())
             return cast(T, new_state)
@@ -576,6 +580,9 @@ class Flow(Generic[T], metaclass=FlowMeta):
                 state_dict = {
                     k: v for k, v in model.__dict__.items() if not k.startswith("_")
                 }
+
+            # Merge kwargs into state_dict
+            state_dict.update(kwargs)
 
             # Create new instance of the same class
             model_class = type(model)


### PR DESCRIPTION
Related Issues
Closes [#3629](https://github.com/crewAIInc/crewAI/issues/3629)

**Changes**
This PR fixes the initialization issue when using Pydantic BaseModel with required fields as Flow state by enabling kwargs to be passed during state creation.

**What Changed**
- Modified `_create_initial_state()` method signature
    - Added kwargs: `dict[str, Any] | None = None` parameter
    - Pass kwargs when instantiating BaseModel classes
    - Merge kwargs into dictionary states

- Updated `__init__()` method
    - Pass kwargs to `_create_initial_state()`
    - Removed redundant `_initialize_state(kwargs)` call from init since kwargs are now handled during state creation

**Files Changed**
- `src/crewai/flow/flow.py`

**Why This Solution**
- Minimal changes: Only modifies the initialization flow, no breaking changes
- Reuses existing logic: Leverages Pydantic's built-in validation with kwargs
- Backwards compatible: Existing code without kwargs continues to work
- Type safe: Pydantic validates kwargs against the model schema
- Consistent: All state types (dict, BaseModel, FlowState) handle kwargs uniformly

*Additional Notes**
The `_initialize_state()` method remains unchanged and continues to be used by `kickoff_async()` for runtime state updates. This separation of concerns maintains clarity:
- `_create_initial_state()`: Creates the initial state during Flow instantiation
- `_initialize_state()`: Updates state during Flow execution (kickoff)