### PR TITLE
Fix CodeQL configuration to properly exclude template directories

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+name: "CodeQL Config"
+
+paths-ignore:
+  # Ignore template files - these are boilerplate code that shouldn't be analyzed
+  - "src/crewai/cli/templates/**"
+  # Ignore test cassettes - these are test fixtures/recordings
+  - "tests/cassettes/**"
+  # Ignore cache and build artifacts
+  - ".cache/**"
+  # Ignore documentation build artifacts
+  - "docs/.cache/**"
+  
+paths:
+  # Include all Python source code
+  - "src/**"
+  # Include tests (but exclude cassettes)
+  - "tests/**"
+
+# Configure specific queries or packs if needed
+# queries:
+#   - uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,6 +73,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## Problem
The CodeQL workflow's paths-ignore configuration was not working to exclude template directories from analysis because CodeQL requires a separate configuration file.

## Solution
- Created .github/codeql/codeql-config.yml to exclude template files from analysis
- Updated CodeQL workflow to use config-file parameter  
- Excludes src/crewai/cli/templates/** and other non-source directories

## Benefits
- Improved CodeQL performance by focusing on relevant code
- Cleaner security scan results
- Excludes template/boilerplate files from analysis