### PR TITLE
chore: add scheduled cache rebuild to prevent expiration

### DIFF
--- a/.github/workflows/build-uv-cache.yml
+++ b/.github/workflows/build-uv-cache.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "uv.lock"
       - "pyproject.toml"
+  schedule:
+    - cron: "0 0 */5 * *"  # Run every 5 days at midnight UTC to prevent cache expiration
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add cron schedule to rebuild UV cache every 5 days, preventing the 7-day expiration policy from invalidating the cache.