### PR TITLE
Qdrant Vector Search Tool docs

### DIFF
--- a/docs/en/tools/database-data/qdrantvectorsearchtool.mdx
+++ b/docs/en/tools/database-data/qdrantvectorsearchtool.mdx
@@ -214,7 +214,7 @@ The tool returns results in JSON format:
 
 ## Default Embedding
 
-By default, the tool uses OpenAI's `text-embedding-3-small` model for vectorization. This requires:
+By default, the tool uses OpenAI's `text-embedding-3-large` model for vectorization. This requires:
 - OpenAI API key set in environment: `OPENAI_API_KEY`
 
 ## Custom Embeddings


### PR DESCRIPTION
According ro documentation it shows that `text-embedding-3-small` is the default model, though with the code `text-embedding-3-large` is the default model.
Fixing that here.

https://github.com/crewAIInc/crewAI-tools/blob/8094f3b9675ec70b5e585a38e7d3f0b8fef64f1c/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py#L139-L143