### PR TITLE
chore: remove lib/crewai exclusion from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,22 @@ repos:
       - id: ruff
         name: ruff
         entry: uv run ruff check
+        args: ["--config", "pyproject.toml", "."]
         language: system
+        pass_filenames: false
         types: [python]
-        exclude: ^lib/crewai/
       - id: ruff-format
         name: ruff-format
         entry: uv run ruff format
+        args: ["--config", "pyproject.toml", "."]
         language: system
+        pass_filenames: false
         types: [python]
-        exclude: ^lib/crewai/
       - id: mypy
         name: mypy
         entry: uv run mypy
+        args: ["--config-file", "pyproject.toml", "."]
         language: system
+        pass_filenames: false
         types: [python]
-        exclude: ^lib/crewai/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dev = [
 
 
 [tool.ruff]
-exclude = [
+src = ["lib/*"]
+extend-exclude = [
     "lib/crewai/src/crewai/cli/templates",
     "lib/crewai/tests/",
     "lib/crewai-tools/tests/",


### PR DESCRIPTION
Remove exclusion patterns for lib/crewai/ directory from pre-commit hooks and configure hooks to use pyproject.toml settings with pass_filenames: false for consistent behavior.