### PR TITLE
Fix: Flow visualizer supports dict-based listener conditions (or*/and*) with minimal changes

### DIFF
--- a/lib/crewai/src/crewai/flow/visualization_utils.py
+++ b/lib/crewai/src/crewai/flow/visualization_utils.py
@@ -27,6 +27,7 @@ from crewai.flow.config import (
     RouterNodeStyle,
     StartNodeStyle,
 )
+from crewai.flow.types import FlowMethodName
 from crewai.flow.utils import (
     build_ancestor_dict,
     build_parent_children_dict,
@@ -37,6 +38,7 @@ from crewai.flow.utils import (
     normalize_condition,
 )
 from crewai.utilities.printer import Printer
+
 
 _printer = Printer()
 
@@ -231,7 +233,7 @@ def add_edges(
     # Edges for normal listeners
     for method_name, condition_data in flow._listeners.items():
         # condition_data can be either a tuple (condition_type, methods) or a dict from or_/and_
-        trigger_methods: list[str] = []
+        trigger_methods: list[FlowMethodName] = []
         is_and_condition = False
 
         if isinstance(condition_data, tuple) and len(condition_data) == 2:
@@ -305,6 +307,7 @@ def add_edges(
         for path in paths:
             for listener_name, condition_data in flow._listeners.items():
                 # Determine triggers for this listener
+                methods: list[FlowMethodName] = []
                 if isinstance(condition_data, tuple) and len(condition_data) == 2:
                     _condition_type, trigger_methods = condition_data
                     methods = trigger_methods


### PR DESCRIPTION
### Title

Fix: Flow visualizer supports dict-based listener conditions (or*/and*) with minimal changes

### Context

Flows created with `or_`/`and_` combinators store listener conditions as dicts. The visualizer and a few utilities assumed tuple-only conditions, which led to missing edges and noisy warnings during plotting when dict-shaped conditions were present.

### Problem

- Router/listener edges derived from dict-shaped conditions were not recognized.
- Plotting produced warnings like “No node found for 'c' …” and omitted edges.

### Solution

Add lightweight dict-awareness alongside the existing tuple path:

- Normalize dict-shaped conditions to retrieve `type` (OR/AND) and the full list of trigger methods.
- Use that information anywhere edges/levels/parent-child relations are computed.
- Preserve the original tuple-based behavior and structure.

### Files Changed (minimal, targeted edits)

- `lib/crewai/src/crewai/flow/visualization_utils.py`

  - `add_edges`: when a listener condition is a dict, normalize and extract methods; same for router return paths. Tuple handling unchanged.

- `lib/crewai/src/crewai/flow/utils.py`
  - `calculate_node_levels`: accept dict conditions by normalizing/extracting before building OR/AND dependencies.
  - `build_parent_children_dict`: include listeners defined via dict conditions when mapping parents/children and router→listener links.
  - `process_router_paths`: trigger listeners that are defined via dict conditions.

### Validation

- Verified the plot includes all expected nodes and edges, including router outcomes; no missing-node warnings.
- Confirmed tuple-only flows render exactly as before.

### How to Test

1. Create a small flow that uses:

- `@listen(or_(a, b))` and `@listen(and_(a, b))`
- `@router(x)` that can return multiple string paths

2. Call `flow.plot()` and verify:

- No warnings about missing nodes
- Router edges are dashed; nodes are placed and labeled as expected

### Backwards Compatibility

- Fully backward compatible. Tuple behavior unchanged; dict support is additive and limited to visualization-related utilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add dict-aware handling of listener conditions (or_/and_) across flow utils and visualizer to correctly compute levels and render edges, including router paths.
> 
> - **Flow utils**:
>   - Add `normalize_condition` and `extract_all_methods` to unify/collect methods from nested condition dicts.
>   - Update `calculate_node_levels` to accept dict-shaped conditions and compute OR/AND dependencies accordingly.
>   - Update `build_parent_children_dict` and `process_router_paths` to map/propagate listeners from dict and tuple conditions; handle router → listener links.
>   - Improve typing (e.g., `visit_*` annotations, `is_flow_method_callable` generics).
> - **Visualizer**:
>   - `add_edges` now resolves listener triggers from dict conditions and correctly styles OR/AND and router edges.
>   - Handle router return-path edges when listeners use dict conditions; reduce spurious missing-node warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5b8a10baffbbdf1d3995b573c28fd07d32176b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->