### PR TITLE
Improve QdrantVectorSearchTool schema descriptions

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
@@ -12,12 +12,16 @@ from pydantic.types import ImportString
 
 
 class QdrantToolSchema(BaseModel):
-    query: str = Field(..., description="Query to search in Qdrant DB")
+    query: str = Field(
+        ..., description="Query to search in Qdrant DB - always required."
+    )
     filter_by: str | None = Field(
-        default=None, description="Parameter to filter the search by."
+        default=None,
+        description="Parameter to filter the search by. When filtering, needs to be used in conjunction with filter_value.",
     )
     filter_value: Any | None = Field(
-        default=None, description="Value to filter the search by."
+        default=None,
+        description="Value to filter the search by. When filtering, needs to be used in conjunction with filter_by.",
     )
 
 


### PR DESCRIPTION
Enhanced schema field descriptions in `QdrantVectorSearchTool` for better clarity:

- Made it explicit that `query` is always required
- Clarified that `filter_by` and `filter_value` must be used together for filtering

**Changes:**
- Updated `QdrantToolSchema` field descriptions in `qdrant_search_tool.py`

**Type:** Documentation enhancement
**Breaking Changes:** None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies `QdrantToolSchema` by stating `query` is always required and `filter_by`/`filter_value` must be used together.
> 
> - **QdrantVectorSearchTool**:
>   - **Schema docs**: Update `QdrantToolSchema` field descriptions in `qdrant_search_tool.py`:
>     - `query`: explicitly marked as always required.
>     - `filter_by` and `filter_value`: clarified they must be used together for filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d625e345a9e366fe05a589b6cddaf180a8a179f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->