### PR TITLE
fix: Make TaskEvaluation.quality optional with default value

### DIFF
--- a/lib/crewai/src/crewai/utilities/evaluators/task_evaluator.py
+++ b/lib/crewai/src/crewai/utilities/evaluators/task_evaluator.py
@@ -29,7 +29,8 @@ class TaskEvaluation(BaseModel):
         description="Suggestions to improve future similar tasks."
     )
     quality: float = Field(
-        description="A score from 0 to 10 evaluating on completion, quality, and overall performance, all taking into account the task description, expected output, and the result of the task."
+        default=5.0,
+        description="A score from 0 to 10 evaluating on completion, quality, and overall performance, all taking into account the task description, expected output, and the result of the task. Defaults to 5.0 if not provided."
     )
     entities: list[Entity] = Field(
         description="Entities extracted from the task output."
@@ -86,9 +87,9 @@ class TaskEvaluator:
             f"Task Description:\n{task.description}\n\n"
             f"Expected Output:\n{task.expected_output}\n\n"
             f"Actual Output:\n{output}\n\n"
-            "Please provide:\n"
+            "Please provide ALL of the following (all fields are required):\n"
             "- Bullet points suggestions to improve future similar tasks\n"
-            "- A score from 0 to 10 evaluating on completion, quality, and overall performance"
+            "- A quality score from 0 to 10 evaluating on completion, quality, and overall performance (REQUIRED - must be a numeric value)\n"
             "- Entities extracted from the task output, if any, their type, description, and relationships"
         )
 


### PR DESCRIPTION
## Problem
TaskEvaluation Pydantic validation fails when LLM streaming responses omit the required `quality` field, causing memory save failures. This matches the issue described in #3915.

## Solution
- Made `quality` field optional with default value of 5.0
- Improved evaluation prompt to emphasize quality requirement
- Added comprehensive tests

## Testing
- Added tests for missing quality field (defaults to 5.0)
- Added tests for provided quality field (backward compatible)
- Verified no linting errors

## Impact
- Fixes validation errors preventing memory saves
- Backward compatible (existing code continues to work)
- Low risk (LongTermMemoryItem already accepts None for quality)

Fixes #3915

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set a 5.0 default for TaskEvaluation.quality, tighten the evaluation prompt requirements, and add tests covering missing/provided quality and JSON parsing.
> 
> - **Utilities**
>   - `TaskEvaluation`: set `quality` default to `5.0` and update its description.
> - **Evaluator Prompt**
>   - `TaskEvaluator.evaluate`: require ALL fields; emphasize numeric, required `quality` score in instructions.
> - **Tests**
>   - Add tests verifying default `quality` when omitted, handling when provided, and `model_validate_json` with partial JSON; update imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d1f44449be3e3dd528fbb89f3f7845ec4c94e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->