### PR TITLE
fix: Stop passing invalid argument during SSE client initialization (#3938)

### DIFF
--- a/lib/crewai/src/crewai/mcp/transports/sse.py
+++ b/lib/crewai/src/crewai/mcp/transports/sse.py
@@ -66,7 +66,6 @@ class SSETransport(BaseTransport):
             self._transport_context = sse_client(
                 self.url,
                 headers=self.headers if self.headers else None,
-                terminate_on_close=True,
             )
 
             read, write = await self._transport_context.__aenter__()


### PR DESCRIPTION
This PR addresses #3938.

## Description
When initializing an MCP client while creating a connection to an MCP server using SSE transport, an invalid argument (`terminate_on_close`) is passed. The argument is valid for [streamable HTTP transport](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/streamable_http.py#L452C5-L452C23), but is not supported for [SSE transport](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/sse.py#L25-L32). This results in a crash when trying to run an agent that connects to an MCP server using SSE transport.

## Changes

- The `terminate_on_close` argument is no longer passed during the initialization of MCP's SSE transport

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unsupported `terminate_on_close` arg from SSE client init to prevent crashes.
> 
> - **Fix**:
>   - Remove unsupported `terminate_on_close` argument when initializing `mcp.client.sse.sse_client` in `lib/crewai/src/crewai/mcp/transports/sse.py`, preventing SSE connection failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a78ae1ae0c9a0634644cf968c104082df122a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->