### PR TITLE
Refactor CacheHandler to avoid shadowing built-in `input`

### DIFF
--- a/lib/crewai/src/crewai/agents/cache/cache_handler.py
+++ b/lib/crewai/src/crewai/agents/cache/cache_handler.py
@@ -20,26 +20,26 @@ class CacheHandler(BaseModel):
     _cache: dict[str, Any] = PrivateAttr(default_factory=dict)
     _lock: RWLock = PrivateAttr(default_factory=RWLock)
 
-    def add(self, tool: str, input: str, output: Any) -> None:
+    def add(self, tool: str, tool_input: str, output: Any) -> None:
         """Add a tool result to the cache.
 
         Args:
             tool: Name of the tool.
-            input: Input string used for the tool.
+            tool_input: Input string used for the tool.
             output: Output result from tool execution.
 
         Notes:
             - TODO: Rename 'input' parameter to avoid shadowing builtin.
         """
         with self._lock.w_locked():
-            self._cache[f"{tool}-{input}"] = output
+            self._cache[f"{tool}-{tool_input}"] = output
 
-    def read(self, tool: str, input: str) -> Any | None:
+    def read(self, tool: str, tool_input: str) -> Any | None:
         """Retrieve a cached tool result.
 
         Args:
             tool: Name of the tool.
-            input: Input string used for the tool.
+            tool_input: Input string used for the tool.
 
         Returns:
             Cached result if found, None otherwise.
@@ -48,4 +48,4 @@ class CacheHandler(BaseModel):
             - TODO: Rename 'input' parameter to avoid shadowing builtin.
         """
         with self._lock.r_locked():
-            return self._cache.get(f"{tool}-{input}")
+            return self._cache.get(f"{tool}-{tool_input}")

--- a/lib/crewai/src/crewai/project/utils.py
+++ b/lib/crewai/src/crewai/project/utils.py
@@ -64,12 +64,12 @@ def memoize(meth: Callable[P, R]) -> Callable[P, R]:
         )
         cache_key = str((hashable_args, hashable_kwargs))
 
-        cached_result: R | None = cache.read(tool=meth.__name__, input=cache_key)
+        cached_result: R | None = cache.read(tool=meth.__name__, tool_input=cache_key)
         if cached_result is not None:
             return cached_result
 
         result = meth(*args, **kwargs)
-        cache.add(tool=meth.__name__, input=cache_key, output=result)
+        cache.add(tool=meth.__name__, tool_input=cache_key, output=result)
         return result
 
     return cast(Callable[P, R], wrapper)

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -215,7 +215,7 @@ class ToolUsage:
                     input_str = str(calling.arguments)
 
             result = self.tools_handler.cache.read(
-                tool=calling.tool_name, input=input_str
+                tool=calling.tool_name, tool_input=input_str
             )  # type: ignore
             from_cache = result is not None
 


### PR DESCRIPTION
**Summary**
Rename the `input` parameter in `CacheHandler` to avoid shadowing Python’s built‑in `input`, and update all call sites accordingly. Behavior is unchanged; this is a small readability and safety improvement.

**Changes**
- lib/crewai/src/crewai/agents/cache/cache_handler.py:
   - Rename:
   `add(self, tool: str, input: str, output: Any)` -> `add(self, tool: str, tool_input: str, output: Any)`.
   - Rename:
   `read(self, tool: str, input: str)` -> `read(self, tool: str, tool_input: str)`.
   - Update docstrings and cache key construction to use `tool_input`.
- lib/crewai/src/crewai/project/utils.py
   - Update memoization helper to call:
   `cache.read(tool=meth.name, tool_input=cache_key)`
   `cache.add(tool=meth.name, tool_input=cache_key, output=result)`
- lib/crewai/src/crewai/tools/tool_usage.py
   - Update cache lookup to:
   `self.tools_handler.cache.read(tool=calling.tool_name, tool_input=input_str)`

**Rationale**
- Avoids shadowing the built‑in `input`, which can be confusing and can trip up linters/tooling.
- Aligns with the existing TODO in `CacheHandler` to rename this parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames CacheHandler parameter `input` to `tool_input` and updates all usages in utils and tool usage; behavior unchanged.
> 
> - **Cache**:
>   - Rename `CacheHandler.add(tool, input, output)` -> `add(tool, tool_input, output)` and `read(tool, input)` -> `read(tool, tool_input)` in `lib/crewai/src/crewai/agents/cache/cache_handler.py`; update docstrings and key construction (`f"{tool}-{tool_input}"`).
> - **Call sites**:
>   - Update memoization calls in `lib/crewai/src/crewai/project/utils.py` to use `tool_input=cache_key` in `cache.read`/`cache.add`.
>   - Update cache lookup in `lib/crewai/src/crewai/tools/tool_usage.py` to `cache.read(tool=calling.tool_name, tool_input=input_str)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e985c1f0f6adf5ab7da2503a058055b816f627a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->