### PR TITLE
chore: update hotfix crewAI version 0.203.1 -> 0.203.2

### DIFF
--- a/src/crewai/__init__.py
+++ b/src/crewai/__init__.py
@@ -40,7 +40,7 @@ def _suppress_pydantic_deprecation_warnings() -> None:
 
 _suppress_pydantic_deprecation_warnings()
 
-__version__ = "0.203.1"
+__version__ = "0.203.2"
 _telemetry_submitted = False
 
 


### PR DESCRIPTION
- Bumped the `crewai` version in `__init__.py` to 0.203.2.