### PR TITLE
Update references from AMP to AOP in documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -326,7 +326,7 @@
             ]
           },
           {
-            "tab": "AMP",
+            "tab": "AOP",
             "icon": "briefcase",
             "groups": [
               {
@@ -753,7 +753,7 @@
             ]
           },
           {
-            "tab": "AMP",
+            "tab": "AOP",
             "icon": "briefcase",
             "groups": [
               {

--- a/docs/en/enterprise/introduction.mdx
+++ b/docs/en/enterprise/introduction.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 ## Introduction
 
-CrewAI AOP(Agent Management Platform) provides a platform for deploying, monitoring, and scaling your crews and agents in a production environment.
+CrewAI AOP(Agent Operations Platform) provides a platform for deploying, monitoring, and scaling your crews and agents in a production environment.
 
 <Frame>
   <img src="/images/enterprise/crewai-enterprise-dashboard.png" alt="CrewAI AOP Dashboard" />

--- a/docs/ko/enterprise/introduction.mdx
+++ b/docs/ko/enterprise/introduction.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 ## 소개
 
-CrewAI AOP(Agent Management Platform)는 프로덕션 환경에서 crew와 agent를 배포, 모니터링, 확장할 수 있는 플랫폼을 제공합니다.
+CrewAI AOP(Agent Operation Platform)는 프로덕션 환경에서 crew와 agent를 배포, 모니터링, 확장할 수 있는 플랫폼을 제공합니다.
 
 <Frame>
   <img src="/images/enterprise/crewai-enterprise-dashboard.png" alt="CrewAI AOP Dashboard" />

--- a/docs/pt-BR/enterprise/introduction.mdx
+++ b/docs/pt-BR/enterprise/introduction.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 ## Introdução
 
-CrewAI AOP(Agent Management Platform) fornece uma plataforma para implementar, monitorar e escalar seus crews e agentes em um ambiente de produção.
+CrewAI AOP(Agent Operation Platform) fornece uma plataforma para implementar, monitorar e escalar seus crews e agentes em um ambiente de produção.
 
 <Frame>
   <img src="/images/enterprise/crewai-enterprise-dashboard.png" alt="CrewAI AOP Dashboard" />


### PR DESCRIPTION
- Changed "AMP" to "AOP" in multiple locations across JSON and MDX files to reflect the correct terminology for the Agent Operations Platform.
- Updated the introduction sections in English, Korean, and Portuguese to ensure consistency in the platform's naming.