### PR TITLE
adding arize eval page link

### DIFF
--- a/docs/en/observability/arize-phoenix.mdx
+++ b/docs/en/observability/arize-phoenix.mdx
@@ -10,6 +10,7 @@ mode: "wide"
 This guide demonstrates how to integrate **Arize Phoenix** with **CrewAI** using OpenTelemetry via the [OpenInference](https://github.com/openinference/openinference) SDK. By the end of this guide, you will be able to trace your CrewAI agents and easily debug your agents.
 
 > **What is Arize Phoenix?** [Arize Phoenix](https://phoenix.arize.com) is an LLM observability platform that provides tracing and evaluation for AI applications.
+[Top LLM Observability Platforms](https://arize.com/llm-evaluation-platforms-top-frameworks)
 
 [![Watch a Video Demo of Our Integration with Phoenix](https://storage.googleapis.com/arize-assets/fixtures/setup_crewai.png)](https://www.youtube.com/watch?v=Yc5q3l6F7Ww)
 


### PR DESCRIPTION
Trying to link to our Arize eval page a bit more on partner sites. Hope adding this one link isn't too much of a problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a link to “Top LLM Observability Platforms” in `docs/en/observability/arize-phoenix.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebe25e758ab5cfd2807aa18eaed990f6796fcdd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->