### PR TITLE
Add Merge Agent Handler to Tools page

### DIFF
--- a/docs/en/concepts/tools.mdx
+++ b/docs/en/concepts/tools.mdx
@@ -13,7 +13,7 @@ This documentation outlines how to create, integrate, and leverage these tools w
 ## What is a Tool?
 
 A tool in CrewAI is a skill or function that agents can utilize to perform various actions.
-This includes tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools),
+This includes tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools), [Merge Agent Handler](https://docs.ah.merge.dev/Overview/Agent-Handler-intro) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools),
 enabling everything from simple searches to complex interactions and effective teamwork among agents.
 
 <Note type="info" title="Enterprise Enhancement: Tools Repository">
@@ -139,6 +139,7 @@ Here is a list of the available tools and their descriptions:
 | **JSONSearchTool**               | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
 | **LlamaIndexTool**               | Enables the use of LlamaIndex tools.                                                           |
 | **MDXSearchTool**                | A RAG tool tailored for searching within Markdown (MDX) files, useful for documentation.       |
+| **MergeAgentHandlerTool**        | Enables use of Merge Agent Handler tools.                                                      |
 | **PDFSearchTool**                | A RAG tool aimed at searching within PDF documents, ideal for processing scanned documents.    |
 | **PGSearchTool**                 | A RAG tool optimized for searching within PostgreSQL databases, suitable for database queries. |
 | **Vision Tool**                  | A tool for generating images using the DALL-E API.                                             |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Merge Agent Handler references and tool listing to the Tools documentation.
> 
> - **Docs › Tools**:
>   - **Overview**: Include `Merge Agent Handler` alongside `crewai-tools` and `LangChain Tools`.
>   - **Available tools table**: Add `MergeAgentHandlerTool` with description for using Merge Agent Handler tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f363fc7d900a85720515f1275cd4da57481b57b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->