### PR TITLE
chore: display error message from response when tool repository login fails

### DIFF
--- a/lib/crewai/src/crewai/cli/tools/main.py
+++ b/lib/crewai/src/crewai/cli/tools/main.py
@@ -1,4 +1,5 @@
 import base64
+from json import JSONDecodeError
 import os
 from pathlib import Path
 import subprocess
@@ -165,10 +166,16 @@ class ToolCommand(BaseCommand, PlusAPIMixin):
                 "Authentication failed. Verify if the currently active organization can access the tool repository, and run 'crewai login' again.",
                 style="bold red",
             )
-            console.print(
-                f"[{login_response.status_code} error - {login_response.json().get('message', 'Unknown error')}]",
-                style="bold red italic",
-            )
+            try:
+                console.print(
+                    f"[{login_response.status_code} error - {login_response.json().get('message', 'Unknown error')}]",
+                    style="bold red italic",
+                )
+            except JSONDecodeError:
+                console.print(
+                    f"[{login_response.status_code} error - Unknown error - Invalid JSON response]",
+                    style="bold red italic",
+                )
             raise SystemExit
 
         login_response_json = login_response.json()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> On failed tool repo login, display HTTP status and server error message, with fallback for invalid JSON responses.
> 
> - **CLI (`crewai/cli/tools/main.py`)**:
>   - Improve login failure feedback in `ToolCommand.login()`:
>     - Prints HTTP status and server `message` from JSON response.
>     - Gracefully handles invalid JSON (`JSONDecodeError`) with a fallback message.
>     - Minor copy edit in the authentication failure prompt.
>   - Add import for `JSONDecodeError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddbc07437aea7805a257a41a3bef50bb65f7767f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




Local testing:
<img width="1402" height="137" alt="image" src="https://github.com/user-attachments/assets/3aaa2270-6744-45e5-a212-346d0ac402a5" />

<img width="1397" height="141" alt="image" src="https://github.com/user-attachments/assets/40f129d1-87e6-4e9c-ab0e-f310ea9b9098" />

towards ENG-1395
