### PR TITLE
feat(tavily): add client_source parameter to Tavily clients

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/tavily_extractor_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/tavily_extractor_tool.py
@@ -89,9 +89,9 @@ class TavilyExtractorTool(BaseTool):
         """
         super().__init__(**kwargs)
         if TAVILY_AVAILABLE:
-            self.client = TavilyClient(api_key=self.api_key, proxies=self.proxies)
+            self.client = TavilyClient(api_key=self.api_key, proxies=self.proxies, client_source="crewai")
             self.async_client = AsyncTavilyClient(
-                api_key=self.api_key, proxies=self.proxies
+                api_key=self.api_key, proxies=self.proxies, client_source="crewai"
             )
         else:
             try:

--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_search_tool/tavily_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_search_tool/tavily_search_tool.py
@@ -117,9 +117,9 @@ class TavilySearchTool(BaseTool):
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
         if TAVILY_AVAILABLE:
-            self.client = TavilyClient(api_key=self.api_key, proxies=self.proxies)
+            self.client = TavilyClient(api_key=self.api_key, proxies=self.proxies, client_source="crewai")
             self.async_client = AsyncTavilyClient(
-                api_key=self.api_key, proxies=self.proxies
+                api_key=self.api_key, proxies=self.proxies, client_source="crewai"
             )
         else:
             try:


### PR DESCRIPTION
Add client_source="crewai" to TavilyClient and AsyncTavilyClient instantiations in both TavilySearchTool and TavilyExtractorTool to enable tracking of integration usage via X-Client-Source header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds client_source="crewai" to TavilyClient and AsyncTavilyClient initialization in both TavilySearchTool and TavilyExtractorTool.
> 
> - **Tavily tools**:
>   - Add `client_source="crewai"` to `TavilyClient` and `AsyncTavilyClient` initialization in:
>     - `crewai_tools/tools/tavily_search_tool/tavily_search_tool.py`
>     - `crewai_tools/tools/tavily_extractor_tool/tavily_extractor_tool.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c971153ceb0f7c067ac64944ff2483885a294940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->