### PR TITLE
feat(tavily): add map tool

### DIFF
--- a/docs/en/tools/search-research/overview.mdx
+++ b/docs/en/tools/search-research/overview.mdx
@@ -54,6 +54,10 @@ These tools enable your agents to search the web, research topics, and find info
     Extract structured content from web pages using the Tavily API.
   </Card>
 
+  <Card title="Tavily Map Tool" icon="sitemap" href="/en/tools/search-research/tavilymaptool">
+    Map website structure and discover pages without full extraction.
+  </Card>
+
   <Card title="Arxiv Paper Tool" icon="box-archive" href="/en/tools/search-research/arxivpapertool">
     Search arXiv and optionally download PDFs.
   </Card>

--- a/docs/en/tools/search-research/tavilymaptool.mdx
+++ b/docs/en/tools/search-research/tavilymaptool.mdx
@@ -1,0 +1,166 @@
+---
+title: "Tavily Map Tool"
+description: "Map website structure and discover pages using the Tavily API"
+icon: "sitemap"
+mode: "wide"
+---
+
+The `TavilyMapTool` allows CrewAI agents to map the structure of websites starting from a base URL using the Tavily API. It discovers pages, links, and site hierarchy without extracting full content, making it ideal for understanding site architecture.
+
+## Installation
+
+To use the `TavilyMapTool`, you need to install the `tavily-python` library:
+
+```shell
+pip install 'crewai[tools]' tavily-python
+```
+
+You also need to set your Tavily API key as an environment variable:
+
+```bash
+export TAVILY_API_KEY='your-tavily-api-key'
+```
+
+Get an API key at https://app.tavily.com/ (sign up, then create a key).
+
+## Example Usage
+
+Here's how to initialize and use the `TavilyMapTool` within a CrewAI agent:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import TavilyMapTool
+
+# Ensure TAVILY_API_KEY is set in your environment
+# os.environ["TAVILY_API_KEY"] = "YOUR_API_KEY"
+
+# Initialize the tool
+map_tool = TavilyMapTool()
+
+# Create an agent that uses the tool
+mapper_agent = Agent(
+    role='Site Mapper',
+    goal='Map website structures and discover all pages',
+    backstory='You are an expert at mapping website structures using the Tavily API.',
+    tools=[map_tool],
+    verbose=True
+)
+
+# Define a task for the agent
+map_task = Task(
+    description='Map the structure of https://docs.example.com to understand the site hierarchy.',
+    expected_output='A JSON string containing the site structure and discovered URLs.',
+    agent=mapper_agent
+)
+
+# Create and run the crew
+crew = Crew(
+    agents=[mapper_agent],
+    tasks=[map_task],
+    verbose=2
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Configuration Options
+
+### Agent-Settable Parameters (Runtime)
+
+These parameters can be provided by the agent at runtime:
+
+- `url` (str): **Required**. The base URL to start mapping from.
+- `max_depth` (int, 1-5, optional): Maximum depth to map (number of link hops from the base URL).
+- `instructions` (str, optional): Natural language instructions to guide the mapping (e.g., 'focus on documentation pages', 'skip API references').
+- `allow_external` (bool, optional): Whether to allow mapping external domains.
+
+### User-Settable Parameters (Initialization)
+
+These parameters are configured when creating the tool:
+
+- `max_breadth` (int, optional): Maximum number of links to follow per page.
+- `limit` (int, optional): Total number of links to process before stopping.
+- `select_paths` (Sequence[str], optional): Regex patterns to select only URLs with specific path patterns.
+- `select_domains` (Sequence[str], optional): Regex patterns to select mapping to specific domains or subdomains.
+- `exclude_paths` (Sequence[str], optional): Regex patterns to exclude URLs with specific path patterns.
+- `exclude_domains` (Sequence[str], optional): Regex patterns to exclude specific domains or subdomains.
+- `include_images` (bool, optional): Whether to include images in the map results.
+- `timeout` (float, optional): The timeout for the map request in seconds. Defaults to `150`.
+- `include_usage` (bool, optional): Whether to include credit usage information in the response.
+- `extra_kwargs` (dict, optional): Additional keyword arguments to pass to tavily-python.
+
+## Advanced Usage
+
+### Mapping with Path Filters
+
+```python
+# Configure the tool to map only specific sections
+custom_mapper = TavilyMapTool(
+    max_breadth=15,
+    limit=200,
+    select_paths=[r'/docs/.*', r'/guides/.*'],
+    exclude_paths=[r'/api/.*', r'/internal/.*'],
+    timeout=120
+)
+
+agent_with_custom_tool = Agent(
+    role="Documentation Mapper",
+    goal="Map documentation site structure",
+    tools=[custom_mapper]
+)
+```
+
+### Using Natural Language Instructions
+
+The agent can provide instructions to guide the mapping:
+
+```python
+# Task with specific mapping instructions
+map_task = Task(
+    description='''Map https://example.com with instructions to focus on 
+    documentation and blog sections. Use max_depth of 3.''',
+    expected_output='A JSON string containing the site map.',
+    agent=mapper_agent
+)
+```
+
+## Features
+
+- **Site Structure Discovery**: Automatically discovers pages and links starting from a base URL
+- **Depth Control**: Configure how deep the mapper should explore
+- **Breadth Control**: Limit the number of links followed per page
+- **Path Filtering**: Select or exclude URLs based on path patterns
+- **Domain Filtering**: Control which domains can be mapped
+- **Natural Language Instructions**: Guide the mapper with plain English instructions
+- **Lightweight Operation**: Discovers structure without extracting full content
+- **Fast Execution**: Optimized for quick site structure analysis
+
+## Response Format
+
+The tool returns a JSON string containing the site map with discovered URLs and their relationships. The response includes:
+- List of discovered URLs
+- Link structure and hierarchy
+- Metadata for each page
+
+Refer to the [Tavily API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/map) for detailed information about the response structure.
+
+## Use Cases
+
+- **Site Audit**: Understand the structure of large websites
+- **Content Planning**: Discover all pages before content migration
+- **SEO Analysis**: Map site structure for SEO optimization
+- **Documentation Discovery**: Find all documentation pages for indexing
+- **Link Analysis**: Understand internal linking structure
+- **Pre-Crawl Planning**: Map a site before performing full content extraction
+
+## Difference from TavilyCrawlTool
+
+| Feature | TavilyMapTool | TavilyCrawlTool |
+|---------|---------------|-----------------|
+| Purpose | Discover structure | Extract content |
+| Speed | Faster | Slower (full extraction) |
+| Output | URLs and links | Full page content |
+| Use Case | Site audits, planning | Content extraction, RAG |
+

--- a/docs/ko/tools/search-research/overview.mdx
+++ b/docs/ko/tools/search-research/overview.mdx
@@ -54,6 +54,10 @@ mode: "wide"
     Tavily API를 사용하여 웹 페이지에서 구조화된 콘텐츠를 추출합니다.
   </Card>
 
+  <Card title="Tavily Map Tool" icon="sitemap" href="/ko/tools/search-research/tavilymaptool">
+    전체 추출 없이 웹사이트 구조를 매핑하고 페이지를 발견합니다.
+  </Card>
+
   <Card title="Arxiv Paper Tool" icon="box-archive" href="/ko/tools/search-research/arxivpapertool">
     arXiv에서 논문을 검색하고 선택적으로 PDF를 다운로드합니다.
   </Card>

--- a/docs/ko/tools/search-research/tavilymaptool.mdx
+++ b/docs/ko/tools/search-research/tavilymaptool.mdx
@@ -1,0 +1,166 @@
+---
+title: "Tavily 맵 도구"
+description: "Tavily API를 사용하여 웹사이트 구조 매핑 및 페이지 발견"
+icon: "sitemap"
+mode: "wide"
+---
+
+`TavilyMapTool`은 CrewAI 에이전트가 Tavily API를 사용하여 기본 URL에서 시작하여 웹사이트의 구조를 매핑할 수 있도록 합니다. 전체 콘텐츠를 추출하지 않고 페이지, 링크 및 사이트 계층 구조를 발견하여 사이트 아키텍처를 이해하는 데 이상적입니다.
+
+## 설치
+
+`TavilyMapTool`을 사용하려면 `tavily-python` 라이브러리를 설치해야 합니다:
+
+```shell
+pip install 'crewai[tools]' tavily-python
+```
+
+또한 환경 변수로 Tavily API 키를 설정해야 합니다:
+
+```bash
+export TAVILY_API_KEY='your-tavily-api-key'
+```
+
+https://app.tavily.com/에서 API 키를 발급받으세요(회원가입 후 키를 생성하면 됩니다).
+
+## 예제 사용법
+
+다음은 CrewAI 에이전트에서 `TavilyMapTool`을 초기화하고 사용하는 방법입니다:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import TavilyMapTool
+
+# Ensure TAVILY_API_KEY is set in your environment
+# os.environ["TAVILY_API_KEY"] = "YOUR_API_KEY"
+
+# Initialize the tool
+map_tool = TavilyMapTool()
+
+# Create an agent that uses the tool
+mapper_agent = Agent(
+    role='Site Mapper',
+    goal='Map website structures and discover all pages',
+    backstory='You are an expert at mapping website structures using the Tavily API.',
+    tools=[map_tool],
+    verbose=True
+)
+
+# Define a task for the agent
+map_task = Task(
+    description='Map the structure of https://docs.example.com to understand the site hierarchy.',
+    expected_output='A JSON string containing the site structure and discovered URLs.',
+    agent=mapper_agent
+)
+
+# Create and run the crew
+crew = Crew(
+    agents=[mapper_agent],
+    tasks=[map_task],
+    verbose=2
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## 구성 옵션
+
+### 에이전트 설정 가능 매개변수 (런타임)
+
+이 매개변수들은 에이전트가 런타임에 제공할 수 있습니다:
+
+- `url` (str): **필수**. 매핑을 시작할 기본 URL.
+- `max_depth` (int, 1-5, 선택): 매핑할 최대 깊이 (기본 URL에서의 링크 홉 수).
+- `instructions` (str, 선택): 매핑을 안내하는 자연어 지시사항 (예: 'focus on documentation pages', 'skip API references').
+- `allow_external` (bool, 선택): 외부 도메인 매핑을 허용할지 여부.
+
+### 사용자 설정 가능 매개변수 (초기화)
+
+이 매개변수들은 도구를 생성할 때 구성됩니다:
+
+- `max_breadth` (int, 선택): 페이지당 팔로우할 최대 링크 수.
+- `limit` (int, 선택): 중지하기 전에 처리할 총 링크 수.
+- `select_paths` (Sequence[str], 선택): 특정 경로 패턴을 가진 URL만 선택하는 정규식 패턴.
+- `select_domains` (Sequence[str], 선택): 특정 도메인 또는 서브도메인에 매핑을 선택하는 정규식 패턴.
+- `exclude_paths` (Sequence[str], 선택): 특정 경로 패턴을 가진 URL을 제외하는 정규식 패턴.
+- `exclude_domains` (Sequence[str], 선택): 특정 도메인 또는 서브도메인을 제외하는 정규식 패턴.
+- `include_images` (bool, 선택): 맵 결과에 이미지를 포함할지 여부.
+- `timeout` (float, 선택): 맵 요청의 타임아웃(초). 기본값은 `150`.
+- `include_usage` (bool, 선택): 응답에 크레딧 사용 정보를 포함할지 여부.
+- `extra_kwargs` (dict, 선택): tavily-python에 전달할 추가 키워드 인자.
+
+## 고급 사용법
+
+### 경로 필터를 사용한 매핑
+
+```python
+# Configure the tool to map only specific sections
+custom_mapper = TavilyMapTool(
+    max_breadth=15,
+    limit=200,
+    select_paths=[r'/docs/.*', r'/guides/.*'],
+    exclude_paths=[r'/api/.*', r'/internal/.*'],
+    timeout=120
+)
+
+agent_with_custom_tool = Agent(
+    role="Documentation Mapper",
+    goal="Map documentation site structure",
+    tools=[custom_mapper]
+)
+```
+
+### 자연어 지시사항 사용
+
+에이전트는 매핑을 안내하는 지시사항을 제공할 수 있습니다:
+
+```python
+# Task with specific mapping instructions
+map_task = Task(
+    description='''Map https://example.com with instructions to focus on 
+    documentation and blog sections. Use max_depth of 3.''',
+    expected_output='A JSON string containing the site map.',
+    agent=mapper_agent
+)
+```
+
+## 기능
+
+- **사이트 구조 발견**: 기본 URL에서 시작하여 자동으로 페이지 및 링크 발견
+- **깊이 제어**: 매퍼가 탐색할 깊이 구성
+- **너비 제어**: 페이지당 팔로우하는 링크 수 제한
+- **경로 필터링**: 경로 패턴에 따라 URL 선택 또는 제외
+- **도메인 필터링**: 매핑할 수 있는 도메인 제어
+- **자연어 지시사항**: 일반 영어로 매퍼 안내
+- **경량 작업**: 전체 콘텐츠를 추출하지 않고 구조 발견
+- **빠른 실행**: 빠른 사이트 구조 분석에 최적화
+
+## 응답 형식
+
+도구는 발견된 URL과 그 관계가 포함된 사이트 맵을 나타내는 JSON 문자열을 반환합니다. 응답에는 다음이 포함됩니다:
+- 발견된 URL 목록
+- 링크 구조 및 계층
+- 각 페이지의 메타데이터
+
+응답 구조에 대한 자세한 정보는 [Tavily API 문서](https://docs.tavily.com/documentation/api-reference/endpoint/map)를 참조하세요.
+
+## 사용 사례
+
+- **사이트 감사**: 대규모 웹사이트의 구조 이해
+- **콘텐츠 계획**: 콘텐츠 마이그레이션 전 모든 페이지 발견
+- **SEO 분석**: SEO 최적화를 위한 사이트 구조 매핑
+- **문서 발견**: 인덱싱을 위한 모든 문서 페이지 찾기
+- **링크 분석**: 내부 링크 구조 이해
+- **크롤 전 계획**: 전체 콘텐츠 추출 전 사이트 매핑
+
+## TavilyCrawlTool과의 차이점
+
+| 기능 | TavilyMapTool | TavilyCrawlTool |
+|---------|---------------|-----------------|
+| 목적 | 구조 발견 | 콘텐츠 추출 |
+| 속도 | 더 빠름 | 더 느림 (전체 추출) |
+| 출력 | URL 및 링크 | 전체 페이지 콘텐츠 |
+| 사용 사례 | 사이트 감사, 계획 | 콘텐츠 추출, RAG |
+

--- a/docs/pt-BR/tools/search-research/overview.mdx
+++ b/docs/pt-BR/tools/search-research/overview.mdx
@@ -45,6 +45,10 @@ Essas ferramentas permitem que seus agentes pesquisem na web, explorem tópicos 
   <Card title="YouTube Video Search" icon="play" href="/pt-BR/tools/search-research/youtubevideosearchtool">
     Encontre e analise vídeos do YouTube por assunto, palavra-chave ou critério.
   </Card>
+
+  <Card title="Tavily Map Tool" icon="sitemap" href="/pt-BR/tools/search-research/tavilymaptool">
+    Mapeie a estrutura do site e descubra páginas sem extração completa.
+  </Card>
 </CardGroup>
 
 ## **Casos de Uso Comuns**

--- a/docs/pt-BR/tools/search-research/tavilymaptool.mdx
+++ b/docs/pt-BR/tools/search-research/tavilymaptool.mdx
@@ -1,0 +1,157 @@
+---
+title: "Tavily Map Tool"
+description: "Map website structure and discover pages using the Tavily API"
+icon: "sitemap"
+mode: "wide"
+---
+
+The `TavilyMapTool` allows CrewAI agents to map the structure of websites starting from a base URL using the Tavily API. It discovers pages, links, and site hierarchy without extracting full content, making it ideal for understanding site architecture.
+
+## Installation
+
+To use the `TavilyMapTool`, you need to install the `tavily-python` library:
+
+```shell
+pip install 'crewai[tools]' tavily-python
+```
+
+You also need to set your Tavily API key as an environment variable:
+
+```bash
+export TAVILY_API_KEY='your-tavily-api-key'
+```
+
+Get an API key at https://app.tavily.com/ (sign up, then create a key).
+
+## Example Usage
+
+Here's how to initialize and use the `TavilyMapTool` within a CrewAI agent:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import TavilyMapTool
+
+# Ensure TAVILY_API_KEY is set in your environment
+# os.environ["TAVILY_API_KEY"] = "YOUR_API_KEY"
+
+# Initialize the tool
+map_tool = TavilyMapTool()
+
+# Create an agent that uses the tool
+mapper_agent = Agent(
+    role='Site Mapper',
+    goal='Map website structures and discover all pages',
+    backstory='You are an expert at mapping website structures using the Tavily API.',
+    tools=[map_tool],
+    verbose=True
+)
+
+# Define a task for the agent
+map_task = Task(
+    description='Map the structure of https://docs.example.com to understand the site hierarchy.',
+    expected_output='A JSON string containing the site structure and discovered URLs.',
+    agent=mapper_agent
+)
+
+# Create and run the crew
+crew = Crew(
+    agents=[mapper_agent],
+    tasks=[map_task],
+    verbose=2
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Configuration Options
+
+The `TavilyMapTool` accepts the following arguments:
+
+- `url` (str): **Required**. The base URL to start mapping from.
+- `max_depth` (int, 1-5, optional): Maximum depth to map (number of link hops from the base URL).
+- `max_breadth` (int, optional): Maximum number of links to follow per page.
+- `limit` (int, optional): Total number of links to process before stopping.
+- `instructions` (str, optional): Natural language instructions to guide the mapping.
+- `select_paths` (Sequence[str], optional): Regex patterns to select specific paths.
+- `select_domains` (Sequence[str], optional): Regex patterns to select specific domains.
+- `exclude_paths` (Sequence[str], optional): Regex patterns to exclude specific paths.
+- `exclude_domains` (Sequence[str], optional): Regex patterns to exclude specific domains.
+- `allow_external` (bool, optional): Whether to allow mapping external domains.
+- `include_images` (bool, optional): Whether to include images in the map results.
+- `timeout` (float, optional): The timeout for the map request in seconds. Defaults to `150`.
+
+## Advanced Usage
+
+### Mapping with Path Filters
+
+```python
+# Configure the tool to map only specific sections
+custom_mapper = TavilyMapTool(
+    max_breadth=15,
+    limit=200,
+    select_paths=[r'/docs/.*', r'/guides/.*'],
+    exclude_paths=[r'/api/.*', r'/internal/.*'],
+    timeout=120
+)
+
+agent_with_custom_tool = Agent(
+    role="Documentation Mapper",
+    goal="Map documentation site structure",
+    tools=[custom_mapper]
+)
+```
+
+### Using Natural Language Instructions
+
+The agent can provide instructions to guide the mapping:
+
+```python
+# Task with specific mapping instructions
+map_task = Task(
+    description='''Map https://example.com with instructions to focus on 
+    documentation and blog sections. Use max_depth of 3.''',
+    expected_output='A JSON string containing the site map.',
+    agent=mapper_agent
+)
+```
+
+## Features
+
+- **Site Structure Discovery**: Automatically discovers pages and links starting from a base URL
+- **Depth Control**: Configure how deep the mapper should explore
+- **Breadth Control**: Limit the number of links followed per page
+- **Path Filtering**: Select or exclude URLs based on path patterns
+- **Domain Filtering**: Control which domains can be mapped
+- **Natural Language Instructions**: Guide the mapper with plain English instructions
+- **Lightweight Operation**: Discovers structure without extracting full content
+- **Fast Execution**: Optimized for quick site structure analysis
+
+## Response Format
+
+The tool returns a JSON string containing the site map with discovered URLs and their relationships. The response includes:
+- List of discovered URLs
+- Link structure and hierarchy
+- Metadata for each page
+
+Refer to the [Tavily API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/map) for detailed information about the response structure.
+
+## Use Cases
+
+- **Site Audit**: Understand the structure of large websites
+- **Content Planning**: Discover all pages before content migration
+- **SEO Analysis**: Map site structure for SEO optimization
+- **Documentation Discovery**: Find all documentation pages for indexing
+- **Link Analysis**: Understand internal linking structure
+- **Pre-Crawl Planning**: Map a site before performing full content extraction
+
+## Difference from TavilyCrawlTool
+
+| Feature | TavilyMapTool | TavilyCrawlTool |
+|---------|---------------|-----------------|
+| Purpose | Discover structure | Extract content |
+| Speed | Faster | Slower (full extraction) |
+| Output | URLs and links | Full page content |
+| Use Case | Site audits, planning | Content extraction, RAG |
+

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -179,6 +179,7 @@ from crewai_tools.tools.stagehand_tool.stagehand_tool import StagehandTool
 from crewai_tools.tools.tavily_extractor_tool.tavily_extractor_tool import (
     TavilyExtractorTool,
 )
+from crewai_tools.tools.tavily_map_tool.tavily_map_tool import TavilyMapTool
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
@@ -280,6 +281,7 @@ __all__ = [
     "StagehandTool",
     "TXTSearchTool",
     "TavilyExtractorTool",
+    "TavilyMapTool",
     "TavilySearchTool",
     "VisionTool",
     "WeaviateVectorSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -166,6 +166,7 @@ from crewai_tools.tools.stagehand_tool.stagehand_tool import StagehandTool
 from crewai_tools.tools.tavily_extractor_tool.tavily_extractor_tool import (
     TavilyExtractorTool,
 )
+from crewai_tools.tools.tavily_map_tool.tavily_map_tool import TavilyMapTool
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
@@ -263,6 +264,7 @@ __all__ = [
     "StagehandTool",
     "TXTSearchTool",
     "TavilyExtractorTool",
+    "TavilyMapTool",
     "TavilySearchTool",
     "VisionTool",
     "WeaviateVectorSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_map_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_map_tool/README.md
@@ -1,0 +1,117 @@
+# TavilyMapTool
+
+## Description
+
+The `TavilyMapTool` allows CrewAI agents to map the structure of websites starting from a base URL using the Tavily API. It discovers pages, links, and site hierarchy without extracting full content, making it ideal for understanding site architecture.
+
+## Installation
+
+To use the `TavilyMapTool`, you need to install the `tavily-python` library:
+
+```shell
+pip install 'crewai[tools]' tavily-python
+```
+
+You also need to set your Tavily API key as an environment variable:
+
+```bash
+export TAVILY_API_KEY='your-tavily-api-key'
+```
+
+## Example
+
+Here's how to initialize and use the `TavilyMapTool` within a CrewAI agent:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import TavilyMapTool
+
+# Ensure TAVILY_API_KEY is set in your environment
+# os.environ["TAVILY_API_KEY"] = "YOUR_API_KEY"
+
+# Initialize the tool
+map_tool = TavilyMapTool()
+
+# Create an agent that uses the tool
+mapper_agent = Agent(
+    role='Site Mapper',
+    goal='Map website structures and discover all pages',
+    backstory='You are an expert at mapping website structures using the Tavily API.',
+    tools=[map_tool],
+    verbose=True
+)
+
+# Define a task for the agent
+map_task = Task(
+    description='Map the structure of https://docs.example.com to understand the site hierarchy.',
+    expected_output='A JSON string containing the site structure and discovered URLs.',
+    agent=mapper_agent
+)
+
+# Create and run the crew
+crew = Crew(
+    agents=[mapper_agent],
+    tasks=[map_task],
+    verbose=2
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Arguments
+
+The `TavilyMapTool` accepts the following arguments:
+
+### Agent-Settable (Runtime)
+
+These parameters can be provided by the agent at runtime:
+
+- `url` (str): **Required**. The base URL to start mapping from.
+- `max_depth` (int, 1-5): Maximum depth to map (number of link hops from the base URL).
+- `instructions` (str): Natural language instructions to guide the mapping.
+- `allow_external` (bool): Whether to allow mapping external domains.
+
+### User-Settable (Initialization)
+
+These parameters are configured when creating the tool:
+
+- `api_key` (str): Your Tavily API key. Defaults to the `TAVILY_API_KEY` environment variable.
+- `proxies` (dict[str, str]): Proxies to use for the API requests.
+- `max_breadth` (int): Maximum number of links to follow per page.
+- `limit` (int): Total number of links to process before stopping.
+- `select_paths` (Sequence[str]): Regex patterns to select specific paths.
+- `select_domains` (Sequence[str]): Regex patterns to select specific domains.
+- `exclude_paths` (Sequence[str]): Regex patterns to exclude specific paths.
+- `exclude_domains` (Sequence[str]): Regex patterns to exclude specific domains.
+- `include_images` (bool): Whether to include images in the results.
+- `timeout` (float): The timeout for the map request in seconds. Default is 150.
+- `include_usage` (bool): Whether to include credit usage information.
+- `extra_kwargs` (dict): Additional keyword arguments to pass to tavily-python.
+
+## Advanced Usage
+
+```python
+# Configure the tool with custom parameters
+custom_mapper = TavilyMapTool(
+    max_breadth=15,
+    limit=200,
+    select_paths=[r'/docs/.*', r'/guides/.*'],
+    exclude_paths=[r'/api/.*', r'/internal/.*'],
+    timeout=120
+)
+
+agent_with_custom_tool = Agent(
+    role="Documentation Mapper",
+    goal="Map documentation site structure",
+    tools=[custom_mapper]
+)
+```
+
+## Response Format
+
+The tool returns a JSON string containing the site map with discovered URLs and their relationships. This includes the site hierarchy and link structure.
+
+Refer to the [Tavily API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/map) for details on the response structure.
+

--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_map_tool/tavily_map_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_map_tool/tavily_map_tool.py
@@ -1,0 +1,263 @@
+import json
+import os
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from crewai.tools import BaseTool, EnvVar
+from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict, Field
+
+
+load_dotenv()
+try:
+    from tavily import AsyncTavilyClient, TavilyClient  # type: ignore[import-untyped]
+
+    TAVILY_AVAILABLE = True
+except ImportError:
+    TAVILY_AVAILABLE = False
+    TavilyClient = Any
+    AsyncTavilyClient = Any
+
+
+class TavilyMapToolSchema(BaseModel):
+    """Input schema for TavilyMapTool."""
+
+    url: str = Field(
+        ...,
+        description="The base URL to start mapping from.",
+    )
+    max_depth: int | None = Field(
+        default=None,
+        description="Maximum depth to map (number of link hops from the base URL, 1-5).",
+        ge=1,
+        le=5,
+    )
+    instructions: str | None = Field(
+        default=None,
+        description="Natural language instructions to guide the mapping (e.g., 'focus on documentation pages', 'skip API references').",
+    )
+    allow_external: bool | None = Field(
+        default=None,
+        description="Whether to allow mapping external domains.",
+    )
+
+
+class TavilyMapTool(BaseTool):
+    """Tool that uses the Tavily API to map website structure starting from a base URL.
+
+    Attributes:
+        client: Synchronous Tavily client.
+        async_client: Asynchronous Tavily client.
+        name: The name of the tool.
+        description: The description of the tool.
+        args_schema: The schema for the tool's arguments.
+        api_key: The Tavily API key.
+        proxies: Optional proxies for the API requests.
+        max_breadth: Maximum number of links to follow per page.
+        limit: Total number of links to process before stopping.
+        select_paths: Regex patterns to select specific paths.
+        select_domains: Regex patterns to select specific domains.
+        exclude_paths: Regex patterns to exclude specific paths.
+        exclude_domains: Regex patterns to exclude specific domains.
+        include_images: Whether to include images in the map results.
+        timeout: The timeout for the map request in seconds.
+        include_usage: Whether to include credit usage information.
+        extra_kwargs: Additional kwargs passed directly to tavily-python's map() method.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    client: TavilyClient | None = None
+    async_client: AsyncTavilyClient | None = None
+    name: str = "Tavily Map"
+    description: str = (
+        "Map the structure of a website starting from a base URL. "
+        "Discovers pages, links, and site hierarchy without extracting full content. "
+        "Ideal for understanding site architecture."
+    )
+    args_schema: type[BaseModel] = TavilyMapToolSchema
+    api_key: str | None = Field(
+        default_factory=lambda: os.getenv("TAVILY_API_KEY"),
+        description="The Tavily API key. If not provided, it will be loaded from the environment variable TAVILY_API_KEY.",
+    )
+    proxies: dict[str, str] | None = Field(
+        default=None,
+        description="Optional proxies to use for the Tavily API requests.",
+    )
+    max_breadth: int | None = Field(
+        default=None,
+        description="Maximum number of links to follow per page.",
+    )
+    limit: int | None = Field(
+        default=None,
+        description="Total number of links to process before stopping.",
+    )
+    select_paths: Sequence[str] | None = Field(
+        default=None,
+        description="Regex patterns to select only URLs with specific path patterns.",
+    )
+    select_domains: Sequence[str] | None = Field(
+        default=None,
+        description="Regex patterns to select mapping to specific domains or subdomains.",
+    )
+    exclude_paths: Sequence[str] | None = Field(
+        default=None,
+        description="Regex patterns to exclude URLs with specific path patterns.",
+    )
+    exclude_domains: Sequence[str] | None = Field(
+        default=None,
+        description="Regex patterns to exclude specific domains or subdomains.",
+    )
+    include_images: bool | None = Field(
+        default=None,
+        description="Whether to include images in the map results.",
+    )
+    timeout: float = Field(
+        default=150,
+        description="The timeout for the map request in seconds.",
+    )
+    include_usage: bool | None = Field(
+        default=None,
+        description="Whether to include credit usage information in the response.",
+    )
+    extra_kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments to pass directly to tavily-python's map() method. "
+        "Use this for new tavily-python parameters not yet explicitly supported.",
+    )
+    package_dependencies: list[str] = Field(default_factory=lambda: ["tavily-python"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="TAVILY_API_KEY",
+                description="API key for Tavily map service",
+                required=True,
+            ),
+        ]
+    )
+
+    def __init__(self, **kwargs: Any):
+        """Initializes the TavilyMapTool.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        if TAVILY_AVAILABLE:
+            self.client = TavilyClient(api_key=self.api_key, proxies=self.proxies)
+            self.async_client = AsyncTavilyClient(
+                api_key=self.api_key, proxies=self.proxies
+            )
+        else:
+            try:
+                import subprocess
+
+                import click
+            except ImportError:
+                raise ImportError(
+                    "The 'tavily-python' package is required. 'click' and 'subprocess' are also needed to assist with installation if the package is missing. "
+                    "Please install 'tavily-python' manually (e.g., 'uv add tavily-python') and ensure 'click' and 'subprocess' are available."
+                ) from None
+
+            if click.confirm(
+                "You are missing the 'tavily-python' package, which is required for TavilyMapTool. Would you like to install it?"
+            ):
+                try:
+                    subprocess.run(["uv", "add", "tavily-python"], check=True)  # noqa: S607
+                    raise ImportError(
+                        "'tavily-python' has been installed. Please restart your Python application to use the TavilyMapTool."
+                    )
+                except subprocess.CalledProcessError as e:
+                    raise ImportError(
+                        f"Attempted to install 'tavily-python' but failed: {e}. "
+                        f"Please install it manually to use the TavilyMapTool."
+                    ) from e
+            else:
+                raise ImportError(
+                    "The 'tavily-python' package is required to use the TavilyMapTool. "
+                    "Please install it with: uv add tavily-python"
+                )
+
+    def _run(
+        self,
+        url: str,
+        max_depth: int | None = None,
+        instructions: str | None = None,
+        allow_external: bool | None = None,
+    ) -> str:
+        """Synchronously maps a website structure starting from the given URL.
+
+        Args:
+            url: The base URL to start mapping from.
+            max_depth: Maximum depth to map (overrides class default if provided).
+            instructions: Natural language instructions to guide the mapping.
+            allow_external: Whether to allow mapping external domains.
+
+        Returns:
+            A JSON string containing the map results.
+        """
+        if not self.client:
+            raise ValueError(
+                "Tavily client is not initialized. Ensure 'tavily-python' is installed and API key is set."
+            )
+
+        return json.dumps(
+            self.client.map(
+                url=url,
+                max_depth=max_depth,
+                max_breadth=self.max_breadth,
+                limit=self.limit,
+                instructions=instructions,
+                select_paths=self.select_paths,
+                select_domains=self.select_domains,
+                exclude_paths=self.exclude_paths,
+                exclude_domains=self.exclude_domains,
+                allow_external=allow_external,
+                include_images=self.include_images,
+                timeout=self.timeout,
+                include_usage=self.include_usage,
+                **self.extra_kwargs,
+            ),
+            indent=2,
+        )
+
+    async def _arun(
+        self,
+        url: str,
+        max_depth: int | None = None,
+        instructions: str | None = None,
+        allow_external: bool | None = None,
+    ) -> str:
+        """Asynchronously maps a website structure starting from the given URL.
+
+        Args:
+            url: The base URL to start mapping from.
+            max_depth: Maximum depth to map (overrides class default if provided).
+            instructions: Natural language instructions to guide the mapping.
+            allow_external: Whether to allow mapping external domains.
+
+        Returns:
+            A JSON string containing the map results.
+        """
+        if not self.async_client:
+            raise ValueError(
+                "Tavily async client is not initialized. Ensure 'tavily-python' is installed and API key is set."
+            )
+
+        results = await self.async_client.map(
+            url=url,
+            max_depth=max_depth,
+            max_breadth=self.max_breadth,
+            limit=self.limit,
+            instructions=instructions,
+            select_paths=self.select_paths,
+            select_domains=self.select_domains,
+            exclude_paths=self.exclude_paths,
+            exclude_domains=self.exclude_domains,
+            allow_external=allow_external,
+            include_images=self.include_images,
+            timeout=self.timeout,
+            include_usage=self.include_usage,
+            **self.extra_kwargs,
+        )
+        return json.dumps(results, indent=2)
+


### PR DESCRIPTION
This pull request introduces the new `TavilyMapTool` to the CrewAI toolkit, enabling agents to map website structures using the Tavily API. It adds the tool's implementation, documentation, and multilingual usage guides, and integrates the tool into the codebase and documentation navigation.

**New Tool Implementation and Integration:**

- Added the `TavilyMapTool` implementation in `crewai_tools.tools.tavily_map_tool.tavily_map_tool`, and registered it in both `crewai_tools/__init__.py` and `crewai_tools/tools/__init__.py` for import and availability in the toolkit. [[1]](diffhunk://#diff-21ed8bc05661cba50aa845a89a8591d6cd2f5de74f3b8a1289e6dd579843639aR182) [[2]](diffhunk://#diff-21ed8bc05661cba50aa845a89a8591d6cd2f5de74f3b8a1289e6dd579843639aR284) [[3]](diffhunk://#diff-e2a1b42580dd1ebb66937a5e98b8e6b8278fd9b576090cd87fb72c4770806ec5R169) [[4]](diffhunk://#diff-e2a1b42580dd1ebb66937a5e98b8e6b8278fd9b576090cd87fb72c4770806ec5R267)

**Documentation:**

- Introduced comprehensive English documentation for `TavilyMapTool`, including usage instructions, configuration options, features, response format, use cases, and a comparison with `TavilyCrawlTool` in `docs/en/tools/search-research/tavilymaptool.mdx` and a dedicated README in the tool directory. [[1]](diffhunk://#diff-3fe2426767125623ca7ab8d8ac469316a613e0f1837f0ca8b5a24bdc228da15cR1-R166) [[2]](diffhunk://#diff-9d7bd24daea71d6ddca8cb5c3ff32c95a0dddbdfbd85c1ea3a1eca54e6fe3287R1-R117)
- Added full documentation for `TavilyMapTool` in Korean and Brazilian Portuguese, ensuring accessibility for non-English users. [[1]](diffhunk://#diff-59baf4b9a3fc3addcf3ccf7fb4af173f66906254fc685d24c375781adbcfb08bR1-R166) [[2]](diffhunk://#diff-7f5c5d7b0be317b8e585914d3d6a76c0745b868baf493202b422fe4bc8d8cd84R1-R157)

**Documentation Navigation Updates:**

- Updated the search and research tools overview pages in English, Korean, and Brazilian Portuguese to include `TavilyMapTool` in the tool selection cards, making it discoverable in the docs navigation. [[1]](diffhunk://#diff-b9ca9ddcc320f28f1e7831d9898d584ad33eedc2486cb3bb3834f06b9d34fd5aR57-R60) [[2]](diffhunk://#diff-69448386b345de0ed148f4e415320306b0002bdd92c342afc5943adf950690acR57-R60) [[3]](diffhunk://#diff-ef7994a248fee7ceea4cbc35611211c779ab85be9c86b39f68119dcf2744b16fR48-R51)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `TavilyMapTool` to map website structures via the Tavily API, with sync/async support, configuration options, and multilingual docs plus nav updates.
> 
> - **Tools**:
>   - **New `TavilyMapTool`** (`crewai_tools.tools.tavily_map_tool.tavily_map_tool`): maps site structure using Tavily API with sync/async clients, runtime params (`url`, `max_depth`, `instructions`, `allow_external`), and init-time filters/limits.
>   - Registered exports in `crewai_tools/__init__.py` and `tools/__init__.py`.
>   - Added tool README.
> - **Docs**:
>   - Added `docs/en|ko|pt-BR/tools/search-research/tavilymaptool.mdx` with installation, usage, config, features, response, and use cases.
>   - Updated overview pages to include a `Tavily Map Tool` card in EN/KO/PT-BR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4b2be86c899e862147d2c79a7bd80de8425f760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->