### PR TITLE
feat(tavily): search updates

### DIFF
--- a/docs/en/tools/search-research/tavilysearchtool.mdx
+++ b/docs/en/tools/search-research/tavilysearchtool.mdx
@@ -69,20 +69,34 @@ print(result)
 
 ## Configuration Options
 
-The `TavilySearchTool` accepts the following arguments during initialization or when calling the `run` method:
+### Agent-Settable Parameters (Runtime)
+
+These parameters can be provided by the agent at runtime:
 
 - `query` (str): **Required**. The search query string.
-- `search_depth` (Literal["basic", "advanced"], optional): The depth of the search. Defaults to `"basic"`.
+- `search_depth` (Literal["basic", "advanced"], optional): The depth of the search - 'basic' for quick results, 'advanced' for comprehensive search.
+- `time_range` (Literal["day", "week", "month", "year"], optional): The time range for the search results.
+
+### User-Settable Parameters (Initialization)
+
+These parameters are configured when creating the tool:
+
 - `topic` (Literal["general", "news", "finance"], optional): The topic to focus the search on. Defaults to `"general"`.
-- `time_range` (Literal["day", "week", "month", "year"], optional): The time range for the search. Defaults to `None`.
-- `days` (int, optional): The number of days to search back. Relevant if `time_range` is not set. Defaults to `7`.
+- `start_date` (str, optional): Start date for the search results (format: YYYY-MM-DD).
+- `end_date` (str, optional): End date for the search results (format: YYYY-MM-DD).
+- `days` (int, optional): The number of days to search back. Defaults to `7`.
 - `max_results` (int, optional): The maximum number of search results to return. Defaults to `5`.
 - `include_domains` (Sequence[str], optional): A list of domains to prioritize in the search. Defaults to `None`.
 - `exclude_domains` (Sequence[str], optional): A list of domains to exclude from the search. Defaults to `None`.
 - `include_answer` (Union[bool, Literal["basic", "advanced"]], optional): Whether to include a direct answer synthesized from the search results. Defaults to `False`.
-- `include_raw_content` (bool, optional): Whether to include the raw HTML content of the searched pages. Defaults to `False`.
+- `include_raw_content` (Union[bool, Literal["markdown", "text"]], optional): Whether to include the raw content of the searched pages. Defaults to `False`.
 - `include_images` (bool, optional): Whether to include image results. Defaults to `False`.
 - `timeout` (int, optional): The request timeout in seconds. Defaults to `60`.
+- `country` (str, optional): Country code to filter search results.
+- `auto_parameters` (bool, optional): Whether to automatically optimize search parameters.
+- `include_favicon` (bool, optional): Whether to include favicon URLs in the search results.
+- `include_usage` (bool, optional): Whether to include credit usage information in the response.
+- `extra_kwargs` (dict, optional): Additional keyword arguments to pass to tavily-python.
 
 ## Advanced Usage
 
@@ -96,7 +110,7 @@ custom_tavily_tool = TavilySearchTool(
     include_answer=True
 )
 
-# The agent will use these defaults
+# The agent will use these defaults, but can override search_depth and time_range
 agent_with_custom_tool = Agent(
     role="Advanced Researcher",
     goal="Conduct detailed research with comprehensive results",
@@ -120,6 +134,8 @@ The tool returns search results as a JSON string containing:
 - Search results with titles, URLs, and content snippets
 - Optional direct answers to queries
 - Optional image results
-- Optional raw HTML content (when enabled)
+- Optional raw content (when enabled)
 
 Content for each result is automatically truncated to prevent context window issues while maintaining the most relevant information.
+
+Refer to the [Tavily API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/search) for details on the response structure.

--- a/docs/ko/tools/search-research/tavilysearchtool.mdx
+++ b/docs/ko/tools/search-research/tavilysearchtool.mdx
@@ -69,20 +69,34 @@ print(result)
 
 ## 구성 옵션
 
-`TavilySearchTool`은 초기화 시 또는 `run` 메서드를 호출할 때 다음과 같은 인자를 받습니다:
+### 에이전트 설정 가능 매개변수 (런타임)
+
+이 매개변수들은 에이전트가 런타임에 제공할 수 있습니다:
 
 - `query` (str): **필수**. 검색 쿼리 문자열입니다.
-- `search_depth` (Literal["basic", "advanced"], 선택): 검색의 심도입니다. 기본값은 `"basic"`입니다.
+- `search_depth` (Literal["basic", "advanced"], 선택): 검색의 심도 - 'basic'은 빠른 결과, 'advanced'는 종합적인 검색.
+- `time_range` (Literal["day", "week", "month", "year"], 선택): 검색 결과의 시간 범위입니다.
+
+### 사용자 설정 가능 매개변수 (초기화)
+
+이 매개변수들은 도구를 생성할 때 구성됩니다:
+
 - `topic` (Literal["general", "news", "finance"], 선택): 검색을 집중할 주제입니다. 기본값은 `"general"`입니다.
-- `time_range` (Literal["day", "week", "month", "year"], 선택): 검색을 위한 시간 범위입니다. 기본값은 `None`입니다.
-- `days` (int, 선택): 과거 며칠까지 검색할지 지정합니다. `time_range`가 설정되지 않은 경우에 해당합니다. 기본값은 `7`입니다.
+- `start_date` (str, 선택): 검색 결과의 시작 날짜 (형식: YYYY-MM-DD).
+- `end_date` (str, 선택): 검색 결과의 종료 날짜 (형식: YYYY-MM-DD).
+- `days` (int, 선택): 과거 며칠까지 검색할지 지정합니다. 기본값은 `7`입니다.
 - `max_results` (int, 선택): 반환할 최대 검색 결과 수입니다. 기본값은 `5`입니다.
-- `include_domains` (Sequence[str], 선택): 검색 시 우선순위를 둘 도메인 목록입니다. 기본값은 `None`입니다.
-- `exclude_domains` (Sequence[str], 선택): 검색에서 제외할 도메인 목록입니다. 기본값은 `None`입니다.
+- `include_domains` (Sequence[str], 선택): 검색 시 우선순위를 둘 도메인 목록입니다.
+- `exclude_domains` (Sequence[str], 선택): 검색에서 제외할 도메인 목록입니다.
 - `include_answer` (Union[bool, Literal["basic", "advanced"]], 선택): 검색 결과로부터 직접적으로 생성된 답변을 포함할지 여부입니다. 기본값은 `False`입니다.
-- `include_raw_content` (bool, 선택): 검색된 페이지의 원시 HTML 콘텐츠를 포함할지 여부입니다. 기본값은 `False`입니다.
+- `include_raw_content` (Union[bool, Literal["markdown", "text"]], 선택): 검색된 페이지의 원시 콘텐츠를 포함할지 여부입니다. 기본값은 `False`입니다.
 - `include_images` (bool, 선택): 이미지 결과를 포함할지 여부입니다. 기본값은 `False`입니다.
 - `timeout` (int, 선택): 요청의 타임아웃(초)입니다. 기본값은 `60`입니다.
+- `country` (str, 선택): 검색 결과를 필터링할 국가 코드.
+- `auto_parameters` (bool, 선택): 검색 매개변수를 자동으로 최적화할지 여부.
+- `include_favicon` (bool, 선택): 검색 결과에 파비콘 URL을 포함할지 여부.
+- `include_usage` (bool, 선택): 응답에 크레딧 사용 정보를 포함할지 여부.
+- `extra_kwargs` (dict, 선택): tavily-python에 전달할 추가 키워드 인자.
 
 ## 고급 사용법
 
@@ -91,12 +105,13 @@ print(result)
 ```python
 # Example: Initialize with specific parameters
 custom_tavily_tool = TavilySearchTool(
-    search_depth='advanced',
+    topic='news',
     max_results=10,
-    include_answer=True
+    include_answer=True,
+    include_domains=['reuters.com', 'bloomberg.com']
 )
 
-# The agent will use these defaults
+# The agent will use these defaults, but can override search_depth and time_range
 agent_with_custom_tool = Agent(
     role="Advanced Researcher",
     goal="Conduct detailed research with comprehensive results",
@@ -120,6 +135,8 @@ agent_with_custom_tool = Agent(
 - 제목, URL, 본문 요약이 포함된 검색 결과
 - 선택적으로 쿼리에 대한 직접 답변
 - 선택적으로 이미지 결과
-- 선택적으로 원시 HTML 콘텐츠(활성화된 경우)
+- 선택적으로 원시 콘텐츠(활성화된 경우)
 
 각 결과의 콘텐츠는 컨텍스트 윈도우 문제를 방지하면서 가장 관련성 높은 정보를 유지하도록 자동으로 잘립니다.
+
+응답 구조에 대한 자세한 내용은 [Tavily API 문서](https://docs.tavily.com/documentation/api-reference/endpoint/search)를 참조하세요.

--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_search_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_search_tool/README.md
@@ -90,6 +90,7 @@ The `TavilySearchTool` accepts the following arguments during initialization or 
 - `timeout` (int, optional): The request timeout in seconds. Defaults to `60`.
 - `api_key` (str, optional): Your Tavily API key. If not provided, it's read from the `TAVILY_API_KEY` environment variable.
 - `proxies` (dict[str, str], optional): A dictionary of proxies to use for the API request. Defaults to `None`.
+- `extra_kwargs` (dict[str, Any], optional): Additional keyword arguments passed directly to tavily-python's `search()` method. Use this for new tavily-python parameters not yet explicitly supported.
 
 ## Custom Configuration
 
@@ -113,3 +114,17 @@ agent_with_custom_tool = Agent(
 ```
 
 Note: The `config` dictionary allows setting default values for the arguments defined in `TavilySearchToolSchema`. These defaults can be overridden when the tool is executed if the specific parameters are provided in the agent's action input.
+
+## Using New tavily-python Parameters
+
+When tavily-python adds new parameters that aren't yet explicitly supported, you can use `extra_kwargs` to pass them through:
+
+```python
+# Use new tavily-python parameters via extra_kwargs
+tavily_tool = TavilySearchTool(
+    extra_kwargs={
+        "some_new_param": "value",
+        "another_param": True
+    }
+)
+```


### PR DESCRIPTION
This pull request enhances the `TavilySearchTool` by expanding its configuration options, improving documentation, and ensuring support for new parameters introduced by tavily-python. The changes make the tool more flexible and future-proof, allowing both users and agents to fine-tune search behavior at runtime or initialization, and to pass through new options as needed.

**Key changes:**

#### Feature Enhancements

* Added new parameters to `TavilySearchTool` and its schema, including `start_date`, `end_date`, `country`, `auto_parameters`, `include_favicon`, `include_usage`, and support for `extra_kwargs` to pass arbitrary arguments to tavily-python. Also, `include_raw_content` now accepts `"markdown"` and `"text"` in addition to `bool`. [[1]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R26-R33) [[2]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349L92-R101) [[3]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R111-R143)
* Updated both synchronous (`_run`) and asynchronous (`_arun`) search methods to accept and forward the new parameters and `extra_kwargs` to the underlying tavily-python client. [[1]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R195-R204) [[2]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349L174-R220) [[3]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R229-R233) [[4]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R258-R267) [[5]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349L226-R283) [[6]](diffhunk://#diff-ee90ee2f356a0900c96d25e90e544f49e98a6c10e64d31eac79674388631b349R292-R296)

#### Documentation Updates

* Significantly revised English and Korean documentation to clearly distinguish between agent-settable (runtime) and user-settable (initialization) parameters. All new parameters are now documented, and examples have been updated to reflect these changes. [[1]](diffhunk://#diff-0bd86d34e005641a96b616c6d7f0d00649943b14cfbce5ae280a5b1da420ef34L72-R99) [[2]](diffhunk://#diff-be76c783bca82853749df46e4b9e7f15327eeaddc86b174a6cd37fbe3382f772L72-R99) [[3]](diffhunk://#diff-be76c783bca82853749df46e4b9e7f15327eeaddc86b174a6cd37fbe3382f772L94-R114)
* Added documentation and usage examples for `extra_kwargs` in both the main README and tool documentation, explaining how to forward new tavily-python parameters not yet explicitly supported. [[1]](diffhunk://#diff-761db1c55ff4b13e424e2de9d11ffae85642b896b2bc5033f6f85d16b1c9b9faR93) [[2]](diffhunk://#diff-761db1c55ff4b13e424e2de9d11ffae85642b896b2bc5033f6f85d16b1c9b9faR117-R130)

#### Minor Improvements

* Clarified output documentation to refer to "raw content" instead of "raw HTML content" and linked to the Tavily API docs for response structure details in both English and Korean. [[1]](diffhunk://#diff-0bd86d34e005641a96b616c6d7f0d00649943b14cfbce5ae280a5b1da420ef34L123-R141) [[2]](diffhunk://#diff-be76c783bca82853749df46e4b9e7f15327eeaddc86b174a6cd37fbe3382f772L123-R142)

These updates make the tool easier to use, more adaptable to future API changes, and better documented for both English and Korean users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new Tavily parameters (dates, country, auto-tuning, favicon/usage), runtime overrides for depth/time, `extra_kwargs` passthrough, and updates EN/KO docs accordingly.
> 
> - **Tool Enhancements (`lib/crewai-tools/.../tavily_search_tool.py`)**:
>   - Extend `TavilySearchToolSchema` with runtime `search_depth` and `time_range`.
>   - Add new config fields: `start_date`, `end_date`, `country`, `auto_parameters`, `include_favicon`, `include_usage`, and `extra_kwargs`.
>   - Broaden `include_raw_content` to accept `"markdown" | "text"` in addition to `bool`.
>   - Update `_run` and `_arun` to accept runtime `search_depth`/`time_range`, forward all new params, and pass through `**extra_kwargs` to tavily-python.
> - **Documentation**:
>   - EN/KO guides (`docs/en/.../tavilysearchtool.mdx`, `docs/ko/.../tavilysearchtool.mdx`): clarify agent-settable vs. user-settable params; document new options; update examples; switch phrasing to "raw content" and add link to Tavily API response docs.
>   - README (`lib/crewai-tools/.../README.md`): document `extra_kwargs` argument and provide usage example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65becd133051cd537bcb3e9b87357d9a994b913e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->