### PR TITLE
feat(tools): Add OlostepTool for web scraping, crawling, mapping, and…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -226,7 +226,8 @@
                           "en/tools/web-scraping/firecrawlcrawlwebsitetool",
                           "en/tools/web-scraping/firecrawlscrapewebsitetool",
                           "en/tools/web-scraping/oxylabsscraperstool",
-                          "en/tools/web-scraping/brightdata-tools"
+                          "en/tools/web-scraping/brightdata-tools",
+                          "en/tools/web-scraping/olosteptool"
                         ]
                       },
                       {

--- a/docs/en/tools/web-scraping/olosteptool.mdx
+++ b/docs/en/tools/web-scraping/olosteptool.mdx
@@ -1,0 +1,250 @@
+---
+title: "OlostepTool"
+description: "The most reliable and cost-effective web search, scraping and crawling API for AI. Build intelligent agents that can search, scrape, analyze, and structure data from any website."
+icon: "rocket"
+mode: "wide"
+---
+
+## Description
+
+[Olostep](https://olostep.com) is the most reliable and cost-effective web search, scraping and crawling API for AI. Build intelligent agents that can search, scrape, analyze, and structure data from any website. OlostepTool offers four operation modes:
+
+- **Scrape Mode**: Extract clean content from single webpages with support for LLM extraction and built-in parsers
+- **Crawl Mode**: Follow links and extract content from multiple pages
+- **Map Mode**: Discover all URLs on a website (sitemap generation)
+- **Answer Mode**: AI-powered web search with structured JSON responses
+
+Key features include JavaScript rendering, country-based geolocation, built-in parsers for Google/LinkedIn/etc., and LLM-powered structured data extraction.
+
+## Installation
+
+Install the required packages:
+
+```bash
+pip install crewai-tools olostep
+```
+
+Set your API key:
+
+```bash
+export OLOSTEP_API_KEY="your-api-key-here"
+```
+
+Get your API key at [olostep.com/dashboard](https://olostep.com/dashboard)
+
+## Available Tools
+
+| Tool | Mode | Use Case |
+|------|------|----------|
+| `OlostepTool` | All modes | General purpose - supports all operations |
+| `OlostepScrapeTool` | Scrape | Single page extraction |
+| `OlostepCrawlTool` | Crawl | Multi-page crawling |
+| `OlostepMapTool` | Map | URL discovery |
+| `OlostepAnswerTool` | Answer | AI-powered web search |
+
+## Example - Basic Scraping
+
+```python
+from crewai import Agent, Task, Crew
+from crewai_tools import OlostepTool
+
+# Create the tool
+scrape_tool = OlostepTool()
+
+# Create an agent with the tool
+researcher = Agent(
+    role="Web Researcher",
+    goal="Extract information from websites",
+    backstory="Expert at web research and data extraction",
+    tools=[scrape_tool]
+)
+
+# Create a task
+task = Task(
+    description="Scrape the content from https://example.com and summarize it",
+    agent=researcher,
+    expected_output="A summary of the webpage content"
+)
+
+# Run the crew
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+```
+
+## Example - Using Built-in Parsers
+
+Olostep provides built-in parsers for popular websites:
+
+```python
+from crewai_tools import OlostepTool
+
+tool = OlostepTool()
+
+# Parse Google search results
+results = tool.run(
+    url="https://www.google.com/search?q=python+programming",
+    mode="scrape",
+    parser="@olostep/google-search"
+)
+
+# Parse LinkedIn profile
+profile = tool.run(
+    url="https://www.linkedin.com/in/username",
+    mode="scrape",
+    parser="@olostep/linkedin-profile"
+)
+```
+
+**Available parsers:**
+- `@olostep/google-search` - Google search results
+- `@olostep/google-news` - Google News articles
+- `@olostep/google-maps` - Google Maps places
+- `@olostep/linkedin-profile` - LinkedIn profiles
+- `@olostep/linkedin-company` - LinkedIn companies
+- `@olostep/perplexity-search` - Perplexity AI search
+- `@olostep/brave-search` - Brave search results
+
+## Example - LLM Extraction
+
+Extract structured data using JSON schemas:
+
+```python
+from crewai_tools import OlostepTool
+
+tool = OlostepTool()
+
+# Extract event data with a schema
+event_data = tool.run(
+    url="https://example.com/event-page",
+    mode="scrape",
+    llm_extract_schema={
+        "event_name": {"type": "string"},
+        "date": {"type": "string"},
+        "venue": {"type": "string"},
+        "ticket_price": {"type": "number"}
+    }
+)
+```
+
+## Example - Crawling Websites
+
+```python
+from crewai_tools import OlostepCrawlTool
+
+crawl_tool = OlostepCrawlTool()
+
+# Crawl a website with up to 50 pages
+result = crawl_tool.run(
+    url="https://docs.example.com",
+    max_pages=50,
+    include_patterns=["/docs/*", "/api/*"]
+)
+```
+
+## Example - URL Discovery
+
+```python
+from crewai_tools import OlostepMapTool
+
+map_tool = OlostepMapTool()
+
+# Discover all URLs on a website
+urls = map_tool.run(url="https://example.com")
+```
+
+## Example - AI-Powered Search
+
+```python
+from crewai_tools import OlostepAnswerTool
+
+answer_tool = OlostepAnswerTool()
+
+# Ask a question
+answer = answer_tool.run(
+    task="What are the latest AI trends in 2024?"
+)
+
+# Get structured response
+structured = answer_tool.run(
+    task="What are the top 3 programming languages?",
+    json_schema={
+        "languages": [{"name": "", "rank": 0, "use_case": ""}]
+    }
+)
+```
+
+## Arguments
+
+### OlostepTool (All Modes)
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | `str` | Yes* | URL to process (*required for scrape/crawl/map) |
+| `mode` | `str` | No | Operation mode: `"scrape"`, `"crawl"`, `"map"`, `"answer"` (default: `"scrape"`) |
+| `formats` | `list[str]` | No | Output formats: `"markdown"`, `"html"`, `"text"`, `"json"` |
+| `wait_before_scraping` | `int` | No | Milliseconds to wait for JavaScript content |
+| `country` | `str` | No | Country code for geolocation (e.g., `"US"`, `"UK"`, `"DE"`) |
+| `parser` | `str` | No | Parser ID for structured extraction |
+| `llm_extract_schema` | `dict` | No | JSON schema for LLM-powered extraction |
+| `max_pages` | `int` | No | Max pages for crawl mode (1-1000, default: 10) |
+| `include_patterns` | `list[str]` | No | URL patterns to include in crawl |
+| `exclude_patterns` | `list[str]` | No | URL patterns to exclude from crawl |
+| `task` | `str` | Yes* | Question for answer mode (*required for answer mode) |
+| `json_schema` | `dict` | No | JSON schema for structured answer output |
+
+### Constructor Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `api_key` | `str` | `None` | Olostep API key (uses `OLOSTEP_API_KEY` env var if not provided) |
+| `default_mode` | `str` | `"scrape"` | Default operation mode |
+| `default_formats` | `list[str]` | `["markdown"]` | Default output formats |
+| `default_max_pages` | `int` | `10` | Default max pages for crawling |
+| `log_failures` | `bool` | `True` | Whether to log errors |
+
+## Full Agent Example
+
+```python
+from crewai import Agent, Task, Crew
+from crewai_tools import OlostepTool, OlostepAnswerTool, OlostepCrawlTool
+
+# Create specialized tools
+scrape_tool = OlostepTool()
+answer_tool = OlostepAnswerTool()
+crawl_tool = OlostepCrawlTool()
+
+# Create a comprehensive researcher
+researcher = Agent(
+    role="Senior Web Researcher",
+    goal="Find, extract, and analyze information from the web",
+    backstory="""You are an expert web researcher with access to powerful
+    tools for scraping websites, crawling documentation, and getting 
+    AI-powered answers to questions.""",
+    tools=[scrape_tool, answer_tool, crawl_tool],
+    verbose=True
+)
+
+# Research task
+research_task = Task(
+    description="""
+    Research the latest developments in AI agents:
+    1. Search for recent news about AI agents
+    2. Crawl key documentation sites
+    3. Extract structured information about top frameworks
+    4. Summarize your findings
+    """,
+    agent=researcher,
+    expected_output="A comprehensive report on AI agent developments with sources"
+)
+
+# Run
+crew = Crew(agents=[researcher], tasks=[research_task])
+result = crew.kickoff()
+print(result)
+```
+
+## Links
+
+- [Olostep Website](https://olostep.com)
+- [API Documentation](https://docs.olostep.com)
+- [Get API Key](https://olostep.com/dashboard)

--- a/docs/en/tools/web-scraping/overview.mdx
+++ b/docs/en/tools/web-scraping/overview.mdx
@@ -65,6 +65,10 @@ These tools enable your agents to interact with the web, extract data from websi
   <Card title="Bright Data Tools" icon="spider" href="/en/tools/web-scraping/brightdata-tools">
     SERP search, Web Unlocker, and Dataset API integrations.
   </Card>
+
+  <Card title="Olostep Tool" icon="rocket" href="/en/tools/web-scraping/olosteptool">
+    Fast web scraping, crawling, and site mapping with Olostep's API.
+  </Card>
 </CardGroup>
 
 ## **Common Use Cases**

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -109,6 +109,18 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.olostep_tool.olostep_tool import (
+    OlostepAnswerSchema,
+    OlostepAnswerTool,
+    OlostepCrawlSchema,
+    OlostepCrawlTool,
+    OlostepMapSchema,
+    OlostepMapTool,
+    OlostepScrapeSchema,
+    OlostepScrapeTool,
+    OlostepTool,
+    OlostepToolSchema,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -259,6 +271,16 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OlostepAnswerSchema",
+    "OlostepAnswerTool",
+    "OlostepCrawlSchema",
+    "OlostepCrawlTool",
+    "OlostepMapSchema",
+    "OlostepMapTool",
+    "OlostepScrapeSchema",
+    "OlostepScrapeTool",
+    "OlostepTool",
+    "OlostepToolSchema",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -99,6 +99,18 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.olostep_tool.olostep_tool import (
+    OlostepAnswerSchema,
+    OlostepAnswerTool,
+    OlostepCrawlSchema,
+    OlostepCrawlTool,
+    OlostepMapSchema,
+    OlostepMapTool,
+    OlostepScrapeSchema,
+    OlostepScrapeTool,
+    OlostepTool,
+    OlostepToolSchema,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -243,6 +255,16 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OlostepAnswerSchema",
+    "OlostepAnswerTool",
+    "OlostepCrawlSchema",
+    "OlostepCrawlTool",
+    "OlostepMapSchema",
+    "OlostepMapTool",
+    "OlostepScrapeSchema",
+    "OlostepScrapeTool",
+    "OlostepTool",
+    "OlostepToolSchema",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/README.md
@@ -1,0 +1,236 @@
+# OlostepTool
+
+The most reliable and cost-effective web search, scraping and crawling API for AI. Build intelligent agents that can search, scrape, analyze, and structure data from any website using the [Olostep API](https://olostep.com).
+
+## Features
+
+- **Scrape Mode**: Extract clean content from any webpage
+  - Markdown, HTML, text, and JSON formats
+  - LLM-powered structured data extraction
+  - Built-in parsers for Google, LinkedIn, etc.
+  - JavaScript rendering support
+  - Country-based geolocation
+
+- **Crawl Mode**: Follow links and extract content from multiple pages
+  - Configurable max pages (up to 1000)
+  - Include/exclude URL patterns
+
+- **Map Mode**: Discover all URLs on a website
+  - Comprehensive sitemap generation
+
+- **Answer Mode**: AI-powered web search
+  - Ask questions in natural language
+  - Get structured JSON responses
+  - Sources included for verification
+
+## Installation
+
+```bash
+pip install crewai-tools olostep
+```
+
+## Environment Variables
+
+```bash
+export OLOSTEP_API_KEY="your-api-key-here"
+```
+
+Get your API key at [olostep.com/dashboard](https://olostep.com/dashboard)
+
+## Usage
+
+### Basic Scraping
+
+```python
+from crewai_tools import OlostepTool
+
+# Create the tool
+scrape_tool = OlostepTool()
+
+# Scrape a webpage
+content = scrape_tool.run(
+    url="https://example.com/article",
+    mode="scrape"
+)
+print(content)
+```
+
+### Using Built-in Parsers
+
+```python
+from crewai_tools import OlostepTool
+
+tool = OlostepTool()
+
+# Parse Google search results
+results = tool.run(
+    url="https://www.google.com/search?q=python+programming",
+    mode="scrape",
+    parser="@olostep/google-search"
+)
+
+# Parse LinkedIn profile
+profile = tool.run(
+    url="https://www.linkedin.com/in/username",
+    mode="scrape",
+    parser="@olostep/linkedin-profile"
+)
+```
+
+**Available parsers:**
+- `@olostep/google-search` - Google search results
+- `@olostep/google-news` - Google News articles
+- `@olostep/google-maps` - Google Maps places
+- `@olostep/linkedin-profile` - LinkedIn profiles
+- `@olostep/linkedin-company` - LinkedIn companies
+- `@olostep/perplexity-search` - Perplexity AI search
+- `@olostep/brave-search` - Brave search results
+
+### LLM Extraction with JSON Schema
+
+```python
+from crewai_tools import OlostepTool
+
+tool = OlostepTool()
+
+# Extract structured data using LLM
+event_data = tool.run(
+    url="https://example.com/event-page",
+    mode="scrape",
+    llm_extract_schema={
+        "event_name": {"type": "string"},
+        "date": {"type": "string"},
+        "venue": {"type": "string"},
+        "price": {"type": "number"}
+    }
+)
+```
+
+### Crawling Websites
+
+```python
+from crewai_tools import OlostepCrawlTool
+
+crawl_tool = OlostepCrawlTool()
+
+# Crawl a website
+result = crawl_tool.run(
+    url="https://example.com",
+    max_pages=50,
+    include_patterns=["/blog/*", "/docs/*"]
+)
+```
+
+### Discovering URLs (Sitemap)
+
+```python
+from crewai_tools import OlostepMapTool
+
+map_tool = OlostepMapTool()
+
+# Get all URLs on a website
+urls = map_tool.run(url="https://example.com")
+```
+
+### AI-Powered Web Search
+
+```python
+from crewai_tools import OlostepAnswerTool
+
+answer_tool = OlostepAnswerTool()
+
+# Ask a question
+answer = answer_tool.run(
+    task="What is the latest version of Python?"
+)
+
+# Get structured answer
+structured_answer = answer_tool.run(
+    task="What are the top 3 programming languages in 2024?",
+    json_schema={
+        "languages": [{"name": "", "rank": 0}]
+    }
+)
+```
+
+## Specialized Tools
+
+For convenience, you can use pre-configured tools for each mode:
+
+| Tool | Mode | Use Case |
+|------|------|----------|
+| `OlostepTool` | All modes | General purpose |
+| `OlostepScrapeTool` | Scrape | Single page extraction |
+| `OlostepCrawlTool` | Crawl | Multi-page crawling |
+| `OlostepMapTool` | Map | URL discovery |
+| `OlostepAnswerTool` | Answer | AI web search |
+
+## Arguments
+
+### Common Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `url` | str | URL to process (required for scrape/crawl/map) |
+| `mode` | str | Operation mode: "scrape", "crawl", "map", "answer" |
+
+### Scrape Mode Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `formats` | list[str] | Output formats: "markdown", "html", "text", "json" |
+| `wait_before_scraping` | int | Milliseconds to wait for JS content |
+| `country` | str | Country code for geolocation (e.g., "US", "UK") |
+| `parser` | str | Parser ID for structured extraction |
+| `llm_extract_schema` | dict | JSON schema for LLM extraction |
+
+### Crawl Mode Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `max_pages` | int | Maximum pages to crawl (1-1000) |
+| `include_patterns` | list[str] | URL patterns to include (regex) |
+| `exclude_patterns` | list[str] | URL patterns to exclude (regex) |
+
+### Answer Mode Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `task` | str | Question or task for AI to answer |
+| `json_schema` | dict | JSON schema for structured output |
+
+## Integration with CrewAI Agents
+
+```python
+from crewai import Agent, Task, Crew
+from crewai_tools import OlostepTool, OlostepAnswerTool
+
+# Create tools
+scrape_tool = OlostepTool()
+answer_tool = OlostepAnswerTool()
+
+# Create a researcher agent
+researcher = Agent(
+    role="Web Researcher",
+    goal="Find and analyze information from the web",
+    backstory="Expert at finding and extracting information from websites",
+    tools=[scrape_tool, answer_tool]
+)
+
+# Create a task
+task = Task(
+    description="Research the latest trends in AI and summarize key findings",
+    agent=researcher,
+    expected_output="A summary of AI trends with sources"
+)
+
+# Run the crew
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+```
+
+## Links
+
+- [Olostep Website](https://olostep.com)
+- [Olostep API Documentation](https://docs.olostep.com)
+- [Get API Key](https://olostep.com/dashboard)

--- a/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/__init__.py
@@ -1,0 +1,25 @@
+from crewai_tools.tools.olostep_tool.olostep_tool import (
+    OlostepAnswerSchema,
+    OlostepAnswerTool,
+    OlostepCrawlSchema,
+    OlostepCrawlTool,
+    OlostepMapSchema,
+    OlostepMapTool,
+    OlostepScrapeSchema,
+    OlostepScrapeTool,
+    OlostepTool,
+    OlostepToolSchema,
+)
+
+__all__ = [
+    "OlostepTool",
+    "OlostepToolSchema",
+    "OlostepScrapeTool",
+    "OlostepScrapeSchema",
+    "OlostepCrawlTool",
+    "OlostepCrawlSchema",
+    "OlostepMapTool",
+    "OlostepMapSchema",
+    "OlostepAnswerTool",
+    "OlostepAnswerSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/olostep_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/olostep_tool/olostep_tool.py
@@ -1,0 +1,677 @@
+"""Olostep Tool for CrewAI - Web scraping, crawling, mapping, and AI search.
+
+Olostep (https://olostep.com) provides:
+- Scraping: Extract clean content from any webpage
+- Crawling: Follow links and extract content from multiple pages
+- Sitemap: Discover all URLs on a website
+- Answers: AI-powered web search with structured JSON output
+- LLM Extract: Extract structured data from pages using schemas
+- Parsers: Built-in parsers for Google Search, News, LinkedIn, etc.
+"""
+
+import logging
+import subprocess
+from typing import Any, Literal
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field, field_validator
+
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Input Schemas for different modes
+# ============================================================================
+
+class OlostepScrapeSchema(BaseModel):
+    """Input schema for scraping a single page."""
+
+    url: str = Field(
+        ..., description="The URL of the webpage to scrape"
+    )
+    formats: list[str] | None = Field(
+        default=None,
+        description="Output formats: 'markdown', 'html', 'text', 'json'. Defaults to ['markdown']"
+    )
+    wait_before_scraping: int | None = Field(
+        default=None,
+        description="Milliseconds to wait for JavaScript content to load"
+    )
+    country: str | None = Field(
+        default=None,
+        description="Country code for geolocation (e.g., 'US', 'UK', 'DE')"
+    )
+    parser: str | None = Field(
+        default=None,
+        description="Parser ID for structured extraction (e.g., '@olostep/google-search', '@olostep/linkedin-profile')"
+    )
+    llm_extract_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="JSON schema for LLM-powered structured data extraction"
+    )
+
+
+class OlostepCrawlSchema(BaseModel):
+    """Input schema for crawling a website."""
+
+    url: str = Field(
+        ..., description="The starting URL for the crawl"
+    )
+    max_pages: int = Field(
+        default=10,
+        description="Maximum number of pages to crawl (1-1000)"
+    )
+    include_patterns: list[str] | None = Field(
+        default=None,
+        description="URL patterns to include (regex)"
+    )
+    exclude_patterns: list[str] | None = Field(
+        default=None,
+        description="URL patterns to exclude (regex)"
+    )
+
+    @field_validator("max_pages")
+    @classmethod
+    def validate_max_pages(cls, v: int) -> int:
+        if v < 1:
+            return 1
+        if v > 1000:
+            return 1000
+        return v
+
+
+class OlostepMapSchema(BaseModel):
+    """Input schema for mapping/discovering URLs on a website."""
+
+    url: str = Field(
+        ..., description="The website URL to map"
+    )
+
+
+class OlostepAnswerSchema(BaseModel):
+    """Input schema for AI-powered web search answers."""
+
+    task: str = Field(
+        ..., description="The question or task for AI to answer using web search"
+    )
+    json_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="JSON schema to structure the answer output"
+    )
+
+
+class OlostepToolSchema(BaseModel):
+    """Main input schema for OlostepTool - supports all modes."""
+
+    url: str | None = Field(
+        default=None,
+        description="URL to process (required for scrape, crawl, map modes)"
+    )
+    mode: Literal["scrape", "crawl", "map", "answer"] = Field(
+        default="scrape",
+        description="Operation mode: 'scrape' (single page), 'crawl' (follow links), 'map' (discover URLs), 'answer' (AI search)"
+    )
+    
+    # Scrape-specific
+    formats: list[str] | None = Field(
+        default=None,
+        description="Output formats for scrape mode: 'markdown', 'html', 'text', 'json'"
+    )
+    wait_before_scraping: int | None = Field(
+        default=None,
+        description="Milliseconds to wait for JavaScript content"
+    )
+    country: str | None = Field(
+        default=None,
+        description="Country code for geolocation (e.g., 'US', 'UK')"
+    )
+    parser: str | None = Field(
+        default=None,
+        description="Parser ID (e.g., '@olostep/google-search', '@olostep/linkedin-profile')"
+    )
+    llm_extract_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="JSON schema for LLM extraction"
+    )
+    
+    # Crawl-specific
+    max_pages: int | None = Field(
+        default=None,
+        description="Max pages for crawl mode (1-1000)"
+    )
+    include_patterns: list[str] | None = Field(
+        default=None,
+        description="URL patterns to include in crawl"
+    )
+    exclude_patterns: list[str] | None = Field(
+        default=None,
+        description="URL patterns to exclude from crawl"
+    )
+    
+    # Answer-specific
+    task: str | None = Field(
+        default=None,
+        description="Question/task for answer mode"
+    )
+    json_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="JSON schema for answer output"
+    )
+
+    @field_validator("max_pages")
+    @classmethod
+    def validate_max_pages(cls, v: int | None) -> int | None:
+        if v is None:
+            return v
+        if v < 1:
+            return 1
+        if v > 1000:
+            return 1000
+        return v
+
+
+# ============================================================================
+# Main Tool Class
+# ============================================================================
+
+class OlostepTool(BaseTool):
+    """Tool for web scraping, crawling, and AI-powered search using Olostep.
+
+    Olostep (https://olostep.com) provides LLM-ready web content extraction
+    with support for JavaScript rendering and dynamic content.
+
+    **Modes:**
+    
+    - **scrape**: Extract content from a single webpage
+      - Supports markdown, HTML, text, JSON formats
+      - LLM extraction with JSON schemas
+      - Built-in parsers for Google, LinkedIn, etc.
+      - Country-based geolocation
+      
+    - **crawl**: Follow links and extract content from multiple pages
+      - Configurable max pages (up to 1000)
+      - Include/exclude URL patterns
+      
+    - **map**: Discover all URLs on a website
+      - Returns a comprehensive sitemap
+      
+    - **answer**: AI-powered web search
+      - Ask questions in natural language
+      - Get structured JSON responses
+      - Sources included for verification
+
+    **Example parsers:**
+    - @olostep/google-search - Google search results
+    - @olostep/google-news - Google News articles
+    - @olostep/linkedin-profile - LinkedIn profiles
+    - @olostep/google-maps - Google Maps places
+    - @olostep/perplexity-search - Perplexity AI search
+
+    Attributes:
+        name: Tool name for identification
+        description: Tool description for LLM understanding
+        api_key: Olostep API key
+        default_mode: Default operation mode
+        default_formats: Default output formats
+    """
+
+    name: str = "OlostepTool"
+    description: str = (
+        "The most reliable and cost-effective web search, scraping and crawling API for AI. "
+        "Build intelligent agents that can search, scrape, analyze, and structure data from any website.\n\n"
+        "Modes: 'scrape' (single page), 'crawl' (multiple pages), 'map' (sitemap), 'answer' (AI search).\n"
+        "Features: LLM extraction, parsers (@olostep/google-search, etc.), country geolocation, JS rendering."
+    )
+    args_schema: type[BaseModel] = OlostepToolSchema
+    
+    # Configuration
+    api_key: str | None = None
+    default_mode: Literal["scrape", "crawl", "map", "answer"] = "scrape"
+    default_formats: list[str] = Field(default_factory=lambda: ["markdown"])
+    default_max_pages: int = 10
+    
+    # Internal state
+    _client: Any = None
+    log_failures: bool = True
+    
+    package_dependencies: list[str] = Field(default_factory=lambda: ["olostep"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="OLOSTEP_API_KEY",
+                description="API key for Olostep. Get one at https://olostep.com/dashboard",
+                required=True,
+            ),
+        ]
+    )
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        default_mode: Literal["scrape", "crawl", "map", "answer"] = "scrape",
+        default_formats: list[str] | None = None,
+        default_max_pages: int = 10,
+        log_failures: bool = True,
+        **kwargs,
+    ):
+        """Initialize OlostepTool.
+
+        Args:
+            api_key: Olostep API key. Uses OLOSTEP_API_KEY env var if not provided.
+            default_mode: Default operation mode.
+            default_formats: Default output formats for scraping.
+            default_max_pages: Default max pages for crawling.
+            log_failures: Whether to log errors.
+            **kwargs: Additional arguments for BaseTool.
+        """
+        super().__init__(**kwargs)
+        
+        self.api_key = api_key
+        self.default_mode = default_mode
+        self.default_formats = default_formats or ["markdown"]
+        self.default_max_pages = default_max_pages
+        self.log_failures = log_failures
+        
+        # Initialize client lazily
+        self._client = None
+
+    def _get_client(self) -> Any:
+        """Get or create the Olostep client."""
+        if self._client is None:
+            try:
+                from olostep import SyncOlostepClient
+            except ImportError:
+                import click
+
+                if click.confirm(
+                    "The 'olostep' package is required. Install it now?"
+                ):
+                    subprocess.run(["uv", "pip", "install", "olostep"], check=True)  # noqa: S607
+                    from olostep import SyncOlostepClient
+                else:
+                    raise ImportError(
+                        "olostep package not found. Install with: pip install olostep"
+                    ) from None
+
+            self._client = SyncOlostepClient(api_key=self.api_key)
+        
+        return self._client
+
+    def _run(
+        self,
+        url: str | None = None,
+        mode: Literal["scrape", "crawl", "map", "answer"] | None = None,
+        # Scrape options
+        formats: list[str] | None = None,
+        wait_before_scraping: int | None = None,
+        country: str | None = None,
+        parser: str | None = None,
+        llm_extract_schema: dict[str, Any] | None = None,
+        # Crawl options
+        max_pages: int | None = None,
+        include_patterns: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+        # Answer options
+        task: str | None = None,
+        json_schema: dict[str, Any] | None = None,
+    ) -> str:
+        """Execute the Olostep tool.
+
+        Args:
+            url: URL to process (required for scrape/crawl/map modes)
+            mode: Operation mode
+            formats: Output formats for scrape mode
+            wait_before_scraping: Wait time in ms for JS content
+            country: Country code for geolocation
+            parser: Parser ID for structured extraction
+            llm_extract_schema: JSON schema for LLM extraction
+            max_pages: Max pages for crawl mode
+            include_patterns: URL patterns to include in crawl
+            exclude_patterns: URL patterns to exclude from crawl
+            task: Question for answer mode
+            json_schema: JSON schema for answer output
+
+        Returns:
+            Extracted content, crawl summary, URL list, or AI answer
+        """
+        mode = mode or self.default_mode
+
+        try:
+            if mode == "scrape":
+                if not url:
+                    return "Error: URL is required for scrape mode"
+                return self._scrape(
+                    url=url,
+                    formats=formats,
+                    wait_before_scraping=wait_before_scraping,
+                    country=country,
+                    parser=parser,
+                    llm_extract_schema=llm_extract_schema,
+                )
+            
+            elif mode == "crawl":
+                if not url:
+                    return "Error: URL is required for crawl mode"
+                return self._crawl(
+                    url=url,
+                    max_pages=max_pages,
+                    include_patterns=include_patterns,
+                    exclude_patterns=exclude_patterns,
+                )
+            
+            elif mode == "map":
+                if not url:
+                    return "Error: URL is required for map mode"
+                return self._map(url=url)
+            
+            elif mode == "answer":
+                if not task:
+                    return "Error: 'task' is required for answer mode"
+                return self._answer(task=task, json_schema=json_schema)
+            
+            else:
+                return f"Error: Unknown mode '{mode}'. Use 'scrape', 'crawl', 'map', or 'answer'."
+
+        except Exception as e:
+            error_msg = f"Olostep error: {str(e)}"
+            if self.log_failures:
+                logger.error(error_msg)
+            return error_msg
+
+    def _scrape(
+        self,
+        url: str,
+        formats: list[str] | None = None,
+        wait_before_scraping: int | None = None,
+        country: str | None = None,
+        parser: str | None = None,
+        llm_extract_schema: dict[str, Any] | None = None,
+    ) -> str:
+        """Scrape a single webpage.
+
+        Args:
+            url: URL to scrape
+            formats: Output formats (markdown, html, text, json)
+            wait_before_scraping: Wait time in ms
+            country: Country code for geolocation
+            parser: Parser ID for structured extraction
+            llm_extract_schema: JSON schema for LLM extraction
+
+        Returns:
+            Scraped content
+        """
+        client = self._get_client()
+        
+        # Build parameters
+        kwargs: dict[str, Any] = {
+            "url": url,
+        }
+        
+        if formats:
+            kwargs["formats"] = formats
+        else:
+            kwargs["formats"] = self.default_formats
+            
+        if wait_before_scraping is not None:
+            kwargs["wait_before_scraping"] = wait_before_scraping
+            
+        if country:
+            kwargs["country"] = country
+            
+        if parser:
+            kwargs["parser"] = {"id": parser}
+            
+        if llm_extract_schema:
+            kwargs["llm_extract"] = {"schema": llm_extract_schema}
+
+        # Call the API
+        result = client.scrape.create(**kwargs)
+        
+        # Extract content
+        content = None
+        
+        # Check for LLM extract result first
+        if hasattr(result, "llm_extract") and result.llm_extract:
+            import json
+            return json.dumps(result.llm_extract, indent=2)
+        
+        # Check for parser result
+        if hasattr(result, "parser_result") and result.parser_result:
+            import json
+            return json.dumps(result.parser_result, indent=2)
+        
+        # Return content based on format priority
+        if hasattr(result, "markdown") and result.markdown:
+            content = result.markdown
+        elif hasattr(result, "markdown_content") and result.markdown_content:
+            content = result.markdown_content
+        elif hasattr(result, "html") and result.html:
+            content = result.html
+        elif hasattr(result, "html_content") and result.html_content:
+            content = result.html_content
+        elif hasattr(result, "text") and result.text:
+            content = result.text
+        elif hasattr(result, "text_content") and result.text_content:
+            content = result.text_content
+        else:
+            content = str(result)
+            
+        return content
+
+    def _crawl(
+        self,
+        url: str,
+        max_pages: int | None = None,
+        include_patterns: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+    ) -> str:
+        """Crawl a website by following links.
+
+        Args:
+            url: Starting URL
+            max_pages: Maximum pages to crawl
+            include_patterns: URL patterns to include
+            exclude_patterns: URL patterns to exclude
+
+        Returns:
+            Crawl results summary
+        """
+        client = self._get_client()
+        
+        max_pages = max_pages or self.default_max_pages
+        max_pages = max(1, min(max_pages, 1000))  # Clamp between 1 and 1000
+        
+        kwargs: dict[str, Any] = {
+            "url": url,
+            "max_pages": max_pages,
+        }
+        
+        if include_patterns:
+            kwargs["include_patterns"] = include_patterns
+        if exclude_patterns:
+            kwargs["exclude_patterns"] = exclude_patterns
+
+        # Start the crawl
+        result = client.crawl.start(**kwargs)
+        
+        # Get crawl ID
+        crawl_id = getattr(result, "id", None) or getattr(result, "crawl_id", None)
+        
+        if crawl_id:
+            # Try to get pages if available
+            pages = []
+            if hasattr(result, "pages"):
+                pages = result.pages or []
+            
+            output = [
+                "Crawl started successfully!",
+                "",
+                f"Crawl ID: {crawl_id}",
+                f"Starting URL: {url}",
+                f"Max pages: {max_pages}",
+            ]
+            
+            if pages:
+                output.append(f"Pages crawled: {len(pages)}")
+                output.append("")
+                output.append("Crawled URLs:")
+                for page in pages[:20]:  # Show first 20
+                    page_url = getattr(page, "url", str(page))
+                    output.append(f"  • {page_url}")
+                if len(pages) > 20:
+                    output.append(f"  ... and {len(pages) - 20} more")
+            
+            return "\n".join(output)
+        
+        return f"Crawl initiated for {url}: {result}"
+
+    def _map(self, url: str) -> str:
+        """Map/discover all URLs on a website.
+
+        Args:
+            url: Website URL to map
+
+        Returns:
+            List of discovered URLs
+        """
+        client = self._get_client()
+        
+        # Create sitemap
+        result = client.sitemap.create(url=url)
+        
+        # Extract URLs
+        urls = []
+        if hasattr(result, "urls") and result.urls:
+            urls = result.urls
+        elif hasattr(result, "links") and result.links:
+            urls = result.links
+        elif isinstance(result, dict):
+            urls = result.get("urls", []) or result.get("links", [])
+        
+        if urls:
+            output = [
+                f"Found {len(urls)} URLs on {url}:",
+                "",
+            ]
+            for u in urls[:100]:  # Show first 100
+                output.append(f"  • {u}")
+            if len(urls) > 100:
+                output.append(f"  ... and {len(urls) - 100} more")
+            return "\n".join(output)
+        
+        return f"No URLs found on {url}"
+
+    def _answer(
+        self,
+        task: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> str:
+        """Get AI-powered answer using web search.
+
+        Args:
+            task: Question or task to answer
+            json_schema: Optional JSON schema for structured output
+
+        Returns:
+            AI-generated answer with sources
+        """
+        import json as json_module
+        import os
+
+        import requests
+        
+        # Get API key
+        api_key = self.api_key or os.environ.get("OLOSTEP_API_KEY")
+        if not api_key:
+            return "Error: OLOSTEP_API_KEY not found"
+        
+        # Call Answers API directly (not yet in SDK)
+        endpoint = "https://api.olostep.com/v1/answers"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        
+        payload: dict[str, Any] = {"task": task}
+        if json_schema:
+            payload["json"] = json_schema
+        
+        response = requests.post(endpoint, json=payload, headers=headers, timeout=60)
+        response.raise_for_status()
+        
+        data = response.json()
+        
+        # Format output
+        if "result" in data:
+            if isinstance(data["result"], dict):
+                return json_module.dumps(data["result"], indent=2)
+            return str(data["result"])
+        
+        return json_module.dumps(data, indent=2)
+
+
+# Convenience tool classes for specific modes
+class OlostepScrapeTool(OlostepTool):
+    """Olostep tool pre-configured for scraping."""
+    
+    name: str = "OlostepScrapeTool"
+    description: str = (
+        "Scrape content from a webpage. Returns clean markdown content. "
+        "Supports LLM extraction with schemas and built-in parsers "
+        "(e.g., @olostep/google-search, @olostep/linkedin-profile)."
+    )
+    args_schema: type[BaseModel] = OlostepScrapeSchema
+    default_mode: Literal["scrape", "crawl", "map", "answer"] = "scrape"
+    
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_mode", "scrape")
+        super().__init__(**kwargs)
+
+
+class OlostepCrawlTool(OlostepTool):
+    """Olostep tool pre-configured for crawling."""
+    
+    name: str = "OlostepCrawlTool"
+    description: str = (
+        "Crawl a website by following links. Extracts content from multiple pages. "
+        "Configure max_pages and URL patterns to control the crawl."
+    )
+    args_schema: type[BaseModel] = OlostepCrawlSchema
+    default_mode: Literal["scrape", "crawl", "map", "answer"] = "crawl"
+    
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_mode", "crawl")
+        super().__init__(**kwargs)
+
+
+class OlostepMapTool(OlostepTool):
+    """Olostep tool pre-configured for mapping/sitemap."""
+    
+    name: str = "OlostepMapTool"
+    description: str = (
+        "Discover all URLs on a website. Returns a comprehensive list of pages."
+    )
+    args_schema: type[BaseModel] = OlostepMapSchema
+    default_mode: Literal["scrape", "crawl", "map", "answer"] = "map"
+    
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_mode", "map")
+        super().__init__(**kwargs)
+
+
+class OlostepAnswerTool(OlostepTool):
+    """Olostep tool pre-configured for AI-powered web search."""
+    
+    name: str = "OlostepAnswerTool"
+    description: str = (
+        "AI-powered web search that answers questions with real-world data. "
+        "Returns structured JSON answers with sources. Use json_schema to "
+        "specify the output format."
+    )
+    args_schema: type[BaseModel] = OlostepAnswerSchema
+    default_mode: Literal["scrape", "crawl", "map", "answer"] = "answer"
+    
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_mode", "answer")
+        super().__init__(**kwargs)

--- a/lib/crewai-tools/tests/tools/olostep_tool_test.py
+++ b/lib/crewai-tools/tests/tools/olostep_tool_test.py
@@ -1,0 +1,515 @@
+"""Tests for OlostepTool and related tools.
+
+This module contains comprehensive tests for the Olostep integration with CrewAI,
+covering all modes: scrape, crawl, map, and answer.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools import (
+    OlostepAnswerTool,
+    OlostepCrawlTool,
+    OlostepMapTool,
+    OlostepScrapeTool,
+    OlostepTool,
+)
+
+
+class TestOlostepToolSchema:
+    """Tests for OlostepToolSchema validation."""
+
+    def test_schema_default_mode_is_scrape(self):
+        """Test that default mode is scrape."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        schema = OlostepToolSchema(url="https://example.com")
+        assert schema.mode == "scrape"
+
+    def test_schema_accepts_all_modes(self):
+        """Test that schema accepts all valid modes."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        for mode in ["scrape", "crawl", "map", "answer"]:
+            schema = OlostepToolSchema(url="https://example.com", mode=mode)
+            assert schema.mode == mode
+
+    def test_schema_accepts_optional_parameters(self):
+        """Test that schema accepts optional parameters."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        schema = OlostepToolSchema(
+            url="https://example.com",
+            mode="scrape",
+            formats=["markdown", "html"],
+            wait_before_scraping=1000,
+            country="US",
+            parser="@olostep/google-search",
+        )
+        assert schema.formats == ["markdown", "html"]
+        assert schema.wait_before_scraping == 1000
+        assert schema.country == "US"
+        assert schema.parser == "@olostep/google-search"
+
+
+class TestOlostepCrawlSchema:
+    """Tests for OlostepCrawlSchema validation."""
+
+    def test_max_pages_validation_caps_at_1000(self):
+        """Test that max_pages is capped at 1000."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepCrawlSchema
+
+        schema = OlostepCrawlSchema(url="https://example.com", max_pages=5000)
+        assert schema.max_pages == 1000
+
+    def test_max_pages_validation_minimum_is_1(self):
+        """Test that max_pages minimum is 1."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepCrawlSchema
+
+        schema = OlostepCrawlSchema(url="https://example.com", max_pages=0)
+        assert schema.max_pages == 1
+
+    def test_default_max_pages_is_10(self):
+        """Test that default max_pages is 10."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepCrawlSchema
+
+        schema = OlostepCrawlSchema(url="https://example.com")
+        assert schema.max_pages == 10
+
+
+class TestOlostepToolSchemaMaxPages:
+    """Tests for OlostepToolSchema max_pages validation."""
+
+    def test_max_pages_validation_caps_at_1000(self):
+        """Test that max_pages is capped at 1000 in main schema."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        schema = OlostepToolSchema(url="https://example.com", mode="crawl", max_pages=5000)
+        assert schema.max_pages == 1000
+
+    def test_max_pages_validation_minimum_is_1(self):
+        """Test that max_pages minimum is 1 in main schema."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        schema = OlostepToolSchema(url="https://example.com", mode="crawl", max_pages=-5)
+        assert schema.max_pages == 1
+
+    def test_max_pages_validation_allows_none(self):
+        """Test that max_pages can be None in main schema."""
+        from crewai_tools.tools.olostep_tool.olostep_tool import OlostepToolSchema
+
+        schema = OlostepToolSchema(url="https://example.com", mode="crawl", max_pages=None)
+        assert schema.max_pages is None
+
+
+class TestOlostepToolInitialization:
+    """Tests for OlostepTool initialization."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_tool_initialization_defaults(self):
+        """Test tool initializes with default values."""
+        tool = OlostepTool()
+        assert tool.name == "OlostepTool"
+        assert tool.default_mode == "scrape"
+        assert tool.default_formats == ["markdown"]
+        assert tool.default_max_pages == 10
+        assert tool.log_failures is True
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_tool_initialization_with_custom_values(self):
+        """Test tool initializes with custom values."""
+        tool = OlostepTool(
+            api_key="custom-key",
+            default_mode="crawl",
+            default_formats=["html", "text"],
+            default_max_pages=50,
+            log_failures=False,
+        )
+        assert tool.api_key == "custom-key"
+        assert tool.default_mode == "crawl"
+        assert tool.default_formats == ["html", "text"]
+        assert tool.default_max_pages == 50
+        assert tool.log_failures is False
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_tool_has_package_dependencies(self):
+        """Test tool declares olostep as package dependency."""
+        tool = OlostepTool()
+        assert "olostep" in tool.package_dependencies
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_tool_has_env_vars(self):
+        """Test tool declares OLOSTEP_API_KEY env var."""
+        tool = OlostepTool()
+        env_var_names = [ev.name for ev in tool.env_vars]
+        assert "OLOSTEP_API_KEY" in env_var_names
+
+
+class TestOlostepToolScrapeMode:
+    """Tests for OlostepTool scrape mode."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_scrape_returns_markdown_content(self, mock_client_class):
+        """Test scrape mode returns markdown content."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.markdown = "# Test Content\n\nThis is test content."
+        mock_result.llm_extract = None
+        mock_result.parser_result = None
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(url="https://example.com", mode="scrape")
+
+        assert "Test Content" in result
+        mock_client.scrape.create.assert_called_once()
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_scrape_with_parser(self, mock_client_class):
+        """Test scrape mode with parser returns structured data."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.llm_extract = None
+        mock_result.parser_result = {"title": "Test", "description": "Test desc"}
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            url="https://google.com/search?q=test",
+            mode="scrape",
+            parser="@olostep/google-search",
+        )
+
+        assert "title" in result
+        call_kwargs = mock_client.scrape.create.call_args[1]
+        assert call_kwargs["parser"] == {"id": "@olostep/google-search"}
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_scrape_with_llm_extract(self, mock_client_class):
+        """Test scrape mode with LLM extraction."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.llm_extract = {"event_name": "Concert", "date": "2024-01-01"}
+        mock_result.parser_result = None
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            url="https://example.com/event",
+            mode="scrape",
+            llm_extract_schema={"event_name": {"type": "string"}, "date": {"type": "string"}},
+        )
+
+        assert "event_name" in result
+        assert "Concert" in result
+        call_kwargs = mock_client.scrape.create.call_args[1]
+        assert "llm_extract" in call_kwargs
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_scrape_with_country(self, mock_client_class):
+        """Test scrape mode with country parameter."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.markdown = "Content from US"
+        mock_result.llm_extract = None
+        mock_result.parser_result = None
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        tool._run(url="https://example.com", mode="scrape", country="US")
+
+        call_kwargs = mock_client.scrape.create.call_args[1]
+        assert call_kwargs["country"] == "US"
+
+
+class TestOlostepToolCrawlMode:
+    """Tests for OlostepTool crawl mode."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_crawl_returns_job_info(self, mock_client_class):
+        """Test crawl mode returns job information."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.id = "crawl-123"
+        mock_result.pages = []
+        mock_client.crawl.start.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(url="https://example.com", mode="crawl")
+
+        assert "Crawl started successfully" in result
+        assert "crawl-123" in result
+        mock_client.crawl.start.assert_called_once()
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_crawl_respects_max_pages(self, mock_client_class):
+        """Test crawl mode respects max_pages parameter."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.id = "crawl-456"
+        mock_result.pages = []
+        mock_client.crawl.start.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        tool._run(url="https://example.com", mode="crawl", max_pages=25)
+
+        call_kwargs = mock_client.crawl.start.call_args[1]
+        assert call_kwargs["max_pages"] == 25
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_crawl_caps_max_pages_at_1000(self, mock_client_class):
+        """Test crawl mode caps max_pages at 1000."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.id = "crawl-789"
+        mock_result.pages = []
+        mock_client.crawl.start.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        tool._run(url="https://example.com", mode="crawl", max_pages=5000)
+
+        call_kwargs = mock_client.crawl.start.call_args[1]
+        assert call_kwargs["max_pages"] == 1000
+
+
+class TestOlostepToolMapMode:
+    """Tests for OlostepTool map mode."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_map_returns_url_list(self, mock_client_class):
+        """Test map mode returns list of URLs."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.urls = [
+            "https://example.com/",
+            "https://example.com/about",
+            "https://example.com/contact",
+        ]
+        mock_client.sitemap.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(url="https://example.com", mode="map")
+
+        assert "Found 3 URLs" in result
+        assert "example.com/about" in result
+        mock_client.sitemap.create.assert_called_once()
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_map_handles_empty_result(self, mock_client_class):
+        """Test map mode handles empty result gracefully."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.urls = []
+        mock_result.links = None
+        mock_client.sitemap.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(url="https://example.com", mode="map")
+
+        assert "No URLs found" in result
+
+
+class TestOlostepToolAnswerMode:
+    """Tests for OlostepTool answer mode."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("requests.post")
+    def test_answer_returns_ai_response(self, mock_post):
+        """Test answer mode returns AI response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "result": "The latest iPhone is iPhone 15"
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            mode="answer",
+            task="What is the latest iPhone model?",
+        )
+
+        assert "iPhone" in result
+        mock_post.assert_called_once()
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("requests.post")
+    def test_answer_with_json_schema(self, mock_post):
+        """Test answer mode with JSON schema."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "result": {"model": "iPhone 15", "release_year": 2023}
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            mode="answer",
+            task="What is the latest iPhone model?",
+            json_schema={"model": "", "release_year": 0},
+        )
+
+        assert "iPhone 15" in result
+        assert "2023" in result
+
+
+class TestOlostepToolErrorHandling:
+    """Tests for OlostepTool error handling."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_scrape_requires_url(self):
+        """Test scrape mode requires URL."""
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(mode="scrape")
+
+        assert "Error" in result
+        assert "URL is required" in result
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_crawl_requires_url(self):
+        """Test crawl mode requires URL."""
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(mode="crawl")
+
+        assert "Error" in result
+        assert "URL is required" in result
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_map_requires_url(self):
+        """Test map mode requires URL."""
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(mode="map")
+
+        assert "Error" in result
+        assert "URL is required" in result
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_answer_requires_task(self):
+        """Test answer mode requires task."""
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(mode="answer")
+
+        assert "Error" in result
+        assert "task" in result.lower()
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_handles_api_error(self, mock_client_class):
+        """Test tool handles API errors gracefully."""
+        mock_client = MagicMock()
+        mock_client.scrape.create.side_effect = Exception("API Error: Rate limit exceeded")
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(url="https://example.com", mode="scrape")
+
+        assert "error" in result.lower()
+        assert "Rate limit" in result
+
+
+class TestSpecializedTools:
+    """Tests for specialized Olostep tools."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_scrape_tool_defaults_to_scrape_mode(self):
+        """Test OlostepScrapeTool defaults to scrape mode."""
+        tool = OlostepScrapeTool()
+        assert tool.default_mode == "scrape"
+        assert tool.name == "OlostepScrapeTool"
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_crawl_tool_defaults_to_crawl_mode(self):
+        """Test OlostepCrawlTool defaults to crawl mode."""
+        tool = OlostepCrawlTool()
+        assert tool.default_mode == "crawl"
+        assert tool.name == "OlostepCrawlTool"
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_map_tool_defaults_to_map_mode(self):
+        """Test OlostepMapTool defaults to map mode."""
+        tool = OlostepMapTool()
+        assert tool.default_mode == "map"
+        assert tool.name == "OlostepMapTool"
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    def test_answer_tool_defaults_to_answer_mode(self):
+        """Test OlostepAnswerTool defaults to answer mode."""
+        tool = OlostepAnswerTool()
+        assert tool.default_mode == "answer"
+        assert tool.name == "OlostepAnswerTool"
+
+
+class TestOlostepToolParsers:
+    """Tests for built-in parser support."""
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_google_search_parser(self, mock_client_class):
+        """Test Google Search parser."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.llm_extract = None
+        mock_result.parser_result = {
+            "organic_results": [
+                {"title": "Result 1", "link": "https://example.com"},
+            ]
+        }
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            url="https://www.google.com/search?q=python",
+            mode="scrape",
+            parser="@olostep/google-search",
+        )
+
+        assert "organic_results" in result
+        call_kwargs = mock_client.scrape.create.call_args[1]
+        assert call_kwargs["parser"]["id"] == "@olostep/google-search"
+
+    @patch.dict(os.environ, {"OLOSTEP_API_KEY": "test-api-key"})
+    @patch("olostep.SyncOlostepClient")
+    def test_linkedin_profile_parser(self, mock_client_class):
+        """Test LinkedIn profile parser."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.llm_extract = None
+        mock_result.parser_result = {
+            "name": "John Doe",
+            "headline": "Software Engineer",
+        }
+        mock_client.scrape.create.return_value = mock_result
+        mock_client_class.return_value = mock_client
+
+        tool = OlostepTool(api_key="test-key")
+        result = tool._run(
+            url="https://www.linkedin.com/in/johndoe",
+            mode="scrape",
+            parser="@olostep/linkedin-profile",
+        )
+
+        assert "John Doe" in result
+        call_kwargs = mock_client.scrape.create.call_args[1]
+        assert call_kwargs["parser"]["id"] == "@olostep/linkedin-profile"


### PR DESCRIPTION
… AI answers

- Implements OlostepTool with 4 modes: scrape, crawl, map, answer
- Adds 4 specialized tools: OlostepScrapeTool, OlostepCrawlTool, OlostepMapTool, OlostepAnswerTool
- Supports LLM extraction with custom JSON schemas
- Supports parsers: @olostep/google-search, @olostep/linkedin-profile, @olostep/youtube-transcript, etc.
- Supports country geolocation (us, de, gb, fr, etc.)
- Multiple output formats: html, markdown, text, readability
- Full test coverage with 32 tests
- Comprehensive documentation in README.md and olosteptool.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce OlostepTool with scrape/crawl/map/answer modes, specialized tool wrappers, exports, docs, and comprehensive tests.
> 
> - **Tools**:
>   - Add `OlostepTool` with modes: `scrape`, `crawl`, `map`, `answer`; supports formats, JS wait, geolocation, parsers, and LLM JSON extraction.
>   - Add specialized wrappers: `OlostepScrapeTool`, `OlostepCrawlTool`, `OlostepMapTool`, `OlostepAnswerTool` with corresponding `*Schema` classes.
>   - Export all Olostep tools/schemas via `crewai_tools/__init__.py` and `tools/__init__.py`; add `tools/olostep_tool/__init__.py`.
>   - Implement Answers API call (direct HTTP) and Olostep client integration; requires `OLOSTEP_API_KEY`.
> - **Docs**:
>   - New page `docs/en/tools/web-scraping/olosteptool.mdx` with setup and examples; add card to `web-scraping/overview.mdx`.
>   - Update `docs/docs.json` navigation to include `en/tools/web-scraping/olosteptool`.
>   - Add tool README at `tools/olostep_tool/README.md`.
> - **Tests**:
>   - Add `tests/tools/olostep_tool_test.py` covering schemas, scrape/crawl/map/answer flows, parser handling, and errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfbc838d740a6795d9263524a73d6964951d533c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->