### PR TITLE
fix: prevent crew inside flow to finish trace batch prematurely on failure

### DIFF
--- a/lib/crewai/src/crewai/events/listeners/tracing/trace_listener.py
+++ b/lib/crewai/src/crewai/events/listeners/tracing/trace_listener.py
@@ -221,11 +221,12 @@ class TraceCollectionListener(BaseEventListener):
         @event_bus.on(CrewKickoffFailedEvent)
         def on_crew_failed(source: Any, event: CrewKickoffFailedEvent) -> None:
             self._handle_trace_event("crew_kickoff_failed", source, event)
-            if self.first_time_handler.is_first_time:
-                self.first_time_handler.mark_events_collected()
-                self.first_time_handler.handle_execution_completion()
-            else:
-                self.batch_manager.finalize_batch()
+            if self.batch_manager.batch_owner_type == "crew":
+                if self.first_time_handler.is_first_time:
+                    self.first_time_handler.mark_events_collected()
+                    self.first_time_handler.handle_execution_completion()
+                else:
+                    self.batch_manager.finalize_batch()
 
         @event_bus.on(TaskStartedEvent)
         def on_task_started(source: Any, event: TaskStartedEvent) -> None:


### PR DESCRIPTION
Adds the same checking we have on `CrewKickoffCompletedEvent` to `CrewKickoffFailedEvent`, to prevent premature end of trace batch when a nested crew inside a flow fails.

towards ENG-718