### PR TITLE
fix: save updated task result to output file

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -495,10 +495,10 @@ class Task(BaseModel):
     ) -> None:
         """Execute the task asynchronously with context handling."""
         try:
-          result = self._execute_core(agent, context, tools)
-          future.set_result(result)
+            result = self._execute_core(agent, context, tools)
+            future.set_result(result)
         except Exception as e:
-          future.set_exception(e)
+            future.set_exception(e)
 
     async def aexecute_sync(
         self,
@@ -584,10 +584,12 @@ class Task(BaseModel):
 
             if self.output_file:
                 content = (
-                    json_output
-                    if json_output
+                    task_output.json_dict
+                    if task_output.json_dict
                     else (
-                        pydantic_output.model_dump_json() if pydantic_output else result
+                        task_output.pydantic.model_dump_json()
+                        if task_output.pydantic
+                        else task_output.raw
                     )
                 )
                 self._save_file(content)
@@ -677,10 +679,12 @@ class Task(BaseModel):
 
             if self.output_file:
                 content = (
-                    json_output
-                    if json_output
+                    task_output.json_dict
+                    if task_output.json_dict
                     else (
-                        pydantic_output.model_dump_json() if pydantic_output else result
+                        task_output.pydantic.model_dump_json()
+                        if task_output.pydantic
+                        else task_output.raw
                     )
                 )
                 self._save_file(content)


### PR DESCRIPTION
Fixes bug where only pre-guardrail task results were being saved to the output file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes output persistence of final task results**
> 
> - When `output_file` is set, save from `task_output.json_dict` → `task_output.pydantic.model_dump_json()` → `task_output.raw`, ensuring the final post-guardrail result is written (applies to both `execute` and `aexecute` paths)
> - Minor no-op formatting in `_execute_task_async`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a04e11b62e4860a0b7fc5921cb6890bfa585cc1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->