### PR TITLE
fix: ensure task-bound tools propagate in hierarchical mode

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1189,6 +1189,8 @@ class Crew(FlowTrackable, BaseModel):
     def _prepare_tools(
         self, agent: BaseAgent, task: Task, tools: list[BaseTool]
     ) -> list[BaseTool]:
+        task_agent = task.agent or agent
+        
         # Add delegation tools if agent allows delegation
         if hasattr(agent, "allow_delegation") and getattr(
             agent, "allow_delegation", False
@@ -1217,10 +1219,10 @@ class Crew(FlowTrackable, BaseModel):
         ):
             tools = self._add_multimodal_tools(agent, tools)
 
-        if agent and (hasattr(agent, "apps") and getattr(agent, "apps", None)):
+        if task_agent and (hasattr(task_agent, "apps") and getattr(task_agent, "apps", None)):
             tools = self._add_platform_tools(task, tools)
 
-        if agent and (hasattr(agent, "mcps") and getattr(agent, "mcps", None)):
+        if task_agent and (hasattr(task_agent, "mcps") and getattr(task_agent, "mcps", None)):
             tools = self._add_mcp_tools(task, tools)
 
         # Return a list[BaseTool] compatible with Task.execute_sync and execute_async


### PR DESCRIPTION
### Summary

When kicking off a crew run in hierarchical mode, any MCP tools owned by agents are ignored even if they are required for successful task completion. The cause is simple: in hierarchical mode, the agent_to_use for prepare_tools is *always* the manager agent.

From `prepare_task_execution` in utils.py:

```python
    tools_for_task = task.tools or agent_to_use.tools or []
    tools_for_task = crew._prepare_tools(
        agent_to_use,
        task,
        tools_for_task,
    )
```

Effectively, this function is checking the *manager* agent against tasks assigned to subordinate agents to see if any tools should be made available for the upcoming agent activation. As a result, subordinate agents never have the necessary tools for task execution in hierarchical mode.

### Fix:

In the `_prepare_tools` function in crew.py, check to see if there is an agent assigned to the task:

```python
        task_agent = task.agent or agent
```

Then, when preparing mcp and platform tools, use that task's agent instead of the manager agent to retrieve the relevant tools for the activation:

```python
        if task_agent and (hasattr(task_agent, "apps") and getattr(task_agent, "apps", None)):
            tools = self._add_platform_tools(task, tools)

        if task_agent and (hasattr(task_agent, "mcps") and getattr(task_agent, "mcps", None)):
            tools = self._add_mcp_tools(task, tools)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes tool resolution in hierarchical mode by selecting the task’s agent when preparing tools.
> 
> - In `Crew._prepare_tools`, introduce `task_agent = task.agent or agent` and use it to add `platform` and `mcp` tools via `_add_platform_tools` and `_add_mcp_tools`
> - Prevents loss of task-bound tools when the manager agent is passed during hierarchical execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c245affd78e9ede98abc21213ddc8751837e656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->