### PR TITLE
fix: use the internal token usage tracker when using litellm

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1185,6 +1185,8 @@ class LLM(BaseLLM):
                             start_time=0,
                             end_time=0,
                         )
+                        self._track_token_usage_internal(usage_info)
+
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -72,6 +72,9 @@ def test_llm_call_with_string_input_and_callbacks():
     assert len(result.strip()) > 0
     assert usage_metrics.successful_requests == 1
 
+    usage_metrics_internal = llm.get_token_usage_summary()
+    assert usage_metrics_internal == usage_metrics
+
 
 @pytest.mark.vcr()
 def test_llm_call_with_message_list():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures internal token accounting stays in sync when using LiteLLM.
> 
> - Calls `self._track_token_usage_internal(usage_info)` in non-streaming callback path of `LLM` after logging success
> - Test `test_llm_call_with_string_input_and_callbacks` now validates `llm.get_token_usage_summary()` matches `TokenCalcHandler` metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df89736584e8523f202c02dc02bca3b1460dffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->