### PR TITLE
Update webhook-streaming.mdx

### DIFF
--- a/docs/en/enterprise/features/webhook-streaming.mdx
+++ b/docs/en/enterprise/features/webhook-streaming.mdx
@@ -55,7 +55,7 @@ Each webhook sends a list of events:
 }
 ```
 
-The `data` object structure varies by event type. Refer to the [event list](https://github.com/crewAIInc/crewAI/tree/main/src/crewai/utilities/events) on GitHub.
+The `data` object structure varies by event type. Refer to the [event list](https://github.com/crewAIInc/crewAI/tree/main/lib/crewai/src/crewai/events/types) on GitHub.
 
 As requests are sent over HTTP, the order of events can't be guaranteed. If you need ordering, use the `timestamp` field.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates webhook streaming docs to point the in-text "event list" link to the new GitHub path for event types.
> 
> - Replaces old `src/crewai/utilities/events` reference with `lib/crewai/src/crewai/events/types`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9e93cf0b48c58ab5738eec9875191b98526b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->