### PR TITLE
fix: resolve type signature incompatibility in LongTermMemory

### DIFF
--- a/lib/crewai/src/crewai/memory/long_term/long_term_memory.py
+++ b/lib/crewai/src/crewai/memory/long_term/long_term_memory.py
@@ -111,21 +111,36 @@ class LongTermMemory(Memory):
 
     def search(
         self,
-        query: str,
-        limit: int = 3,
+        query: str | None = None,
+        limit: int | None = None,
         score_threshold: float = 0.6,
+        *,
+        task: str | None = None,
+        latest_n: int | None = None,
     ) -> list[Any]:
         """Search long-term memory for relevant entries.
 
         Args:
-            query: The task description to search for.
-            limit: Maximum number of results to return.
+            query: The task description to search for (or use 'task' for backward compatibility).
+            limit: Maximum number of results to return (or use 'latest_n' for backward compatibility).
             score_threshold: Minimum similarity score (not used in long-term memory).
+            task: (Deprecated) Old parameter name for query.
+            latest_n: (Deprecated) Old parameter name for limit.
 
         Returns:
             List of matching memory entries.
         """
-        # For backward compatibility, support 'task' parameter name
+        # Handle backward compatibility for parameter names
+        if task is not None:
+            query = task
+        if latest_n is not None:
+            limit = latest_n
+        
+        if query is None:
+            raise ValueError("Either 'query' or 'task' parameter is required")
+        if limit is None:
+            limit = 3
+        
         task = query
         latest_n = limit
         crewai_event_bus.emit(
@@ -246,21 +261,36 @@ class LongTermMemory(Memory):
 
     async def asearch(
         self,
-        query: str,
-        limit: int = 3,
+        query: str | None = None,
+        limit: int | None = None,
         score_threshold: float = 0.6,
+        *,
+        task: str | None = None,
+        latest_n: int | None = None,
     ) -> list[Any]:
         """Search long-term memory asynchronously.
 
         Args:
-            query: The task description to search for.
-            limit: Maximum number of results to return.
+            query: The task description to search for (or use 'task' for backward compatibility).
+            limit: Maximum number of results to return (or use 'latest_n' for backward compatibility).
             score_threshold: Minimum similarity score (not used in long-term memory).
+            task: (Deprecated) Old parameter name for query.
+            latest_n: (Deprecated) Old parameter name for limit.
 
         Returns:
             List of matching memory entries.
         """
-        # For backward compatibility, support 'task' parameter name
+        # Handle backward compatibility for parameter names
+        if task is not None:
+            query = task
+        if latest_n is not None:
+            limit = latest_n
+        
+        if query is None:
+            raise ValueError("Either 'query' or 'task' parameter is required")
+        if limit is None:
+            limit = 3
+        
         task = query
         latest_n = limit
         crewai_event_bus.emit(


### PR DESCRIPTION
Closes #4213

### What's wrong?

LongTermMemory wasn't playing nice with its parent class Memory. The method signatures didn't match, so there were a bunch of `# type: ignore` comments scattered around to silence mypy. Not great.

The parent class expected:
save(self, value: Any, metadata: dict | None = None)
search(self, query: str, limit: int = 5, score_threshold: float = 0.6)But LongTermMemory was doing its own thing:
save(self, item: LongTermMemoryItem)  # type: ignore
search(self, task: str, latest_n: int = 3)  # type: ignore### The fix

Made LongTermMemory match the parent signatures while keeping everything backward compatible:

def save(self, value: Any | LongTermMemoryItem, metadata: dict | None = None):
    # If it's the old LongTermMemoryItem, use it directly
    if isinstance(value, LongTermMemoryItem):
        item = value
    else:
        # Convert to LongTermMemoryItem
        item = LongTermMemoryItem(...)Same approach for `save()`, `asave()`, `search()`, and `asearch()`.

### What changed

- Updated all four methods to match parent class signatures
- Added isinstance checks for backward compatibility
- Removed all the `# type: ignore` comments
- Now follows proper Liskov Substitution Principle

### Backward compatible

Old code still works:
item = LongTermMemoryItem(...)
memory.save(item)  # Still works!New way also works:
memory.save("task description", metadata={...})### No breaking changes

Type safety is back, inheritance is proper, and all existing code keeps working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Aligns `LongTermMemory` with base `Memory` signatures while preserving backward compatibility.**
> 
> - Updates `save`/`asave` to accept `value: Any | LongTermMemoryItem` plus optional `metadata`; auto-wraps non-item values into `LongTermMemoryItem`.
> - Updates `search`/`asearch` to use `query`/`limit` (with deprecated `task`/`latest_n` aliases), adds input validation and default `limit=3`.
> - Safer metadata handling: copy dict, merge agent/expected_output, and default `score` via `metadata.get("quality", 0.0)` to avoid KeyError.
> - Retains event emissions and storage calls with updated parameters; removes prior type signature inconsistencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b36e3d7c88d528fd739c94e6816c5b59da1e94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->