### PR TITLE
feat: Support disabling tool reminder

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -79,6 +79,7 @@ class Task(BaseModel):
         output_pydantic: Pydantic model for task output.
         security_config: Security configuration including fingerprinting.
         tools: List of tools/resources limited for task execution.
+        tool_reminder_after_usage: Number of tool usages after which to remind the agent of available tools.
         allow_crewai_trigger_context: Optional flag to control crewai_trigger_payload injection.
                               None (default): Auto-inject for first task only.
                               True: Always inject trigger payload for this task.
@@ -141,6 +142,10 @@ class Task(BaseModel):
     tools: list[BaseTool] | None = Field(
         default_factory=list,
         description="Tools the agent is limited to use for this task.",
+    )
+    tool_reminder_after_usage: int | None = Field(
+        default=None,
+        description="Number of tool usages after which to remind the agent of available tools. Set to 0 to disable reminders.",
     )
     security_config: SecurityConfig = Field(
         default_factory=SecurityConfig,

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -97,7 +97,9 @@ class ToolUsage:
         self._telemetry: Telemetry = Telemetry()
         self._run_attempts: int = 1
         self._max_parsing_attempts: int = 3
-        self._remember_format_after_usages: int = 3
+        self._remember_format_after_usages: int = (
+            task.tool_reminder_after_usage if task and task.tool_reminder_after_usage is not None else 3
+        )
         self.agent = agent
         self.tools_description = render_text_description_and_args(tools)
         self.tools_names = get_tool_names(tools)
@@ -114,7 +116,8 @@ class ToolUsage:
             and self.function_calling_llm.model in OPENAI_BIGGER_MODELS
         ):
             self._max_parsing_attempts = 2
-            self._remember_format_after_usages = 4
+            if task is None or task.tool_reminder_after_usage is None:
+                self._remember_format_after_usages = 4
 
     def parse_tool_calling(
         self, tool_string: str
@@ -606,7 +609,7 @@ class ToolUsage:
         return str(result)
 
     def _should_remember_format(self) -> bool:
-        if self.task:
+        if self.task and self._remember_format_after_usages > 0:
             return self.task.used_tools % self._remember_format_after_usages == 0
         return False
 


### PR DESCRIPTION
Currently a tool reminder message is appended to tool response on every third tool call.
For a large number of tools, this behavior might flood the agent's context and cause it to underperform.

While I understand the reason to have the reminder, the developer should be able to disable them in situations where they are not needed, e.g. short tool responses and thoughts or short context window.
At this moment there is no way to disable this behavior. 

This PR adds support for spacing or disabling the reminders by defining the reminder rate at the task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable tool reminder cadence and ability to disable it.
> 
> - Adds `tool_reminder_after_usage` to `Task` to control how often the tools reminder is appended; set to `0` to disable
> - `ToolUsage` reads this setting to initialize `_remember_format_after_usages`, preserving defaults (3; or 4 for larger OpenAI models when unset)
> - Reminder check updated to honor `0` (no reminders) and only trigger on the configured interval
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 725e4331da682758c4cd704dae50635865f02773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->