### PR TITLE
Fix: prevent Thought leakage in final answers

### DIFF
--- a/lib/crewai/src/crewai/agents/parser.py
+++ b/lib/crewai/src/crewai/agents/parser.py
@@ -223,6 +223,16 @@ def _strip_trailing_react_blocks(final_answer: str) -> str:
         marker_index = match.start(1)
         if _is_in_code(marker_index):
             continue
+
+        # Reduce false positives: only strip if the remaining tail looks like
+        # a real ReAct control block (e.g., includes Action Input).
+        tail = final_answer[marker_index:]
+        marker = match.group(1)
+        if marker.startswith("Thought:") and ("Action:" not in tail and "Action Input:" not in tail):
+            continue
+        if marker.startswith("Action:") and "Action Input:" not in tail:
+            continue
+
         return final_answer[:marker_index].strip()
 
     return final_answer

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -169,7 +169,15 @@ def handle_max_iterations_exceeded(
         )
         raise ValueError("Invalid response from LLM call - None or empty.")
 
-    formatted = format_answer(answer=answer)
+    try:
+        formatted = format_answer(answer=answer)
+    except OutputParserError:
+        # Last-resort fallback: do not crash or leak raw output after max iterations.
+        return AgentFinish(
+            thought="",
+            output="I'm sorry, I couldn't produce a valid final answer. Please try again.",
+            text=str(answer),
+        )
 
     # If format_answer returned an AgentAction, convert it to AgentFinish
     if isinstance(formatted, AgentFinish):


### PR DESCRIPTION
### Problem
Agents can leak internal ReAct control text (e.g., Thought:, Action:, Action Input:, Observation:) to end users in two ways:
1) format_answer() fails open on parse errors by returning the raw model output as AgentFinish.output.
2) Some models output a valid Final Answer: and then append Thought/Action/... afterward; the parser currently treats all text after Final Answer: as user-visible.

This shows up heavily with models that mimic prior Thought/Action/Observation patterns in history (e.g., Gemini), but it can happen with any provider.

### Changes
- Fail closed on parse errors: crewai.utilities.agent_utils.format_answer() no longer returns raw model output on parsing failures; it raises OutputParserError (wrapped for unexpected exceptions).
- Sanitize Final Answer outputs: crewai.agents.parser.parse() now strips trailing ReAct control blocks accidentally appended after Final Answer:
- Includes a guard to reduce false positives: only strips when the tail resembles a real control block (e.g., Action: only stripped if Action Input: appears).
- Does not strip markers inside `<code> / <pre><code>` spans.
- Max-iterations safety: handle_max_iterations_exceeded() catches OutputParserError on the last forced final-answer call and returns a safe generic message rather than crashing or leaking raw output.

This PR enforces a strict output contract at the framework boundary (where AgentFinish.output is produced), rather than relying on app-side sanitizers. It prevents both parse-failure leaks and parse-success-but-contaminated leaks, while keeping the agent retry loop functional and avoiding crashes in the max-iterations edge case.

++ https://github.com/crewAIInc/crewAI/issues/4186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents leakage of internal ReAct control text to end users and hardens parsing behavior.
> 
> - Parser: When `Final Answer:` is present, strips trailing `Thought:`/`Action:`/`Action Input:`/`Observation:` blocks outside code spans via `_strip_trailing_react_blocks`; also normalizes stray trailing backticks.
> - Utilities: `format_answer()` now fails closed by raising `OutputParserError` (no raw output fallback); unexpected errors are wrapped into `OutputParserError` for retries.
> - Max-iterations: `handle_max_iterations_exceeded()` catches `OutputParserError` and returns a safe generic `AgentFinish` message instead of crashing or exposing raw model output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11eacca9d7d40fa6d8ed9a3314031d3842615ad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->