### PR TITLE
Increase frame inspection depth to detect `parent_flow`

### DIFF
--- a/lib/crewai/src/crewai/flow/flow_trackable.py
+++ b/lib/crewai/src/crewai/flow/flow_trackable.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import Any
 
 from pydantic import BaseModel, Field, InstanceOf, model_validator
 from typing_extensions import Self
@@ -14,14 +15,14 @@ class FlowTrackable(BaseModel):
     inspecting the call stack.
     """
 
-    parent_flow: InstanceOf[Flow] | None = Field(
+    parent_flow: InstanceOf[Flow[Any]] | None = Field(
         default=None,
         description="The parent flow of the instance, if it was created inside a flow.",
     )
 
     @model_validator(mode="after")
     def _set_parent_flow(self) -> Self:
-        max_depth = 5
+        max_depth = 8
         frame = inspect.currentframe()
 
         try:


### PR DESCRIPTION
This commit fixes a bug where `parent_flow` was not being set because the maximum depth was not sufficient to search for an instance of `Flow` in the current call stack frame during Flow instantiation.
