### PR TITLE
Add allow_repeated_usage flag for stateful tools

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -93,6 +93,12 @@ class BaseTool(BaseModel, ABC):
         default=0,
         description="Current number of times this tool has been used.",
     )
+    allow_repeated_usage: bool = Field(
+        default=False,
+        description="If True, allows the tool to be called consecutively with the same arguments. "
+        "Useful for stateful tools like browser automation where repeated calls with the same "
+        "arguments may produce different results due to external state changes.",
+    )
 
     @field_validator("args_schema", mode="before")
     @classmethod
@@ -227,6 +233,7 @@ class BaseTool(BaseModel, ABC):
             result_as_answer=self.result_as_answer,
             max_usage_count=self.max_usage_count,
             current_usage_count=self.current_usage_count,
+            allow_repeated_usage=self.allow_repeated_usage,
         )
         structured_tool._original_tool = self
         return structured_tool

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -36,6 +36,7 @@ class CrewStructuredTool:
         result_as_answer: bool = False,
         max_usage_count: int | None = None,
         current_usage_count: int = 0,
+        allow_repeated_usage: bool = False,
     ) -> None:
         """Initialize the structured tool.
 
@@ -47,6 +48,7 @@ class CrewStructuredTool:
             result_as_answer: Whether to return the output directly
             max_usage_count: Maximum number of times this tool can be used. None means unlimited usage.
             current_usage_count: Current number of times this tool has been used.
+            allow_repeated_usage: If True, allows the tool to be called consecutively with the same arguments.
         """
         self.name = name
         self.description = description
@@ -56,6 +58,7 @@ class CrewStructuredTool:
         self.result_as_answer = result_as_answer
         self.max_usage_count = max_usage_count
         self.current_usage_count = current_usage_count
+        self.allow_repeated_usage = allow_repeated_usage
         self._original_tool: BaseTool | None = None
 
         # Validate the function signature matches the schema

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -226,7 +226,7 @@ class ToolUsage:
         Returns:
             The result of the tool execution as a string.
         """
-        if self._check_tool_repeated_usage(calling=calling):
+        if self._check_tool_repeated_usage(calling=calling, tool=tool):
             try:
                 result = self._i18n.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
@@ -412,7 +412,7 @@ class ToolUsage:
         tool: CrewStructuredTool,
         calling: ToolCalling | InstructorToolCalling,
     ) -> str:
-        if self._check_tool_repeated_usage(calling=calling):
+        if self._check_tool_repeated_usage(calling=calling, tool=tool):
             try:
                 result = self._i18n.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
@@ -618,9 +618,12 @@ class ToolUsage:
         return result
 
     def _check_tool_repeated_usage(
-        self, calling: ToolCalling | InstructorToolCalling
+        self, calling: ToolCalling | InstructorToolCalling, tool: Any = None
     ) -> bool:
         if not self.tools_handler:
+            return False
+        # Check if the tool allows repeated usage (e.g., stateful tools like browser automation)
+        if tool is not None and getattr(tool, "allow_repeated_usage", False):
             return False
         if last_tool_usage := self.tools_handler.last_used_tool:
             return (calling.tool_name == last_tool_usage.tool_name) and (


### PR DESCRIPTION
Add a new `allow_repeated_usage` flag to BaseTool and CrewStructuredTool that allows tools to bypass the repeated usage check. This is essential for stateful tools like browser automation (e.g., Playwright MCP), where calling the same tool with the same arguments can produce different results due to external state changes. Currently, using the Playwright MCP tool with an agent does not work properly.

The repeated usage check was blocking consecutive calls to tools like `browser_snapshot` with the same (empty) arguments, even though the browser state had changed between calls. This made browser automation with MCP servers unusable.

Changes:
- Add `allow_repeated_usage: bool = False` field to BaseTool
- Add `allow_repeated_usage` parameter to CrewStructuredTool
- Update `to_structured_tool()` to copy the flag
- Update `_check_tool_repeated_usage()` to check for the flag

Usage:
```python
class MyStatefulTool(BaseTool):
    name = "my_tool"
    description = "A stateful tool"
    allow_repeated_usage = True  # Allow same args consecutively

    def _run(self, **kwargs):
        # Tool implementation
        pass
```

Fixes: Browser automation with MCP servers not working due to repeated usage check blocking consecutive tool calls.

Note: For MCP adapters to work, a follow-up change to `mcpadapt` is necessary, too. I have a fix ready, and can submit the PR as soon as this is 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables stateful tools (e.g., browser automation) to be invoked consecutively with identical arguments when explicitly allowed.
> 
> - Adds `allow_repeated_usage: bool` to `BaseTool` and `CrewStructuredTool` (default `False`)
> - Propagates the flag via `BaseTool.to_structured_tool()` and `CrewStructuredTool` constructor
> - Updates `ToolUsage._use` and `ToolUsage._ause` to pass the tool into `_check_tool_repeated_usage()`
> - Modifies `_check_tool_repeated_usage()` to skip the block when `tool.allow_repeated_usage` is True
> - No changes to usage limits or caching logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d3c78621abb916daf70316d92c274d5c14412c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->