### PR TITLE
docs: fix broken Google Sheets integration link

### DIFF
--- a/docs/en/enterprise/integrations/google_sheets.mdx
+++ b/docs/en/enterprise/integrations/google_sheets.mdx
@@ -15,14 +15,14 @@ Before using the Google Sheets integration, ensure you have:
 
 - A [CrewAI AMP](https://app.crewai.com) account with an active subscription
 - A Google account with Google Sheets access
-- Connected your Google account through the [Integrations page](https://app.crewai.com/crewai_plus/connectors)
+- Connected your Google account through the [Integrations page](https://app.crewai.com/crewai_plus/unified_tools)
 - Spreadsheets with proper column headers for data operations
 
 ## Setting Up Google Sheets Integration
 
 ### 1. Connect Your Google Account
 
-1. Navigate to [CrewAI AMP Integrations](https://app.crewai.com/crewai_plus/connectors)
+1. Navigate to [CrewAI AMP Integrations](https://app.crewai.com/crewai_plus/unified_tools)
 2. Find **Google Sheets** in the Authentication Integrations section
 3. Click **Connect** and complete the OAuth flow
 4. Grant the necessary permissions for spreadsheet access


### PR DESCRIPTION
## Summary
- Fixed broken URL for CrewAI AMP Integrations in Google Sheets documentation
- Changed `/crewai_plus/connectors` to `/crewai_plus/unified_tools` (2 occurrences)
- The old URL was returning an error page

## Test plan
- [x] Verified the new URL https://app.crewai.com/crewai_plus/unified_tools is the correct destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Google Sheets integration documentation to point to the correct Integrations URL.
> 
> - Replaces `.../crewai_plus/connectors` with `.../crewai_plus/unified_tools` in prerequisites and step 1
> - No code or behavior changes; docs-only fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63a6b010cd5f87046f00e7f0fbf7158950c6c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->