### PR TITLE
Add model field to LLM failed events

### DIFF
--- a/lib/crewai/src/crewai/events/types/llm_events.py
+++ b/lib/crewai/src/crewai/events/types/llm_events.py
@@ -9,6 +9,7 @@ from crewai.events.base_events import BaseEvent
 class LLMEventBase(BaseEvent):
     from_task: Any | None = None
     from_agent: Any | None = None
+    model: str | None = None
 
     def __init__(self, **data: Any) -> None:
         if data.get("from_task"):
@@ -42,7 +43,6 @@ class LLMCallStartedEvent(LLMEventBase):
     """
 
     type: str = "llm_call_started"
-    model: str | None = None
     messages: str | list[dict[str, Any]] | None = None
     tools: list[dict[str, Any]] | None = None
     callbacks: list[Any] | None = None
@@ -56,7 +56,6 @@ class LLMCallCompletedEvent(LLMEventBase):
     messages: str | list[dict[str, Any]] | None = None
     response: Any
     call_type: LLMCallType
-    model: str | None = None
 
 
 class LLMCallFailedEvent(LLMEventBase):

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -345,6 +345,7 @@ class BaseLLM(ABC):
                 error=error,
                 from_task=from_task,
                 from_agent=from_agent,
+                model=self.model,
             ),
         )
 


### PR DESCRIPTION
Move the `model` field from `LLMCallStartedEvent` and `LLMCallCompletedEvent` to the base `LLMEventBase` class.
