### PR TITLE
fix: capture per-task token usage to fix race condition in async execution

### DIFF
--- a/lib/crewai/src/crewai/tasks/task_output.py
+++ b/lib/crewai/src/crewai/tasks/task_output.py
@@ -1,12 +1,18 @@
 """Task output representation and formatting."""
 
+from __future__ import annotations
+
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, model_validator
 
 from crewai.tasks.output_format import OutputFormat
 from crewai.utilities.types import LLMMessage
+
+
+if TYPE_CHECKING:
+    from crewai.types.usage_metrics import UsageMetrics
 
 
 class TaskOutput(BaseModel):
@@ -22,6 +28,7 @@ class TaskOutput(BaseModel):
         json_dict: JSON dictionary output of the task
         agent: Agent that executed the task
         output_format: Output format of the task (JSON, PYDANTIC, or RAW)
+        token_usage: Token usage metrics for this specific task execution
     """
 
     description: str = Field(description="Description of the task")
@@ -42,6 +49,10 @@ class TaskOutput(BaseModel):
         description="Output format of the task", default=OutputFormat.RAW
     )
     messages: list[LLMMessage] = Field(description="Messages of the task", default=[])
+    token_usage: UsageMetrics | None = Field(
+        description="Token usage metrics for this specific task execution",
+        default=None,
+    )
 
     @model_validator(mode="after")
     def set_summary(self):


### PR DESCRIPTION
## Summary

Fixes #4168

The per-task token tracking had a race condition when using threading-based `async_execution` (`task.async_execution=True` with `crew.kickoff()`). Multiple concurrent tasks from the same agent would get incorrect token attribution because `tokens_before` was captured when tasks were queued, but `tokens_after` was captured sequentially when processing futures.

### Problem

When multiple tasks with `async_execution=True` are executed by the same agent:
1. `tokens_before` was captured when the task was queued
2. Tasks run concurrently in threads
3. All concurrent tasks captured similar `tokens_before` values
4. `tokens_after` was captured sequentially in `_process_async_tasks` after calling `future.result()`
5. Later tasks got credited with tokens from earlier tasks that ran in parallel

### Solution

Capture token usage snapshots within the execution context (thread or async task) rather than after futures are resolved:

- Add `token_usage` field to `TaskOutput` to store per-task metrics
- Add `_get_agent_token_usage()` helper to capture token snapshot from agent's LLM
- Add `_calculate_token_delta()` helper to compute token differences
- Modify `_execute_task_async()` to capture tokens within the thread immediately before and after task execution
- Update `_execute_core()` and `_aexecute_core()` for consistent token tracking across all execution paths

### Files Changed

- `lib/crewai/src/crewai/task.py` - Token tracking logic in task execution
- `lib/crewai/src/crewai/tasks/task_output.py` - Add `token_usage` field
- `lib/crewai/tests/task/test_task_token_tracking.py` - Tests for the fix



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds accurate per-task token tracking and resolves async race conditions in token attribution.
> 
> - Introduces `token_usage` on `TaskOutput` and imports `UsageMetrics`
> - Adds `_get_agent_token_usage()` and `_calculate_token_delta()` helpers
> - Updates `_execute_task_async()` to snapshot tokens before/after execution within the thread and store the delta on the result
> - Applies the same before/after token snapshotting in `_execute_core()` and `_aexecute_core()` so sync and async paths are consistent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c3d02383fc894a812537fd17f0c9bf79f0e9df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->