### PR TITLE
fix: relax openai version

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     # Core Dependencies
     "pydantic~=2.11.9",
-    "openai~=1.83.0",
+    "openai>=1.83.0,<3.0.0",
     "instructor>=1.3.3",
     # Text Processing
     "pdfplumber~=0.11.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = "~=1.74.9" },
     { name = "mcp", specifier = "~=1.23.1" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = "~=0.1.94" },
-    { name = "openai", specifier = "~=1.83.0" },
+    { name = "openai", specifier = ">=1.83.0,<3.0.0" },
     { name = "openpyxl", specifier = "~=3.1.5" },
     { name = "openpyxl", marker = "extra == 'openpyxl'", specifier = "~=3.1.5" },
     { name = "opentelemetry-api", specifier = "~=1.34.0" },


### PR DESCRIPTION
# Fix OpenAI dependency constraint for ecosystem compatibility

### CrewAI's strict OpenAI dependency constraint openai~=1.83.0 (equivalent to >=1.83.0,<1.84.0) was causing dependency conflicts with popular AI ecosystem packages:

LangChain ecosystem requires openai>=1.109.1
LiteLLM requires openai>=1.50.0
Observability tools like LangFuse require openai>=1.100.0
Modern AI applications commonly use newer OpenAI SDK versions
This prevented CrewAI from being used in comprehensive AI stacks and caused installation failures when combining with other AI libraries.

✅ Solution
Current OpenAI version is 2.16.0.
Changed OpenAI dependency constraint from:

- " - openai~=1.83.0"
- "+ openai>=1.83.0,<3.0.0" for the future use.
- I think "openai<2" is incompatible in the future.

📁 Files Changed
- pyproject.toml
- uv.lock - Regenerated lock file with new constraint

Close #4300 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxing the `openai` version range can introduce runtime incompatibilities if CrewAI relies on behaviors that changed in newer SDK releases. The change is limited to dependency metadata/lockfile updates but affects all downstream installations.
> 
> **Overview**
> Relaxes the core `openai` dependency constraint from a narrow `~=` pin to a wider `>=1.83.0,<3.0.0` range to reduce conflicts with other AI ecosystem packages.
> 
> Updates `uv.lock` to reflect the new constraint for resolved dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e841978d8935b680b6ef7a8b06d5277a4f51db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->