### PR TITLE
adds additional brave-search-api params

### DIFF
--- a/lib/crewai-tools/tests/tools/brave_search_tool_test.py
+++ b/lib/crewai-tools/tests/tools/brave_search_tool_test.py
@@ -1,7 +1,9 @@
+import json
 from unittest.mock import patch
 
-from crewai_tools.tools.brave_search_tool.brave_search_tool import BraveSearchTool
 import pytest
+
+from crewai_tools.tools.brave_search_tool.brave_search_tool import BraveSearchTool
 
 
 @pytest.fixture
@@ -30,16 +32,43 @@ def test_brave_tool_search(mock_get, brave_tool):
     }
     mock_get.return_value.json.return_value = mock_response
 
-    result = brave_tool.run(search_query="test")
+    result = brave_tool.run(query="test")
     assert "Test Title" in result
     assert "http://test.com" in result
 
 
-def test_brave_tool():
-    tool = BraveSearchTool(
-        n_results=2,
-    )
-    tool.run(search_query="ChatGPT")
+@patch("requests.get")
+def test_brave_tool(mock_get):
+    mock_response = {
+        "web": {
+            "results": [
+                {
+                    "title": "Brave Browser",
+                    "url": "https://brave.com",
+                    "description": "Brave Browser description",
+                }
+            ]
+        }
+    }
+    mock_get.return_value.json.return_value = mock_response
+
+    tool = BraveSearchTool(n_results=2)
+    result = tool.run(query="Brave Browser")
+    assert result is not None
+
+    # Parse JSON so we can examine the structure
+    data = json.loads(result)
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+    # First item should have expected fields: title, url, and description
+    first = data[0]
+    assert "title" in first
+    assert first["title"] == "Brave Browser"
+    assert "url" in first
+    assert first["url"] == "https://brave.com"
+    assert "description" in first
+    assert first["description"] == "Brave Browser description"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduces support for additional Brave Search API web-search parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because `BraveSearchTool` now returns JSON-encoded structured results instead of the previous human-readable text, which may break downstream consumers expecting the old format. It also widens request parameter surface area and changes default query argument naming (while keeping input backward compatibility).
> 
> **Overview**
> **BraveSearchTool** now supports many additional Brave web-search parameters (e.g., `country`, `search_language`, `count`/`offset`, `safesearch`, `freshness`, and several boolean flags), with Pydantic validation for constrained fields like `freshness` and `safesearch`.
> 
> The tool’s output format changes to a JSON list of result objects (with `url`, `title`, optional `description`, optional `snippets`) and requests are forced to `result_filter=web`; tests are updated to call `query` and to validate the JSON structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e6119fd0f9467fb273554e6c7f18f9b42ba2b88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->