### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-uv-cache.yml
+++ b/.github/workflows/build-uv-cache.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/docs-broken-links.yml
+++ b/.github/workflows/docs-broken-links.yml
@@ -18,10 +18,10 @@ jobs:
     name: Check broken links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "latest"
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
             uv-main-py3.11-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: "3.11"

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -21,7 +21,7 @@ jobs:
           private_key: ${{ secrets.OSS_SYNC_APP_PRIVATE_KEY }}
 
       - name: Notify Repo B
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ secrets.OSS_SYNC_DOWNSTREAM_REPO }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: "3.12"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,17 @@ jobs:
             echo "tag=" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.release.outputs.tag || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Build packages
         run: |
@@ -47,7 +47,7 @@ jobs:
           rm dist/.gitignore
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -73,7 +73,7 @@ jobs:
           enable-cache: false
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'no-issue-activity'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for proper diff
 
@@ -34,7 +34,7 @@ jobs:
             uv-main-py${{ matrix.python-version }}-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/trigger-deployment-tests.yml
+++ b/.github/workflows/trigger-deployment-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger deployment tests
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CREWAI_DEPLOYMENTS_PAT }}
           repository: ${{ secrets.CREWAI_DEPLOYMENTS_REPOSITORY }}

--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for proper diff
 
@@ -33,7 +33,7 @@ jobs:
             uv-main-py${{ matrix.python-version }}-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore global uv cache
         id: cache-restore
@@ -38,7 +38,7 @@ jobs:
             uv-main-py${{ matrix.python-version }}-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.4"
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/linter.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docs-broken-links.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/publish.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/publish.yml`
- Updated `peter-evans/repository-dispatch` from `v3` to `v4` in `.github/workflows/notify-downstream.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/publish.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/codeql.yml`
- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/workflows/update-test-durations.yml`
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale.yml`
- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/workflows/tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-test-durations.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/publish.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/tests.yml`
- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/workflows/build-uv-cache.yml`
- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/workflows/type-checker.yml`
- Updated `astral-sh/setup-uv` from `v4` to `v7` in `.github/workflows/publish.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/type-checker.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/docs-broken-links.yml`
- Updated `peter-evans/repository-dispatch` from `v3` to `v4` in `.github/workflows/trigger-deployment-tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build-uv-cache.yml`
- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/workflows/linter.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bumps to third-party GitHub Actions only; behavior should be equivalent but may surface minor CI differences due to new major action releases.
> 
> **Overview**
> Updates multiple GitHub Actions workflow dependencies to newer major versions across CI and automation (e.g., `actions/checkout`, `astral-sh/setup-uv`, `actions/setup-node`, `actions/setup-python`, artifact upload/download, `peter-evans/repository-dispatch`, and `actions/stale`).
> 
> No workflow logic is changed; this is primarily a maintenance bump to keep CI, publishing, downstream notifications, and stale-issue management on current action releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc07f28bfbc6d9d4b0af615f5fe5d6d6b0932085. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->