### PR TITLE
fix: Add Anthropic error pattern for context window detection

### DIFF
--- a/lib/crewai/src/crewai/utilities/exceptions/context_window_exceeding_exception.py
+++ b/lib/crewai/src/crewai/utilities/exceptions/context_window_exceeding_exception.py
@@ -10,6 +10,7 @@ CONTEXT_LIMIT_ERRORS: Final[list[str]] = [
     "too many tokens",
     "input is too long",
     "exceeds token limit",
+    "prompt is too long",
 ]
 
 


### PR DESCRIPTION
When using Anthropic/Claude models with `respect_context_window=True`, context window errors are not detected because Anthropic's error message format doesn't match the existing patterns.

**Anthropic error format:** `"prompt is too long: 210094 tokens > 200000 maximum"`

## Solution
Add `"prompt is too long"` to `CONTEXT_LIMIT_ERRORS` list to support Anthropic/Claude error detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string match extension to error detection; minimal behavioral change limited to recognizing additional context-limit errors.
> 
> **Overview**
> Improves context-window overflow detection by extending `CONTEXT_LIMIT_ERRORS` with the Anthropic/Claude error pattern `"prompt is too long"`, so `LLMContextLengthExceededError` classification triggers for Claude-style token limit messages (e.g., when `respect_context_window=True`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf0be27a9b89afbe93439b386d499677434d9e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->