### PR TITLE
chore: improve hook typing and registration

### DIFF
--- a/lib/crewai/src/crewai/hooks/llm_hooks.py
+++ b/lib/crewai/src/crewai/hooks/llm_hooks.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from crewai.events.event_listener import event_listener
-from crewai.hooks.types import AfterLLMCallHookType, BeforeLLMCallHookType
+from crewai.hooks.types import (
+    AfterLLMCallHookCallable,
+    AfterLLMCallHookType,
+    BeforeLLMCallHookCallable,
+    BeforeLLMCallHookType,
+)
 from crewai.utilities.printer import Printer
 
 
@@ -149,12 +154,12 @@ class LLMCallHookContext:
             event_listener.formatter.resume_live_updates()
 
 
-_before_llm_call_hooks: list[BeforeLLMCallHookType] = []
-_after_llm_call_hooks: list[AfterLLMCallHookType] = []
+_before_llm_call_hooks: list[BeforeLLMCallHookType | BeforeLLMCallHookCallable] = []
+_after_llm_call_hooks: list[AfterLLMCallHookType | AfterLLMCallHookCallable] = []
 
 
 def register_before_llm_call_hook(
-    hook: BeforeLLMCallHookType,
+    hook: BeforeLLMCallHookType | BeforeLLMCallHookCallable,
 ) -> None:
     """Register a global before_llm_call hook.
 
@@ -190,7 +195,7 @@ def register_before_llm_call_hook(
 
 
 def register_after_llm_call_hook(
-    hook: AfterLLMCallHookType,
+    hook: AfterLLMCallHookType | AfterLLMCallHookCallable,
 ) -> None:
     """Register a global after_llm_call hook.
 
@@ -217,7 +222,9 @@ def register_after_llm_call_hook(
     _after_llm_call_hooks.append(hook)
 
 
-def get_before_llm_call_hooks() -> list[BeforeLLMCallHookType]:
+def get_before_llm_call_hooks() -> list[
+    BeforeLLMCallHookType | BeforeLLMCallHookCallable
+]:
     """Get all registered global before_llm_call hooks.
 
     Returns:
@@ -226,7 +233,7 @@ def get_before_llm_call_hooks() -> list[BeforeLLMCallHookType]:
     return _before_llm_call_hooks.copy()
 
 
-def get_after_llm_call_hooks() -> list[AfterLLMCallHookType]:
+def get_after_llm_call_hooks() -> list[AfterLLMCallHookType | AfterLLMCallHookCallable]:
     """Get all registered global after_llm_call hooks.
 
     Returns:
@@ -236,7 +243,7 @@ def get_after_llm_call_hooks() -> list[AfterLLMCallHookType]:
 
 
 def unregister_before_llm_call_hook(
-    hook: BeforeLLMCallHookType,
+    hook: BeforeLLMCallHookType | BeforeLLMCallHookCallable,
 ) -> bool:
     """Unregister a specific global before_llm_call hook.
 
@@ -262,7 +269,7 @@ def unregister_before_llm_call_hook(
 
 
 def unregister_after_llm_call_hook(
-    hook: AfterLLMCallHookType,
+    hook: AfterLLMCallHookType | AfterLLMCallHookCallable,
 ) -> bool:
     """Unregister a specific global after_llm_call hook.
 

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from crewai.events.event_listener import event_listener
-from crewai.hooks.types import AfterToolCallHookType, BeforeToolCallHookType
+from crewai.hooks.types import (
+    AfterToolCallHookCallable,
+    AfterToolCallHookType,
+    BeforeToolCallHookCallable,
+    BeforeToolCallHookType,
+)
 from crewai.utilities.printer import Printer
 
 
@@ -112,12 +117,12 @@ class ToolCallHookContext:
 
 
 # Global hook registries
-_before_tool_call_hooks: list[BeforeToolCallHookType] = []
-_after_tool_call_hooks: list[AfterToolCallHookType] = []
+_before_tool_call_hooks: list[BeforeToolCallHookType | BeforeToolCallHookCallable] = []
+_after_tool_call_hooks: list[AfterToolCallHookType | AfterToolCallHookCallable] = []
 
 
 def register_before_tool_call_hook(
-    hook: BeforeToolCallHookType,
+    hook: BeforeToolCallHookType | BeforeToolCallHookCallable,
 ) -> None:
     """Register a global before_tool_call hook.
 
@@ -154,7 +159,7 @@ def register_before_tool_call_hook(
 
 
 def register_after_tool_call_hook(
-    hook: AfterToolCallHookType,
+    hook: AfterToolCallHookType | AfterToolCallHookCallable,
 ) -> None:
     """Register a global after_tool_call hook.
 
@@ -184,7 +189,9 @@ def register_after_tool_call_hook(
     _after_tool_call_hooks.append(hook)
 
 
-def get_before_tool_call_hooks() -> list[BeforeToolCallHookType]:
+def get_before_tool_call_hooks() -> list[
+    BeforeToolCallHookType | BeforeToolCallHookCallable
+]:
     """Get all registered global before_tool_call hooks.
 
     Returns:
@@ -193,7 +200,9 @@ def get_before_tool_call_hooks() -> list[BeforeToolCallHookType]:
     return _before_tool_call_hooks.copy()
 
 
-def get_after_tool_call_hooks() -> list[AfterToolCallHookType]:
+def get_after_tool_call_hooks() -> list[
+    AfterToolCallHookType | AfterToolCallHookCallable
+]:
     """Get all registered global after_tool_call hooks.
 
     Returns:
@@ -203,7 +212,7 @@ def get_after_tool_call_hooks() -> list[AfterToolCallHookType]:
 
 
 def unregister_before_tool_call_hook(
-    hook: BeforeToolCallHookType,
+    hook: BeforeToolCallHookType | BeforeToolCallHookCallable,
 ) -> bool:
     """Unregister a specific global before_tool_call hook.
 
@@ -229,7 +238,7 @@ def unregister_before_tool_call_hook(
 
 
 def unregister_after_tool_call_hook(
-    hook: AfterToolCallHookType,
+    hook: AfterToolCallHookType | AfterToolCallHookCallable,
 ) -> bool:
     """Unregister a specific global after_tool_call hook.
 

--- a/lib/crewai/src/crewai/project/wrappers.py
+++ b/lib/crewai/src/crewai/project/wrappers.py
@@ -72,6 +72,8 @@ class CrewInstance(Protocol):
     __crew_metadata__: CrewMetadata
     _mcp_server_adapter: Any
     _all_methods: dict[str, Callable[..., Any]]
+    _registered_hook_functions: list[tuple[str, Callable[..., Any]]]
+    _hooks_being_registered: bool
     agents: list[Agent]
     tasks: list[Task]
     base_directory: Path


### PR DESCRIPTION
Allow hook registration to accept both typed hook types and plain callables by importing and using After*/Before*CallHookCallable types; add explicit LLMCallHookContext and ToolCallHookContext typing in crew_base. Introduce a post-initialize crew hook list and invoke hooks after Crew instance initialization. Refactor filtered hook factory functions to include precise typing and clearer local names (before_llm_hook/after_llm_hook/before_tool_hook/after_tool_hook) and register those with the instance. Update CrewInstance protocol to include _registered_hook_functions and _hooks_being_registered fields.