### PR TITLE
Add MIME Type Detection to Vision Tool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/vision_tool/vision_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/vision_tool/vision_tool.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 from pathlib import Path
 
 from crewai import LLM
@@ -101,8 +102,11 @@ class VisionTool(BaseTool):
                 image_data = image_path_url
             else:
                 try:
+                    mime_type, _ = mimetypes.guess_type(image_path_url)
+                    mime_type = mime_type or "image/jpeg"  # fallback to image/jpeg
+
                     base64_image = self._encode_image(image_path_url)
-                    image_data = f"data:image/jpeg;base64,{base64_image}"
+                    image_data = f"data:{mime_type};base64,{base64_image}"
                 except Exception as e:
                     return f"Error processing image: {e!s}"
 


### PR DESCRIPTION
This PR improves image handling to Vision Tool by detecting the correct MIME type instead of always defaulting to image/jpeg.

- Added `mimetypes` import and MIME guessing via `guess_type()`
- Fallback to `image/jpeg` when detection fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change isolated to how the `data:` URL is constructed for local images; main risk is mis-detection for uncommon extensions leading to API rejection.
> 
> **Overview**
> Updates `VisionTool` to embed local images as `data:` URLs with a detected MIME type (via `mimetypes.guess_type`) instead of always using `image/jpeg`, with a fallback to `image/jpeg` when detection fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6984209cb1e4aa78aedc6ea9de0d708bf8daea0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->