### PR TITLE
fix(telemetry): skip signal registration on non-main threads

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -173,6 +173,13 @@ class Telemetry:
 
         self._original_handlers: dict[int, Any] = {}
 
+        # Signal handlers can only be registered from the main thread
+        if threading.current_thread() is not threading.main_thread():
+            logger.debug(
+                "Skipping signal handler registration (not running in main thread)"
+            )
+            return
+
         self._register_signal_handler(signal.SIGTERM, SigTermEvent, shutdown=True)
         self._register_signal_handler(signal.SIGINT, SigIntEvent, shutdown=True)
         if hasattr(signal, "SIGHUP"):


### PR DESCRIPTION
Adds a main thread check before attempting to register signal handlers in the telemetry module.

Signal handlers can only be registered from the main thread, and attempting to do so from other threads raises ValueError with noisy tracebacks that clutter the console output.

This commonly occurs when CrewAI is imported from web frameworks like Streamlit, Flask, Django, or Jupyter notebooks which may initialize imports from background threads.

The fix adds a simple check at the start of `_register_shutdown_handlers()`:

```python
if threading.current_thread() is not threading.main_thread():
    logger.debug(
        "Skipping signal handler registration (not running in main thread)"
    )
    return
```

The `atexit` handler is still registered since it works from any thread.

Fixes #4289

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change in shutdown/signal setup that mainly avoids exceptions in non-main-thread environments; it should not affect telemetry behavior in normal main-thread execution.
> 
> **Overview**
> Prevents noisy `ValueError` tracebacks during telemetry initialization by **skipping OS signal handler registration when not running on the main thread**.
> 
> `Telemetry._register_shutdown_handlers()` still registers the `atexit` shutdown hook, but now early-returns (with a debug log) before calling `signal.signal(...)` when imported/initialized from background threads (common in web/notebook environments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1702644c877b7864be638c76e8257d206a448f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->