### PR TITLE
fix: replace lru_cache with instance-level caching in Repository

### DIFF
--- a/lib/crewai/src/crewai/cli/git.py
+++ b/lib/crewai/src/crewai/cli/git.py
@@ -1,10 +1,10 @@
-from functools import lru_cache
 import subprocess
 
 
 class Repository:
     def __init__(self, path: str = ".") -> None:
         self.path = path
+        self._is_git_repo_cached: bool | None = None
 
         if not self.is_git_installed():
             raise ValueError("Git is not installed or not found in your PATH.")
@@ -40,22 +40,25 @@ class Repository:
             encoding="utf-8",
         ).strip()
 
-    @lru_cache(maxsize=None)  # noqa: B019
     def is_git_repo(self) -> bool:
         """Check if the current directory is a git repository.
 
-        Notes:
-          - TODO: This method is cached to avoid redundant checks, but using lru_cache on methods can lead to memory leaks
+        The result is cached per instance to avoid redundant subprocess calls.
         """
+        if self._is_git_repo_cached is not None:
+            return self._is_git_repo_cached
+
         try:
             subprocess.check_output(
                 ["git", "rev-parse", "--is-inside-work-tree"],  # noqa: S607
                 cwd=self.path,
                 encoding="utf-8",
             )
-            return True
+            self._is_git_repo_cached = True
         except subprocess.CalledProcessError:
-            return False
+            self._is_git_repo_cached = False
+
+        return self._is_git_repo_cached
 
     def has_uncommitted_changes(self) -> bool:
         """Check if the repository has uncommitted changes."""


### PR DESCRIPTION
Fixes memory leak in `Repository.is_git_repo()` caused by `@lru_cache` holding references to `self`, preventing garbage collection.

Replaced with an instance variable (`_is_git_repo_cached`) that achieves the same caching behavior without memory leak.

Fixes #4210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI git-repo detection logic; primary risk is stale cached results if the working directory’s git status changes during the lifetime of a `Repository` instance.
> 
> **Overview**
> `Repository.is_git_repo()` no longer uses `@lru_cache`; instead it caches the result on a new instance field (`_is_git_repo_cached`) and returns the cached value on subsequent calls.
> 
> This removes the `functools` import and keeps the same behavior while avoiding global caching that can hold references to `Repository` instances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db428ea145107804dc7133e533b6923a69bec200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->