### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -591,10 +591,10 @@ class BrightDataDatasetTool(BaseTool):
                 )
             )
         except TimeoutError as e:
-            return f"Timeout Exception occured in method : get_dataset_data_async. Details - {e!s}"
+            return f"Timeout Exception occurred in method : get_dataset_data_async. Details - {e!s}"
         except BrightDataDatasetToolException as e:
             return (
-                f"Exception occured in method : get_dataset_data_async. Details - {e!s}"
+                f"Exception occurred in method : get_dataset_data_async. Details - {e!s}"
             )
         except Exception as e:
             return f"Bright Data API error: {e!s}"


### PR DESCRIPTION
Fixes typo in error messages in BrightDataDatasetTool where 'occured' was used instead of 'occurred'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only changes to user-facing error messages; no behavior, control flow, or API interactions are modified.
> 
> **Overview**
> Fixes a typo in `BrightDataDatasetTool._run` error messages by changing "occured" to "occurred" for both `TimeoutError` and `BrightDataDatasetToolException` return strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b3d9b22521c91688b537412f6ced10505c9a607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->