### PR TITLE
fix: broken Task Attributes table in documentation

### DIFF
--- a/docs/en/concepts/tasks.mdx
+++ b/docs/en/concepts/tasks.mdx
@@ -46,7 +46,7 @@ crew = Crew(
 ## Task Attributes
 
 | Attribute                              | Parameters              | Type                        | Description                                                                                                     |
-| :------------------------------------- | :---------------------- | :-------------------------- | :-------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| :------------------------------------- | :---------------------- | :-------------------------- | :-------------------------------------------------------------------------------------------------------------- |
 | **Description**                        | `description`           | `str`                       | A clear, concise statement of what the task entails.                                                            |
 | **Expected Output**                    | `expected_output`       | `str`                       | A detailed description of what the task's completion looks like.                                                |
 | **Name** _(optional)_                  | `name`                  | `Optional[str]`             | A name identifier for the task.                                                                                 |
@@ -63,7 +63,7 @@ crew = Crew(
 | **Output Pydantic** _(optional)_       | `output_pydantic`       | `Optional[Type[BaseModel]]` | A Pydantic model for task output.                                                                               |
 | **Callback** _(optional)_              | `callback`              | `Optional[Any]`             | Function/object to be executed after task completion.                                                           |
 | **Guardrail** _(optional)_             | `guardrail`             | `Optional[Callable]`        | Function to validate task output before proceeding to next task.                                                |
-| **Guardrails** _(optional)_            | `guardrails`            | `Optional[List[Callable]    | List[str]]`                                                                                                     | List of guardrails to validate task output before proceeding to next task. |
+| **Guardrails** _(optional)_            | `guardrails`            | `Optional[List[Callable] \| List[str]]` | List of guardrails to validate task output before proceeding to next task.                                       |
 | **Guardrail Max Retries** _(optional)_ | `guardrail_max_retries` | `Optional[int]`             | Maximum number of retries when guardrail validation fails. Defaults to 3.                                       |
 
 <Note type="warning" title="Deprecated: max_retries">


### PR DESCRIPTION
## Summary

Fixes #4403

The Task Attributes markdown table on the [Tasks documentation page](https://docs.crewai.com/en/concepts/tasks#task-attributes) was rendering incorrectly due to two issues:

- The **Guardrails** row's Type column value `Optional[List[Callable] | List[str]]` contained an unescaped pipe `|` character, which was being interpreted as a markdown table column separator. This caused the row to split into 5 columns instead of 4.
- The table header separator row had an extra column added (likely to compensate for the broken row), making it 5 columns wide instead of 4.

### Fix

- Escaped the pipe character in the Guardrails Type column with a backslash (`\|`)
- Removed the extra column from the header separator row

### Before

![Image](https://github.com/user-attachments/assets/2b8f393b-00ec-4724-a127-249934585257)

### After

The table renders correctly with 4 properly aligned columns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Markdown formatting changes with no runtime or API behavior impact.
> 
> **Overview**
> Fixes the `Task Attributes` table rendering in `docs/en/concepts/tasks.mdx` by restoring the header separator row to 4 columns and escaping the `|` in the `guardrails` type (`Optional[List[Callable] \| List[str]]`) so Markdown doesn’t split the row into extra columns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214dc35406aca5a3a32073d4760e78cc00fbce57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->