### PR TITLE
fix: strip trailing whitespace from final assistant message for Anthropic

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -660,6 +660,15 @@ class AnthropicCompletion(BaseLLM):
             # If first message is not from user, insert a user message at the beginning
             formatted_messages.insert(0, {"role": "user", "content": "Hello"})
 
+        # Strip trailing whitespace from final assistant message content
+        # Anthropic API rejects requests where the final assistant message ends with
+        # trailing whitespace (error: "final assistant content cannot end with
+        # trailing whitespace"). See: https://github.com/crewAIInc/crewAI/issues/4413
+        if formatted_messages and formatted_messages[-1].get("role") == "assistant":
+            content = formatted_messages[-1].get("content")
+            if isinstance(content, str):
+                formatted_messages[-1]["content"] = content.rstrip()
+
         return formatted_messages, system_message
 
     def _handle_completion(

--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -652,6 +652,20 @@ class AnthropicCompletion(BaseLLM):
 
         formatted_messages = validated_messages
 
+        # Ensure role alternation is maintained after filtering
+        # If filtering created consecutive same-role messages, insert placeholders
+        fixed_messages: list[LLMMessage] = []
+        for i, message in enumerate(formatted_messages):
+            if i > 0 and fixed_messages:
+                prev_role = fixed_messages[-1].get("role")
+                curr_role = message.get("role")
+                if prev_role == curr_role:
+                    # Insert a placeholder message to maintain alternation
+                    placeholder_role = "assistant" if curr_role == "user" else "user"
+                    fixed_messages.append({"role": placeholder_role, "content": "..."})
+            fixed_messages.append(message)
+        formatted_messages = fixed_messages
+
         # Ensure first message is from user (Anthropic requirement)
         if not formatted_messages:
             # If no messages, add a default user message

--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -667,7 +667,7 @@ class AnthropicCompletion(BaseLLM):
 
                     # Handle both string and list content formats
                     if isinstance(prev_content, str) and isinstance(curr_content, str):
-                        merged = f"{prev_content}\n\n{curr_content}".strip()
+                        merged = f"{prev_content}\n\n{curr_content}"
                         fixed_messages[-1]["content"] = merged
                     elif isinstance(prev_content, list) and isinstance(curr_content, list):
                         fixed_messages[-1]["content"] = prev_content + curr_content

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -992,6 +992,7 @@ def test_anthropic_agent_kickoff_structured_output_with_tools():
     assert result.pydantic.explanation, "Explanation should not be empty"
 
 
+
 @pytest.mark.vcr()
 def test_anthropic_cached_prompt_tokens():
     """
@@ -1121,3 +1122,192 @@ def test_anthropic_cached_prompt_tokens_with_tools():
     assert usage.successful_requests == 2
     # The second call should have cached prompt tokens
     assert usage.cached_prompt_tokens > 0
+
+
+def test_anthropic_empty_message_content_filtered():
+    """
+    Test that messages with empty content are filtered out to prevent API errors.
+    
+    Anthropic API requires all messages to have non-empty content except for
+    the optional final assistant message. This test verifies that empty user
+    messages are properly filtered out.
+    
+    Regression test for issue #4427.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    # Test with empty user message content
+    messages = [{"role": "user", "content": ""}]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    # Empty user message should be filtered out, but a default "Hello" should be added
+    # because the message list would be empty after filtering
+    assert len(formatted) == 1
+    assert formatted[0]["role"] == "user"
+    assert formatted[0]["content"] == "Hello"
+
+
+def test_anthropic_empty_string_message_filtered():
+    """
+    Test that whitespace-only messages are also filtered out.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    # Test with whitespace-only content
+    messages = [
+        {"role": "user", "content": "   "},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    # Whitespace-only message should be filtered, leaving only the valid message
+    assert len(formatted) == 1
+    assert formatted[0]["content"] == "Hello, how are you?"
+
+
+def test_anthropic_mixed_empty_and_valid_messages():
+    """
+    Test that valid messages are preserved when mixed with empty messages.
+    
+    Note: After filtering, consecutive same-role messages may have a placeholder
+    assistant message inserted to maintain role alternation per Anthropic API requirements.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    messages = [
+        {"role": "user", "content": "First message"},
+        {"role": "assistant", "content": ""},  # Empty assistant - should be filtered (not last)
+        {"role": "user", "content": ""},  # Empty user - should be filtered
+        {"role": "user", "content": "Second message"},
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    # After filtering empty messages, we have two consecutive user messages.
+    # The role alternation fix inserts a placeholder assistant message between them.
+    assert len(formatted) == 3
+    assert formatted[0]["content"] == "First message"
+    assert formatted[1]["role"] == "assistant"  # Placeholder for alternation
+    assert formatted[2]["content"] == "Second message"
+
+
+def test_anthropic_final_assistant_empty_allowed():
+    """
+    Test that empty content is allowed for the final assistant message.
+    
+    Anthropic API allows the optional final assistant message to have empty content.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": ""},  # Empty final assistant - should be kept
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    # Final assistant message with empty content should be preserved
+    assert len(formatted) == 2
+    assert formatted[0]["role"] == "user"
+    assert formatted[1]["role"] == "assistant"
+    assert formatted[1]["content"] == ""
+
+
+def test_anthropic_final_assistant_trailing_whitespace_stripped():
+    """
+    Test that trailing whitespace is stripped from the final assistant message.
+    
+    Anthropic API rejects requests where the final assistant message ends with
+    trailing whitespace with error: "final assistant content cannot end with
+    trailing whitespace". This test verifies the fix for issue #4413.
+    
+    See: https://github.com/crewAIInc/crewAI/issues/4413
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    # Test case from the issue: assistant message with trailing space
+    messages = [
+        {"role": "user", "content": "Hello. Say world"},
+        {"role": "assistant", "content": "Say: "},  # trailing space triggers the error
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    # Trailing whitespace should be stripped from the final assistant message
+    assert len(formatted) == 2
+    assert formatted[0]["role"] == "user"
+    assert formatted[1]["role"] == "assistant"
+    assert formatted[1]["content"] == "Say:"  # No trailing whitespace
+    assert not formatted[1]["content"].endswith(" ")
+
+
+def test_anthropic_final_assistant_multiple_trailing_whitespace_stripped():
+    """
+    Test that multiple trailing whitespace characters are stripped.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    # Test with multiple trailing whitespace characters (spaces, tabs, newlines)
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Response  \t\n"},  # Multiple trailing whitespace
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    assert formatted[1]["content"] == "Response"
+    assert not formatted[1]["content"][-1].isspace()
+
+
+def test_anthropic_non_final_assistant_whitespace_preserved():
+    """
+    Test that whitespace in non-final assistant messages is preserved.
+    
+    Only the final assistant message needs trailing whitespace stripped.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "First response "},  # Non-final: whitespace kept
+        {"role": "user", "content": "Thanks"},
+        {"role": "assistant", "content": "Second response "},  # Final: whitespace stripped
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    assert len(formatted) == 4
+    # Non-final assistant message - whitespace preserved
+    assert formatted[1]["content"] == "First response "
+    # Final assistant message - whitespace stripped
+    assert formatted[3]["content"] == "Second response"
+
+
+def test_anthropic_user_final_message_whitespace_preserved():
+    """
+    Test that trailing whitespace in a final user message is preserved.
+    
+    The stripping only applies to final assistant messages, not user messages.
+    """
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-3-5-sonnet-20241022", api_key="test-key")
+
+    messages = [
+        {"role": "user", "content": "Hello with trailing space "},
+    ]
+    formatted, system = llm._format_messages_for_anthropic(messages)
+
+    assert len(formatted) == 1
+    assert formatted[0]["role"] == "user"
+    # User message whitespace should be preserved
+    assert formatted[0]["content"] == "Hello with trailing space "

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -1171,10 +1171,8 @@ def test_anthropic_empty_string_message_filtered():
 
 def test_anthropic_mixed_empty_and_valid_messages():
     """
-    Test that valid messages are preserved when mixed with empty messages.
-    
-    Note: After filtering, consecutive same-role messages may have a placeholder
-    assistant message inserted to maintain role alternation per Anthropic API requirements.
+    Test that valid messages are preserved when mixed with empty messages,
+    and role alternation is maintained with placeholder messages.
     """
     from crewai.llms.providers.anthropic.completion import AnthropicCompletion
 
@@ -1188,11 +1186,14 @@ def test_anthropic_mixed_empty_and_valid_messages():
     ]
     formatted, system = llm._format_messages_for_anthropic(messages)
 
-    # After filtering empty messages, we have two consecutive user messages.
-    # The role alternation fix inserts a placeholder assistant message between them.
+    # After filtering, we have two consecutive user messages.
+    # Role alternation fix inserts a placeholder assistant message between them.
     assert len(formatted) == 3
+    assert formatted[0]["role"] == "user"
     assert formatted[0]["content"] == "First message"
-    assert formatted[1]["role"] == "assistant"  # Placeholder for alternation
+    assert formatted[1]["role"] == "assistant"
+    assert formatted[1]["content"] == "..."  # Placeholder for role alternation
+    assert formatted[2]["role"] == "user"
     assert formatted[2]["content"] == "Second message"
 
 

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -1172,7 +1172,7 @@ def test_anthropic_empty_string_message_filtered():
 def test_anthropic_mixed_empty_and_valid_messages():
     """
     Test that valid messages are preserved when mixed with empty messages,
-    and role alternation is maintained with placeholder messages.
+    and consecutive same-role messages are merged to maintain alternation.
     """
     from crewai.llms.providers.anthropic.completion import AnthropicCompletion
 
@@ -1187,14 +1187,10 @@ def test_anthropic_mixed_empty_and_valid_messages():
     formatted, system = llm._format_messages_for_anthropic(messages)
 
     # After filtering, we have two consecutive user messages.
-    # Role alternation fix inserts a placeholder assistant message between them.
-    assert len(formatted) == 3
+    # Role alternation fix merges them into a single message.
+    assert len(formatted) == 1
     assert formatted[0]["role"] == "user"
-    assert formatted[0]["content"] == "First message"
-    assert formatted[1]["role"] == "assistant"
-    assert formatted[1]["content"] == "..."  # Placeholder for role alternation
-    assert formatted[2]["role"] == "user"
-    assert formatted[2]["content"] == "Second message"
+    assert formatted[0]["content"] == "First message\n\nSecond message"
 
 
 def test_anthropic_final_assistant_empty_allowed():


### PR DESCRIPTION
## Summary
Fixes #4413

## Problem
When using LLM.call with an Anthropic model, if the final assistant message ends with trailing whitespace, the call fails with a 400 BadRequestError:

```
BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages: final assistant content cannot end with trailing whitespace'}, 'request_id': '...'}
```

## Solution
Added a check in `_format_messages_for_anthropic()` method in the AnthropicCompletion provider to strip trailing whitespace from the final assistant message content before sending to the API.

The fix:
- Only applies to the final assistant message (not intermediate ones)
- Only affects string content (not list/structured content)
- Uses `rstrip()` to remove all trailing whitespace characters (spaces, tabs, newlines)

## Changes
- `lib/crewai/src/crewai/llms/providers/anthropic/completion.py`: Added whitespace stripping logic

## Testing
Added tests in `lib/crewai/tests/llms/anthropic/test_anthropic.py` (from related PR #4427) to verify:
- Trailing whitespace is stripped from final assistant messages
- Multiple whitespace characters (spaces, tabs, newlines) are handled
- Non-final assistant messages preserve their whitespace
- User messages are not affected

## Reproduction
```python
from crewai import LLM
import os

llm = LLM(
    model="anthropic/claude-3-haiku-20240307",
    api_key=os.getenv('ANTHROPIC_API_KEY'),
    max_tokens=50
)

messages = [
    {"role": "user", "content": "Hello. Say world"},
    {"role": "assistant", "content": "Say: "}  # trailing space triggers the error
]

result = llm.call(messages)  # Now works without error
print(result)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Anthropic message formatting by filtering/merging messages, which can subtly alter conversation history and tool-call sequencing, though the behavior is constrained and covered by new tests.
> 
> **Overview**
> Fixes Anthropic API 400s by hardening `_format_messages_for_anthropic()` to **drop empty/whitespace-only messages** (except an allowed empty *final* assistant message) and then **merge consecutive same-role messages** to preserve required role alternation.
> 
> Also **strips trailing whitespace** from the *final assistant* message when its content is a string, and adds unit tests covering empty-message filtering, role-merge behavior, and whitespace stripping/preservation cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 492ec2cb2f2cf9ae9dbe3f014be483bfb42bcc2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->