### PR TITLE
fix: handle JSON string config in Mem0Storage

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/mem0_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/mem0_storage.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable
+import json
 import os
 import re
 from typing import Any
@@ -24,10 +25,33 @@ class Mem0Storage(Storage):
         self._validate_type(type)
         self.memory_type = type
         self.crew = crew
-        self.config = config or {}
+        self.config = self._parse_config(config)
 
         self._extract_config_values()
         self._initialize_memory()
+
+    def _parse_config(self, config) -> dict:
+        """Parse config, handling JSON strings, dicts, or None."""
+        if config is None:
+            return {}
+        if isinstance(config, dict):
+            return config
+        if isinstance(config, str):
+            try:
+                parsed = json.loads(config)
+                if isinstance(parsed, dict):
+                    return parsed
+                raise TypeError(
+                    f"Mem0Storage config must be a dict, got {type(parsed).__name__} "
+                    "after parsing JSON string"
+                )
+            except json.JSONDecodeError as e:
+                raise TypeError(
+                    f"Mem0Storage config string is not valid JSON: {e}"
+                ) from e
+        raise TypeError(
+            f"Mem0Storage config must be a dict or JSON string, got {type(config).__name__}"
+        )
 
     def _validate_type(self, type):
         supported_types = {"short_term", "long_term", "entities", "external"}


### PR DESCRIPTION
## Summary
Fixes #4423

When `Mem0Storage` receives a JSON string as config (common when loading from env vars or config files), it now automatically parses it instead of crashing with `AttributeError: 'str' object has no attribute 'get'`.

## Problem
```python
from crewai.memory.storage.mem0_storage import Mem0Storage

config = '{"agent_id":"agent-123","user_id":"user-123"}'

# Before: Crashes with AttributeError
Mem0Storage(type="external", config=config)
```

## Solution
Added a `_parse_config()` method that handles:
- `None` → returns `{}`
- `dict` → passes through unchanged  
- JSON string → parses using `json.loads()`
- Invalid types → raises clear `TypeError` with helpful message

## Changes
- `lib/crewai/src/crewai/memory/storage/mem0_storage.py`: Add `_parse_config()` method and use it in `__init__`
- `lib/crewai/tests/storage/test_mem0_storage.py`: Add comprehensive tests for config parsing edge cases

## Testing
All new test cases cover:
- JSON string config parsing
- Dict passthrough (backwards compatible)
- None defaults to empty dict
- Invalid JSON raises helpful error
- Non-dict JSON (arrays) raises helpful error
- Invalid types raise helpful error
- Nested JSON objects parse correctly