### PR TITLE
fix: ensure TaskOutput.pydantic is populated on first guardrail invocation

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -585,10 +585,8 @@ class Task(BaseModel):
 
             self._post_agent_execution(agent)
 
-            if not self._guardrails and not self._guardrail:
-                pydantic_output, json_output = self._export_output(result)
-            else:
-                pydantic_output, json_output = None, None
+            # Always parse pydantic/json output so it's available to guardrails
+            pydantic_output, json_output = self._export_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,
@@ -682,10 +680,8 @@ class Task(BaseModel):
 
             self._post_agent_execution(agent)
 
-            if not self._guardrails and not self._guardrail:
-                pydantic_output, json_output = self._export_output(result)
-            else:
-                pydantic_output, json_output = None, None
+            # Always parse pydantic/json output so it's available to guardrails
+            pydantic_output, json_output = self._export_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,


### PR DESCRIPTION
## Summary
Fixes #4369

## Problem
When guardrails were configured, `TaskOutput.pydantic` was `None` on the first guardrail invocation, but correctly populated on retry attempts. This inconsistency made it difficult to write guardrail functions that needed access to the structured Pydantic output.

## Root Cause
In both `_execute_core()` and `_aexecute_core()`, `_export_output()` was intentionally skipped when guardrails exist:

```python
if not self._guardrails and not self._guardrail:
    pydantic_output, json_output = self._export_output(result)
else:
    pydantic_output, json_output = None, None  # ← SKIPPED!
```

However, on retry attempts (inside `_invoke_guardrail_function`), `_export_output()` was always called, creating inconsistent behavior.

## Solution
Remove the conditional skip - `_export_output()` is now always called so that pydantic/json output is available to guardrails on the first attempt.

## Changes
- `lib/crewai/src/crewai/task.py`: Always parse pydantic/json output in both `_execute_core()` and `_aexecute_core()`
- `lib/crewai/tests/test_task_guardrails.py`: Added regression tests for both sync and async paths

## Testing
Added two new tests:
- `test_guardrail_receives_pydantic_output_on_first_attempt` - Verifies sync execution
- `test_async_guardrail_receives_pydantic_output_on_first_attempt` - Verifies async execution

Both tests verify that:
1. `TaskOutput.pydantic` is not `None` on first guardrail invocation
2. The parsed Pydantic model has correct field values