### PR TITLE
fix: replace @lru_cache with instance-level caching in Repository.is_git_repo()

### DIFF
--- a/lib/crewai/src/crewai/cli/git.py
+++ b/lib/crewai/src/crewai/cli/git.py
@@ -1,10 +1,10 @@
-from functools import lru_cache
 import subprocess
 
 
 class Repository:
     def __init__(self, path: str = ".") -> None:
         self.path = path
+        self._is_git_repo_cache: bool | None = None
 
         if not self.is_git_installed():
             raise ValueError("Git is not installed or not found in your PATH.")
@@ -40,22 +40,26 @@ class Repository:
             encoding="utf-8",
         ).strip()
 
-    @lru_cache(maxsize=None)  # noqa: B019
     def is_git_repo(self) -> bool:
         """Check if the current directory is a git repository.
 
-        Notes:
-          - TODO: This method is cached to avoid redundant checks, but using lru_cache on methods can lead to memory leaks
+        Uses instance-level caching to avoid redundant checks while allowing
+        proper garbage collection of Repository instances.
         """
+        if self._is_git_repo_cache is not None:
+            return self._is_git_repo_cache
+
         try:
             subprocess.check_output(
                 ["git", "rev-parse", "--is-inside-work-tree"],  # noqa: S607
                 cwd=self.path,
                 encoding="utf-8",
             )
-            return True
+            self._is_git_repo_cache = True
         except subprocess.CalledProcessError:
-            return False
+            self._is_git_repo_cache = False
+
+        return self._is_git_repo_cache
 
     def has_uncommitted_changes(self) -> bool:
         """Check if the repository has uncommitted changes."""

--- a/lib/crewai/tests/cli/test_git.py
+++ b/lib/crewai/tests/cli/test_git.py
@@ -99,3 +99,100 @@ def test_origin_url(fp, repository):
         stdout="https://github.com/user/repo.git\n",
     )
     assert repository.origin_url() == "https://github.com/user/repo.git"
+
+
+# ============================================================================
+# Memory Leak Tests for Issue #4210
+# ============================================================================
+# These tests verify that Repository instances are properly garbage collected
+# after the fix that replaced @lru_cache with instance-level caching.
+
+
+import gc
+import weakref
+
+
+def test_repository_can_be_garbage_collected(fp):
+    """Verify Repository instances are garbage collected after going out of scope.
+
+    This test ensures the fix for issue #4210 works correctly. The @lru_cache
+    decorator was causing memory leaks because it held references to `self`,
+    preventing garbage collection.
+    """
+    fp.register(["git", "--version"], stdout="git version 2.30.0\n")
+    fp.register(["git", "rev-parse", "--is-inside-work-tree"], stdout="true\n")
+    fp.register(["git", "fetch"], stdout="")
+
+    repo = Repository(path=".")
+    weak_ref = weakref.ref(repo)
+
+    # Call is_git_repo to trigger caching
+    assert repo.is_git_repo() is True
+    # Call again to verify cache works
+    assert repo.is_git_repo() is True
+
+    # Delete the repository instance
+    del repo
+
+    # Force garbage collection
+    gc.collect()
+
+    # The weak reference should be dead (None) if garbage collection worked
+    assert weak_ref() is None, (
+        "Repository instance was not garbage collected. "
+        "This indicates a memory leak, likely due to @lru_cache holding references."
+    )
+
+
+def test_multiple_repositories_are_garbage_collected(fp):
+    """Verify multiple Repository instances are all properly garbage collected.
+
+    This test simulates the scenario described in issue #4210 where
+    multiple Repository instances are created in a loop.
+    """
+    weak_refs = []
+
+    # Create multiple Repository instances
+    for i in range(5):
+        fp.register(["git", "--version"], stdout="git version 2.30.0\n")
+        fp.register(["git", "rev-parse", "--is-inside-work-tree"], stdout="true\n")
+        fp.register(["git", "fetch"], stdout="")
+
+        repo = Repository(path=".")
+        # Use the cached method
+        repo.is_git_repo()
+        weak_refs.append(weakref.ref(repo))
+        del repo
+
+    # Force garbage collection
+    gc.collect()
+
+    # All instances should be garbage collected
+    collected = sum(1 for ref in weak_refs if ref() is None)
+    assert collected == 5, (
+        f"Only {collected}/5 Repository instances were garbage collected. "
+        "Memory leak detected."
+    )
+
+
+def test_is_git_repo_caching_works(fp):
+    """Verify is_git_repo() still caches results correctly with instance-level caching."""
+    fp.register(["git", "--version"], stdout="git version 2.30.0\n")
+    fp.register(["git", "rev-parse", "--is-inside-work-tree"], stdout="true\n")
+    fp.register(["git", "fetch"], stdout="")
+
+    repo = Repository(path=".")
+
+    # First call populates cache
+    result1 = repo.is_git_repo()
+    assert result1 is True
+
+    # Verify cache attribute is set
+    assert repo._is_git_repo_cache is True
+
+    # Second call should use cache
+    result2 = repo.is_git_repo()
+    assert result2 is True
+
+    # Results should be consistent
+    assert result1 == result2


### PR DESCRIPTION
## Summary
Fixes #4210

Resolves the memory leak in `Repository.is_git_repo()` caused by the `@lru_cache` decorator holding references to `self`.

## Root Cause
The `@lru_cache` decorator on instance methods is a well-known Python gotcha. When applied to a method, the cache dictionary stores references to `self` as part of the cache key. This prevents the garbage collector from cleaning up instances even after they go out of scope.

The code already had a TODO comment acknowledging this issue:
```python
@lru_cache(maxsize=None)  # noqa: B019
def is_git_repo(self) -> bool:
    """...
    Notes:
      - TODO: This method is cached to avoid redundant checks, but using lru_cache on methods can lead to memory leaks
    """
```

## Changes
1. **Removed** the `@lru_cache` decorator and `functools` import
2. **Added** an instance-level cache attribute: `self._is_git_repo_cache: bool | None = None`
3. **Modified** `is_git_repo()` to use manual instance-level caching:
   - Check cache at start of method
   - Populate cache on first call
   - Return cached value on subsequent calls

## Benefits
- ✅ Same O(1) performance for repeated calls
- ✅ Proper garbage collection of Repository instances
- ✅ No memory accumulation in long-running processes
- ✅ Resolves the acknowledged TODO

## Testing
Added three regression tests using `weakref` to verify:
- Single Repository instances are properly garbage collected
- Multiple Repository instances created in loops are all collected
- Caching behavior is preserved (results are consistent)