### PR TITLE
feat: add Hindsight memory integration

### DIFF
--- a/docs/en/concepts/memory.mdx
+++ b/docs/en/concepts/memory.mdx
@@ -761,6 +761,73 @@ memory = Memory(
 - **Custom backend**: Implement the `StorageBackend` protocol (see `crewai.memory.storage.backend`) and pass an instance to `Memory(storage=your_backend)`.
 
 
+## Hindsight Memory
+
+[Hindsight](https://hindsight.sh) is a purpose-built memory system for AI agents that provides fact extraction, entity tracking, temporal awareness, and multi-strategy retrieval out of the box. `HindsightMemory` is a drop-in replacement for the default `Memory` class -- pass it directly to `Crew(memory=...)`.
+
+### Installation
+
+```bash
+pip install 'crewai[hindsight]'
+```
+
+### Quick Start
+
+```python
+from crewai import Crew, Agent, Task, Process
+from crewai.memory.storage.hindsight_storage import HindsightMemory, HindsightConfig
+
+memory = HindsightMemory(HindsightConfig(
+    api_url="http://localhost:8888",
+    bank_id="my-crew",
+    mission="Track research findings and decisions",
+))
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find and analyze information",
+    backstory="Expert researcher with attention to detail",
+)
+
+task = Task(
+    description="Research the latest trends in AI memory systems.",
+    expected_output="A summary of key findings.",
+    agent=researcher,
+)
+
+crew = Crew(
+    agents=[researcher],
+    tasks=[task],
+    memory=memory,
+    process=Process.sequential,
+)
+
+crew.kickoff()
+```
+
+### Configuration
+
+| Parameter | Default | Description |
+| :--- | :--- | :--- |
+| `api_url` | *(required)* | Hindsight API URL (e.g. `http://localhost:8888`). |
+| `bank_id` | *(required)* | Memory bank ID. Each bank is an isolated memory store. |
+| `api_key` | `None` | API key. Falls back to `HINDSIGHT_API_KEY` env var. |
+| `budget` | `"mid"` | Recall budget (`"low"`, `"mid"`, or `"high"`). Higher budgets retrieve more context. |
+| `max_tokens` | `4096` | Maximum tokens for recall results. |
+| `tags` | `None` | Tags applied to all memories stored via this instance. |
+| `mission` | `None` | Bank mission statement. When set, the bank is created automatically on initialization. |
+
+### How It Works
+
+Hindsight handles its own LLM analysis, embeddings, and retrieval -- `HindsightMemory` bypasses CrewAI's built-in encoding and recall pipelines entirely:
+
+- **`remember(content)`** calls Hindsight's retain API, which extracts facts, entities, and relationships automatically.
+- **`recall(query)`** calls Hindsight's recall API, which uses four parallel retrieval strategies (semantic, BM25, graph, temporal) with cross-encoder reranking.
+- **`reset()`** deletes and recreates the memory bank.
+
+This means you don't need to configure an LLM or embedder for memory -- Hindsight provides its own.
+
+
 ## Discovery
 
 Inspect the scope hierarchy, categories, and records:

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -64,6 +64,7 @@ openpyxl = [
     "openpyxl~=3.1.5",
 ]
 mem0 = ["mem0ai~=0.1.94"]
+hindsight = ["hindsight-client>=0.4.0"]
 docling = [
     "docling~=2.63.0",
 ]

--- a/lib/crewai/src/crewai/memory/storage/hindsight_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/hindsight_storage.py
@@ -1,0 +1,509 @@
+"""CrewAI Memory backend powered by Hindsight.
+
+Implements the same duck-type interface as CrewAI's ``Memory`` class so it
+can be passed directly to ``Crew(memory=hindsight_memory)``.  All memory
+operations (remember, recall, reset) are delegated to Hindsight's
+retain/recall APIs, giving crews persistent memory with fact extraction,
+entity tracking, and temporal awareness.
+
+Usage::
+
+    from crewai.memory.storage.hindsight_storage import HindsightMemory, HindsightConfig
+
+    memory = HindsightMemory(HindsightConfig(
+        api_url="http://localhost:8888",
+        bank_id="my-crew",
+        mission="Track research findings",
+    ))
+
+    crew = Crew(agents=[...], tasks=[...], memory=memory)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import os
+import threading
+from typing import Any
+
+from pydantic import BaseModel, field_validator, model_validator
+
+from crewai.memory.types import MemoryMatch, MemoryRecord, ScopeInfo
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Async compatibility helpers
+# ---------------------------------------------------------------------------
+# CrewAI runs inside an async event loop. The Hindsight client's sync
+# methods internally call loop.run_until_complete(), which fails when a
+# loop is already running. We use a dedicated worker thread with a
+# persistent event loop for all Hindsight API calls.
+
+_thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+_thread_init_lock = threading.Lock()
+_initialized_threads: set[int] = set()
+
+
+def _ensure_thread_loop() -> None:
+    """Ensure the current thread has a persistent event loop."""
+    tid = threading.get_ident()
+    if tid not in _initialized_threads:
+        with _thread_init_lock:
+            if tid not in _initialized_threads:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                _initialized_threads.add(tid)
+
+
+def _call_sync(fn: Any, *args: Any, **kwargs: Any) -> Any:
+    """Run a sync Hindsight client method in a dedicated thread pool."""
+
+    def _run() -> Any:
+        _ensure_thread_loop()
+        return fn(*args, **kwargs)
+
+    future = _thread_pool.submit(_run)
+    return future.result(timeout=60)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class HindsightConfig(BaseModel):
+    """Configuration for the Hindsight memory backend.
+
+    Attributes:
+        api_url: Hindsight API URL (e.g. ``http://localhost:8888``).
+        api_key: API key for authentication. Falls back to
+            ``HINDSIGHT_API_KEY`` environment variable.
+        bank_id: Memory bank ID to use for this crew.
+        budget: Recall budget level (``low``, ``mid``, or ``high``).
+        max_tokens: Maximum tokens for recall results.
+        tags: Tags applied when storing memories via retain.
+        mission: Optional bank mission for organizing memories.
+    """
+
+    api_url: str
+    api_key: str | None = None
+    bank_id: str
+    budget: str = "mid"
+    max_tokens: int = 4096
+    tags: list[str] | None = None
+    mission: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+    @field_validator("api_url")
+    @classmethod
+    def api_url_not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("api_url must not be empty")
+        return v.strip().rstrip("/")
+
+    @field_validator("bank_id")
+    @classmethod
+    def bank_id_not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("bank_id must not be empty")
+        return v.strip()
+
+    @field_validator("budget")
+    @classmethod
+    def budget_valid(cls, v: str) -> str:
+        allowed = {"low", "mid", "high"}
+        if v not in allowed:
+            raise ValueError(f"budget must be one of {allowed}, got '{v}'")
+        return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_api_key(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if not values.get("api_key"):
+            values["api_key"] = os.environ.get("HINDSIGHT_API_KEY")
+        return values
+
+
+# ---------------------------------------------------------------------------
+# HindsightMemory — duck-type compatible with CrewAI's Memory class
+# ---------------------------------------------------------------------------
+
+
+class HindsightMemory:
+    """CrewAI Memory backend that persists memories to Hindsight.
+
+    Duck-type compatible with :class:`crewai.memory.unified_memory.Memory`.
+    Pass an instance directly to ``Crew(memory=hindsight_memory)``.
+
+    Maps CrewAI's Memory interface to Hindsight's memory API:
+
+    - ``remember(content)``  -> ``client.retain(bank_id, content)``
+    - ``recall(query)``      -> ``client.recall(bank_id, query)``
+    - ``reset()``            -> ``client.delete_bank()`` + recreate
+
+    Args:
+        config: A :class:`HindsightConfig` instance with connection details.
+    """
+
+    def __init__(self, config: HindsightConfig) -> None:
+        self.config = config
+        self._local = threading.local()
+        self._created_banks: set[str] = set()
+
+        # Eagerly create the bank if a mission is provided
+        if config.mission:
+            self._ensure_bank(config.bank_id)
+
+    def _get_client(self) -> Any:
+        """Get or create a thread-local Hindsight client."""
+        client = getattr(self._local, "client", None)
+        if client is None:
+            try:
+                from hindsight_client import Hindsight
+            except ModuleNotFoundError as err:
+                raise ModuleNotFoundError(
+                    "The 'hindsight-client' package is required for Hindsight memory. "
+                    "Install it with: pip install 'crewai[hindsight]'"
+                ) from err
+            client = Hindsight(
+                base_url=self.config.api_url,
+                api_key=self.config.api_key,
+                timeout=30.0,
+            )
+            self._local.client = client
+        return client
+
+    def _ensure_bank(self, bank_id: str) -> None:
+        """Create bank if not already created in this session."""
+        if bank_id in self._created_banks:
+            return
+
+        def _create() -> None:
+            self._get_client().create_bank(
+                bank_id=bank_id,
+                name=bank_id,
+                mission=self.config.mission,
+            )
+
+        try:
+            _call_sync(_create)
+            self._created_banks.add(bank_id)
+        except Exception as exc:
+            exc_str = str(exc).lower()
+            if "409" in exc_str or "already exists" in exc_str or "conflict" in exc_str:
+                self._created_banks.add(bank_id)
+            else:
+                logger.debug("Bank creation for %s failed (will retry): %s", bank_id, exc)
+
+    # ------------------------------------------------------------------
+    # Memory interface — remember
+    # ------------------------------------------------------------------
+
+    def remember(
+        self,
+        content: str,
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        importance: float | None = None,
+        source: str | None = None,
+        private: bool = False,
+        agent_role: str | None = None,
+    ) -> MemoryRecord:
+        """Store a single item in memory via Hindsight's retain API.
+
+        Args:
+            content: Text to remember.
+            scope: Ignored (Hindsight uses bank_id for isolation).
+            categories: Mapped to Hindsight tags.
+            metadata: Passed through to Hindsight retain metadata.
+            importance: Ignored (Hindsight infers importance).
+            source: Included in retain metadata.
+            private: Ignored (Hindsight manages access via API keys).
+            agent_role: Included in retain metadata.
+
+        Returns:
+            A ``MemoryRecord`` representing the stored memory.
+        """
+        bank_id = self.config.bank_id
+        self._ensure_bank(bank_id)
+
+        # Build retain metadata — Hindsight requires dict[str, str]
+        retain_metadata: dict[str, str] = {"source": "crewai"}
+        if metadata:
+            for k, v in metadata.items():
+                retain_metadata[k] = str(v)
+        if source:
+            retain_metadata["provenance"] = source
+        if agent_role:
+            retain_metadata["agent_role"] = agent_role
+
+        # Merge config tags with category tags
+        tags = list(self.config.tags) if self.config.tags else []
+        if categories:
+            tags.extend(categories)
+
+        def _retain() -> None:
+            self._get_client().retain(
+                bank_id=bank_id,
+                content=str(content),
+                metadata=retain_metadata,
+                tags=tags or None,
+            )
+
+        try:
+            _call_sync(_retain)
+        except Exception as e:
+            raise RuntimeError(f"Hindsight retain failed: {e}") from e
+
+        return MemoryRecord(
+            content=content,
+            scope=scope or "/",
+            categories=categories or [],
+            metadata=metadata or {},
+            importance=importance or 0.5,
+        )
+
+    def remember_many(
+        self,
+        contents: list[str],
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        importance: float | None = None,
+        source: str | None = None,
+        private: bool = False,
+        agent_role: str | None = None,
+    ) -> list[MemoryRecord]:
+        """Store multiple items in memory.
+
+        Calls ``remember()`` for each item sequentially. Returns the
+        list of created ``MemoryRecord`` instances.
+        """
+        if not contents:
+            return []
+        return [
+            self.remember(
+                c,
+                scope=scope,
+                categories=categories,
+                metadata=metadata,
+                importance=importance,
+                source=source,
+                private=private,
+                agent_role=agent_role,
+            )
+            for c in contents
+        ]
+
+    # ------------------------------------------------------------------
+    # Memory interface — recall
+    # ------------------------------------------------------------------
+
+    def recall(
+        self,
+        query: str,
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        limit: int = 10,
+        depth: str = "deep",
+        source: str | None = None,
+        include_private: bool = False,
+    ) -> list[MemoryMatch]:
+        """Retrieve relevant memories via Hindsight's recall API.
+
+        Args:
+            query: Natural language query.
+            scope: Ignored (Hindsight uses bank_id for isolation).
+            categories: Ignored (Hindsight does its own retrieval).
+            limit: Maximum number of results to return.
+            depth: Ignored (Hindsight always uses multi-strategy retrieval).
+            source: Ignored (Hindsight manages access via API keys).
+            include_private: Ignored.
+
+        Returns:
+            List of ``MemoryMatch`` objects ordered by relevance.
+        """
+        bank_id = self.config.bank_id
+
+        def _recall() -> Any:
+            return self._get_client().recall(
+                bank_id=bank_id,
+                query=query,
+                budget=self.config.budget,
+                max_tokens=self.config.max_tokens,
+            )
+
+        try:
+            response = _call_sync(_recall)
+
+            recall_results = response.results if hasattr(response, "results") else []
+            sliced = recall_results[:limit]
+            denom = max(len(sliced) * 2, 1)
+
+            matches: list[MemoryMatch] = []
+            for i, r in enumerate(sliced):
+                score = round(1.0 - (i / denom), 4)
+
+                result_metadata: dict[str, Any] = {}
+                if hasattr(r, "type") and r.type:
+                    result_metadata["type"] = r.type
+                if hasattr(r, "context") and r.context:
+                    result_metadata["source_context"] = r.context
+                if hasattr(r, "occurred_start") and r.occurred_start:
+                    result_metadata["occurred_start"] = r.occurred_start
+                if hasattr(r, "document_id") and r.document_id:
+                    result_metadata["document_id"] = r.document_id
+                if hasattr(r, "metadata") and r.metadata:
+                    result_metadata.update(r.metadata)
+                if hasattr(r, "tags") and r.tags:
+                    result_metadata["tags"] = r.tags
+
+                record = MemoryRecord(
+                    content=r.text,
+                    scope="/",
+                    categories=list(r.tags) if hasattr(r, "tags") and r.tags else [],
+                    metadata=result_metadata,
+                )
+
+                matches.append(
+                    MemoryMatch(
+                        record=record,
+                        score=score,
+                        match_reasons=["semantic"],
+                    )
+                )
+
+            return matches
+
+        except Exception as e:
+            raise RuntimeError(f"Hindsight recall failed: {e}") from e
+
+    # ------------------------------------------------------------------
+    # Memory interface — other methods
+    # ------------------------------------------------------------------
+
+    def extract_memories(self, content: str) -> list[str]:
+        """Extract discrete memories from raw content.
+
+        Simple implementation: returns the content as a single item.
+        Hindsight's retain API handles its own fact extraction.
+        """
+        return [content]
+
+    def forget(
+        self,
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        older_than: Any = None,
+        metadata_filter: dict[str, Any] | None = None,
+        record_ids: list[str] | None = None,
+    ) -> int:
+        """Delete memories. Delegates to reset() since Hindsight manages its own storage."""
+        self.reset()
+        return 0
+
+    def reset(self, scope: str | None = None) -> None:
+        """Clear all memories by deleting and recreating the bank."""
+        bank_id = self.config.bank_id
+
+        def _delete() -> None:
+            self._get_client().delete_bank(bank_id)
+
+        try:
+            _call_sync(_delete)
+            self._created_banks.discard(bank_id)
+            self._ensure_bank(bank_id)
+        except Exception:
+            logger.debug("Failed to reset bank %s", bank_id, exc_info=True)
+
+    def drain_writes(self) -> None:
+        """No-op. Hindsight retain is synchronous from the client perspective."""
+
+    def close(self) -> None:
+        """No-op. Thread-local clients are cleaned up by the GC."""
+
+    def scope(self, path: str) -> HindsightMemory:
+        """Return self. Hindsight uses bank_id for isolation, not scopes."""
+        return self
+
+    def info(self, path: str = "/") -> ScopeInfo:
+        """Return basic scope info."""
+        return ScopeInfo(path=path)
+
+    # Async variants — delegate to sync implementations
+
+    async def aremember(
+        self,
+        content: str,
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        importance: float | None = None,
+        source: str | None = None,
+        private: bool = False,
+    ) -> MemoryRecord:
+        """Async remember: delegates to sync."""
+        return self.remember(
+            content,
+            scope=scope,
+            categories=categories,
+            metadata=metadata,
+            importance=importance,
+            source=source,
+            private=private,
+        )
+
+    async def aremember_many(
+        self,
+        contents: list[str],
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        importance: float | None = None,
+        source: str | None = None,
+        private: bool = False,
+        agent_role: str | None = None,
+    ) -> list[MemoryRecord]:
+        """Async remember_many: delegates to sync."""
+        return self.remember_many(
+            contents,
+            scope=scope,
+            categories=categories,
+            metadata=metadata,
+            importance=importance,
+            source=source,
+            private=private,
+            agent_role=agent_role,
+        )
+
+    async def arecall(
+        self,
+        query: str,
+        scope: str | None = None,
+        categories: list[str] | None = None,
+        limit: int = 10,
+        depth: str = "deep",
+        source: str | None = None,
+        include_private: bool = False,
+    ) -> list[MemoryMatch]:
+        """Async recall: delegates to sync."""
+        return self.recall(
+            query,
+            scope=scope,
+            categories=categories,
+            limit=limit,
+            depth=depth,
+            source=source,
+            include_private=include_private,
+        )
+
+    async def aextract_memories(self, content: str) -> list[str]:
+        """Async extract_memories: delegates to sync."""
+        return self.extract_memories(content)

--- a/lib/crewai/tests/storage/test_hindsight_storage.py
+++ b/lib/crewai/tests/storage/test_hindsight_storage.py
@@ -1,0 +1,652 @@
+"""Unit tests for HindsightMemory (Hindsight memory backend for CrewAI)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from crewai.memory.storage.hindsight_storage import (
+    HindsightConfig,
+    HindsightMemory,
+    _call_sync,
+)
+from crewai.memory.types import MemoryMatch, MemoryRecord, ScopeInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _passthrough(fn, *args, **kwargs):
+    """Replace _call_sync with a direct call for testing."""
+    return fn(*args, **kwargs)
+
+
+def _make_recall_result(text="Memory text", type_="world", **kwargs):
+    """Create a mock RecallResult."""
+    r = MagicMock()
+    r.text = text
+    r.type = type_
+    r.context = kwargs.get("context")
+    r.occurred_start = kwargs.get("occurred_start")
+    r.document_id = kwargs.get("document_id")
+    r.metadata = kwargs.get("metadata")
+    r.tags = kwargs.get("tags")
+    return r
+
+
+def _make_config(**overrides):
+    """Create a HindsightConfig with sensible defaults."""
+    defaults = {
+        "api_url": "http://localhost:8888",
+        "bank_id": "test-bank",
+    }
+    defaults.update(overrides)
+    return HindsightConfig(**defaults)
+
+
+def _make_memory(config=None, **config_overrides):
+    """Create a HindsightMemory with a mocked client."""
+    cfg = config or _make_config(**config_overrides)
+    memory = HindsightMemory(config=cfg)
+    mock_client = MagicMock()
+    memory._local.client = mock_client
+    memory._created_banks.add(cfg.bank_id)
+    return memory, mock_client
+
+
+# ---------------------------------------------------------------------------
+# HindsightConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestHindsightConfig:
+    def test_valid_config(self):
+        config = HindsightConfig(
+            api_url="http://localhost:8888",
+            bank_id="my-bank",
+        )
+        assert config.api_url == "http://localhost:8888"
+        assert config.bank_id == "my-bank"
+        assert config.budget == "mid"
+        assert config.max_tokens == 4096
+        assert config.tags is None
+        assert config.mission is None
+
+    def test_defaults(self):
+        config = _make_config()
+        assert config.budget == "mid"
+        assert config.max_tokens == 4096
+
+    def test_api_url_required(self):
+        with pytest.raises(ValidationError):
+            HindsightConfig(bank_id="test")
+
+    def test_bank_id_required(self):
+        with pytest.raises(ValidationError):
+            HindsightConfig(api_url="http://localhost:8888")
+
+    def test_empty_api_url_rejected(self):
+        with pytest.raises(ValidationError, match="api_url must not be empty"):
+            HindsightConfig(api_url="", bank_id="test")
+
+    def test_empty_bank_id_rejected(self):
+        with pytest.raises(ValidationError, match="bank_id must not be empty"):
+            HindsightConfig(api_url="http://localhost:8888", bank_id="")
+
+    def test_invalid_budget_rejected(self):
+        with pytest.raises(ValidationError, match="budget must be one of"):
+            HindsightConfig(
+                api_url="http://localhost:8888",
+                bank_id="test",
+                budget="extreme",
+            )
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            HindsightConfig(
+                api_url="http://localhost:8888",
+                bank_id="test",
+                unknown_field="value",
+            )
+
+    def test_api_url_trailing_slash_stripped(self):
+        config = HindsightConfig(
+            api_url="http://localhost:8888/",
+            bank_id="test",
+        )
+        assert config.api_url == "http://localhost:8888"
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "env-key-123")
+        config = HindsightConfig(
+            api_url="http://localhost:8888",
+            bank_id="test",
+        )
+        assert config.api_key == "env-key-123"
+
+    def test_explicit_api_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "env-key")
+        config = HindsightConfig(
+            api_url="http://localhost:8888",
+            bank_id="test",
+            api_key="explicit-key",
+        )
+        assert config.api_key == "explicit-key"
+
+    def test_all_fields(self):
+        config = HindsightConfig(
+            api_url="http://localhost:8888",
+            api_key="key-123",
+            bank_id="my-bank",
+            budget="high",
+            max_tokens=8192,
+            tags=["env:prod", "team:ml"],
+            mission="Track user preferences",
+        )
+        assert config.budget == "high"
+        assert config.max_tokens == 8192
+        assert config.tags == ["env:prod", "team:ml"]
+        assert config.mission == "Track user preferences"
+
+    def test_whitespace_api_url_rejected(self):
+        with pytest.raises(ValidationError, match="api_url must not be empty"):
+            HindsightConfig(api_url="   ", bank_id="test")
+
+    def test_whitespace_bank_id_rejected(self):
+        with pytest.raises(ValidationError, match="bank_id must not be empty"):
+            HindsightConfig(api_url="http://localhost:8888", bank_id="   ")
+
+
+# ---------------------------------------------------------------------------
+# HindsightMemory.remember() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRemember:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_calls_retain(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        record = memory.remember("Task output text", metadata={"task": "research"})
+
+        mock_client.retain.assert_called_once()
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["content"] == "Task output text"
+        assert call_kwargs["metadata"]["source"] == "crewai"
+        assert call_kwargs["metadata"]["task"] == "research"
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_returns_memory_record(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        record = memory.remember("Some fact")
+
+        assert isinstance(record, MemoryRecord)
+        assert record.content == "Some fact"
+        assert record.scope == "/"
+        assert record.importance == 0.5
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_stringifies_metadata_values(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.remember("text", metadata={"count": 42, "active": True})
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["metadata"]["count"] == "42"
+        assert call_kwargs["metadata"]["active"] == "True"
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_without_metadata(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.remember("text")
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["metadata"] == {"source": "crewai"}
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_raises_on_failure(self, _mock_cs):
+        memory, mock_client = _make_memory()
+        mock_client.retain.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="Hindsight retain failed"):
+            memory.remember("text")
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_passes_tags(self, _mock_cs):
+        memory, mock_client = _make_memory(tags=["env:prod"])
+
+        memory.remember("text")
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["tags"] == ["env:prod"]
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_merges_categories_with_tags(self, _mock_cs):
+        memory, mock_client = _make_memory(tags=["env:prod"])
+
+        memory.remember("text", categories=["research", "ml"])
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["tags"] == ["env:prod", "research", "ml"]
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_includes_source_in_metadata(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.remember("text", source="user-123")
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["metadata"]["provenance"] == "user-123"
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_includes_agent_role_in_metadata(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.remember("text", agent_role="researcher")
+
+        call_kwargs = mock_client.retain.call_args[1]
+        assert call_kwargs["metadata"]["agent_role"] == "researcher"
+
+
+# ---------------------------------------------------------------------------
+# HindsightMemory.remember_many() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRememberMany:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_many_calls_retain_for_each(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        records = memory.remember_many(["fact1", "fact2", "fact3"])
+
+        assert mock_client.retain.call_count == 3
+        assert len(records) == 3
+        assert all(isinstance(r, MemoryRecord) for r in records)
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_remember_many_empty_list(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        records = memory.remember_many([])
+
+        assert records == []
+        mock_client.retain.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HindsightMemory.recall() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecall:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_calls_recall_api(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        mock_response = MagicMock()
+        mock_response.results = [_make_recall_result()]
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("programming preferences", limit=5)
+
+        mock_client.recall.assert_called_once()
+        call_kwargs = mock_client.recall.call_args[1]
+        assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["query"] == "programming preferences"
+        assert call_kwargs["budget"] == "mid"
+        assert call_kwargs["max_tokens"] == 4096
+        assert len(matches) == 1
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_returns_memory_match_objects(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        mock_response = MagicMock()
+        mock_response.results = [_make_recall_result(text="Found fact")]
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("test")
+
+        assert len(matches) == 1
+        assert isinstance(matches[0], MemoryMatch)
+        assert isinstance(matches[0].record, MemoryRecord)
+        assert matches[0].record.content == "Found fact"
+        assert matches[0].score > 0
+        assert "semantic" in matches[0].match_reasons
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_respects_limit(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            _make_recall_result(text=f"Memory {i}") for i in range(10)
+        ]
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("test", limit=3)
+        assert len(matches) == 3
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_returns_empty_on_no_results(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        mock_response = MagicMock()
+        mock_response.results = []
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("nonexistent topic")
+        assert matches == []
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_includes_rich_metadata(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        r = _make_recall_result(
+            context="conversation",
+            occurred_start="2024-01-01",
+            document_id="doc-1",
+            metadata={"key": "value"},
+            tags=["tag1"],
+        )
+        mock_response = MagicMock()
+        mock_response.results = [r]
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("test")
+        meta = matches[0].record.metadata
+        assert meta["source_context"] == "conversation"
+        assert meta["occurred_start"] == "2024-01-01"
+        assert meta["document_id"] == "doc-1"
+        assert meta["key"] == "value"
+        assert meta["tags"] == ["tag1"]
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_raises_on_failure(self, _mock_cs):
+        memory, mock_client = _make_memory()
+        mock_client.recall.side_effect = RuntimeError("timeout")
+
+        with pytest.raises(RuntimeError, match="Hindsight recall failed"):
+            memory.recall("test")
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_scores_descend(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            _make_recall_result(text=f"Memory {i}") for i in range(5)
+        ]
+        mock_client.recall.return_value = mock_response
+
+        matches = memory.recall("test", limit=5)
+        scores = [m.score for m in matches]
+        assert scores == sorted(scores, reverse=True)
+        assert scores[0] == 1.0
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_recall_uses_config_budget_and_max_tokens(self, _mock_cs):
+        memory, mock_client = _make_memory(budget="high", max_tokens=8192)
+
+        mock_response = MagicMock()
+        mock_response.results = []
+        mock_client.recall.return_value = mock_response
+
+        memory.recall("test")
+
+        call_kwargs = mock_client.recall.call_args[1]
+        assert call_kwargs["budget"] == "high"
+        assert call_kwargs["max_tokens"] == 8192
+
+
+# ---------------------------------------------------------------------------
+# HindsightMemory.reset() tests
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_reset_deletes_bank(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.reset()
+
+        mock_client.delete_bank.assert_called_once_with("test-bank")
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_reset_recreates_bank(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.reset()
+
+        # After delete, _ensure_bank should be called (which calls create_bank)
+        assert mock_client.create_bank.called
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_reset_is_best_effort(self, _mock_cs):
+        memory, mock_client = _make_memory()
+        mock_client.delete_bank.side_effect = RuntimeError("not found")
+
+        # Should not raise
+        memory.reset()
+
+
+# ---------------------------------------------------------------------------
+# drain_writes / close tests
+# ---------------------------------------------------------------------------
+
+
+class TestDrainWritesAndClose:
+    def test_drain_writes_no_op(self):
+        memory, _ = _make_memory()
+        # Should not raise
+        memory.drain_writes()
+
+    def test_close_no_op(self):
+        memory, _ = _make_memory()
+        # Should not raise
+        memory.close()
+
+
+# ---------------------------------------------------------------------------
+# scope / info tests
+# ---------------------------------------------------------------------------
+
+
+class TestScopeAndInfo:
+    def test_scope_returns_self(self):
+        memory, _ = _make_memory()
+        scoped = memory.scope("/project/alpha")
+        assert scoped is memory
+
+    def test_info_returns_scope_info(self):
+        memory, _ = _make_memory()
+        info = memory.info("/project")
+        assert isinstance(info, ScopeInfo)
+        assert info.path == "/project"
+        assert info.record_count == 0
+
+
+# ---------------------------------------------------------------------------
+# extract_memories test
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMemories:
+    def test_extract_memories_returns_content_as_list(self):
+        memory, _ = _make_memory()
+        result = memory.extract_memories("Some raw content")
+        assert result == ["Some raw content"]
+
+
+# ---------------------------------------------------------------------------
+# Bank lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestBankLifecycle:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_ensure_bank_on_first_remember(self, _mock_cs):
+        """Bank should be created on first remember if not already cached."""
+        cfg = _make_config()
+        memory = HindsightMemory(config=cfg)
+        mock_client = MagicMock()
+        memory._local.client = mock_client
+        # Don't pre-add the bank to _created_banks
+
+        memory.remember("text")
+
+        mock_client.create_bank.assert_called_once()
+        mock_client.retain.assert_called_once()
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_409_cached_no_retry(self, _mock_cs):
+        """409 conflict should be cached so subsequent calls don't retry."""
+        cfg = _make_config()
+        memory = HindsightMemory(config=cfg)
+        mock_client = MagicMock()
+        memory._local.client = mock_client
+        mock_client.create_bank.side_effect = Exception("409 Conflict")
+
+        memory.remember("text1")
+        memory.remember("text2")
+
+        # create_bank called once (first remember), 409 cached, not called again
+        assert mock_client.create_bank.call_count == 1
+        assert mock_client.retain.call_count == 2
+
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_transient_error_retries(self, _mock_cs):
+        """Non-409 errors should NOT be cached so creation is retried."""
+        cfg = _make_config()
+        memory = HindsightMemory(config=cfg)
+        mock_client = MagicMock()
+        memory._local.client = mock_client
+        # First call fails transiently, second succeeds
+        mock_client.create_bank.side_effect = [
+            Exception("Connection reset"),
+            None,
+        ]
+
+        memory.remember("text1")
+        memory.remember("text2")
+
+        # create_bank called twice (first failed, not cached, second succeeded)
+        assert mock_client.create_bank.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Import error test
+# ---------------------------------------------------------------------------
+
+
+class TestImportError:
+    def test_import_error_when_client_not_installed(self):
+        config = _make_config()
+        memory = HindsightMemory(config=config)
+        # Clear any cached client
+        memory._local = MagicMock()
+        memory._local.client = None
+
+        with patch.dict("sys.modules", {"hindsight_client": None}):
+            with pytest.raises(ModuleNotFoundError, match="hindsight-client"):
+                memory._get_client()
+
+
+# ---------------------------------------------------------------------------
+# forget() test
+# ---------------------------------------------------------------------------
+
+
+class TestForget:
+    @patch(
+        "crewai.memory.storage.hindsight_storage._call_sync",
+        side_effect=_passthrough,
+    )
+    def test_forget_calls_reset(self, _mock_cs):
+        memory, mock_client = _make_memory()
+
+        memory.forget()
+
+        mock_client.delete_bank.assert_called_once_with("test-bank")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,10 @@ python_functions = "test_*"
 
 [tool.uv]
 
+# vcrpy 7.0.0 has a urllib3<2 constraint for PyPy, which conflicts with
+# deps requiring urllib3>=2. Restrict resolution to CPython only.
+environments = ["platform_python_implementation == 'CPython'"]
+
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.
 override-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -2,14 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation == 'CPython'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'CPython'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'CPython'",
+    "python_full_version < '3.11' and platform_python_implementation == 'CPython'",
+]
+supported-markers = [
+    "platform_python_implementation == 'CPython'",
 ]
 
 [manifest]
@@ -54,11 +53,11 @@ name = "a2a-sdk"
 version = "0.3.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "protobuf" },
-    { name = "pydantic" },
+    { name = "google-api-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx-sse", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/a3/76f2d94a32a1b0dc760432d893a09ec5ed31de5ad51b1ef0f9d199ceb260/a2a_sdk-0.3.22.tar.gz", hash = "sha256:77a5694bfc4f26679c11b70c7f1062522206d430b34bc1215cfbb1eba67b7e7d", size = 231535, upload-time = "2025-12-16T18:39:21.19Z" }
 wheels = [
@@ -70,13 +69,13 @@ name = "accelerate"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "psutil" },
-    { name = "pyyaml" },
-    { name = "safetensors" },
-    { name = "torch" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "psutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "safetensors", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
 wheels = [
@@ -88,13 +87,13 @@ name = "aiobotocore"
 version = "2.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aioitertools" },
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "multidict" },
-    { name = "python-dateutil" },
-    { name = "wrapt" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aioitertools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "botocore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jmespath", marker = "platform_python_implementation == 'CPython'" },
+    { name = "multidict", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "wrapt", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/48/cf3c88c5e3fecdeed824f97a8a98a9fc0d7ef33e603f8f22c2fd32b9ef09/aiobotocore-2.25.2.tar.gz", hash = "sha256:ae0a512b34127097910b7af60752956254099ae54402a84c2021830768f92cda", size = 120585, upload-time = "2025-11-11T18:51:28.056Z" }
 wheels = [
@@ -112,10 +111,10 @@ wheels = [
 
 [package.optional-dependencies]
 memcached = [
-    { name = "aiomcache" },
+    { name = "aiomcache", marker = "platform_python_implementation == 'CPython'" },
 ]
 redis = [
-    { name = "redis" },
+    { name = "redis", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -141,14 +140,14 @@ name = "aiohttp"
 version = "3.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aiosignal", marker = "platform_python_implementation == 'CPython'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "frozenlist", marker = "platform_python_implementation == 'CPython'" },
+    { name = "multidict", marker = "platform_python_implementation == 'CPython'" },
+    { name = "propcache", marker = "platform_python_implementation == 'CPython'" },
+    { name = "yarl", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
 wheels = [
@@ -223,6 +222,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
 name = "aioitertools"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -245,7 +256,7 @@ name = "aiomcache"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/0a/914d8df1002d88ca70679d192f6e16d113e6b5cbcc13c51008db9230025f/aiomcache-0.8.2.tar.gz", hash = "sha256:43b220d7f499a32a71871c4f457116eb23460fa216e69c1d32b81e3209e51359", size = 10640, upload-time = "2024-05-07T15:03:14.434Z" }
 wheels = [
@@ -257,8 +268,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "frozenlist", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -270,7 +281,7 @@ name = "aiosqlite"
 version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
 wheels = [
@@ -300,14 +311,14 @@ name = "anthropic"
 version = "0.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docstring-parser", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jiter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/07/f550112c3f5299d02f06580577f602e8a112b1988ad7c98ac1a8f7292d7e/anthropic-0.73.0.tar.gz", hash = "sha256:30f0d7d86390165f86af6ca7c3041f8720bb2e1b0e12a44525c8edfdbd2c5239", size = 425168, upload-time = "2025-11-14T18:47:52.635Z" }
 wheels = [
@@ -325,9 +336,9 @@ name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -339,10 +350,10 @@ name = "apify-client"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apify-shared" },
-    { name = "colorama" },
-    { name = "impit" },
-    { name = "more-itertools" },
+    { name = "apify-shared", marker = "platform_python_implementation == 'CPython'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython'" },
+    { name = "impit", marker = "platform_python_implementation == 'CPython'" },
+    { name = "more-itertools", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/0a/82a4129bc0fcbd0761a3a1f83adca3fe0b7569ec8eb82a26dead6bd7b17a/apify_client-2.4.1.tar.gz", hash = "sha256:125d2874d364bd7fa17f7db8464ad10700caa3cb0f5502a624f6edd606469124", size = 376316, upload-time = "2026-01-30T10:52:58.817Z" }
 wheels = [
@@ -408,7 +419,7 @@ name = "authlib"
 version = "1.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950, upload-time = "2026-02-06T14:04:14.171Z" }
 wheels = [
@@ -458,9 +469,9 @@ name = "azure-ai-inference"
 version = "1.0.0b9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "isodate" },
-    { name = "typing-extensions" },
+    { name = "azure-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "isodate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/6a/ed85592e5c64e08c291992f58b1a94dab6869f28fb0f40fd753dced73ba6/azure_ai_inference-1.0.0b9.tar.gz", hash = "sha256:1feb496bd84b01ee2691befc04358fa25d7c344d8288e99364438859ad7cd5a4", size = 182408, upload-time = "2025-02-15T00:37:28.464Z" }
 wheels = [
@@ -472,8 +483,8 @@ name = "azure-core"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
 wheels = [
@@ -503,10 +514,10 @@ name = "bandit"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "stevedore", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/72/f704a97aac430aeb704fa16435dfa24fbeaf087d46724d0965eb1f756a2c/bandit-1.9.2.tar.gz", hash = "sha256:32410415cd93bf9c8b91972159d5cf1e7f063a9146d70345641cd3877de348ce", size = 4241659, upload-time = "2025-11-23T21:36:18.722Z" }
 wheels = [
@@ -575,8 +586,8 @@ name = "beautifulsoup4"
 version = "4.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
+    { name = "soupsieve", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
@@ -588,15 +599,14 @@ name = "bedrock-agentcore"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "uvicorn" },
-    { name = "websockets" },
+    { name = "boto3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "botocore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "starlette", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uvicorn", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websockets", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/5f/f0275db8f9d7dec3c30f56cf510f835f1271aece31881ebf875944c2fd8d/bedrock_agentcore-1.2.1.tar.gz", hash = "sha256:7866ab5652659db3b7d0c669347422ffeca796ea9a12efecdfc1606773e3b909", size = 410250, upload-time = "2026-02-03T22:14:04.764Z" }
 wheels = [
@@ -608,9 +618,9 @@ name = "boto3"
 version = "1.40.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
+    { name = "botocore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jmespath", marker = "platform_python_implementation == 'CPython'" },
+    { name = "s3transfer", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/12/d5ac34e0536e1914dde28245f014a635056dde0427f6efa09f104d7999f4/boto3-1.40.70.tar.gz", hash = "sha256:191443707b391232ed15676bf6bba7e53caec1e71aafa12ccad2e825c5ee15cc", size = 111638, upload-time = "2025-11-10T20:29:15.199Z" }
 wheels = [
@@ -622,9 +632,9 @@ name = "boto3-stubs"
 version = "1.40.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "botocore-stubs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "types-s3transfer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/70/245477b7f07c9e1533c47fa69e611b172814423a6fd4637004f0d2a13b73/boto3_stubs-1.40.54.tar.gz", hash = "sha256:e21a9eda979a451935eb3196de3efbe15b9470e6bf9027406d1f6d0ac08b339e", size = 100919, upload-time = "2025-10-16T19:49:17.079Z" }
 wheels = [
@@ -633,7 +643,7 @@ wheels = [
 
 [package.optional-dependencies]
 bedrock-runtime = [
-    { name = "mypy-boto3-bedrock-runtime" },
+    { name = "mypy-boto3-bedrock-runtime", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -641,10 +651,9 @@ name = "botocore"
 version = "1.40.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "jmespath", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/c1/8c4c199ae1663feee579a15861e34f10b29da11ae6ea0ad7b6a847ef3823/botocore-1.40.70.tar.gz", hash = "sha256:61b1f2cecd54d1b28a081116fa113b97bf4e17da57c62ae2c2751fe4c528af1f", size = 14444592, upload-time = "2025-11-10T20:29:04.046Z" }
 wheels = [
@@ -656,7 +665,7 @@ name = "botocore-stubs"
 version = "1.42.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "types-awscrt" },
+    { name = "types-awscrt", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
 wheels = [
@@ -668,12 +677,12 @@ name = "browserbase"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/df/17ac5e1116ab8f1264c6a9718f935358d20bdcd8ae0e3d1f18fd580cd871/browserbase-1.4.0.tar.gz", hash = "sha256:e2ed36f513c8630b94b826042c4bb9f497c333f3bd28e5b76cb708c65b4318a0", size = 122103, upload-time = "2025-05-16T20:50:40.802Z" }
 wheels = [
@@ -685,11 +694,11 @@ name = "build"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "os_name == 'nt' and platform_python_implementation == 'CPython'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10.2' and platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyproject-hooks", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
 wheels = [
@@ -719,7 +728,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -861,33 +870,33 @@ name = "chromadb"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bcrypt" },
-    { name = "build" },
-    { name = "grpcio" },
-    { name = "httpx" },
-    { name = "importlib-resources" },
-    { name = "jsonschema" },
-    { name = "kubernetes" },
-    { name = "mmh3" },
-    { name = "numpy" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11'" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-sdk" },
-    { name = "orjson" },
-    { name = "overrides" },
-    { name = "posthog" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "pypika" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "bcrypt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "build", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "importlib-resources", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema", marker = "platform_python_implementation == 'CPython'" },
+    { name = "kubernetes", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mmh3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "orjson", marker = "platform_python_implementation == 'CPython'" },
+    { name = "overrides", marker = "platform_python_implementation == 'CPython'" },
+    { name = "posthog", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pybase64", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypika", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uvicorn", extra = ["standard"], marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/48/11851dddeadad6abe36ee071fedc99b5bdd2c324df3afa8cb952ae02798b/chromadb-1.1.1.tar.gz", hash = "sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223", size = 1338109, upload-time = "2025-10-05T02:49:14.834Z" }
 wheels = [
@@ -903,7 +912,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -924,7 +933,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
+    { name = "humanfriendly", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -936,7 +945,7 @@ name = "colorlog"
 version = "6.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
@@ -948,24 +957,24 @@ name = "composio-core"
 version = "0.7.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastapi" },
-    { name = "importlib-metadata" },
-    { name = "inflection" },
-    { name = "jsonref" },
-    { name = "jsonschema" },
-    { name = "paramiko" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "pyperclip" },
-    { name = "pysher" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "semver" },
-    { name = "sentry-sdk" },
-    { name = "uvicorn" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "fastapi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "importlib-metadata", marker = "platform_python_implementation == 'CPython'" },
+    { name = "inflection", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonref", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema", marker = "platform_python_implementation == 'CPython'" },
+    { name = "paramiko", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyperclip", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pysher", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "semver", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sentry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uvicorn", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/e4/b0fadae584fd09290b4244f5bb5b7a067a3bb2b56562115ea55b66246949/composio_core-0.7.21.tar.gz", hash = "sha256:776e8961ffcaaa422d2ce53516fb80a3832cef25be13475cf5282f8626a9abdc", size = 334781, upload-time = "2025-09-09T08:11:54.803Z" }
 wheels = [
@@ -977,12 +986,12 @@ name = "contextual-client"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/b8/511698cc36c985a57a8231f6ace3513a3394510edb2593131f88d5a3ae19/contextual_client-0.11.0.tar.gz", hash = "sha256:9cf7081f3bd3742eef86a83b3638bcfba707927b448587e5c52198983ac15238", size = 163470, upload-time = "2026-01-13T22:34:35.568Z" }
 wheels = [
@@ -994,7 +1003,7 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1092,90 +1101,93 @@ wheels = [
 name = "crewai"
 source = { editable = "lib/crewai" }
 dependencies = [
-    { name = "aiosqlite" },
-    { name = "appdirs" },
-    { name = "chromadb" },
-    { name = "click" },
-    { name = "instructor" },
-    { name = "json-repair" },
-    { name = "json5" },
-    { name = "jsonref" },
-    { name = "lancedb" },
-    { name = "mcp" },
-    { name = "openai" },
-    { name = "openpyxl" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
-    { name = "pdfplumber" },
-    { name = "portalocker" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt" },
-    { name = "python-dotenv" },
-    { name = "regex" },
-    { name = "textual" },
-    { name = "tokenizers" },
-    { name = "tomli" },
-    { name = "tomli-w" },
-    { name = "uv" },
+    { name = "aiosqlite", marker = "platform_python_implementation == 'CPython'" },
+    { name = "appdirs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "chromadb", marker = "platform_python_implementation == 'CPython'" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "instructor", marker = "platform_python_implementation == 'CPython'" },
+    { name = "json-repair", marker = "platform_python_implementation == 'CPython'" },
+    { name = "json5", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonref", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lancedb", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mcp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openpyxl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdfplumber", marker = "platform_python_implementation == 'CPython'" },
+    { name = "portalocker", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-settings", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyjwt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "regex", marker = "platform_python_implementation == 'CPython'" },
+    { name = "textual", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli-w", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uv", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.optional-dependencies]
 a2a = [
-    { name = "a2a-sdk" },
-    { name = "aiocache", extra = ["memcached", "redis"] },
-    { name = "httpx-auth" },
-    { name = "httpx-sse" },
+    { name = "a2a-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aiocache", extra = ["memcached", "redis"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx-auth", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx-sse", marker = "platform_python_implementation == 'CPython'" },
 ]
 anthropic = [
-    { name = "anthropic" },
+    { name = "anthropic", marker = "platform_python_implementation == 'CPython'" },
 ]
 aws = [
-    { name = "aiobotocore" },
-    { name = "boto3" },
+    { name = "aiobotocore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "boto3", marker = "platform_python_implementation == 'CPython'" },
 ]
 azure-ai-inference = [
-    { name = "azure-ai-inference" },
+    { name = "azure-ai-inference", marker = "platform_python_implementation == 'CPython'" },
 ]
 bedrock = [
-    { name = "boto3" },
+    { name = "boto3", marker = "platform_python_implementation == 'CPython'" },
 ]
 docling = [
-    { name = "docling" },
+    { name = "docling", marker = "platform_python_implementation == 'CPython'" },
 ]
 embeddings = [
-    { name = "tiktoken" },
+    { name = "tiktoken", marker = "platform_python_implementation == 'CPython'" },
 ]
 file-processing = [
-    { name = "crewai-files" },
+    { name = "crewai-files", marker = "platform_python_implementation == 'CPython'" },
 ]
 google-genai = [
-    { name = "google-genai" },
+    { name = "google-genai", marker = "platform_python_implementation == 'CPython'" },
+]
+hindsight = [
+    { name = "hindsight-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 litellm = [
-    { name = "litellm" },
+    { name = "litellm", marker = "platform_python_implementation == 'CPython'" },
 ]
 mem0 = [
-    { name = "mem0ai" },
+    { name = "mem0ai", marker = "platform_python_implementation == 'CPython'" },
 ]
 openpyxl = [
-    { name = "openpyxl" },
+    { name = "openpyxl", marker = "platform_python_implementation == 'CPython'" },
 ]
 pandas = [
-    { name = "pandas" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
 ]
 qdrant = [
-    { name = "qdrant-client", extra = ["fastembed"] },
+    { name = "qdrant-client", extra = ["fastembed"], marker = "platform_python_implementation == 'CPython'" },
 ]
 tools = [
-    { name = "crewai-tools" },
+    { name = "crewai-tools", marker = "platform_python_implementation == 'CPython'" },
 ]
 voyageai = [
-    { name = "voyageai" },
+    { name = "voyageai", marker = "platform_python_implementation == 'CPython'" },
 ]
 watson = [
-    { name = "ibm-watsonx-ai" },
+    { name = "ibm-watsonx-ai", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.metadata]
@@ -1195,6 +1207,7 @@ requires-dist = [
     { name = "crewai-tools", marker = "extra == 'tools'", editable = "lib/crewai-tools" },
     { name = "docling", marker = "extra == 'docling'", specifier = "~=2.63.0" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = "~=1.49.0" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
     { name = "httpx-auth", marker = "extra == 'a2a'", specifier = "~=0.23.1" },
     { name = "httpx-sse", marker = "extra == 'a2a'", specifier = "~=0.4.0" },
     { name = "ibm-watsonx-ai", marker = "extra == 'watson'", specifier = "~=1.3.39" },
@@ -1229,18 +1242,18 @@ requires-dist = [
     { name = "uv", specifier = "~=0.9.13" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "hindsight", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-devtools"
 source = { editable = "lib/devtools" }
 dependencies = [
-    { name = "click" },
-    { name = "openai" },
-    { name = "pygithub" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "toml" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pygithub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "toml", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.metadata]
@@ -1257,13 +1270,13 @@ requires-dist = [
 name = "crewai-files"
 source = { editable = "lib/crewai-files" }
 dependencies = [
-    { name = "aiocache" },
-    { name = "aiofiles" },
-    { name = "av" },
-    { name = "pillow" },
-    { name = "pypdf" },
-    { name = "python-magic" },
-    { name = "tinytag" },
+    { name = "aiocache", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aiofiles", marker = "platform_python_implementation == 'CPython'" },
+    { name = "av", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-magic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tinytag", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.metadata]
@@ -1281,131 +1294,130 @@ requires-dist = [
 name = "crewai-tools"
 source = { editable = "lib/crewai-tools" }
 dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "crewai" },
-    { name = "docker" },
-    { name = "lancedb" },
-    { name = "pymupdf" },
-    { name = "python-docx" },
-    { name = "pytube" },
-    { name = "requests" },
-    { name = "tiktoken" },
-    { name = "youtube-transcript-api" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
+    { name = "crewai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docker", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lancedb", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pymupdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-docx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pytube", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tiktoken", marker = "platform_python_implementation == 'CPython'" },
+    { name = "youtube-transcript-api", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.optional-dependencies]
 apify = [
-    { name = "langchain-apify" },
+    { name = "langchain-apify", marker = "platform_python_implementation == 'CPython'" },
 ]
 beautifulsoup4 = [
-    { name = "beautifulsoup4" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
 ]
 bedrock = [
-    { name = "beautifulsoup4" },
-    { name = "bedrock-agentcore" },
-    { name = "nest-asyncio" },
-    { name = "playwright" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
+    { name = "bedrock-agentcore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nest-asyncio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "playwright", marker = "platform_python_implementation == 'CPython'" },
 ]
 browserbase = [
-    { name = "browserbase" },
+    { name = "browserbase", marker = "platform_python_implementation == 'CPython'" },
 ]
 composio-core = [
-    { name = "composio-core" },
+    { name = "composio-core", marker = "platform_python_implementation == 'CPython'" },
 ]
 contextual = [
-    { name = "contextual-client" },
-    { name = "nest-asyncio" },
+    { name = "contextual-client", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nest-asyncio", marker = "platform_python_implementation == 'CPython'" },
 ]
 couchbase = [
-    { name = "couchbase" },
+    { name = "couchbase", marker = "platform_python_implementation == 'CPython'" },
 ]
 databricks-sdk = [
-    { name = "databricks-sdk" },
+    { name = "databricks-sdk", marker = "platform_python_implementation == 'CPython'" },
 ]
 exa-py = [
-    { name = "exa-py" },
+    { name = "exa-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 firecrawl-py = [
-    { name = "firecrawl-py" },
+    { name = "firecrawl-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 github = [
-    { name = "gitpython" },
-    { name = "pygithub" },
+    { name = "gitpython", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pygithub", marker = "platform_python_implementation == 'CPython'" },
 ]
 hyperbrowser = [
-    { name = "hyperbrowser" },
+    { name = "hyperbrowser", marker = "platform_python_implementation == 'CPython'" },
 ]
 linkup-sdk = [
-    { name = "linkup-sdk" },
+    { name = "linkup-sdk", marker = "platform_python_implementation == 'CPython'" },
 ]
 mcp = [
-    { name = "mcp" },
-    { name = "mcpadapt" },
+    { name = "mcp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mcpadapt", marker = "platform_python_implementation == 'CPython'" },
 ]
 mongodb = [
-    { name = "pymongo" },
+    { name = "pymongo", marker = "platform_python_implementation == 'CPython'" },
 ]
 multion = [
-    { name = "multion" },
+    { name = "multion", marker = "platform_python_implementation == 'CPython'" },
 ]
 mysql = [
-    { name = "pymysql" },
+    { name = "pymysql", marker = "platform_python_implementation == 'CPython'" },
 ]
 oxylabs = [
-    { name = "oxylabs" },
+    { name = "oxylabs", marker = "platform_python_implementation == 'CPython'" },
 ]
 patronus = [
-    { name = "patronus" },
+    { name = "patronus", marker = "platform_python_implementation == 'CPython'" },
 ]
 postgresql = [
-    { name = "psycopg2-binary" },
+    { name = "psycopg2-binary", marker = "platform_python_implementation == 'CPython'" },
 ]
 qdrant-client = [
-    { name = "qdrant-client" },
+    { name = "qdrant-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 rag = [
-    { name = "lxml" },
-    { name = "python-docx" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-docx", marker = "platform_python_implementation == 'CPython'" },
 ]
 scrapegraph-py = [
-    { name = "scrapegraph-py" },
+    { name = "scrapegraph-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 scrapfly-sdk = [
-    { name = "scrapfly-sdk" },
+    { name = "scrapfly-sdk", marker = "platform_python_implementation == 'CPython'" },
 ]
 selenium = [
-    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "selenium", version = "4.40.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "selenium", marker = "platform_python_implementation == 'CPython'" },
 ]
 serpapi = [
-    { name = "serpapi" },
+    { name = "serpapi", marker = "platform_python_implementation == 'CPython'" },
 ]
 singlestore = [
-    { name = "singlestoredb" },
-    { name = "sqlalchemy" },
+    { name = "singlestoredb", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sqlalchemy", marker = "platform_python_implementation == 'CPython'" },
 ]
 snowflake = [
-    { name = "cryptography" },
-    { name = "snowflake-connector-python" },
-    { name = "snowflake-sqlalchemy" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "snowflake-connector-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "snowflake-sqlalchemy", marker = "platform_python_implementation == 'CPython'" },
 ]
 spider-client = [
-    { name = "spider-client" },
+    { name = "spider-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 sqlalchemy = [
-    { name = "sqlalchemy" },
+    { name = "sqlalchemy", marker = "platform_python_implementation == 'CPython'" },
 ]
 stagehand = [
-    { name = "stagehand" },
+    { name = "stagehand", marker = "platform_python_implementation == 'CPython'" },
 ]
 tavily-python = [
-    { name = "tavily-python" },
+    { name = "tavily-python", marker = "platform_python_implementation == 'CPython'" },
 ]
 weaviate-client = [
-    { name = "weaviate-client" },
+    { name = "weaviate-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 xml = [
-    { name = "unstructured", extra = ["all-docs", "local-inference"] },
+    { name = "unstructured", extra = ["all-docs", "local-inference"], marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.metadata]
@@ -1472,8 +1484,8 @@ name = "cryptography"
 version = "46.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
 wheels = [
@@ -1518,7 +1530,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -1550,9 +1562,9 @@ name = "databricks-sdk"
 version = "0.85.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth" },
-    { name = "protobuf" },
-    { name = "requests" },
+    { name = "google-auth", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/40/3941b6919c3854bd107e04be1686b3e0f1ce3ca4fbeea0c7fd81909bd90c/databricks_sdk-0.85.0.tar.gz", hash = "sha256:0b5f415fba69ea0c5bfc4d0b21cb3366c6b66f678e78e4b3c94cbcf2e9e0972f", size = 846275, upload-time = "2026-02-05T08:22:40.488Z" }
 wheels = [
@@ -1564,8 +1576,8 @@ name = "dataclasses-json"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "marshmallow" },
-    { name = "typing-inspect" },
+    { name = "marshmallow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-inspect", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
 wheels = [
@@ -1595,7 +1607,7 @@ name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
@@ -1607,7 +1619,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -1664,10 +1676,9 @@ name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "pywin32", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
@@ -1679,34 +1690,34 @@ name = "docling"
 version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate" },
-    { name = "beautifulsoup4" },
-    { name = "certifi" },
-    { name = "docling-core", extra = ["chunking"] },
-    { name = "docling-ibm-models" },
-    { name = "docling-parse" },
-    { name = "filetype" },
-    { name = "huggingface-hub" },
-    { name = "lxml" },
-    { name = "marko" },
-    { name = "ocrmac", marker = "sys_platform == 'darwin'" },
-    { name = "openpyxl" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pluggy" },
-    { name = "polyfactory" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pylatexenc" },
-    { name = "pypdfium2" },
-    { name = "python-docx" },
-    { name = "python-pptx" },
-    { name = "rapidocr" },
-    { name = "requests" },
-    { name = "rtree" },
-    { name = "scipy" },
-    { name = "tqdm" },
-    { name = "typer" },
+    { name = "accelerate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docling-core", extra = ["chunking"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "docling-ibm-models", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docling-parse", marker = "platform_python_implementation == 'CPython'" },
+    { name = "filetype", marker = "platform_python_implementation == 'CPython'" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "marko", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ocrmac", marker = "platform_python_implementation == 'CPython' and sys_platform == 'darwin'" },
+    { name = "openpyxl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pluggy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "polyfactory", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-settings", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pylatexenc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdfium2", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-docx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-pptx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rapidocr", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rtree", marker = "platform_python_implementation == 'CPython'" },
+    { name = "scipy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typer", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/c4/a8b7c66f0902ed4d0bcd87db94d3929539ac5fdff5325978744b30bee6b1/docling-2.63.0.tar.gz", hash = "sha256:5592c25e986ebf58811bcbfdbc8217d1a2074638b5412364968a1f1482994cc8", size = 250895, upload-time = "2025-11-20T14:43:53.131Z" }
 wheels = [
@@ -1718,16 +1729,16 @@ name = "docling-core"
 version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonref" },
-    { name = "jsonschema" },
-    { name = "latex2mathml" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tabulate" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "jsonref", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema", marker = "platform_python_implementation == 'CPython'" },
+    { name = "latex2mathml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tabulate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/76/f6a1333c0ce4c20e60358185ff8b7fa92e1e1561a43a6788e7c8aaa9898e/docling_core-2.63.0.tar.gz", hash = "sha256:946cf97f27cb81a2c6507121045a356be91e40b5a06bbaf028ca7036df78b2f1", size = 251016, upload-time = "2026-02-03T14:41:07.158Z" }
 wheels = [
@@ -1736,13 +1747,13 @@ wheels = [
 
 [package.optional-dependencies]
 chunking = [
-    { name = "semchunk" },
-    { name = "transformers" },
-    { name = "tree-sitter" },
-    { name = "tree-sitter-c" },
-    { name = "tree-sitter-javascript" },
-    { name = "tree-sitter-python" },
-    { name = "tree-sitter-typescript" },
+    { name = "semchunk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "transformers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tree-sitter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tree-sitter-c", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tree-sitter-javascript", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tree-sitter-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tree-sitter-typescript", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -1750,19 +1761,19 @@ name = "docling-ibm-models"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate" },
-    { name = "docling-core" },
-    { name = "huggingface-hub" },
-    { name = "jsonlines" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "rtree" },
-    { name = "safetensors", extra = ["torch"] },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
+    { name = "accelerate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docling-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonlines", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rtree", marker = "platform_python_implementation == 'CPython'" },
+    { name = "safetensors", extra = ["torch"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torchvision", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "transformers", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/91/f883e0a2b3466e1126dfd4463f386c70f5b90d271c27b6f5a97d2f8312e6/docling_ibm_models-3.11.0.tar.gz", hash = "sha256:454401563a8e79cb33b718bc559d9bacca8a0183583e48f8e616c9184c1f5eb1", size = 87721, upload-time = "2026-01-23T12:29:35.384Z" }
 wheels = [
@@ -1774,11 +1785,11 @@ name = "docling-parse"
 version = "4.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docling-core" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "tabulate" },
+    { name = "docling-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pywin32", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "tabulate", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/7a/653c3b11920113217724fab9b4740f9f8964864f92a2a27590accecec5ac/docling_parse-4.7.3.tar.gz", hash = "sha256:5936e6bcb7969c2a13f38ecc75cada3b0919422dc845e96da4b0b7b3bbc394ce", size = 67646746, upload-time = "2026-01-14T14:18:19.376Z" }
 wheels = [
@@ -1824,11 +1835,11 @@ name = "effdet"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "omegaconf" },
-    { name = "pycocotools" },
-    { name = "timm" },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "omegaconf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pycocotools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "timm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torchvision", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/c3/12d45167ec36f7f9a5ed80bc2128392b3f6207f760d437287d32a0e43f41/effdet-0.4.1.tar.gz", hash = "sha256:ac5589fd304a5650c201986b2ef5f8e10c111093a71b1c49fa6b8817710812b5", size = 110134, upload-time = "2023-05-21T22:18:01.039Z" }
 wheels = [
@@ -1867,13 +1878,13 @@ name = "exa-py"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "httpcore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/3b/36b15e7fd1e3bd85237378a5ef22f0d84eeb74ae50b72f4aeea5a6e8a84b/exa_py-2.3.0.tar.gz", hash = "sha256:9511848795e2bc6e37c00868a2a85ba4ce6784254d4b5f514c8b29eca6ad362a", size = 47929, upload-time = "2026-02-01T23:51:18.851Z" }
 wheels = [
@@ -1885,7 +1896,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1906,7 +1917,7 @@ name = "faker"
 version = "40.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/7e/dccb7013c9f3d66f2e379383600629fec75e4da2698548bdbf2041ea4b51/faker-40.4.0.tar.gz", hash = "sha256:76f8e74a3df28c3e2ec2caafa956e19e37a132fdc7ea067bc41783affcfee364", size = 1952221, upload-time = "2026-02-06T23:30:15.515Z" }
 wheels = [
@@ -1918,11 +1929,11 @@ name = "fastapi"
 version = "0.128.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-doc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "starlette", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-inspection", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/d4/811e7283aaaa84f1e7bd55fb642b58f8c01895e4884a9b7628cb55e00d63/fastapi-0.128.5.tar.gz", hash = "sha256:a7173579fc162d6471e3c6fbd9a4b7610c7a3b367bcacf6c4f90d5d022cab711", size = 374636, upload-time = "2026-02-08T10:22:30.493Z" }
 wheels = [
@@ -1934,19 +1945,18 @@ name = "fastembed"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation == 'CPython'",
 ]
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version >= '3.13'" },
-    { name = "loguru", marker = "python_full_version >= '3.13'" },
-    { name = "mmh3", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", marker = "python_full_version >= '3.13'" },
-    { name = "pillow", marker = "python_full_version >= '3.13'" },
-    { name = "py-rust-stemmers", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "tokenizers", marker = "python_full_version >= '3.13'" },
-    { name = "tqdm", marker = "python_full_version >= '3.13'" },
+    { name = "huggingface-hub", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "loguru", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "mmh3", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "py-rust-stemmers", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/f6/e8d3d9d487f95b698c9ff0d04d4e050d8fca9fa4cba58cff60fd519d1976/fastembed-0.7.3.tar.gz", hash = "sha256:04e95eb5ccc706513166c23bf8e5429ed160c5783b7b11514431a77624d480a5", size = 66561, upload-time = "2025-08-29T11:19:46.521Z" }
 wheels = [
@@ -1958,24 +1968,21 @@ name = "fastembed"
 version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'CPython'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'CPython'",
+    "python_full_version < '3.11' and platform_python_implementation == 'CPython'",
 ]
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version < '3.13'" },
-    { name = "loguru", marker = "python_full_version < '3.13'" },
-    { name = "mmh3", marker = "python_full_version < '3.13'" },
-    { name = "numpy", marker = "python_full_version < '3.13'" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.13'" },
-    { name = "py-rust-stemmers", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
-    { name = "tokenizers", marker = "python_full_version < '3.13'" },
-    { name = "tqdm", marker = "python_full_version < '3.13'" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "loguru", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "mmh3", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "py-rust-stemmers", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/c2/9c708680de1b54480161e0505f9d6d3d8eb47a1dc1a1f7f3c5106ba355d2/fastembed-0.7.4.tar.gz", hash = "sha256:8b8a4ea860ca295002f4754e8f5820a636e1065a9444959e18d5988d7f27093b", size = 68807, upload-time = "2025-12-05T12:08:10.447Z" }
 wheels = [
@@ -1987,7 +1994,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future" },
+    { name = "future", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -2017,13 +2024,13 @@ name = "firecrawl-py"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "httpx" },
-    { name = "nest-asyncio" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "websockets" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nest-asyncio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websockets", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/d0/772ab9337c99f67efdacb85188fa45d67fe960b650d63df3159ddc97943e/firecrawl_py-4.14.0.tar.gz", hash = "sha256:c4f341d7e0a26c23761ba87b75083dc38561075055c92f71f7399ca590b94e39", size = 164283, upload-time = "2026-01-30T00:02:41.083Z" }
 wheels = [
@@ -2191,7 +2198,7 @@ name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smmap" },
+    { name = "smmap", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
 wheels = [
@@ -2203,7 +2210,7 @@ name = "gitpython"
 version = "3.1.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gitdb" },
+    { name = "gitdb", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/45/cee7af549b6fa33f04531e402693a772b776cd9f845a2cbeca99cfac3331/GitPython-3.1.38.tar.gz", hash = "sha256:4d683e8957c8998b58ddb937e3e6cd167215a180e1ffd4da769ab81c620a89fe", size = 200632, upload-time = "2023-10-17T06:09:52.235Z" }
 wheels = [
@@ -2215,11 +2222,11 @@ name = "google-api-core"
 version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
+    { name = "google-auth", marker = "platform_python_implementation == 'CPython'" },
+    { name = "googleapis-common-protos", marker = "platform_python_implementation == 'CPython'" },
+    { name = "proto-plus", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", size = 177828, upload-time = "2026-01-08T22:21:39.269Z" }
 wheels = [
@@ -2228,8 +2235,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio" },
-    { name = "grpcio-status" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio-status", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -2237,9 +2244,9 @@ name = "google-auth"
 version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-    { name = "rsa" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyasn1-modules", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rsa", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
 wheels = [
@@ -2251,11 +2258,11 @@ name = "google-cloud-vision"
 version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
+    { name = "google-api-core", extra = ["grpc"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "google-auth", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "proto-plus", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/97/ceb4ace86ac302042f409ba1b3887e8a5c0adec7849cde3eec01c42872c1/google_cloud_vision-3.12.1.tar.gz", hash = "sha256:f99b83af7588d30e708b87e09ff73e43e380497fe82c799b9f05e03f310027c8", size = 587767, upload-time = "2026-02-05T18:59:23.603Z" }
 wheels = [
@@ -2267,14 +2274,14 @@ name = "google-genai"
 version = "1.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "google-auth" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "google-auth", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websockets", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/49/1a724ee3c3748fa50721d53a52d9fee88c67d0c43bb16eb2b10ee89ab239/google_genai-1.49.0.tar.gz", hash = "sha256:35eb16023b72e298571ae30e919c810694f258f2ba68fc77a2185c7c8829ad5a", size = 253493, upload-time = "2025-11-05T22:41:03.278Z" }
 wheels = [
@@ -2286,7 +2293,7 @@ name = "googleapis-common-protos"
 version = "1.72.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
@@ -2341,7 +2348,7 @@ name = "grpcio"
 version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
@@ -2392,9 +2399,9 @@ name = "grpcio-status"
 version = "1.71.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "protobuf" },
+    { name = "googleapis-common-protos", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
 wheels = [
@@ -2415,8 +2422,8 @@ name = "h2"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
+    { name = "hpack", marker = "platform_python_implementation == 'CPython'" },
+    { name = "hyperframe", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
@@ -2446,6 +2453,23 @@ wheels = [
 ]
 
 [[package]]
+name = "hindsight-client"
+version = "0.4.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aiohttp-retry", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/e0/da34dc62a72ef1b5f70ad989ac908a330c100a555bcd833f75e1937626de/hindsight_client-0.4.12.tar.gz", hash = "sha256:704d0a01a1b94277f7e6f69e0beeae9adb82b643f1d67a7f404fcf50cc03cbe8", size = 66529, upload-time = "2026-02-18T13:14:05.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/31/9d236a77a046bc30c45d36ac3de8fbf45da0ad6faf553c752a96c89a3fef/hindsight_client-0.4.12-py3-none-any.whl", hash = "sha256:b87cd82e5e967bc0aaca5bc6d5939092789d49af4fd80a21f170533c3b72e55d", size = 161378, upload-time = "2026-02-18T13:14:03.937Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2459,8 +2483,8 @@ name = "html5lib"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
-    { name = "webencodings" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "webencodings", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
 wheels = [
@@ -2472,8 +2496,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "h11", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -2521,10 +2545,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpcore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -2533,7 +2557,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2" },
+    { name = "h2", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -2541,7 +2565,7 @@ name = "httpx-auth"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/d4/6bd616f89d1ce43f602b62ec274e33beee6c2bce3d68396e692daafdb57d/httpx_auth-0.23.1.tar.gz", hash = "sha256:27b5a6022ad1b41a303b8737fa2e3e4bce6bbbe7ab67fed0b261359be62e0434", size = 121418, upload-time = "2025-01-07T18:47:20.05Z" }
 wheels = [
@@ -2562,14 +2586,14 @@ name = "huggingface-hub"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "platform_python_implementation == 'CPython'" },
+    { name = "fsspec", marker = "platform_python_implementation == 'CPython'" },
+    { name = "hf-xet", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython') or (platform_machine == 'amd64' and platform_python_implementation == 'CPython') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython')" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
@@ -2581,7 +2605,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2593,9 +2617,9 @@ name = "hyperbrowser"
 version = "0.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "jsonref" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonref", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/4a/0305447a79e8ee8b66ebabb686d5bce3618126bd322d8c6fa16e4822a366/hyperbrowser-0.83.0.tar.gz", hash = "sha256:7000a77b2d0bd5d6522d960b52e1aa5bf952abf72871d330d60c0439f935bf0d", size = 34250, upload-time = "2026-02-08T00:35:03.591Z" }
 wheels = [
@@ -2613,101 +2637,33 @@ wheels = [
 
 [[package]]
 name = "ibm-cos-sdk"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-]
-dependencies = [
-    { name = "ibm-cos-sdk-core", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "ibm-cos-sdk-s3transfer", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "jmespath", marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/0f/976e187ba09f5efee94a371f0d65edca82714975de7e71bf6ad8d30f20a7/ibm_cos_sdk-2.14.2.tar.gz", hash = "sha256:d859422c1dfd03e52cd66acbb2b45b4c944a390725c3a91d4a8e003f0cfc4e4b", size = 58847, upload-time = "2025-06-18T05:04:01.193Z" }
-
-[[package]]
-name = "ibm-cos-sdk"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
-]
 dependencies = [
-    { name = "ibm-cos-sdk-core", version = "2.14.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "ibm-cos-sdk-s3transfer", version = "2.14.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "jmespath", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "ibm-cos-sdk-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ibm-cos-sdk-s3transfer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jmespath", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/b8/b99f17ece72d4bccd7e75539b9a294d0f73ace5c6c475d8f2631afd6f65b/ibm_cos_sdk-2.14.3.tar.gz", hash = "sha256:643b6f2aa1683adad7f432df23407d11ae5adb9d9ad01214115bee77dc64364a", size = 58831, upload-time = "2025-08-01T06:35:51.722Z" }
 
 [[package]]
 name = "ibm-cos-sdk-core"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-]
-dependencies = [
-    { name = "jmespath", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "python-dateutil", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "requests", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/db/e913f210d66c2ad09521925f29754fb9b7240da11238a29a0186ebad4ffa/ibm_cos_sdk_core-2.14.2.tar.gz", hash = "sha256:d594b2af58f70e892aa3b0f6ae4b0fa5d412422c05beeba083d4561b5fad91b4", size = 1103504, upload-time = "2025-06-18T05:03:42.969Z" }
-
-[[package]]
-name = "ibm-cos-sdk-core"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
-]
 dependencies = [
-    { name = "jmespath", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "python-dateutil", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "requests", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "jmespath", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/45/80c23aa1e13175a9deefe43cbf8e853a3d3bfc8dfa8b6d6fe83e5785fe21/ibm_cos_sdk_core-2.14.3.tar.gz", hash = "sha256:85dee7790c92e8db69bf39dae4c02cac211e3c1d81bb86e64fa2d1e929674623", size = 1103637, upload-time = "2025-08-01T06:35:41.645Z" }
 
 [[package]]
 name = "ibm-cos-sdk-s3transfer"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-]
-dependencies = [
-    { name = "ibm-cos-sdk-core", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ca/3c4c48c2a180e3410d08b400435b72648e6630c2d556beb126b7a21a78d7/ibm_cos_sdk_s3transfer-2.14.2.tar.gz", hash = "sha256:01d1cb14c0decaeef273979da7a13f7a874f1d4c542ff3ae0a186c7b090569bc", size = 139579, upload-time = "2025-06-18T05:03:48.841Z" }
-
-[[package]]
-name = "ibm-cos-sdk-s3transfer"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
-]
 dependencies = [
-    { name = "ibm-cos-sdk-core", version = "2.14.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "ibm-cos-sdk-core", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ff/c9baf0997266d398ae08347951a2970e5e96ed6232ed0252f649f2b9a7eb/ibm_cos_sdk_s3transfer-2.14.3.tar.gz", hash = "sha256:2251ebfc4a46144401e431f4a5d9f04c262a0d6f95c88a8e71071da056e55f72", size = 139594, upload-time = "2025-08-01T06:35:46.403Z" }
 
@@ -2716,18 +2672,16 @@ name = "ibm-watsonx-ai"
 version = "1.3.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "ibm-cos-sdk", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "ibm-cos-sdk", version = "2.14.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "lomond" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cachetools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ibm-cos-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lomond", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tabulate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/56/2e3df38a1f13062095d7bde23c87a92f3898982993a15186b1bfecbd206f/ibm_watsonx_ai-1.3.42.tar.gz", hash = "sha256:ee5be59009004245d957ce97d1227355516df95a2640189749487614fef674ff", size = 688651, upload-time = "2025-10-01T13:35:41.527Z" }
 wheels = [
@@ -2868,7 +2822,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2907,19 +2861,19 @@ name = "instructor"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "diskcache" },
-    { name = "docstring-parser" },
-    { name = "jinja2" },
-    { name = "jiter" },
-    { name = "openai" },
-    { name = "pre-commit" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "tenacity" },
-    { name = "typer" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "diskcache", marker = "platform_python_implementation == 'CPython'" },
+    { name = "docstring-parser", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jinja2", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jiter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pre-commit", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typer", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/4d/cc37bc2bb0fcd9584f4935ecb5f4b23d33c63ddeea20d899d4d99f72a69a/instructor-1.12.0.tar.gz", hash = "sha256:f0e4dd7f275120f49200df0204af6a2d4e3e2f1f698b6b8c0f776e3a8c977e54", size = 69892486, upload-time = "2025-10-27T18:47:55.191Z" }
 wheels = [
@@ -2949,7 +2903,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -3056,7 +3010,7 @@ name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/87/bcda8e46c88d0e34cad2f09ee2d0c7f5957bccdb9791b0b934ec84d84be4/jsonlines-4.0.0.tar.gz", hash = "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74", size = 11359, upload-time = "2023-09-01T12:34:44.187Z" }
 wheels = [
@@ -3068,7 +3022,7 @@ name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpointer" },
+    { name = "jsonpointer", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
@@ -3098,10 +3052,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema-specifications", marker = "platform_python_implementation == 'CPython'" },
+    { name = "referencing", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rpds-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -3113,7 +3067,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -3207,16 +3161,15 @@ name = "kubernetes"
 version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "durationpy" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "six" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "websocket-client" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "durationpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests-oauthlib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websocket-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
 wheels = [
@@ -3228,19 +3181,19 @@ name = "lancedb"
 version = "0.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "cachetools" },
-    { name = "click" },
-    { name = "deprecation" },
-    { name = "overrides" },
-    { name = "pydantic" },
-    { name = "pylance" },
-    { name = "pyyaml" },
-    { name = "ratelimiter" },
-    { name = "requests" },
-    { name = "retry" },
-    { name = "semver" },
-    { name = "tqdm" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cachetools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "deprecation", marker = "platform_python_implementation == 'CPython'" },
+    { name = "overrides", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pylance", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ratelimiter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "retry", marker = "platform_python_implementation == 'CPython'" },
+    { name = "semver", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/1b/f87a2b6420f6f55ea64e5f8f18f231450cc602a0854739bcf946cebc080a/lancedb-0.5.7.tar.gz", hash = "sha256:878914b493f91d09a77b14f1528104741f273234cbdd6671be705f447701fd51", size = 102890, upload-time = "2024-02-22T20:11:29.988Z" }
 wheels = [
@@ -3252,9 +3205,9 @@ name = "langchain-apify"
 version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apify-client" },
-    { name = "eval-type-backport" },
-    { name = "langchain-core" },
+    { name = "apify-client", marker = "platform_python_implementation == 'CPython'" },
+    { name = "eval-type-backport", marker = "platform_python_implementation == 'CPython'" },
+    { name = "langchain-core", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/ab/82bf8840ec6ee13cf217862eeb12d341007cefa25130122c6519422489b5/langchain_apify-0.1.6.tar.gz", hash = "sha256:9816df0a3f59f756dfda4f8fe36a283ae31902ad5b64f2fc493c3d56e58b13e3", size = 15226, upload-time = "2025-11-25T15:54:45.324Z" }
 wheels = [
@@ -3266,13 +3219,13 @@ name = "langchain-core"
 version = "0.3.76"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpatch" },
-    { name = "langsmith" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
+    { name = "jsonpatch", marker = "platform_python_implementation == 'CPython'" },
+    { name = "langsmith", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/4d/5e2ea7754ee0a1f524c412801c6ba9ad49318ecb58b0d524903c3d9efe0a/langchain_core-0.3.76.tar.gz", hash = "sha256:71136a122dd1abae2c289c5809d035cf12b5f2bb682d8a4c1078cd94feae7419", size = 573568, upload-time = "2025-09-10T14:49:39.863Z" }
 wheels = [
@@ -3284,7 +3237,7 @@ name = "langchain-text-splitters"
 version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "langchain-core", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
 wheels = [
@@ -3296,7 +3249,7 @@ name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
 
@@ -3305,15 +3258,15 @@ name = "langsmith"
 version = "0.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "uuid-utils" },
-    { name = "xxhash" },
-    { name = "zstandard" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "orjson", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests-toolbelt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uuid-utils", marker = "platform_python_implementation == 'CPython'" },
+    { name = "xxhash", marker = "platform_python_implementation == 'CPython'" },
+    { name = "zstandard", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/e0/463a70b43d6755b01598bb59932eec8e2029afcab455b5312c318ac457b5/langsmith-0.6.9.tar.gz", hash = "sha256:aae04cec6e6d8e133f63ba71c332ce0fbd2cda95260db7746ff4c3b6a3c41db1", size = 973557, upload-time = "2026-02-05T20:10:55.629Z" }
 wheels = [
@@ -3385,7 +3338,7 @@ name = "linkify-it-py"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "uc-micro-py" },
+    { name = "uc-micro-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
 wheels = [
@@ -3397,8 +3350,8 @@ name = "linkup-sdk"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/02/d04165f652c3bb3f38f2c2c737c7e2664d3a9c49cabb6f22f8bb443a6f5a/linkup_sdk-0.10.0.tar.gz", hash = "sha256:8905423199504a1c9df78f0f4cab8f2d15cd1a9f98b14e7e2ca5e3997fed0d20", size = 60732, upload-time = "2026-01-15T18:09:48.706Z" }
 wheels = [
@@ -3410,17 +3363,17 @@ name = "litellm"
 version = "1.75.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "importlib-metadata", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jinja2", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema", marker = "platform_python_implementation == 'CPython'" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tiktoken", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/98/ea40c48fda5121af00e44c9c6d01a0cd8cb9987bb0ce91c6add917d9db9d/litellm-1.75.3.tar.gz", hash = "sha256:a6a0f33884f35a9391a9a4363043114d7f2513ab2e5c2e1fa54c56d695663764", size = 10104437, upload-time = "2025-08-08T14:58:09.423Z" }
 wheels = [
@@ -3456,8 +3409,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -3469,7 +3422,7 @@ name = "lomond"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/9e/ef7813c910d4a893f2bc763ce9246269f55cc68db21dc1327e376d6a2d02/lomond-0.3.3.tar.gz", hash = "sha256:427936596b144b4ec387ead99aac1560b77c8a78107d3d49415d3abbe79acbd3", size = 28789, upload-time = "2018-09-21T15:17:43.297Z" }
 wheels = [
@@ -3572,7 +3525,7 @@ name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -3581,7 +3534,7 @@ wheels = [
 
 [package.optional-dependencies]
 linkify = [
-    { name = "linkify-it-py" },
+    { name = "linkify-it-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -3661,7 +3614,7 @@ name = "marshmallow"
 version = "3.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
@@ -3673,15 +3626,15 @@ name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy" },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cycler", marker = "platform_python_implementation == 'CPython'" },
+    { name = "fonttools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "kiwisolver", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyparsing", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269, upload-time = "2025-12-10T22:56:51.155Z" }
 wheels = [
@@ -3732,20 +3685,20 @@ name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx-sse", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jsonschema", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-settings", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-multipart", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pywin32", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "sse-starlette", marker = "platform_python_implementation == 'CPython'" },
+    { name = "starlette", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-inspection", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uvicorn", marker = "platform_python_implementation == 'CPython' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -3754,7 +3707,7 @@ wheels = [
 
 [package.optional-dependencies]
 ws = [
-    { name = "websockets" },
+    { name = "websockets", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -3762,10 +3715,10 @@ name = "mcpadapt"
 version = "0.1.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonref" },
-    { name = "mcp", extra = ["ws"] },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
+    { name = "jsonref", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mcp", extra = ["ws"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3777,7 +3730,7 @@ name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
 wheels = [
@@ -3798,13 +3751,13 @@ name = "mem0ai"
 version = "0.1.116"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openai" },
-    { name = "posthog" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pytz" },
-    { name = "qdrant-client" },
-    { name = "sqlalchemy" },
+    { name = "openai", marker = "platform_python_implementation == 'CPython'" },
+    { name = "posthog", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pytz", marker = "platform_python_implementation == 'CPython'" },
+    { name = "qdrant-client", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sqlalchemy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/a0/10482cc437e96d609d5fbbb65ad8eae144fc84f0cb2655d913bfb58d7dff/mem0ai-0.1.116.tar.gz", hash = "sha256:c33e08c5464f96b1cf109893dba5d394d8cc5788a8400d85cb1ceed696ee3204", size = 122053, upload-time = "2025-08-13T20:19:41.119Z" }
 wheels = [
@@ -3816,7 +3769,7 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -3937,9 +3890,9 @@ name = "mpire"
 version = "2.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "tqdm" },
+    { name = "pygments", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pywin32", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/93/80ac75c20ce54c785648b4ed363c88f148bf22637e10c9863db4fbe73e74/mpire-2.10.2.tar.gz", hash = "sha256:f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97", size = 271270, upload-time = "2024-05-07T14:00:31.815Z" }
 wheels = [
@@ -3948,7 +3901,7 @@ wheels = [
 
 [package.optional-dependencies]
 dill = [
-    { name = "multiprocess" },
+    { name = "multiprocess", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -3965,8 +3918,8 @@ name = "msoffcrypto-tool"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "olefile" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "olefile", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/34/6250bdddaeaae24098e45449ea362fb3555a65fba30cad0ad5630ea48d1a/msoffcrypto_tool-6.0.0.tar.gz", hash = "sha256:9a5ebc4c0096b42e5d7ebc2350afdc92dc511061e935ca188468094fdd032bbe", size = 40593, upload-time = "2026-01-12T08:59:56.73Z" }
 wheels = [
@@ -3978,7 +3931,7 @@ name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
@@ -4080,10 +4033,10 @@ name = "multion"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "pydantic" },
-    { name = "typing-extensions" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx-sse", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/88/08fe355223be0ff0f9d6c975958235a0306de091c16a0fa2b5eea533a3b4/multion-1.1.0.tar.gz", hash = "sha256:a71780426a5401a528eadc89206e2217e8a5b1e4fd332952418716675f32cf81", size = 19245, upload-time = "2024-04-25T03:43:14.417Z" }
 wheels = [
@@ -4095,7 +4048,7 @@ name = "multiprocess"
 version = "0.70.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
+    { name = "dill", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
 wheels = [
@@ -4117,11 +4070,11 @@ name = "mypy"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
+    { name = "librt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mypy-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pathspec", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/b5/b58cdc25fadd424552804bf410855d52324183112aa004f0732c5f6324cf/mypy-1.19.0.tar.gz", hash = "sha256:f6b874ca77f733222641e5c46e4711648c4037ea13646fd0cdc814c2eaec2528", size = 3579025, upload-time = "2025-11-28T15:49:01.26Z" }
 wheels = [
@@ -4157,7 +4110,7 @@ name = "mypy-boto3-bedrock-runtime"
 version = "1.40.76"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/db/cc668a48a27973df31c7044a6785bd0e8691b1a0419dae001c4c29f1c98f/mypy_boto3_bedrock_runtime-1.40.76.tar.gz", hash = "sha256:52f2a2b3955eb9f4f0d075398f2d430abcc6bf56ff00815b94e3371e66030059", size = 28428, upload-time = "2025-11-18T21:42:43.41Z" }
 wheels = [
@@ -4196,10 +4149,10 @@ name = "nltk"
 version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "joblib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "regex", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
 wheels = [
@@ -4220,8 +4173,8 @@ name = "numba"
 version = "0.63.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
+    { name = "llvmlite", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/60/0145d479b2209bd8fdae5f44201eceb8ce5a23e0ed54c71f57db24618665/numba-0.63.1.tar.gz", hash = "sha256:b320aa675d0e3b17b40364935ea52a7b1c670c9037c39cf92c49502a75902f4b", size = 2761666, upload-time = "2025-12-10T02:57:39.002Z" }
 wheels = [
@@ -4342,7 +4295,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4353,7 +4306,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4380,9 +4333,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4393,7 +4346,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4453,9 +4406,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-vision", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -4476,8 +4429,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "pyyaml" },
+    { name = "antlr4-python3-runtime", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -4489,10 +4442,10 @@ name = "onnx"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "ml-dtypes", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/8a/335c03a8683a88a32f9a6bb98899ea6df241a41df64b37b9696772414794/onnx-1.20.1.tar.gz", hash = "sha256:ded16de1df563d51fbc1ad885f2a426f814039d8b5f4feb77febe09c0295ad67", size = 12048980, upload-time = "2026-01-10T01:40:03.043Z" }
 wheels = [
@@ -4525,12 +4478,12 @@ name = "onnxruntime"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
-    { name = "numpy", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
-    { name = "sympy", marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "flatbuffers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sympy", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -4562,14 +4515,14 @@ name = "openai"
 version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jiter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/5b/b9390060fa75c41281f30a139a9362be591337febde996400021aa8751fd/openai-1.83.0.tar.gz", hash = "sha256:dfb421837962d9e8078929d8fc7e36e51c2a110b23a777a14e27f579d1afd6b6", size = 465976, upload-time = "2025-06-02T19:39:56.991Z" }
 wheels = [
@@ -4581,7 +4534,7 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -4599,7 +4552,7 @@ name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "et-xmlfile" },
+    { name = "et-xmlfile", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
@@ -4611,8 +4564,8 @@ name = "opentelemetry-api"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
+    { name = "importlib-metadata", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/5e/94a8cb759e4e409022229418294e098ca7feca00eb3c467bb20cbd329bda/opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3", size = 64987, upload-time = "2025-06-10T08:55:19.818Z" }
 wheels = [
@@ -4624,8 +4577,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/ba/786b4de7e39d88043622d901b92c4485835f43e0be76c2824d2687911bc2/opentelemetry_exporter_otlp-1.34.1.tar.gz", hash = "sha256:71c9ad342d665d9e4235898d205db17c5764cd7a69acb8a5dcd6d5e04c4c9988", size = 6173, upload-time = "2025-06-10T08:55:21.595Z" }
 wheels = [
@@ -4637,7 +4590,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-proto", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/f0/ff235936ee40db93360233b62da932d4fd9e8d103cd090c6bcb9afaf5f01/opentelemetry_exporter_otlp_proto_common-1.34.1.tar.gz", hash = "sha256:b59a20a927facd5eac06edaf87a07e49f9e4a13db487b7d8a52b37cb87710f8b", size = 20817, upload-time = "2025-06-10T08:55:22.55Z" }
 wheels = [
@@ -4649,13 +4602,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-proto", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/f7/bb63837a3edb9ca857aaf5760796874e7cecddc88a2571b0992865a48fb6/opentelemetry_exporter_otlp_proto_grpc-1.34.1.tar.gz", hash = "sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd", size = 22566, upload-time = "2025-06-10T08:55:23.214Z" }
 wheels = [
@@ -4667,13 +4620,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-proto", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", size = 15351, upload-time = "2025-06-10T08:55:24.657Z" }
 wheels = [
@@ -4685,7 +4638,7 @@ name = "opentelemetry-proto"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/b3/c3158dd012463bb7c0eb7304a85a6f63baeeb5b4c93a53845cf89f848c7e/opentelemetry_proto-1.34.1.tar.gz", hash = "sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e", size = 34344, upload-time = "2025-06-10T08:55:32.25Z" }
 wheels = [
@@ -4697,9 +4650,9 @@ name = "opentelemetry-sdk"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-semantic-conventions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/41/fe20f9036433da8e0fcef568984da4c1d1c771fa072ecd1a4d98779dccdd/opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d", size = 159441, upload-time = "2025-06-10T08:55:33.028Z" }
 wheels = [
@@ -4711,8 +4664,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.55b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", size = 119829, upload-time = "2025-06-10T08:55:33.881Z" }
 wheels = [
@@ -4790,7 +4743,7 @@ name = "outcome"
 version = "1.3.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
 wheels = [
@@ -4811,8 +4764,8 @@ name = "oxylabs"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "requests" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/03/eb10466e12d2a7aba1ff1e70264c443dedeba0e5721a9a1be7e9ac9e9092/oxylabs-2.0.0.tar.gz", hash = "sha256:a6ee24140509c7ea7935ce4c878469558402dd43657718a1cae399740b66beb0", size = 29130, upload-time = "2025-03-28T13:54:16.285Z" }
 wheels = [
@@ -4833,10 +4786,10 @@ name = "pandas"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pytz", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tzdata", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
 wheels = [
@@ -4881,10 +4834,10 @@ name = "paramiko"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bcrypt" },
-    { name = "cryptography" },
-    { name = "invoke" },
-    { name = "pynacl" },
+    { name = "bcrypt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "invoke", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pynacl", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/81fdcbc7f190cdb058cffc9431587eb289833bdd633e2002455ca9bb13d4/paramiko-4.0.0.tar.gz", hash = "sha256:6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f", size = 1630743, upload-time = "2025-08-04T01:02:03.711Z" }
 wheels = [
@@ -4896,7 +4849,7 @@ name = "parsimonious"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex" },
+    { name = "regex", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/0b/8a3b9f4a4943b56e67247c65e1b0564ec9bf0718b85f3fd9502d70afaf32/parsimonious-0.11.0.tar.gz", hash = "sha256:e080377d98957beec053580d38ae54fcdf7c470fb78670ba4bf8b5f9d5cad2a9", size = 54238, upload-time = "2025-11-12T01:33:48.172Z" }
 wheels = [
@@ -4917,16 +4870,16 @@ name = "patronus"
 version = "0.1.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "patronus-api" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-exporter-otlp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opentelemetry-sdk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "patronus-api", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-settings", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/58/9816c13cf60dd842436bbc8e1068d221c07127e9322ab1d4aa5fa87e2fd6/patronus-0.1.24.tar.gz", hash = "sha256:72719b2889e467e01606a4689fa384350ce7590819ee5ee01a3e9266f963d72b", size = 357654, upload-time = "2025-10-17T11:56:06.247Z" }
 wheels = [
@@ -4938,12 +4891,12 @@ name = "patronus-api"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/fd/c7574e8557c7b695ed8e59463b5bf97329050618be5ffa1cf2d89ba76b7b/patronus_api-0.3.0.tar.gz", hash = "sha256:1fac77b4e1bf1678aa3210cf986e7a8c6ba9f8de7afe199a4ff0ba304da839b0", size = 127515, upload-time = "2025-06-24T14:54:42.144Z" }
 wheels = [
@@ -4955,7 +4908,7 @@ name = "pdf2image"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pillow" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/d8/b280f01045555dc257b8153c00dee3bc75830f91a744cd5f84ef3a0a64b1/pdf2image-1.17.0.tar.gz", hash = "sha256:eaa959bc116b420dd7ec415fcae49b98100dda3dd18cd2fdfa86d09f112f6d57", size = 12811, upload-time = "2024-01-07T20:33:01.965Z" }
 wheels = [
@@ -4967,8 +4920,8 @@ name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "charset-normalizer" },
-    { name = "cryptography" },
+    { name = "charset-normalizer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload-time = "2025-12-30T15:49:13.104Z" }
 wheels = [
@@ -4980,9 +4933,9 @@ name = "pdfplumber"
 version = "0.11.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pdfminer-six" },
-    { name = "pillow" },
-    { name = "pypdfium2" },
+    { name = "pdfminer-six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdfium2", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
@@ -4994,7 +4947,7 @@ name = "pi-heif"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pillow" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/90/ff6dcd9aa3b725f7eba9d70e1a12003effe45aa5bd438e3a20d14818f846/pi_heif-0.22.0.tar.gz", hash = "sha256:489ddda3c9fed948715a9c8642c6ee24c3b438a7fbf85b3a8f097d632d7082a8", size = 18548972, upload-time = "2025-03-15T13:21:38.631Z" }
 wheels = [
@@ -5038,10 +4991,10 @@ name = "pikepdf"
 version = "10.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
-    { name = "lxml" },
-    { name = "packaging" },
-    { name = "pillow" },
+    { name = "deprecated", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/ba/7635a5f4259a2a91ed4f094e358dec3068ecedc891d70b8e76a02904ca0c/pikepdf-10.3.0.tar.gz", hash = "sha256:e2a64a5f1ebf8c411193126b9eeff7faf5739a40bce7441e579531422469fbb1", size = 4575749, upload-time = "2026-01-30T07:33:53.317Z" }
 wheels = [
@@ -5148,8 +5101,8 @@ name = "playwright"
 version = "1.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet" },
-    { name = "pyee" },
+    { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyee", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
@@ -5176,8 +5129,8 @@ name = "polyfactory"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faker" },
-    { name = "typing-extensions" },
+    { name = "faker", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/92/e90639b1d2abe982749eba7e734571a343ea062f7d486498b1c2b852f019/polyfactory-3.2.0.tar.gz", hash = "sha256:879242f55208f023eee1de48522de5cb1f9fd2d09b2314e999a9592829d596d1", size = 346878, upload-time = "2025-12-21T11:18:51.017Z" }
 wheels = [
@@ -5189,7 +5142,7 @@ name = "portalocker"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f8/969e6f280201b40b31bcb62843c619f343dcc351dff83a5891530c9dd60e/portalocker-2.7.0.tar.gz", hash = "sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51", size = 20183, upload-time = "2023-01-18T23:36:14.436Z" }
 wheels = [
@@ -5201,11 +5154,11 @@ name = "posthog"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff" },
-    { name = "distro" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "six" },
+    { name = "backoff", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/20/60ae67bb9d82f00427946218d49e2e7e80fb41c15dc5019482289ec9ce8d/posthog-5.4.0.tar.gz", hash = "sha256:701669261b8d07cdde0276e5bc096b87f9e200e3b9589c5ebff14df658c5893c", size = 88076, upload-time = "2025-06-20T23:19:23.485Z" }
 wheels = [
@@ -5217,11 +5170,11 @@ name = "pre-commit"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
+    { name = "cfgv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "identify", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nodeenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "virtualenv", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/9b/6a4ffb4ed980519da959e1cf3122fc6cb41211daa58dbae1c73c0e519a37/pre_commit-4.5.0.tar.gz", hash = "sha256:dc5a065e932b19fc1d4c653c6939068fe54325af8e741e74e88db4d28a4dd66b", size = 198428, upload-time = "2025-11-22T21:02:42.304Z" }
 wheels = [
@@ -5317,7 +5270,7 @@ name = "proto-plus"
 version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929, upload-time = "2026-02-02T17:34:49.035Z" }
 wheels = [
@@ -5530,7 +5483,7 @@ name = "pyasn1-modules"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyasn1" },
+    { name = "pyasn1", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
@@ -5705,7 +5658,7 @@ name = "pycocotools"
 version = "2.0.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
 wheels = [
@@ -5753,10 +5706,10 @@ name = "pydantic"
 version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-inspection", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
 wheels = [
@@ -5768,7 +5721,7 @@ name = "pydantic-core"
 version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -5855,9 +5808,9 @@ name = "pydantic-settings"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-inspection", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
@@ -5869,7 +5822,7 @@ name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
@@ -5881,10 +5834,10 @@ name = "pygithub"
 version = "1.59.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "pynacl" },
-    { name = "requests" },
+    { name = "deprecated", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "pynacl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/30/203d3420960853e399de3b85d6613cea1cf17c1cf7fc9716f7ee7e17e0fc/PyGithub-1.59.1.tar.gz", hash = "sha256:c44e3a121c15bf9d3a5cc98d94c9a047a5132a9b01d22264627f58ade9ddc217", size = 3295328, upload-time = "2023-08-03T09:43:01.794Z" }
 wheels = [
@@ -5911,7 +5864,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -5919,8 +5872,8 @@ name = "pylance"
 version = "0.9.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyarrow", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/b8/15d4d380f0858dde46d42891776017e3bf9eb40129b3fe222637eecf8f43/pylance-0.9.18-cp38-abi3-macosx_10_15_x86_64.whl", hash = "sha256:fe2445d922c594d90e89111385106f6b152caab27996217db7bb4b8947eb0bea", size = 20319043, upload-time = "2024-02-19T07:36:11.206Z" },
@@ -5941,7 +5894,7 @@ name = "pymongo"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython" },
+    { name = "dnspython", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/9c/a4895c4b785fc9865a84a56e14b5bd21ca75aadc3dab79c14187cdca189b/pymongo-4.16.0.tar.gz", hash = "sha256:8ba8405065f6e258a6f872fe62d797a28f383a12178c7153c01ed04e845c600c", size = 2495323, upload-time = "2026-01-07T18:05:48.107Z" }
 wheels = [
@@ -6016,7 +5969,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -6052,7 +6005,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -6068,8 +6021,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-cocoa", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -6085,8 +6038,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-cocoa", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -6102,10 +6055,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-cocoa", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-coreml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyobjc-framework-quartz", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6121,8 +6074,8 @@ name = "pyopenssl"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
 wheels = [
@@ -6190,7 +6143,7 @@ name = "pypika"
 version = "0.51.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919, upload-time = "2026-02-04T11:27:48.304Z" }
 wheels = [
@@ -6220,8 +6173,8 @@ name = "pysher"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "websocket-client" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websocket-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/a0/d0638470df605ce266991fb04f74c69ab1bed3b90ac3838e9c3c8b69b66a/Pysher-1.0.8.tar.gz", hash = "sha256:7849c56032b208e49df67d7bd8d49029a69042ab0bb45b2ed59fa08f11ac5988", size = 9071, upload-time = "2022-10-10T13:41:09.936Z" }
 
@@ -6239,13 +6192,13 @@ name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "iniconfig", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pluggy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pygments", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -6257,9 +6210,9 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -6271,7 +6224,7 @@ name = "pytest-randomly"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
 wheels = [
@@ -6283,8 +6236,8 @@ name = "pytest-recording"
 version = "0.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
-    { name = "vcrpy" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
+    { name = "vcrpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/9c/f4027c5f1693847b06d11caf4b4f6bb09f22c1581ada4663877ec166b8c6/pytest_recording-0.13.4.tar.gz", hash = "sha256:568d64b2a85992eec4ae0a419c855d5fd96782c5fb016784d86f18053792768c", size = 26576, upload-time = "2025-05-08T10:41:11.231Z" }
 wheels = [
@@ -6296,7 +6249,7 @@ name = "pytest-split"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/d7/e30ba44adf83f15aee3f636daea54efadf735769edc0f0a7d98163f61038/pytest_split-0.10.0.tar.gz", hash = "sha256:adf80ba9fef7be89500d571e705b4f963dfa05038edf35e4925817e6b34ea66f", size = 13903, upload-time = "2024-10-16T15:45:19.783Z" }
 wheels = [
@@ -6308,7 +6261,7 @@ name = "pytest-subprocess"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ae/3ad5c609a5088936608af12f42ad72567a877d3c64303500ebc3b7df0297/pytest_subprocess-1.5.3.tar.gz", hash = "sha256:c00b1140fb0211b3153e09500d770db10770baccbe6e05ee9c140036d1d811d5", size = 42282, upload-time = "2025-01-04T13:08:16.877Z" }
 wheels = [
@@ -6320,7 +6273,7 @@ name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
@@ -6332,8 +6285,8 @@ name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
+    { name = "execnet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
@@ -6345,7 +6298,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -6357,8 +6310,8 @@ name = "python-docx"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
-    { name = "typing-extensions" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
 wheels = [
@@ -6406,9 +6359,9 @@ name = "python-oxmsg"
 version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "olefile" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "olefile", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/4e/869f34faedbc968796d2c7e9837dede079c9cb9750917356b1f1eda926e9/python_oxmsg-0.0.2.tar.gz", hash = "sha256:a6aff4deb1b5975d44d49dab1d9384089ffeec819e19c6940bc7ffbc84775fad", size = 34713, upload-time = "2025-02-03T17:13:47.415Z" }
 wheels = [
@@ -6420,10 +6373,10 @@ name = "python-pptx"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
-    { name = "pillow" },
-    { name = "typing-extensions" },
-    { name = "xlsxwriter" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "xlsxwriter", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
@@ -6518,14 +6471,13 @@ name = "qdrant-client"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "grpcio" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "numpy" },
-    { name = "portalocker" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", extra = ["http2"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "portalocker", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/56/3f355f931c239c260b4fe3bd6433ec6c9e6185cd5ae0970fe89d0ca6daee/qdrant_client-1.14.3.tar.gz", hash = "sha256:bb899e3e065b79c04f5e47053d59176150c0a5dabc09d7f476c8ce8e52f4d281", size = 286766, upload-time = "2025-06-16T11:13:47.838Z" }
 wheels = [
@@ -6534,8 +6486,8 @@ wheels = [
 
 [package.optional-dependencies]
 fastembed = [
-    { name = "fastembed", version = "0.7.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "fastembed", version = "0.7.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "fastembed", version = "0.7.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and platform_python_implementation == 'CPython'" },
+    { name = "fastembed", version = "0.7.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -6611,17 +6563,17 @@ name = "rapidocr"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorlog" },
-    { name = "numpy" },
-    { name = "omegaconf" },
-    { name = "opencv-python" },
-    { name = "pillow" },
-    { name = "pyclipper" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "shapely" },
-    { name = "six" },
-    { name = "tqdm" },
+    { name = "colorlog", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "omegaconf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "opencv-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyclipper", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "shapely", marker = "platform_python_implementation == 'CPython'" },
+    { name = "six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/fd/0d025466f0f84552634f2a94c018df34568fe55cc97184a6bb2c719c5b3a/rapidocr-3.6.0-py3-none-any.whl", hash = "sha256:d16b43872fc4dfa1e60996334dcd0dc3e3f1f64161e2332bc1873b9f65754e6b", size = 15067340, upload-time = "2026-01-28T14:45:04.271Z" },
@@ -6641,7 +6593,7 @@ name = "redis"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11.3' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669, upload-time = "2025-11-19T15:54:39.961Z" }
 wheels = [
@@ -6653,9 +6605,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rpds-py", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -6756,11 +6708,10 @@ name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "charset-normalizer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -6772,8 +6723,8 @@ name = "requests-oauthlib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
+    { name = "oauthlib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
@@ -6785,7 +6736,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -6797,8 +6748,8 @@ name = "retry"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator" },
-    { name = "py" },
+    { name = "decorator", marker = "platform_python_implementation == 'CPython'" },
+    { name = "py", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
 wheels = [
@@ -6810,8 +6761,8 @@ name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pygments", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
 wheels = [
@@ -6916,7 +6867,7 @@ name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyasn1" },
+    { name = "pyasn1", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
@@ -6970,7 +6921,7 @@ name = "s3transfer"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
+    { name = "botocore", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
@@ -7005,9 +6956,9 @@ wheels = [
 
 [package.optional-dependencies]
 torch = [
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "torch" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -7015,7 +6966,7 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -7071,12 +7022,12 @@ name = "scrapegraph-py"
 version = "1.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "beautifulsoup4" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "toonify" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "toonify", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/3c/573fd78a01d27af4bae28134129eaf81b5dd270cb6fbd5229833298a8058/scrapegraph_py-1.46.0.tar.gz", hash = "sha256:95cab89d63b1d5809bb96ddabd3dffc53f16dc9b92dda2d642e9155c3db2806d", size = 327431, upload-time = "2026-01-26T13:59:24.237Z" }
 wheels = [
@@ -7088,13 +7039,12 @@ name = "scrapfly-sdk"
 version = "0.8.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff" },
-    { name = "decorator" },
-    { name = "loguru" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "backoff", marker = "platform_python_implementation == 'CPython'" },
+    { name = "decorator", marker = "platform_python_implementation == 'CPython'" },
+    { name = "loguru", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dateutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/40/f2baf15372fba9e67c0f918ea9d753916bf875019ead972cd76e8aa0ff1b/scrapfly_sdk-0.8.24.tar.gz", hash = "sha256:84fb0a22c3df9cf3aca9bdc1ed191419e27d92a055ae70d06147ac0ced7ee654", size = 42460, upload-time = "2026-01-07T11:10:50.236Z" }
 wheels = [
@@ -7103,47 +7053,18 @@ wheels = [
 
 [[package]]
 name = "selenium"
-version = "4.32.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-]
-dependencies = [
-    { name = "certifi", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "trio", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "trio-websocket", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "typing-extensions", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "platform_python_implementation == 'PyPy'" },
-    { name = "websocket-client", marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/2d/fafffe946099033ccf22bf89e12eede14c1d3c5936110c5f6f2b9830722c/selenium-4.32.0.tar.gz", hash = "sha256:b9509bef4056f4083772abb1ae19ff57247d617a29255384b26be6956615b206", size = 870997, upload-time = "2025-05-02T20:35:27.325Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/37/d07ed9d13e571b2115d4ed6956d156c66816ceec0b03b2e463e80d09f572/selenium-4.32.0-py3-none-any.whl", hash = "sha256:c4d9613f8a45693d61530c9660560fadb52db7d730237bc788ddedf442391f97", size = 9369668, upload-time = "2025-05-02T20:35:24.726Z" },
-]
-
-[[package]]
-name = "selenium"
 version = "4.40.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
-]
 dependencies = [
-    { name = "certifi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "trio", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "trio-typing", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "trio-websocket", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "types-certifi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "types-urllib3", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "platform_python_implementation != 'PyPy'" },
-    { name = "websocket-client", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "trio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "trio-typing", marker = "platform_python_implementation == 'CPython'" },
+    { name = "trio-websocket", marker = "platform_python_implementation == 'CPython'" },
+    { name = "types-certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "types-urllib3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", extra = ["socks"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "websocket-client", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/ef/a5727fa7b33d20d296322adf851b76072d8d3513e1b151969d3228437faf/selenium-4.40.0.tar.gz", hash = "sha256:a88f5905d88ad0b84991c2386ea39e2bbde6d6c334be38df5842318ba98eaa8c", size = 930444, upload-time = "2026-01-18T23:12:31.565Z" }
 wheels = [
@@ -7155,8 +7076,8 @@ name = "semchunk"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpire", extra = ["dill"] },
-    { name = "tqdm" },
+    { name = "mpire", extra = ["dill"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/96/c418c322730b385e81d4ab462e68dd48bb2dbda4d8efa17cad2ca468d9ac/semchunk-2.2.2.tar.gz", hash = "sha256:940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52", size = 12271, upload-time = "2024-12-17T22:54:30.332Z" }
 wheels = [
@@ -7177,9 +7098,8 @@ name = "sentry-sdk"
 version = "2.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/eb/1b497650eb564701f9a7b8a95c51b2abe9347ed2c0b290ba78f027ebe4ea/sentry_sdk-2.52.0.tar.gz", hash = "sha256:fa0bec872cfec0302970b2996825723d67390cdd5f0229fb9efed93bd5384899", size = 410273, upload-time = "2026-02-04T15:03:54.706Z" }
 wheels = [
@@ -7191,7 +7111,7 @@ name = "serpapi"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/fa/3fd8809287f3977a3e752bb88610e918d49cb1038b14f4bc51e13e594197/serpapi-0.1.5.tar.gz", hash = "sha256:b9707ed54750fdd2f62dc3a17c6a3fb7fa421dc37902fd65b2263c0ac765a1a5", size = 14191, upload-time = "2023-11-01T14:00:43.602Z" }
 wheels = [
@@ -7212,7 +7132,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -7272,12 +7192,12 @@ name = "singlestoredb"
 version = "1.16.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parsimonious" },
-    { name = "pyjwt" },
-    { name = "requests" },
-    { name = "sqlparams" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "parsimonious", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyjwt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sqlparams", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/15/4ae4f961f939574f328db4a9d0de8698bdf8b174579274a47625f9f1002e/singlestoredb-1.16.9.tar.gz", hash = "sha256:92e72112268ec362c19b1923eeff7a8da31d756b9ae1060e0eaf8eb03db3596d", size = 376737, upload-time = "2026-02-05T19:28:50.234Z" }
 wheels = [
@@ -7321,23 +7241,23 @@ name = "snowflake-connector-python"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asn1crypto" },
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "cryptography" },
-    { name = "filelock" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pyjwt" },
-    { name = "pyopenssl" },
-    { name = "pytz" },
-    { name = "requests" },
-    { name = "sortedcontainers" },
-    { name = "tomlkit" },
-    { name = "typing-extensions" },
+    { name = "asn1crypto", marker = "platform_python_implementation == 'CPython'" },
+    { name = "boto3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "botocore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "certifi", marker = "platform_python_implementation == 'CPython'" },
+    { name = "charset-normalizer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "filelock", marker = "platform_python_implementation == 'CPython'" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "platformdirs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyjwt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyopenssl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pytz", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sortedcontainers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tomlkit", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/d2/4ae9fc7a0df36ad0ac06bc959757dfbfc58f160f58e1d62e7cebe9901fc7/snowflake_connector_python-4.2.0.tar.gz", hash = "sha256:74b1028caee3af4550a366ef89b33de80940bbf856844dd4d788a6b7a6511aff", size = 915327, upload-time = "2026-01-07T16:44:32.541Z" }
 wheels = [
@@ -7368,8 +7288,8 @@ name = "snowflake-sqlalchemy"
 version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "snowflake-connector-python" },
-    { name = "sqlalchemy" },
+    { name = "snowflake-connector-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sqlalchemy", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/0b/5e90eb28191ad6e0318254394c7e2902c4037fd566aa299dc8b5b16238f8/snowflake_sqlalchemy-1.8.2.tar.gz", hash = "sha256:91ca38719e117f94dd195ba94c22dd22f69c585b136ed129ba4e2dd93252b0c2", size = 122603, upload-time = "2025-12-10T08:33:49.116Z" }
 wheels = [
@@ -7399,10 +7319,10 @@ name = "spider-client"
 version = "0.1.85"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "ijson" },
-    { name = "requests" },
-    { name = "tenacity" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ijson", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/97/b44e3d877c9f1afe8975b9af6b96a1aed8aa7f8342021145f2e04edb69b2/spider_client-0.1.85.tar.gz", hash = "sha256:471b2d2ba1e2e16203dd5c69f6537bc06fcd1d2b70468732c1dd803460d28f55", size = 15583, upload-time = "2026-01-21T13:40:35.437Z" }
 wheels = [
@@ -7414,8 +7334,8 @@ name = "sqlalchemy"
 version = "2.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-    { name = "typing-extensions" },
+    { name = "greenlet", marker = "(platform_machine == 'AMD64' and platform_python_implementation == 'CPython') or (platform_machine == 'WIN32' and platform_python_implementation == 'CPython') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython') or (platform_machine == 'amd64' and platform_python_implementation == 'CPython') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython') or (platform_machine == 'win32' and platform_python_implementation == 'CPython') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython')" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
 wheels = [
@@ -7468,8 +7388,8 @@ name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "starlette", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
 wheels = [
@@ -7481,12 +7401,12 @@ name = "stagehand"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "distro", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/e3/264f867657b62cdab967e65301e8aaa4f01cff644cb294e1ce9759c9febb/stagehand-3.5.0.tar.gz", hash = "sha256:42202ca13fde9aa75ee0af4892ad99bd4df140148a98ed2e1cc0d54a6ceec147", size = 257277, upload-time = "2026-01-29T19:44:35.792Z" }
 wheels = [
@@ -7501,8 +7421,8 @@ name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
@@ -7523,7 +7443,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -7544,9 +7464,9 @@ name = "tavily-python"
 version = "0.7.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "requests" },
-    { name = "tiktoken" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tiktoken", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/1f/9d5c4ca7034754d1fc232af64638b905162bdf3012e9629030e3d755856f/tavily_python-0.7.21.tar.gz", hash = "sha256:897bedf9b1c2fad8605be642e417d6c7ec1b79bf6199563477cf69c4313f824a", size = 21813, upload-time = "2026-01-30T16:57:33.186Z" }
 wheels = [
@@ -7567,12 +7487,12 @@ name = "textual"
 version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify"] },
-    { name = "mdit-py-plugins" },
-    { name = "platformdirs" },
-    { name = "pygments" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "markdown-it-py", extra = ["linkify"], marker = "platform_python_implementation == 'CPython'" },
+    { name = "mdit-py-plugins", marker = "platform_python_implementation == 'CPython'" },
+    { name = "platformdirs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pygments", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/38/7d169a765993efde5095c70a668bf4f5831bb7ac099e932f2783e9b71abf/textual-7.5.0.tar.gz", hash = "sha256:c730cba1e3d704e8f1ca915b6a3af01451e3bca380114baacf6abf87e9dac8b6", size = 1592319, upload-time = "2026-01-30T13:46:39.881Z" }
 wheels = [
@@ -7584,8 +7504,8 @@ name = "tiktoken"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex" },
-    { name = "requests" },
+    { name = "regex", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", size = 35107, upload-time = "2024-10-03T22:44:04.196Z" }
 wheels = [
@@ -7620,11 +7540,11 @@ name = "timm"
 version = "1.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "pyyaml" },
-    { name = "safetensors" },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "safetensors", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torchvision", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/9d/0ea45640be447445c8664ce2b10c74f763b0b0b9ed11620d41a4d4baa10c/timm-1.0.24.tar.gz", hash = "sha256:c7b909f43fe2ef8fe62c505e270cd4f1af230dfbc37f2ee93e3608492b9d9a40", size = 2412239, upload-time = "2026-01-07T00:26:17.541Z" }
 wheels = [
@@ -7645,7 +7565,7 @@ name = "tokenizers"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/25/b1681c1c30ea3ea6e584ae3fffd552430b12faa599b558c4c4783f56d7ff/tokenizers-0.20.3.tar.gz", hash = "sha256:2278b34c5d0dd78e087e1ca7f9b1dcbf129d80211afa645f214bd6e051037539", size = 340513, upload-time = "2024-11-05T17:34:10.403Z" }
 wheels = [
@@ -7747,7 +7667,7 @@ name = "toonify"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tiktoken" },
+    { name = "tiktoken", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/53/409a1dd7bcb52c74da019994cb866e875d0bf9020b89c7fcfcdea2866ce3/toonify-1.6.0.tar.gz", hash = "sha256:57bf6fbc9d73e463e8773c491123b233b0c79482235e0c27b908b4e58b54ec77", size = 30106, upload-time = "2026-02-06T16:00:02.622Z" }
 wheels = [
@@ -7759,30 +7679,30 @@ name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "platform_python_implementation == 'CPython'" },
+    { name = "fsspec", marker = "platform_python_implementation == 'CPython'" },
+    { name = "jinja2", marker = "platform_python_implementation == 'CPython'" },
+    { name = "networkx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and platform_python_implementation == 'CPython'" },
+    { name = "sympy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
@@ -7816,9 +7736,9 @@ name = "torchvision"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/ae/cbf727421eb73f1cf907fbe5788326a08f111b3f6b6ddca15426b53fec9a/torchvision-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a95c47abb817d4e90ea1a8e57bd0d728e3e6b533b3495ae77d84d883c4d11f56", size = 1874919, upload-time = "2026-01-21T16:27:47.617Z" },
@@ -7848,7 +7768,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -7860,16 +7780,16 @@ name = "transformers"
 version = "4.46.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
+    { name = "filelock", marker = "platform_python_implementation == 'CPython'" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "regex", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "safetensors", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/5a/58f96c83e566f907ae39f16d4401bbefd8bb85c60bd1e6a95c419752ab90/transformers-4.46.3.tar.gz", hash = "sha256:8ee4b3ae943fe33e82afff8e837f4b052058b07ca9be3cb5b729ed31295f72cc", size = 8627944, upload-time = "2024-11-18T22:13:01.012Z" }
 wheels = [
@@ -7979,13 +7899,13 @@ name = "trio"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "outcome" },
-    { name = "sniffio" },
-    { name = "sortedcontainers" },
+    { name = "attrs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt' and platform_python_implementation == 'CPython'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
+    { name = "outcome", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sortedcontainers", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323, upload-time = "2025-10-31T07:18:17.466Z" }
 wheels = [
@@ -7997,12 +7917,12 @@ name = "trio-typing"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-generator", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "importlib-metadata", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "trio", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "async-generator", marker = "platform_python_implementation == 'CPython'" },
+    { name = "importlib-metadata", marker = "platform_python_implementation == 'CPython'" },
+    { name = "mypy-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "trio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/74/a87aafa40ec3a37089148b859892cbe2eef08d132c816d58a60459be5337/trio-typing-0.10.0.tar.gz", hash = "sha256:065ee684296d52a8ab0e2374666301aec36ee5747ac0e7a61f230250f8907ac3", size = 38747, upload-time = "2023-12-01T02:54:55.508Z" }
 wheels = [
@@ -8014,10 +7934,10 @@ name = "trio-websocket"
 version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "outcome" },
-    { name = "trio" },
-    { name = "wsproto" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "outcome", marker = "platform_python_implementation == 'CPython'" },
+    { name = "trio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "wsproto", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
 wheels = [
@@ -8041,10 +7961,10 @@ name = "typer"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rich", marker = "platform_python_implementation == 'CPython'" },
+    { name = "shellingham", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
 wheels = [
@@ -8128,7 +8048,7 @@ name = "types-requests"
 version = "2.31.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "types-urllib3" },
+    { name = "types-urllib3", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535, upload-time = "2023-09-27T06:19:38.443Z" }
 wheels = [
@@ -8167,8 +8087,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
+    { name = "mypy-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
@@ -8180,7 +8100,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -8210,28 +8130,28 @@ name = "unstructured"
 version = "0.18.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff" },
-    { name = "beautifulsoup4" },
-    { name = "charset-normalizer" },
-    { name = "dataclasses-json" },
-    { name = "emoji" },
-    { name = "filetype" },
-    { name = "html5lib" },
-    { name = "langdetect" },
-    { name = "lxml" },
-    { name = "nltk" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "psutil" },
-    { name = "python-iso639" },
-    { name = "python-magic" },
-    { name = "python-oxmsg" },
-    { name = "rapidfuzz" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-    { name = "unstructured-client" },
-    { name = "wrapt" },
+    { name = "backoff", marker = "platform_python_implementation == 'CPython'" },
+    { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
+    { name = "charset-normalizer", marker = "platform_python_implementation == 'CPython'" },
+    { name = "dataclasses-json", marker = "platform_python_implementation == 'CPython'" },
+    { name = "emoji", marker = "platform_python_implementation == 'CPython'" },
+    { name = "filetype", marker = "platform_python_implementation == 'CPython'" },
+    { name = "html5lib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "langdetect", marker = "platform_python_implementation == 'CPython'" },
+    { name = "lxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "nltk", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numba", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "psutil", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-iso639", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-magic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-oxmsg", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rapidfuzz", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tqdm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
+    { name = "unstructured-client", marker = "platform_python_implementation == 'CPython'" },
+    { name = "wrapt", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/5f/64285bd69a538bc28753f1423fcaa9d64cd79a9e7c097171b1f0d27e9cdb/unstructured-0.18.31.tar.gz", hash = "sha256:af4bbe32d1894ae6e755f0da6fc0dd307a1d0adeebe0e7cc6278f6cf744339ca", size = 1707700, upload-time = "2026-01-27T15:33:05.378Z" }
 wheels = [
@@ -8240,48 +8160,48 @@ wheels = [
 
 [package.optional-dependencies]
 all-docs = [
-    { name = "effdet" },
-    { name = "google-cloud-vision" },
-    { name = "markdown" },
-    { name = "msoffcrypto-tool" },
-    { name = "networkx" },
-    { name = "onnx" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11'" },
-    { name = "openpyxl" },
-    { name = "pandas" },
-    { name = "pdf2image" },
-    { name = "pdfminer-six" },
-    { name = "pi-heif" },
-    { name = "pikepdf" },
-    { name = "pypandoc" },
-    { name = "pypdf" },
-    { name = "python-docx" },
-    { name = "python-pptx" },
-    { name = "unstructured-inference" },
-    { name = "unstructured-pytesseract" },
-    { name = "xlrd" },
+    { name = "effdet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "google-cloud-vision", marker = "platform_python_implementation == 'CPython'" },
+    { name = "markdown", marker = "platform_python_implementation == 'CPython'" },
+    { name = "msoffcrypto-tool", marker = "platform_python_implementation == 'CPython'" },
+    { name = "networkx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "openpyxl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdf2image", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdfminer-six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pi-heif", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pikepdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypandoc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-docx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-pptx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "unstructured-inference", marker = "platform_python_implementation == 'CPython'" },
+    { name = "unstructured-pytesseract", marker = "platform_python_implementation == 'CPython'" },
+    { name = "xlrd", marker = "platform_python_implementation == 'CPython'" },
 ]
 local-inference = [
-    { name = "effdet" },
-    { name = "google-cloud-vision" },
-    { name = "markdown" },
-    { name = "msoffcrypto-tool" },
-    { name = "networkx" },
-    { name = "onnx" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11'" },
-    { name = "openpyxl" },
-    { name = "pandas" },
-    { name = "pdf2image" },
-    { name = "pdfminer-six" },
-    { name = "pi-heif" },
-    { name = "pikepdf" },
-    { name = "pypandoc" },
-    { name = "pypdf" },
-    { name = "python-docx" },
-    { name = "python-pptx" },
-    { name = "unstructured-inference" },
-    { name = "unstructured-pytesseract" },
-    { name = "xlrd" },
+    { name = "effdet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "google-cloud-vision", marker = "platform_python_implementation == 'CPython'" },
+    { name = "markdown", marker = "platform_python_implementation == 'CPython'" },
+    { name = "msoffcrypto-tool", marker = "platform_python_implementation == 'CPython'" },
+    { name = "networkx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "openpyxl", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdf2image", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdfminer-six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pi-heif", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pikepdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypandoc", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-docx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-pptx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "unstructured-inference", marker = "platform_python_implementation == 'CPython'" },
+    { name = "unstructured-pytesseract", marker = "platform_python_implementation == 'CPython'" },
+    { name = "xlrd", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -8289,13 +8209,13 @@ name = "unstructured-client"
 version = "0.42.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "cryptography" },
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pypdf" },
-    { name = "requests-toolbelt" },
+    { name = "aiofiles", marker = "platform_python_implementation == 'CPython'" },
+    { name = "cryptography", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpcore", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests-toolbelt", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/45/0d605c1c4ed6e38845e9e7d95758abddc7d66e1d096ef9acdf2ecdeaf009/unstructured_client-0.42.3.tar.gz", hash = "sha256:a568d8b281fafdf452647d874060cd0647e33e4a19e811b4db821eb1f3051163", size = 91379, upload-time = "2025-08-12T20:48:04.937Z" }
 wheels = [
@@ -8307,22 +8227,22 @@ name = "unstructured-inference"
 version = "1.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate" },
-    { name = "huggingface-hub" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "onnx" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11'" },
-    { name = "opencv-python" },
-    { name = "pandas" },
-    { name = "pdfminer-six" },
-    { name = "pypdfium2" },
-    { name = "python-multipart" },
-    { name = "rapidfuzz" },
-    { name = "scipy" },
-    { name = "timm" },
-    { name = "torch" },
-    { name = "transformers" },
+    { name = "accelerate", marker = "platform_python_implementation == 'CPython'" },
+    { name = "huggingface-hub", marker = "platform_python_implementation == 'CPython'" },
+    { name = "matplotlib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "opencv-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pandas", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pdfminer-six", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pypdfium2", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-multipart", marker = "platform_python_implementation == 'CPython'" },
+    { name = "rapidfuzz", marker = "platform_python_implementation == 'CPython'" },
+    { name = "scipy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "timm", marker = "platform_python_implementation == 'CPython'" },
+    { name = "torch", marker = "platform_python_implementation == 'CPython'" },
+    { name = "transformers", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/cc/721ffd9dab7dd08e19de7debc652f47e6701c0a280868926589887f0576c/unstructured_inference-1.1.7.tar.gz", hash = "sha256:3684a160a89d1c51900d5fccf71691b22336a4a100f8dd9342e268f6f88d5c78", size = 44584, upload-time = "2026-01-20T23:03:35.271Z" }
 wheels = [
@@ -8334,8 +8254,8 @@ name = "unstructured-pytesseract"
 version = "0.3.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
-    { name = "pillow" },
+    { name = "packaging", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/b1/4b3a976b76549f22c3f5493a622603617cbe08804402978e1dac9c387997/unstructured.pytesseract-0.3.15.tar.gz", hash = "sha256:4b81bc76cfff4e2ef37b04863f0e48bd66184c0b39c3b2b4e017483bca1a7394", size = 15703, upload-time = "2025-03-05T00:59:17.516Z" }
 wheels = [
@@ -8344,34 +8264,8 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
-]
-
-[package.optional-dependencies]
-socks = [
-    { name = "pysocks", marker = "platform_python_implementation == 'PyPy'" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
@@ -8379,7 +8273,7 @@ wheels = [
 
 [package.optional-dependencies]
 socks = [
-    { name = "pysocks", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "pysocks", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -8442,9 +8336,9 @@ name = "uvicorn"
 version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "click", marker = "platform_python_implementation == 'CPython'" },
+    { name = "h11", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
@@ -8453,13 +8347,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "colorama", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "httptools", marker = "platform_python_implementation == 'CPython'" },
+    { name = "python-dotenv", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", marker = "platform_python_implementation == 'CPython'" },
+    { name = "websockets", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [[package]]
@@ -8508,11 +8402,10 @@ name = "vcrpy"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
-    { name = "wrapt" },
-    { name = "yarl" },
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
+    { name = "wrapt", marker = "platform_python_implementation == 'CPython'" },
+    { name = "yarl", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/d3/856e06184d4572aada1dd559ddec3bedc46df1f2edc5ab2c91121a2cccdb/vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50", size = 85502, upload-time = "2024-12-31T00:07:57.894Z" }
 wheels = [
@@ -8524,10 +8417,10 @@ name = "virtualenv"
 version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "distlib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "filelock", marker = "platform_python_implementation == 'CPython'" },
+    { name = "platformdirs", marker = "platform_python_implementation == 'CPython'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
@@ -8539,16 +8432,16 @@ name = "voyageai"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aiolimiter" },
-    { name = "ffmpeg-python" },
-    { name = "langchain-text-splitters" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "platform_python_implementation == 'CPython'" },
+    { name = "aiolimiter", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ffmpeg-python", marker = "platform_python_implementation == 'CPython'" },
+    { name = "langchain-text-splitters", marker = "platform_python_implementation == 'CPython'" },
+    { name = "numpy", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tenacity", marker = "platform_python_implementation == 'CPython'" },
+    { name = "tokenizers", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
@@ -8560,7 +8453,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -8640,13 +8533,13 @@ name = "weaviate-client"
 version = "4.18.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib" },
-    { name = "deprecation" },
-    { name = "grpcio" },
-    { name = "httpx" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "validators" },
+    { name = "authlib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "deprecation", marker = "platform_python_implementation == 'CPython'" },
+    { name = "grpcio", marker = "platform_python_implementation == 'CPython'" },
+    { name = "httpx", marker = "platform_python_implementation == 'CPython'" },
+    { name = "protobuf", marker = "platform_python_implementation == 'CPython'" },
+    { name = "pydantic", marker = "platform_python_implementation == 'CPython'" },
+    { name = "validators", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/76/14e07761c5fb7e8573e3cff562e2d9073c65f266db0e67511403d10435b1/weaviate_client-4.18.3.tar.gz", hash = "sha256:9d889246d62be36641a7f2b8cedf5fb665b804d46f7a53ae37e02d297a11f119", size = 783634, upload-time = "2025-12-03T09:38:28.261Z" }
 wheels = [
@@ -8793,7 +8686,7 @@ name = "wsproto"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
+    { name = "h11", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
@@ -8911,9 +8804,9 @@ name = "yarl"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "platform_python_implementation == 'CPython'" },
+    { name = "multidict", marker = "platform_python_implementation == 'CPython'" },
+    { name = "propcache", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
 wheels = [
@@ -9005,8 +8898,8 @@ name = "youtube-transcript-api"
 version = "1.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "defusedxml" },
-    { name = "requests" },
+    { name = "defusedxml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Add `HindsightStorage` backend for `ExternalMemory`, enabling persistent agent memory via the [Hindsight](https://github.com/hindsight-ai/hindsight) API
- Hindsight provides automatic fact extraction, entity tracking, temporal awareness, and mental model synthesis — going beyond simple vector storage
- Register `"hindsight"` as a first-class provider in `external_supported_storages()`
- Add `hindsight-client` as an optional dependency (`pip install 'crewai[hindsight]'`)
- Add `tool.uv.environments` to restrict dependency resolution to CPython (avoids a pre-existing PyPy/vcrpy urllib3 conflict)

## Files Changed

| File | Change |
|---|---|
| `lib/crewai/src/crewai/memory/storage/hindsight_storage.py` | **New** — `HindsightConfig` (Pydantic) + `HindsightStorage` (Storage impl) |
| `lib/crewai/src/crewai/memory/external/external_memory.py` | Add `_configure_hindsight()` + register provider |
| `lib/crewai/pyproject.toml` | Add `hindsight` optional dependency |
| `lib/crewai/tests/storage/test_hindsight_storage.py` | **New** — 27 unit tests (config validation, save/search/reset, import error) |
| `lib/crewai/tests/memory/test_external_memory.py` | Add 3 integration tests for provider registration |
| `docs/en/concepts/memory.mdx` | Add Hindsight usage docs with config table and examples |
| `pyproject.toml` | Add `tool.uv.environments` for CPython-only resolution |
| `uv.lock` | Regenerated |

## Usage

```python
from crewai import Crew, Process
from crewai.memory.external.external_memory import ExternalMemory

external_memory = ExternalMemory(
    embedder_config={
        "provider": "hindsight",
        "config": {
            "api_url": "http://localhost:8888",
            "bank_id": "my-crew-memory",
            "budget": "mid",
            "mission": "Track research findings",
        },
    }
)

crew = Crew(
    agents=[...],
    tasks=[...],
    external_memory=external_memory,
    process=Process.sequential,
)
```

## Test plan

- [x] `pytest tests/storage/test_hindsight_storage.py -v` — 27/27 passed
- [x] `pytest tests/memory/test_external_memory.py -v` — 16/16 passed (including 3 new Hindsight tests)
- [x] `ruff check` — all checks passed
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new memory backend that makes external API calls and introduces custom threading/event-loop handling, which could affect runtime stability under load. Changes are mostly additive with isolated code paths and solid unit test coverage.
> 
> **Overview**
> Adds an optional Hindsight-powered memory backend (`HindsightMemory` + `HindsightConfig`) that can be passed to `Crew(memory=...)`, delegating `remember`/`recall`/`reset` to Hindsight’s retain/recall APIs via a dedicated worker thread pool to avoid running sync client calls inside an active event loop.
> 
> Introduces the `crewai[hindsight]` extra (`hindsight-client>=0.4.0`), adds comprehensive unit coverage for the new backend, and documents installation/configuration/usage in `docs/en/concepts/memory.mdx`. Workspace config also pins `uv` resolution to CPython-only to avoid a PyPy `urllib3` constraint conflict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3911aa756f6892c312ed6b9cdff5783dbeb4af2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->