### PR TITLE
fix: correct typo 'occured' to 'occurred' in BrightDataDatasetTool error messages

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -591,10 +591,10 @@ class BrightDataDatasetTool(BaseTool):
                 )
             )
         except TimeoutError as e:
-            return f"Timeout Exception occured in method : get_dataset_data_async. Details - {e!s}"
+            return f"Timeout Exception occurred in method : get_dataset_data_async. Details - {e!s}"
         except BrightDataDatasetToolException as e:
             return (
-                f"Exception occured in method : get_dataset_data_async. Details - {e!s}"
+                f"Exception occurred in method : get_dataset_data_async. Details - {e!s}"
             )
         except Exception as e:
             return f"Bright Data API error: {e!s}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String-only change in returned error messages; no functional logic, API calls, or data handling behavior is modified.
> 
> **Overview**
> Fixes a typo in `BrightDataDatasetTool._run` error messages by changing "occured" to "occurred" for both `TimeoutError` and `BrightDataDatasetToolException` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97786c29c395da52ddd88c6cd8c9fc3b3e9fc9cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->