### PR TITLE
fix: return tool_calls list when streaming with empty content

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -13,6 +13,9 @@ from openai.lib.streaming.chat import ChatCompletionStream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+)
 from openai.types.responses import Response
 from pydantic import BaseModel
 
@@ -1776,6 +1779,31 @@ class OpenAICompletion(BaseLLM):
 
                 if result is not None:
                     return result
+
+        # Handle case where only tool_calls are present (no content)
+        # This mirrors the non-streaming behavior in _handle_completion
+        if tool_calls and not available_functions:
+            tool_calls_list = [
+                ChatCompletionMessageToolCall(
+                    id=call_data["id"],
+                    function={
+                        "name": call_data["name"],
+                        "arguments": call_data["arguments"],
+                    },
+                    type="function",
+                )
+                for call_data in tool_calls.values()
+            ]
+
+            self._emit_call_completed_event(
+                response=tool_calls_list,
+                call_type=LLMCallType.TOOL_CALL,
+                from_task=from_task,
+                from_agent=from_agent,
+                messages=params["messages"],
+            )
+
+            return tool_calls_list
 
         full_response = self._apply_stop_words(full_response)
 


### PR DESCRIPTION
When provider sends only tool_calls in delta (content is null/empty), _handle_streaming_completion should return the accumulated tool_calls list when available_functions is None, instead of returning empty string.

This fixes the issue where some OpenAI-compatible providers (e.g. GLM) send null content in streaming tool_call chunks, causing executor to fail with 'Invalid response from LLM call - None or empty.'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OpenAI streaming completion finalization path and may change what downstream code receives for tool-only responses (and related event payloads), which can impact tool execution flows.
> 
> **Overview**
> Fixes an edge case in OpenAI-compatible *streaming* chat completions where some providers send `tool_calls` chunks with empty/null `content`.
> 
> When streaming finishes with only tool calls and no `available_functions` are provided, `_finalize_streaming_response` now emits a `TOOL_CALL` completion event and returns the accumulated tool calls (as `ChatCompletionMessageToolCall` entries) instead of falling through to an empty text response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e247958e6099ef96e69b9971c72c69f0daf420e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->