### PR TITLE
fix: relax OpenTelemetry version constraints for google-adk compatibility

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.20.0,<2",
+    "opentelemetry-sdk>=1.20.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0,<2",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers~=0.20.3",


### PR DESCRIPTION
Fixes issue #4474

## Changes
- Changed OpenTelemetry version constraints from ~=1.34.0 (patch only) to >=1.20.0,<2
- Allows users to install crewai with google-adk without dependency conflicts

## Why
The restrictive ~=1.34.0 constraint only allows patch versions (1.34.0 to 1.34.x), which conflicts with google-adk dependencies. The new constraint allows any 1.x version, giving users flexibility while staying compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency range change only; main risk is unforeseen incompatibilities when installed with older OpenTelemetry 1.x versions.
> 
> **Overview**
> Relaxes the OpenTelemetry dependency pins in `lib/crewai/pyproject.toml` from `~=1.34.0` to `>=1.20.0,<2` for `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` to avoid dependency conflicts (e.g., with `google-adk`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c8f2de0f7556e2e642a050378815f0b5671f1c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->