### PR TITLE
fix(pre-commit): make hooks cross-platform using uv run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: bash -c 'source .venv/bin/activate && uv run ruff check --config pyproject.toml "$@"' --
+        entry: uv run ruff check --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: bash -c 'source .venv/bin/activate && uv run ruff format --config pyproject.toml "$@"' --
+        entry: uv run ruff format --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: mypy
         name: mypy
-        entry: bash -c 'source .venv/bin/activate && uv run mypy --config-file pyproject.toml "$@"' --
+        entry: uv run mypy --config-file pyproject.toml
         language: system
         pass_filenames: true
         types: [python]


### PR DESCRIPTION
Implemented the changes and enhancements described in issue #4322.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to developer tooling; risk is limited to pre-commit execution differences on some environments if `uv` isn’t available or behaves differently.
> 
> **Overview**
> Updates local pre-commit hooks for `ruff`, `ruff-format`, and `mypy` to invoke tools directly via `uv run` instead of a bash-based `.venv` activation wrapper, improving cross-platform compatibility.
> 
> No functional lint/type-check rule changes; only the hook `entry` commands were simplified while keeping existing filenames/exclude behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ce9003d09eefd02e4f49304c86d6bda63e988a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->