### PR TITLE
chore: implementing handle_agent_action_core TODO

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: bash -c 'source .venv/bin/activate && uv run ruff check --config pyproject.toml "$@"' --
+        entry: uv run ruff check --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: bash -c 'source .venv/bin/activate && uv run ruff format --config pyproject.toml "$@"' --
+        entry: uv run ruff format --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: mypy
         name: mypy
-        entry: bash -c 'source .venv/bin/activate && uv run mypy --config-file pyproject.toml "$@"' --
+        entry: uv run mypy --config-file pyproject.toml
         language: system
         pass_filenames: true
         types: [python]

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1357,7 +1357,6 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         return handle_agent_action_core(
             formatted_answer=formatted_answer,
             tool_result=tool_result,
-            messages=self.messages,
             step_callback=self.step_callback,
             show_logs=self._show_logs,
         )

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1238,7 +1238,6 @@ class AgentExecutor(Flow[AgentReActState], CrewAgentExecutorMixin):
         return handle_agent_action_core(
             formatted_answer=formatted_answer,
             tool_result=tool_result,
-            messages=self.state.messages,
             step_callback=self.step_callback,
             show_logs=self._show_logs,
         )

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -481,7 +481,6 @@ def process_llm_response(
 def handle_agent_action_core(
     formatted_answer: AgentAction,
     tool_result: ToolResult,
-    messages: list[LLMMessage] | None = None,
     step_callback: Callable | None = None,  # type: ignore[type-arg]
     show_logs: Callable | None = None,  # type: ignore[type-arg]
 ) -> AgentAction | AgentFinish:
@@ -497,8 +496,6 @@ def handle_agent_action_core(
     Returns:
         Either an AgentAction or AgentFinish
 
-    Notes:
-        - TODO: Remove messages parameter and its usage.
     """
     if step_callback:
         step_callback(tool_result)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor and tooling tweak; behavior should be unchanged aside from the removed unused parameter, but it touches shared agent execution plumbing so regressions would show up as tool/step-callback issues.
> 
> **Overview**
> Simplifies local `pre-commit` hooks by removing the `.venv` activation wrapper and invoking `ruff`, `ruff-format`, and `mypy` directly via `uv run`.
> 
> Cleans up agent execution plumbing by removing the unused `messages` parameter from `handle_agent_action_core` and updating both `CrewAgentExecutor` and the experimental `AgentExecutor` call sites accordingly (no functional behavior added beyond the signature change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e12a903a603d54d355c32702e012786766333a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->