### PR TITLE
refactor: remove type: ignore by fixing build_embedder typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: bash -c 'source .venv/bin/activate && uv run ruff check --config pyproject.toml "$@"' --
+        entry: uv run ruff check --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: bash -c 'source .venv/bin/activate && uv run ruff format --config pyproject.toml "$@"' --
+        entry: uv run ruff format --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: mypy
         name: mypy
-        entry: bash -c 'source .venv/bin/activate && uv run mypy --config-file pyproject.toml "$@"' --
+        entry: uv run mypy --config-file pyproject.toml
         language: system
         pass_filenames: true
         types: [python]

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -32,8 +32,6 @@ from rich.console import Console
 from rich.panel import Panel
 from typing_extensions import Self
 
-from crewai.rag.core.base_embeddings_provider import BaseEmbeddingsProvider
-
 
 if TYPE_CHECKING:
     from crewai_files import FileInput
@@ -365,7 +363,7 @@ class Crew(FlowTrackable, BaseModel):
         if self.memory is True:
             from crewai.memory.unified_memory import Memory
 
-            embedder: BaseEmbeddingsProvider[Any] | None = None
+            embedder = None
             if self.embedder is not None:
                 from crewai.rag.embeddings.factory import build_embedder
 

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -32,6 +32,8 @@ from rich.console import Console
 from rich.panel import Panel
 from typing_extensions import Self
 
+from crewai.rag.core.base_embeddings_provider import BaseEmbeddingsProvider
+
 
 if TYPE_CHECKING:
     from crewai_files import FileInput
@@ -326,7 +328,12 @@ class Crew(FlowTrackable, BaseModel):
         """
 
         # TODO: Improve typing
-        return json.loads(v) if isinstance(v, Json) else v  # type: ignore
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except json.JSONDecodeError:
+                return v
+        return v
 
     @model_validator(mode="after")
     def set_private_attrs(self) -> Crew:
@@ -358,11 +365,11 @@ class Crew(FlowTrackable, BaseModel):
         if self.memory is True:
             from crewai.memory.unified_memory import Memory
 
-            embedder = None
+            embedder: BaseEmbeddingsProvider[Any] | None = None
             if self.embedder is not None:
                 from crewai.rag.embeddings.factory import build_embedder
 
-                embedder = build_embedder(self.embedder)
+                embedder = build_embedder(cast(Any, self.embedder))
             self._memory = Memory(embedder=embedder)
         elif self.memory:
             # User passed a Memory / MemoryScope / MemorySlice instance
@@ -1410,9 +1417,7 @@ class Crew(FlowTrackable, BaseModel):
             return self._merge_tools(tools, cast(list[BaseTool], code_tools))
         return tools
 
-    def _add_memory_tools(
-        self, tools: list[BaseTool], memory: Any
-    ) -> list[BaseTool]:
+    def _add_memory_tools(self, tools: list[BaseTool], memory: Any) -> list[BaseTool]:
         """Add recall and remember tools when memory is available.
 
         Args:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: mostly developer-tooling cleanup and small validation/typing adjustments; only minor behavioral change is more permissive handling of non-JSON `config` strings.
> 
> **Overview**
> Simplifies local pre-commit hooks by removing the venv `bash -c 'source ...'` wrappers and running `ruff`, `ruff format`, and `mypy` directly via `uv run`.
> 
> In `Crew`, updates `config` validation to attempt `json.loads` for string inputs but fall back to returning the original string when it isn’t valid JSON (instead of assuming `Json`), and adjusts typing around embedder initialization by casting `self.embedder` when calling `build_embedder` plus a small signature formatting cleanup for `_add_memory_tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d588b1f950ecf6324f67e619adca0ec1f1e083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->