### PR TITLE
fix(llm): prevent infinite recursion and params overwrite in call()/acall()

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1769,31 +1769,43 @@ class LLM(BaseLLM):
                     ) and "'stop'" in str(e)
 
                     if unsupported_stop:
-                        if (
-                            "additional_drop_params" in self.additional_params
-                            and isinstance(
-                                self.additional_params["additional_drop_params"], list
-                            )
-                        ):
-                            self.additional_params["additional_drop_params"].append(
-                                "stop"
-                            )
-                        else:
-                            self.additional_params = {
-                                "additional_drop_params": ["stop"]
-                            }
-
-                        logging.info("Retrying LLM call without the unsupported 'stop'")
-
-                        return self.call(
-                            messages,
-                            tools=tools,
-                            callbacks=callbacks,
-                            available_functions=available_functions,
-                            from_task=from_task,
-                            from_agent=from_agent,
-                            response_model=response_model,
+                        existing_drop_params = self.additional_params.get(
+                            "additional_drop_params", []
                         )
+                        already_dropping_stop = (
+                            isinstance(existing_drop_params, list)
+                            and "stop" in existing_drop_params
+                        )
+
+                        if not already_dropping_stop:
+                            if (
+                                "additional_drop_params" in self.additional_params
+                                and isinstance(
+                                    self.additional_params["additional_drop_params"],
+                                    list,
+                                )
+                            ):
+                                self.additional_params[
+                                    "additional_drop_params"
+                                ].append("stop")
+                            else:
+                                self.additional_params["additional_drop_params"] = [
+                                    "stop"
+                                ]
+
+                            logging.info(
+                                "Retrying LLM call without the unsupported 'stop'"
+                            )
+
+                            return self.call(
+                                messages,
+                                tools=tools,
+                                callbacks=callbacks,
+                                available_functions=available_functions,
+                                from_task=from_task,
+                                from_agent=from_agent,
+                                response_model=response_model,
+                            )
 
                     crewai_event_bus.emit(
                         self,
@@ -1905,31 +1917,45 @@ class LLM(BaseLLM):
                     ) and "'stop'" in str(e)
 
                     if unsupported_stop:
-                        if (
-                            "additional_drop_params" in self.additional_params
-                            and isinstance(
-                                self.additional_params["additional_drop_params"], list
-                            )
-                        ):
-                            self.additional_params["additional_drop_params"].append(
-                                "stop"
-                            )
-                        else:
-                            self.additional_params = {
-                                "additional_drop_params": ["stop"]
-                            }
-
-                        logging.info("Retrying LLM call without the unsupported 'stop'")
-
-                        return await self.acall(
-                            messages,
-                            tools=tools,
-                            callbacks=callbacks,
-                            available_functions=available_functions,
-                            from_task=from_task,
-                            from_agent=from_agent,
-                            response_model=response_model,
+                        existing_drop_params = self.additional_params.get(
+                            "additional_drop_params", []
                         )
+                        already_dropping_stop = (
+                            isinstance(existing_drop_params, list)
+                            and "stop" in existing_drop_params
+                        )
+
+                        if not already_dropping_stop:
+                            if (
+                                "additional_drop_params" in self.additional_params
+                                and isinstance(
+                                    self.additional_params[
+                                        "additional_drop_params"
+                                    ],
+                                    list,
+                                )
+                            ):
+                                self.additional_params[
+                                    "additional_drop_params"
+                                ].append("stop")
+                            else:
+                                self.additional_params["additional_drop_params"] = [
+                                    "stop"
+                                ]
+
+                            logging.info(
+                                "Retrying LLM call without the unsupported 'stop'"
+                            )
+
+                            return await self.acall(
+                                messages,
+                                tools=tools,
+                                callbacks=callbacks,
+                                available_functions=available_functions,
+                                from_task=from_task,
+                                from_agent=from_agent,
+                                response_model=response_model,
+                            )
 
                     crewai_event_bus.emit(
                         self,


### PR DESCRIPTION
## Summary

Fixes two critical bugs in `LLM.call()` and `LLM.acall()` that occur when a provider permanently rejects the `stop` parameter with an `Unsupported parameter: 'stop'` error.

### Bug 1: Infinite Recursion (RecursionError)

When the `stop` parameter is unsupported, the error handler adds `"stop"` to `additional_drop_params` and recursively calls `self.call()` / `self.acall()`. However, if the provider **still** rejects the parameter (e.g., due to a provider-side bug, or if the drop_params mechanism fails to strip it), there is no guard to prevent re-entry. The method keeps calling itself until Python hits `RecursionError` after ~1000 frames.

**Before (crashes):**
```python
# No check if we already tried dropping 'stop'
except Exception as e:
    if "Unsupported parameter" in str(e) and "'stop'" in str(e):
        self.additional_params = {"additional_drop_params": ["stop"]}
        return self.call(...)  # infinite loop if error persists
```

**After (fails cleanly after one retry):**
```python
except Exception as e:
    if "Unsupported parameter" in str(e) and "'stop'" in str(e):
        existing = self.additional_params.get("additional_drop_params", [])
        if isinstance(existing, list) and "stop" in existing:
            raise  # already tried, don't recurse again
        # ... append "stop" and retry once
```

### Bug 2: Additional Parameters Overwritten

The `else` branch replaces `self.additional_params` entirely:
```python
self.additional_params = {"additional_drop_params": ["stop"]}
```

This **destroys** any existing keys (`extra_headers`, `seed`, `top_k`, etc.) that were previously configured. The fix appends to the existing dict instead:
```python
self.additional_params["additional_drop_params"] = ["stop"]
```

### Scope

Both bugs exist in the sync `call()` method and the async `acall()` method. Both are fixed with identical logic.

## Test Plan

Added 7 tests in `TestUnsupportedStopRetryGuard`:

- [x] `test_retries_once_then_raises_on_persistent_stop_error` - Verifies exactly 2 calls (not infinite), then raises
- [x] `test_preserves_existing_additional_params` - Confirms `extra_headers` and `seed` survive the retry
- [x] `test_appends_to_existing_drop_params` - Verifies `["another_param"]` becomes `["another_param", "stop"]`
- [x] `test_non_stop_exceptions_are_not_retried` - Non-stop errors propagate immediately (1 call only)
- [x] `test_acall_retries_once_then_raises_on_persistent_stop_error` - Async version of recursion guard
- [x] `test_acall_preserves_existing_additional_params` - Async version of params preservation

### Reproduction

```python
from crewai import LLM

llm = LLM(model="some-provider/model", extra_headers={"X-Key": "val"}, seed=42)

# Before fix: RecursionError after ~1000 frames
# Before fix: extra_headers and seed are lost
# After fix: clean exception after 1 retry, params preserved
llm.call(messages=[{"role": "user", "content": "hello"}])
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LLM invocation error-handling and retry logic in both sync and async codepaths; incorrect conditions could change retry behavior or error propagation across providers.
> 
> **Overview**
> Fixes `LLM.call()` and `LLM.acall()` retry behavior when a provider errors on the `stop` parameter by **retrying at most once** (detecting when `stop` is already in `additional_drop_params`) and by **adding `stop` to `additional_drop_params` without clobbering other `additional_params`**.
> 
> Adds a focused test suite (`TestUnsupportedStopRetryGuard`) validating single-retry semantics, non-`stop` errors not being retried, appending to existing drop params, and preservation of pre-existing `additional_params` for both sync and async paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03890d7106f438f32d14b0578da354eaa6c3c626. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->