### PR TITLE
Fix Bedrock tool input parsing (L722 short-circuit bug)

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
Root cause:
The default "{}" in:

    func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})

causes short-circuiting because "{}" is truthy.  
For Bedrock-style tool calls (which use `input` instead of `function.arguments`),
this prevents `tool_call.get("input", {})` from ever being evaluated.

Minimal fix:
Remove the default "{}" so `None` falls through correctly:

    func_args = func_info.get("arguments") or tool_call.get("input", {})

This ensures Bedrock tool inputs are parsed as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change in tool-call argument parsing; main risk is slight behavior change when `function.arguments` is absent, but it should improve cross-provider compatibility.
> 
> **Overview**
> Fixes native tool-call parsing to correctly handle Bedrock-style tool calls that provide arguments under `input` instead of `function.arguments`.
> 
> In `CrewAgentExecutor._parse_native_tool_call`, removes the truthy default for `function.arguments` so missing arguments now fall through to `tool_call["input"]` rather than always producing the string `"{}"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f199feda97f7aab531c888aefb0837fb32e09dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->