### PR TITLE
fix: relax opentelemetry version pins to allow >=1.34.0,<2

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.34.0,<2",
+    "opentelemetry-sdk>=1.34.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers~=0.20.3",


### PR DESCRIPTION
## Summary

Relaxes the OpenTelemetry dependency version pins from `~=1.34.0` (which resolves to `>=1.34.0,<1.35.0`) to `>=1.34.0,<2`.

## Problem

The current tight pins on `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` prevent users from installing newer OpenTelemetry versions (e.g., `1.38.x`, `1.39.x`) alongside crewAI. This causes dependency resolution failures when users need newer OTel versions for other packages like Langfuse.

Example error:
```
Because crewai==1.9.3 depends on opentelemetry-exporter-otlp-proto-http>=1.34.0,<1.35.dev0
and your project depends on opentelemetry-exporter-otlp-proto-http>=1.38,<2.dev0,
your project's requirements are unsatisfiable.
```

## Changes

- `opentelemetry-api`: `~=1.34.0` → `>=1.34.0,<2`
- `opentelemetry-sdk`: `~=1.34.0` → `>=1.34.0,<2`
- `opentelemetry-exporter-otlp-proto-http`: `~=1.34.0` → `>=1.34.0,<2`

The OpenTelemetry libraries follow semantic versioning, so any 1.x release should be backward compatible. The `<2` upper bound protects against breaking changes in a future 2.0 release.

Fixes #4511

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint-only change with no runtime logic modifications; risk is limited to potential incompatibilities if newer OpenTelemetry 1.x introduces unexpected behavior.
> 
> **Overview**
> Updates `lib/crewai/pyproject.toml` to relax the version constraints for `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` from `~=1.34.0` to `>=1.34.0,<2`, improving compatibility with other packages that require newer OpenTelemetry 1.x versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd1dcaa9c947dfec634bff36e822fdd8a33f5da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->