### PR TITLE
fix: handle non-hyphenated GPT-5 model names in detection logic

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -460,7 +460,7 @@ class LLM(BaseLLM):
         if provider == "openai":
             return any(
                 model_lower.startswith(prefix)
-                for prefix in ["gpt-", "o1", "o3", "o4", "whisper-"]
+                for prefix in ["gpt-", "gpt5", "o1", "o3", "o4", "whisper-"]
             )
 
         if provider == "anthropic" or provider == "claude":
@@ -480,7 +480,7 @@ class LLM(BaseLLM):
         if provider == "azure":
             return any(
                 model_lower.startswith(prefix)
-                for prefix in ["gpt-", "gpt-35-", "o1", "o3", "o4", "azure-"]
+                for prefix in ["gpt-", "gpt5", "gpt-35-", "o1", "o3", "o4", "azure-"]
             )
 
         return False

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -172,7 +172,8 @@ class AzureCompletion(BaseLLM):
         self.response_format = response_format
 
         self.is_openai_model = any(
-            prefix in model.lower() for prefix in ["gpt-", "o1-", "text-"]
+            prefix in model.lower()
+            for prefix in ["gpt-", "gpt5", "o1-", "text-"]
         )
 
         self.is_azure_openai_endpoint = (
@@ -1017,7 +1018,7 @@ class AzureCompletion(BaseLLM):
         """
         model_lower = self.model.lower() if self.model else ""
 
-        if "gpt-5" in model_lower:
+        if "gpt-5" in model_lower or "gpt5" in model_lower:
             return False
 
         o_series_models = ["o1", "o3", "o4", "o1-mini", "o3-mini", "o4-mini"]

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -457,6 +457,30 @@ def test_azure_model_capabilities():
     assert llm_gpt35.supports_function_calling() == True
 
 
+def test_azure_gpt5_non_hyphenated_model_detection():
+    """
+    Test that GPT-5 models without hyphens (e.g. gpt5nano, gpt5) are correctly
+    detected as OpenAI models. Regression test for #4478.
+    """
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    gpt5_non_hyphenated = [
+        "azure/gpt5",
+        "azure/gpt5nano",
+        "azure/gpt5mini",
+    ]
+
+    for model_name in gpt5_non_hyphenated:
+        llm = LLM(model=model_name)
+        assert isinstance(llm, AzureCompletion), f"Failed for model: {model_name}"
+        assert (
+            llm.is_openai_model == True
+        ), f"Expected {model_name} to be detected as OpenAI model"
+        assert (
+            llm.supports_function_calling() == True
+        ), f"Expected {model_name} to support function calling"
+
+
 def test_azure_completion_params_preparation():
     """
     Test that completion parameters are properly prepared
@@ -539,6 +563,24 @@ def test_azure_gpt5_models_do_not_support_stop_words():
     for model_name in gpt5_models:
         llm = LLM(model=model_name)
         assert llm.supports_stop_words() == False, f"Expected {model_name} to NOT support stop words"
+
+
+def test_azure_gpt5_non_hyphenated_models_do_not_support_stop_words():
+    """
+    Test that non-hyphenated GPT-5 model names (e.g. gpt5nano) also do not
+    support stop words. Regression test for #4478.
+    """
+    gpt5_non_hyphenated = [
+        "azure/gpt5",
+        "azure/gpt5nano",
+        "azure/gpt5mini",
+    ]
+
+    for model_name in gpt5_non_hyphenated:
+        llm = LLM(model=model_name)
+        assert (
+            llm.supports_stop_words() == False
+        ), f"Expected {model_name} to NOT support stop words"
 
 
 def test_azure_o_series_models_do_not_support_stop_words():


### PR DESCRIPTION
## Summary

Fixes #4478

- Add `"gpt5"` prefix to model detection logic alongside `"gpt-"` so non-hyphenated GPT-5 model names (e.g. `gpt5`, `gpt5nano`, `gpt5mini`) are correctly recognized as OpenAI models
- Update `is_openai_model` check in `AzureCompletion.__init__` to detect `gpt5*` variants
- Update `supports_stop_words()` to treat `gpt5*` models the same as `gpt-5*` models
- Update `_is_model_from_provider()` for both `openai` and `azure` providers

## Context

When using Azure OpenAI with a deployment named `gpt5nano`, `gpt5`, etc., the model detection logic only checked for the `"gpt-"` prefix. This caused `is_openai_model` to be `False`, which in turn caused `response_model` (Pydantic structured output) to be ignored.

## Test plan

- [x] Added `test_azure_gpt5_non_hyphenated_model_detection` — verifies `is_openai_model` and `supports_function_calling()` for `gpt5`, `gpt5nano`, `gpt5mini`
- [x] Added `test_azure_gpt5_non_hyphenated_models_do_not_support_stop_words` — verifies stop words are correctly disabled for non-hyphenated GPT-5 names
- [x] All 59 Azure tests pass