### PR TITLE
fix: strip File objects from messages for non-multimodal LLMs

### DIFF
--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -602,6 +602,10 @@ class BaseLLM(ABC):
             Messages with files formatted into content blocks.
         """
         if not HAS_CREWAI_FILES or not self.supports_multimodal():
+            # Strip files from messages to prevent JSON serialization errors
+            # when File objects are passed to providers that don't support them
+            for msg in messages:
+                msg.pop("files", None)
             return messages
 
         provider = getattr(self, "provider", None) or getattr(self, "model", "openai")


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Object of type File is not JSON serializable` when using `input_files` with LLMs that don't support multimodal (e.g., Ollama/Gemma 3)
- Root cause: `BaseLLM._process_message_files()` returned early for non-multimodal LLMs without removing the `files` key from messages, leaving non-serializable `File` objects in the message dicts that get passed to `json.dumps()` by the httpx client
- Fix: always strip the `files` key from all messages when multimodal is not supported, before returning

## Test plan

- [x] Added 5 unit tests in `TestProcessMessageFiles` class covering:
  - Non-multimodal LLM strips `files` key from messages
  - Messages are JSON-serializable after processing (reproduces the exact TypeError from the issue)
  - Messages without `files` key are unaffected
  - Multimodal LLM also strips `files` after converting to content blocks
  - Multimodal LLM properly converts files to provider content blocks

Fixes #4498