### PR TITLE
fix: strip trailing whitespace from assistant messages for Anthropic

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2113,6 +2113,15 @@ class LLM(BaseLLM):
         if not self.is_anthropic:
             return messages  # type: ignore[return-value]
 
+        # Anthropic rejects final assistant content with trailing whitespace
+        if (
+            messages
+            and messages[-1]["role"] == "assistant"
+            and isinstance(messages[-1]["content"], str)
+            and messages[-1]["content"] != messages[-1]["content"].rstrip()
+        ):
+            messages = [*messages[:-1], {**messages[-1], "content": messages[-1]["content"].rstrip()}]
+
         # Anthropic requires messages to start with 'user' role
         if not messages or messages[0]["role"] == "system":
             # If first message is system or empty, add a placeholder user message


### PR DESCRIPTION
## Summary

Fixes #4413

Anthropic API returns a `400 BadRequestError` when the final assistant message content ends with trailing whitespace:
> `messages: final assistant content cannot end with trailing whitespace`

This PR strips trailing whitespace from the final assistant message before sending the request to Anthropic, in both code paths:

- **`LLM._format_messages_for_provider`** — the litellm path, where Anthropic models are detected via `self.is_anthropic`
- **`AnthropicCompletion._format_messages_for_anthropic`** — the direct Anthropic SDK path, handling both plain string content and structured content blocks (e.g. thinking + text)

## Test plan

- [x] Added `test_anthropic_strips_trailing_whitespace_from_final_assistant_message` covering:
  - Trailing space is stripped from final assistant message
  - Clean messages (no trailing whitespace) are unchanged
  - Multiple whitespace types (spaces, tabs, newlines) are handled
- [x] Existing `test_anthropic_message_formatting_edge_cases` still passes