### PR TITLE
fix: validate agent type in Task to give clear error message

### DIFF
--- a/lib/crewai/src/crewai/utilities/config.py
+++ b/lib/crewai/src/crewai/utilities/config.py
@@ -14,7 +14,19 @@ def process_config(
 
     Returns:
         The updated values dictionary.
+
+    Raises:
+        ValueError: If values is not a dictionary, indicating an invalid type
+            was passed where a model instance or config dict was expected.
     """
+    if not isinstance(values, dict):
+        raise ValueError(
+            f"Expected a dictionary or {model_class.__name__} instance, "
+            f"got {type(values).__name__}. "
+            f"Please provide a valid {model_class.__name__} object or a "
+            f"configuration dictionary."
+        )
+
     config = values.get("config", {})
     if not config:
         return values

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -874,6 +874,19 @@ def test_task_definition_based_on_dict():
     assert task.agent is None
 
 
+
+def test_task_with_invalid_agent_type_raises_validation_error():
+    """Test that passing an invalid type for agent raises a clear ValidationError."""
+    with pytest.raises(ValidationError, match="Expected a dictionary or BaseAgent instance"):
+        Task(description="test task", expected_output="test output", agent="not_an_agent")
+
+    with pytest.raises(ValidationError, match="Expected a dictionary or BaseAgent instance"):
+        Task(description="test task", expected_output="test output", agent=123)
+
+    with pytest.raises(ValidationError, match="Expected a dictionary or BaseAgent instance"):
+        Task(description="test task", expected_output="test output", agent=["invalid"])
+
+
 def test_conditional_task_definition_based_on_dict():
     config = {
         "description": "Give me an integer score between 1-5 for the following title: 'The impact of AI in the future of work', check examples to based your evaluation.",


### PR DESCRIPTION
## Summary

- Fixes #4419: `Task(agent="not_an_agent")` now raises a clear `ValidationError` instead of crashing with `AttributeError: 'str' object has no attribute 'get'`
- Adds an `isinstance` guard in `process_config()` that raises `ValueError` when non-dict values are passed, which Pydantic wraps into a proper `ValidationError`
- This also protects `BaseAgent` and any other model using `process_config()` from the same class of input errors

## Error before this fix

```
AttributeError: 'str' object has no attribute 'get'
```

## Error after this fix

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Task
agent
  Value error, Expected a dictionary or BaseAgent instance, got str.
  Please provide a valid BaseAgent object or a configuration dictionary.
```

## Test plan

- [x] Added `test_task_with_invalid_agent_type_raises_validation_error` covering string, int, and list inputs
- [x] Verified existing tests (`test_task_definition_based_on_dict`, `test_task_callback`, `test_task_copy_*`) still pass
- [x] Verified that `Task(agent=None)` and `Task()` (no agent) continue to work correctly