### PR TITLE
fix: save post-guardrail output to output_file instead of stale pre-guardrail result

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -632,10 +632,12 @@ class Task(BaseModel):
 
             if self.output_file:
                 content = (
-                    json_output
-                    if json_output
+                    task_output.json_dict
+                    if task_output.json_dict
                     else (
-                        pydantic_output.model_dump_json() if pydantic_output else result
+                        task_output.pydantic.model_dump_json()
+                        if task_output.pydantic
+                        else task_output.raw
                     )
                 )
                 self._save_file(content)
@@ -730,10 +732,12 @@ class Task(BaseModel):
 
             if self.output_file:
                 content = (
-                    json_output
-                    if json_output
+                    task_output.json_dict
+                    if task_output.json_dict
                     else (
-                        pydantic_output.model_dump_json() if pydantic_output else result
+                        task_output.pydantic.model_dump_json()
+                        if task_output.pydantic
+                        else task_output.raw
                     )
                 )
                 self._save_file(content)


### PR DESCRIPTION
## Summary

Fixes a bug where `output_file` always receives the raw pre-guardrail result instead of the final post-guardrail output when guardrails are present.

**Root cause:** In both `_execute_core` (sync) and `_aexecute_core` (async), the `output_file` save logic used stale local variables (`json_output`, `pydantic_output`, `result`) that were explicitly set to `None`/raw-string when guardrails are present (lines 687-688). After guardrails process and update `task_output`, the file save still referenced these stale locals, writing the original raw result instead of the guardrail-transformed output.

**Fix:** Replace local variable references with `task_output` attributes (`task_output.json_dict`, `task_output.pydantic`, `task_output.raw`) in both sync and async code paths. This ensures the file always reflects the final post-guardrail result, consistent with what `task.output` and the `TaskCompletedEvent` receive.

## Changes

- `lib/crewai/src/crewai/task.py`: Use `task_output.json_dict`, `task_output.pydantic`, and `task_output.raw` for `output_file` save in both `_execute_core` and `_aexecute_core`
- `lib/crewai/tests/test_task_guardrails.py`: Add 3 tests verifying `output_file` content correctness with and without guardrails

## Test plan

- [x] `test_output_file_saves_guardrail_result_not_stale_raw` - verifies guardrail-transformed text is saved (single guardrail)
- [x] `test_output_file_saves_guardrail_result_with_guardrails_list` - verifies with guardrails list
- [x] `test_output_file_saves_without_guardrails` - verifies no regression without guardrails
- [x] All 21 existing guardrail tests pass
- [x] Existing `output_file` tests in `test_task.py` pass