### PR TITLE
docs: add repo-local AGENTS.md contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS Instructions
+
+This file provides machine-readable contributor guidance for CrewAI.
+
+## Scope
+
+- Keep changes focused to one behavior contract per PR.
+- Prefer deterministic behavior and fail-closed defaults for tool/permission boundaries.
+- Do not bundle unrelated refactors.
+
+## Setup
+
+- Python: `>=3.10,<3.14`
+- Package manager: `uv`
+- Create environment from repo root:
+  - `uv venv`
+  - `uv sync`
+
+## Validation (repo-local baseline)
+
+Run these from `lib/crewai/` unless otherwise noted.
+
+1. Format/lint before tests:
+- `uv run ruff check .`
+- `uv run ruff format .`
+
+2. Type checks:
+- `uvx mypy src`
+
+3. Tests:
+- `uv run pytest .`
+
+4. Build sanity (if packaging changes):
+- `uv build`
+
+## Engineering Guardrails
+
+- Preserve deterministic crew/task execution order; add regression tests for ordering and retry semantics.
+- Keep tool execution and permission behavior explicit; prefer hard failure over permissive fallback on ambiguous safety state.
+- For concurrency changes, include tests that verify stable ordering or explicit ordering metadata.
+
+## PR Hygiene
+
+- PR description must include: Problem, What changed, Validation commands + results.
+- Keep branch scope aligned to issue scope.
+- If scope changes, update PR title/body immediately.
+


### PR DESCRIPTION
## Problem
This repo lacked a repo-local AGENTS instruction file, causing inconsistent machine-guided validation behavior.

## Why now
This is active operator friction in current workflows and needs deterministic behavior for repeatable triage/replay.

## What changed
Added root AGENTS.md with deterministic setup/validation commands and safety/PR hygiene guardrails aligned to current repo workflows.

## Validation
- test -f AGENTS.md (pass)

Refs #4564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that doesn’t alter runtime behavior or interfaces.
> 
> **Overview**
> Adds a new root `AGENTS.md` file with machine-readable contributor guidance, including environment setup (`uv`), a repo-local validation checklist (ruff/mypy/pytest/build), and engineering/PR hygiene guardrails emphasizing deterministic execution and fail-closed safety boundaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf2d8b0d7f87eebd9ecc4a86abbe03d6e20602d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->