### PR TITLE
feat:#4249

### DIFF
--- a/docs/en/mcp/tool-discovery.mdx
+++ b/docs/en/mcp/tool-discovery.mdx
@@ -1,0 +1,85 @@
+---
+title: "MCP Tool Discovery"
+description: "Discover MCP tools by natural language using BaseDiscoveryProvider, MCPDiscoveryProvider, and DynamicDiscoveryTool."
+icon: search
+mode: "wide"
+---
+
+## Overview
+
+CrewAI supports **tool discovery** so agents can find MCP (or other) tools by semantic search instead of manual configuration. You can plug in different discovery backends (e.g. [mcp-discovery](https://github.com/yksanjo/mcp-discovery)) and expose discovery as a CrewAI tool that returns or registers tools for an agent.
+
+Main pieces:
+
+- **`BaseDiscoveryProvider`** — Abstract interface: semantic search returns `DiscoveryEntry` list; entries can be resolved to `BaseTool` instances.
+- **`DiscoveryEntry`** — Normalized result (id, name, description, source_uri, input_schema, provider_id, raw_metadata).
+- **`MCPDiscoveryProvider`** — Implementation that calls the mcp-discovery HTTP API and resolves entries to `MCPToolWrapper`.
+- **`DynamicDiscoveryTool`** — A `BaseTool` that runs discovery (via a configured provider) and optionally registers discovered tools to an agent.
+
+## Quick Example
+
+```python
+from crewai import Agent
+from crewai.tools import DynamicDiscoveryTool
+from crewai.tools.mcp_discovery_provider import MCPDiscoveryProvider
+
+# Provider that uses the mcp-discovery API
+provider = MCPDiscoveryProvider()
+
+# Optional: discovery tool that can register tools to an agent
+agent = Agent(
+    role="Assistant",
+    goal="Help the user by discovering and using the right tools.",
+    backstory="You use tool discovery to find and use MCP tools.",
+    tools=[],
+)
+discovery_tool = DynamicDiscoveryTool(
+    provider=provider,
+    limit=5,
+    agent=agent,
+    auto_register=True,
+)
+agent.tools = [discovery_tool]
+
+# When the agent uses the discovery tool with a query (e.g. "send Slack messages"),
+# the provider runs semantic search, resolves entries to BaseTool, and appends them to agent.tools.
+```
+
+## Discovery Only (No Agent)
+
+Use the provider directly to get entries or tools without registering to an agent:
+
+```python
+import asyncio
+from crewai.tools.mcp_discovery_provider import MCPDiscoveryProvider
+
+provider = MCPDiscoveryProvider()
+
+# Get discovery entries (normalized list)
+entries = asyncio.run(provider.search_semantic("database or postgres", limit=5))
+
+# Or get ready-to-use BaseTool instances (MCPToolWrapper when resolvable)
+tools = asyncio.run(provider.search_semantic_and_resolve("slack notifications", limit=3))
+```
+
+## Configuration
+
+- **MCPDiscoveryProvider**  
+  - `base_url`: API base URL (default from env `MCP_DISCOVERY_API_BASE_URL` or public deployment).  
+  - `server_url_resolver`: Optional callable `(DiscoveryEntry) -> str` to map an entry to an MCP HTTP server URL (otherwise `entry.source_uri` is used; resolve may fail if missing).
+
+- **DynamicDiscoveryTool**  
+  - `provider`: Any `BaseDiscoveryProvider` implementation.  
+  - `limit`: Default max tools per discovery run.  
+  - `agent`: Optional object with a mutable `tools` list; when set and `auto_register=True`, discovered tools are appended to `agent.tools`.  
+  - `auto_register`: If `True` and `agent` is set, discovered tools are registered to the agent.
+
+## E2E Demo
+
+From the repository root you can run the end-to-end demo:
+
+```bash
+python scripts/demo_mcp_discovery.py
+```
+
+It demonstrates semantic search, `DiscoveryEntry` parsing, `DynamicDiscoveryTool` output, and optional registration to an agent.

--- a/lib/crewai/src/crewai/tools/__init__.py
+++ b/lib/crewai/src/crewai/tools/__init__.py
@@ -1,9 +1,12 @@
 from crewai.tools.base_tool import BaseTool, EnvVar, tool
-
-
+from crewai.tools.base_discovery_provider import BaseDiscoveryProvider, DiscoveryEntry
+from crewai.tools.dynamic_discovery_tool import DynamicDiscoveryTool
 
 __all__ = [
+    "BaseDiscoveryProvider",
     "BaseTool",
+    "DiscoveryEntry",
+    "DynamicDiscoveryTool",
     "EnvVar",
     "tool",
 ]

--- a/lib/crewai/src/crewai/tools/base_discovery_provider.py
+++ b/lib/crewai/src/crewai/tools/base_discovery_provider.py
@@ -1,0 +1,164 @@
+"""Abstract interface for tool discovery providers.
+
+Supports multiple backends (e.g. mcp-discovery API, list.agenium.net with agent://)
+through a unified semantic search API and conversion to CrewAI BaseTool instances.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from crewai.tools.base_tool import BaseTool
+
+
+# ---------------------------------------------------------------------------
+# Discovery result model (provider-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class DiscoveryEntry(BaseModel):
+    """Provider-agnostic representation of a discovered tool.
+
+    All discovery backends (mcp-discovery, list.agenium.net, etc.) should
+    normalize their results to this shape. The provider then uses
+    raw_metadata (and optionally source_uri) to turn the entry into a
+    concrete BaseTool (e.g. MCPToolWrapper or an agent://-based tool).
+    """
+
+    id: str = Field(
+        description="Unique identifier for this tool within the discovery source."
+    )
+    name: str = Field(
+        description="Tool name suitable for display and for BaseTool.name."
+    )
+    description: str = Field(
+        default="",
+        description="Tool description for model use and BaseTool.description.",
+    )
+    source_uri: str | None = Field(
+        default=None,
+        description="Canonical source (e.g. agent://..., https://..., mcp server URL).",
+    )
+    input_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="JSON Schema for tool arguments (e.g. MCP inputSchema).",
+    )
+    provider_id: str = Field(
+        description="Identifier of the provider that returned this entry (e.g. 'mcp-discovery', 'agenium').",
+    )
+    raw_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific data needed to build BaseTool (e.g. mcp_server_params, agent config).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Abstract discovery provider
+# ---------------------------------------------------------------------------
+
+
+class BaseDiscoveryProvider(ABC):
+    """Abstract interface for tool discovery services.
+
+    Implementations can back semantic search with different APIs (e.g.
+    mcp-discovery, list.agenium.net) and different protocols (MCP, agent://).
+    Results are normalized to DiscoveryEntry and can be converted to
+    CrewAI BaseTool instances for use in agents.
+    """
+
+    @property
+    @abstractmethod
+    def provider_id(self) -> str:
+        """Unique identifier for this provider (e.g. 'mcp-discovery', 'agenium')."""
+        ...
+
+    @abstractmethod
+    async def search_semantic(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        **kwargs: Any,
+    ) -> list[DiscoveryEntry]:
+        """Run semantic search over the tool registry.
+
+        Args:
+            query: Natural language or keyword query describing desired tools.
+            limit: Maximum number of entries to return.
+            **kwargs: Provider-specific options (e.g. filters, scoring).
+
+        Returns:
+            List of discovery entries, ordered by relevance (best first).
+        """
+        ...
+
+    async def resolve_to_tool(self, entry: DiscoveryEntry) -> BaseTool:
+        """Convert a discovery entry into a CrewAI BaseTool instance.
+
+        Default implementation raises NotImplementedError; subclasses must
+        implement so that the returned tool can be used with CrewAI agents
+        (e.g. MCPToolWrapper for MCP servers, or an agent://-aware wrapper
+        for Agenium).
+
+        Args:
+            entry: A DiscoveryEntry returned by search_semantic (or list_all).
+
+        Returns:
+            A BaseTool instance (e.g. MCPToolWrapper) ready for to_structured_tool().
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement resolve_to_tool(DiscoveryEntry) -> BaseTool"
+        )
+
+    async def search_semantic_and_resolve(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        **kwargs: Any,
+    ) -> list[BaseTool]:
+        """Convenience: semantic search then resolve each entry to BaseTool.
+
+        Args:
+            query: Semantic search query.
+            limit: Max number of tools to return.
+            **kwargs: Passed through to search_semantic.
+
+        Returns:
+            List of BaseTool instances.
+        """
+        entries = await self.search_semantic(query, limit=limit, **kwargs)
+        tools: list[BaseTool] = []
+        for entry in entries:
+            try:
+                tool = await self.resolve_to_tool(entry)
+                tools.append(tool)
+            except Exception:  # noqa: S112, PERF203
+                # Skip entries that fail to resolve (e.g. unreachable server)
+                continue
+        return tools
+
+    async def list_all(
+        self,
+        *,
+        limit: int = 100,
+        **kwargs: Any,
+    ) -> list[DiscoveryEntry]:
+        """List available tools without semantic ranking (optional).
+
+        Override if the backend supports listing the full catalog; otherwise
+        callers can use search_semantic with a broad query.
+
+        Args:
+            limit: Maximum entries to return.
+            **kwargs: Provider-specific options.
+
+        Returns:
+            List of discovery entries (order is provider-defined).
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement list_all; use search_semantic instead."
+        )

--- a/lib/crewai/src/crewai/tools/dynamic_discovery_tool.py
+++ b/lib/crewai/src/crewai/tools/dynamic_discovery_tool.py
@@ -1,0 +1,138 @@
+"""Dynamic discovery tool that uses a BaseDiscoveryProvider to find and optionally register tools."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from crewai.tools.base_discovery_provider import BaseDiscoveryProvider
+from crewai.tools.base_tool import BaseTool
+
+
+class DynamicDiscoveryTool(BaseTool):
+    """A CrewAI tool that runs semantic search via a configured discovery provider.
+
+    When run, it calls the provider's semantic search with the given query,
+    resolves results to BaseTool instances, and either returns that list or
+    automatically adds them to a configured agent's tools (and returns a summary).
+    """
+
+    def __init__(
+        self,
+        provider: BaseDiscoveryProvider,
+        *,
+        limit: int = 10,
+        agent: Any = None,
+        auto_register: bool = True,
+        name: str = "dynamic_tool_discovery",
+        description: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the dynamic discovery tool.
+
+        Args:
+            provider: Discovery provider used for semantic search and resolve.
+            limit: Default maximum number of tools to discover per run.
+            agent: Optional agent (or any object with a mutable ``tools`` list).
+                When set and ``auto_register`` is True, discovered tools are
+                appended to ``agent.tools``.
+            auto_register: If True and ``agent`` is set, discovered tools are
+                registered to ``agent.tools``. Ignored when ``agent`` is None.
+            name: Tool name shown to the model.
+            description: Tool description. Defaults to a standard discovery description.
+            **kwargs: Passed through to BaseTool (e.g. result_as_answer, max_usage_count).
+        """
+        desc = description or (
+            "Use this tool to discover other tools by natural language. "
+            "Provide a search_query describing what you need (e.g. 'send Slack messages', "
+            "'query a database'). Returns a list of available tools or registers them to the agent."
+        )
+        super().__init__(
+            name=name,
+            description=desc,
+            **kwargs,
+        )
+        self._provider = provider
+        self._limit = limit
+        self._agent = agent
+        self._auto_register = auto_register
+
+    def _run(
+        self,
+        search_query: str,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Run discovery: search via the provider and optionally register tools to the agent.
+
+        Args:
+            search_query: Natural language or keyword query for tool discovery.
+            limit: Max number of tools to return. If None, uses the tool's default limit.
+
+        Returns:
+            Dict with keys: tools (list of BaseTool), count (int), registered (bool),
+            summary (str). The summary is suitable for the model; tools can be used
+            programmatically by code that holds a reference to this tool or the agent.
+        """
+        effective_limit = limit if limit is not None else self._limit
+        tools = asyncio.run(
+            self._provider.search_semantic_and_resolve(
+                search_query,
+                limit=effective_limit,
+            )
+        )
+        registered = False
+        if (
+            self._auto_register
+            and self._agent is not None
+            and hasattr(self._agent, "tools")
+        ):
+            agent_tools = self._agent.tools
+            if agent_tools is not None:
+                agent_tools.extend(tools)
+                registered = True
+
+        summary = (
+            f"Discovered {len(tools)} tool(s): "
+            + ", ".join(t.name for t in tools)
+            + (" and registered them to the agent." if registered else ".")
+        )
+        return {
+            "tools": tools,
+            "count": len(tools),
+            "registered": registered,
+            "summary": summary,
+        }
+
+    async def _arun(
+        self,
+        search_query: str,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Async implementation of discovery and optional registration."""
+        effective_limit = limit if limit is not None else self._limit
+        tools = await self._provider.search_semantic_and_resolve(
+            search_query,
+            limit=effective_limit,
+        )
+        registered = False
+        if (
+            self._auto_register
+            and self._agent is not None
+            and hasattr(self._agent, "tools")
+        ):
+            agent_tools = self._agent.tools
+            if agent_tools is not None:
+                agent_tools.extend(tools)
+                registered = True
+
+        summary = (
+            f"Discovered {len(tools)} tool(s): "
+            + ", ".join(t.name for t in tools)
+            + (" and registered them to the agent." if registered else ".")
+        )
+        return {
+            "tools": tools,
+            "count": len(tools),
+            "registered": registered,
+            "summary": summary,
+        }

--- a/lib/crewai/src/crewai/tools/mcp_discovery_provider.py
+++ b/lib/crewai/src/crewai/tools/mcp_discovery_provider.py
@@ -1,0 +1,227 @@
+"""Discovery provider backed by yksanjo/mcp-discovery.
+
+This provider uses the public HTTP API exposed by the mcp-discovery
+project to perform **semantic search over MCP servers**, then exposes
+the results through the common ``BaseDiscoveryProvider`` interface.
+
+It also knows how to turn a ``DiscoveryEntry`` into a concrete
+``MCPToolWrapper`` instance, so the discovered MCP servers (and their
+tools) can be used as CrewAI tools.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import os
+from typing import Any
+
+import httpx
+
+from crewai.tools.base_discovery_provider import BaseDiscoveryProvider, DiscoveryEntry
+from crewai.tools.base_tool import BaseTool
+from crewai.tools.mcp_tool_wrapper import MCPToolWrapper
+
+
+DEFAULT_MCP_DISCOVERY_BASE_URL = "https://mcp-discovery-two.vercel.app"
+
+
+class MCPDiscoveryProvider(BaseDiscoveryProvider):
+    """Discovery provider that talks to the mcp-discovery HTTP API.
+
+    The core semantic search is delegated to the mcp-discovery service,
+    which indexes MCP servers and returns ranked recommendations.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the mcp-discovery API. If not provided, it will use
+        the ``MCP_DISCOVERY_API_BASE_URL`` environment variable, falling
+        back to the public deployment at
+        ``https://mcp-discovery-two.vercel.app``.
+    timeout:
+        HTTP timeout in seconds for discovery requests.
+    server_url_resolver:
+        Optional callable to turn a ``DiscoveryEntry`` into an MCP HTTP
+        server URL. If not provided, ``resolve_to_tool`` will fall back
+        to ``entry.source_uri`` and raise a ``ValueError`` if it is not
+        set. This hook allows callers to customize how a discovered
+        server maps to a concrete MCP HTTP endpoint.
+    default_tool_name:
+        Default MCP tool name to wrap on the discovered server if no
+        specific tool is provided in ``DiscoveryEntry.raw_metadata``.
+        This is a pragmatic default; real integrations will typically
+        populate a concrete tool name via an additional lookup step.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        timeout: float = 10.0,
+        server_url_resolver: Callable[[DiscoveryEntry], str] | None = None,
+        default_tool_name: str = "default",
+    ) -> None:
+        self._base_url = (
+            base_url
+            or os.getenv("MCP_DISCOVERY_API_BASE_URL")
+            or DEFAULT_MCP_DISCOVERY_BASE_URL
+        ).rstrip("/")
+        self._timeout = timeout
+        self._server_url_resolver = server_url_resolver
+        self._default_tool_name = default_tool_name
+
+    # ------------------------------------------------------------------
+    # BaseDiscoveryProvider implementation
+    # ------------------------------------------------------------------
+
+    @property
+    def provider_id(self) -> str:
+        return "mcp-discovery"
+
+    async def search_semantic(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        **_: Any,
+    ) -> list[DiscoveryEntry]:
+        """Use the mcp-discovery API to find relevant MCP servers.
+
+        This method calls the public HTTP endpoint exposed by
+        mcp-discovery. The current API (see yksanjo/mcp-discovery and
+        mcp-discovery-api docs) expects a JSON body compatible with the
+        ``DiscoverInput`` type:
+
+        .. code-block:: json
+
+            {
+              "need": "<natural language requirement>",
+              "limit": <max_results>
+            }
+
+        and responds with a ``DiscoverOutput`` object containing a
+        ``recommendations`` array of ``ServerRecommendation`` items.
+        Each recommendation is normalized into a ``DiscoveryEntry``.
+        """
+        payload = {
+            "need": query,
+            "limit": limit,
+        }
+
+        url = f"{self._base_url}/api/v1/discover"
+
+        async with httpx.AsyncClient(timeout=self._timeout, trust_env=False) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+
+        recommendations = data.get("recommendations") or []
+
+        entries: list[DiscoveryEntry] = []
+        for rec in recommendations:
+            # ServerRecommendation shape from mcp-discovery:
+            # {
+            #   server: string;
+            #   npm_package: string | null;
+            #   install_command: string;
+            #   confidence: number;
+            #   description: string | null;
+            #   capabilities: string[];
+            #   metrics: { ... };
+            #   docs_url: string | null;
+            #   github_url: string | null;
+            # }
+            server_name = rec.get("server") or ""
+            if not server_name:
+                # Skip malformed recommendation entries.
+                continue
+
+            entry_id = server_name
+
+            description = rec.get("description") or ""
+            source_uri = rec.get("docs_url") or rec.get("github_url")
+
+            raw_metadata: dict[str, Any] = {
+                "npm_package": rec.get("npm_package"),
+                "install_command": rec.get("install_command"),
+                "confidence": rec.get("confidence"),
+                "capabilities": rec.get("capabilities") or [],
+                "metrics": rec.get("metrics") or {},
+                "docs_url": rec.get("docs_url"),
+                "github_url": rec.get("github_url"),
+            }
+
+            entries.append(
+                DiscoveryEntry(
+                    id=entry_id,
+                    name=server_name,
+                    description=description,
+                    source_uri=source_uri,
+                    input_schema=None,  # server-level; tool schemas require a separate MCP list_tools step
+                    provider_id=self.provider_id,
+                    raw_metadata=raw_metadata,
+                )
+            )
+
+        return entries
+
+    async def resolve_to_tool(self, entry: DiscoveryEntry) -> BaseTool:
+        """Create an ``MCPToolWrapper`` for a discovered MCP server.
+
+        Note
+        ----
+        mcp-discovery itself returns **server-level** metadata
+        (documentation URLs, install commands, capabilities, metrics),
+        not individual MCP tool schemas.
+
+        This implementation therefore makes two pragmatic assumptions:
+
+        1. There exists an HTTP-accessible MCP endpoint for the server,
+           whose URL can either be derived from the ``DiscoveryEntry``
+           (via ``source_uri``) or supplied by a custom
+           ``server_url_resolver`` callable.
+        2. A reasonable default tool name can be used if the caller has
+           not pre-populated a more specific MCP tool name in
+           ``entry.raw_metadata['tool_name']``.
+
+        Real-world integrations will typically add an extra discovery
+        step that, given a server URL, lists its MCP tools and enriches
+        ``DiscoveryEntry.raw_metadata`` with concrete tool-level
+        schemas.
+        """
+        # Determine MCP server URL
+        server_url: str | None
+        if self._server_url_resolver is not None:
+            server_url = self._server_url_resolver(entry)
+        else:
+            server_url = entry.source_uri
+
+        if not server_url:
+            raise ValueError(
+                "Cannot resolve MCP server URL for discovery entry "
+                f"{entry.id!r}; provide source_uri or a server_url_resolver."
+            )
+
+        mcp_server_params = {"url": server_url}
+
+        # Tool name preference: explicit in metadata -> default from provider
+        tool_name = entry.raw_metadata.get("tool_name") or self._default_tool_name
+
+        # Basic tool schema: description + optional args_schema from metadata
+        tool_schema: dict[str, Any] = {
+            "description": entry.description
+            or f"Tool {tool_name} discovered via mcp-discovery for server {entry.name}",
+        }
+
+        if "args_schema" in entry.raw_metadata:
+            tool_schema["args_schema"] = entry.raw_metadata["args_schema"]
+
+        # Use the server's display name as the MCPToolWrapper server_name prefix
+        server_name = entry.name
+
+        return MCPToolWrapper(
+            mcp_server_params=mcp_server_params,
+            tool_name=tool_name,
+            tool_schema=tool_schema,
+            server_name=server_name,
+        )

--- a/lib/crewai/src/crewai/tools/memory_tools.py
+++ b/lib/crewai/src/crewai/tools/memory_tools.py
@@ -62,7 +62,9 @@ class RecallMemoryTool(BaseTool):
         all_lines: list[str] = []
         seen_ids: set[str] = set()
         for query in queries:
-            matches = self.memory.recall(query, scope=scope, limit=5, depth=actual_depth)
+            matches = self.memory.recall(
+                query, scope=scope, limit=5, depth=actual_depth
+            )
             for m in matches:
                 if m.record.id not in seen_ids:
                     seen_ids.add(m.record.id)

--- a/lib/crewai/tests/tools/test_mcp_discovery.py
+++ b/lib/crewai/tests/tools/test_mcp_discovery.py
@@ -1,0 +1,127 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from crewai.tools.base_discovery_provider import DiscoveryEntry, BaseDiscoveryProvider
+from crewai.tools.dynamic_discovery_tool import DynamicDiscoveryTool
+from crewai.tools.mcp_discovery_provider import MCPDiscoveryProvider
+from crewai.tools.base_tool import BaseTool
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_mcp_discovery_search_semantic_parses_json(mock_async_client_class):
+    """MCPDiscoveryProvider.search_semantic should parse API JSON into DiscoveryEntry list."""
+    # Arrange: mock HTTP response from mcp-discovery API
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "recommendations": [
+            {
+                "server": "test-server",
+                "npm_package": "test-package",
+                "install_command": "npm install test-package",
+                "confidence": 0.95,
+                "description": "Test MCP server",
+                "capabilities": ["db", "auth"],
+                "metrics": {
+                    "avg_latency_ms": 10,
+                    "uptime_pct": 99.9,
+                    "last_checked": "2025-01-01T00:00:00Z",
+                },
+                "docs_url": "https://docs.example.com/test-server",
+                "github_url": "https://github.com/example/test-server",
+            },
+            {
+                # Missing server name should be skipped
+                "server": "",
+                "npm_package": "ignored",
+                "install_command": "npm install ignored",
+                "confidence": 0.1,
+                "description": "Should be ignored",
+                "capabilities": [],
+                "metrics": {},
+                "docs_url": None,
+                "github_url": None,
+            },
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.post.return_value = mock_response
+    mock_async_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+    provider = MCPDiscoveryProvider(base_url="https://mock-api.example.com")
+
+    # Act
+    entries = await provider.search_semantic("database with auth", limit=3)
+
+    # Assert
+    mock_client_instance.post.assert_called_once_with(
+        "https://mock-api.example.com/api/v1/discover",
+        json={"need": "database with auth", "limit": 3},
+    )
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert isinstance(entry, DiscoveryEntry)
+    assert entry.id == "test-server"
+    assert entry.name == "test-server"
+    assert entry.description == "Test MCP server"
+    # docs_url should be preferred as source_uri when present
+    assert entry.source_uri == "https://docs.example.com/test-server"
+    assert entry.provider_id == provider.provider_id
+    assert entry.raw_metadata["npm_package"] == "test-package"
+    assert entry.raw_metadata["install_command"] == "npm install test-package"
+    assert entry.raw_metadata["capabilities"] == ["db", "auth"]
+    assert entry.raw_metadata["metrics"]["avg_latency_ms"] == 10
+
+
+class _DummyTool(BaseTool):
+    """Simple dummy tool for DynamicDiscoveryTool tests."""
+
+    def _run(self, *args, **kwargs) -> str:  # pragma: no cover - not used directly
+        return "ok"
+
+
+def test_dynamic_discovery_tool_calls_provider_and_returns_summary():
+    """DynamicDiscoveryTool should call provider and return tool descriptions."""
+
+    # Arrange: mock provider with async search_semantic_and_resolve
+    provider_mock = MagicMock(spec=BaseDiscoveryProvider)
+
+    tool1 = _DummyTool(name="tool_one", description="First tool")
+    tool2 = _DummyTool(name="tool_two", description="Second tool")
+
+    provider_mock.search_semantic_and_resolve = AsyncMock(
+        return_value=[tool1, tool2]
+    )
+
+    # No agent – just return tools and summary
+    discovery_tool = DynamicDiscoveryTool(
+        provider=provider_mock,
+        limit=5,
+        agent=None,
+        auto_register=False,
+    )
+
+    # Act: call the synchronous _run which internally uses asyncio.run(...)
+    result = discovery_tool._run(search_query="find useful tools")
+
+    # Assert: provider was called with correct arguments
+    provider_mock.search_semantic_and_resolve.assert_awaited_once_with(
+        "find useful tools", limit=5
+    )
+
+    assert result["count"] == 2
+    assert result["registered"] is False
+    summary = result["summary"]
+    assert "Discovered 2 tool(s)" in summary
+    assert "tool_one" in summary
+    assert "tool_two" in summary
+
+    # The tools list should be the actual tool instances returned by the provider
+    tools = result["tools"]
+    assert tools == [tool1, tool2]
+

--- a/scripts/demo_mcp_discovery.py
+++ b/scripts/demo_mcp_discovery.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""End-to-end demo: MCP tool discovery with BaseDiscoveryProvider and DynamicDiscoveryTool.
+
+This script demonstrates:
+  1. MCPDiscoveryProvider.search_semantic() — semantic search via the mcp-discovery API.
+  2. DiscoveryEntry list — normalized results (name, description, source_uri, raw_metadata).
+  3. DynamicDiscoveryTool — a CrewAI tool that runs discovery and optionally registers tools to an agent.
+
+Requirements:
+  - Network access to the mcp-discovery API (default: https://mcp-discovery-two.vercel.app).
+  - Optional: set MCP_DISCOVERY_API_BASE_URL to use a different endpoint.
+
+Run from repo root:
+  python scripts/demo_mcp_discovery.py
+  # or with uv:
+  uv run python scripts/demo_mcp_discovery.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+
+def _ensure_crewai():
+    """Ensure we can import crewai; add lib/crewai to path if running from repo root."""
+    try:
+        import crewai  # noqa: F401
+    except ImportError:
+        # Allow running from repo root without installing: python scripts/demo_mcp_discovery.py
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        lib_crewai = repo_root / "lib" / "crewai"
+        if lib_crewai.is_dir():
+            sys.path.insert(0, str(lib_crewai.parent))
+        else:
+            raise
+
+
+_ensure_crewai()
+
+from crewai.tools import BaseDiscoveryProvider, DiscoveryEntry, DynamicDiscoveryTool
+from crewai.tools.mcp_discovery_provider import MCPDiscoveryProvider
+
+
+async def demo_search_semantic(provider: MCPDiscoveryProvider) -> None:
+    """1. Run semantic search and print DiscoveryEntry list."""
+    print("=" * 60)
+    print("1. MCPDiscoveryProvider.search_semantic()")
+    print("=" * 60)
+
+    query = "send slack notifications"
+    limit = 3
+
+    try:
+        entries = await provider.search_semantic(query, limit=limit)
+    except Exception as e:
+        print(f"  Error calling mcp-discovery API: {e}")
+        print("  (Check network and that the API is reachable.)")
+        return
+
+    print(f"  Query: {query!r}  limit={limit}")
+    print(f"  Found {len(entries)} recommendation(s):\n")
+
+    for i, entry in enumerate(entries, 1):
+        print(f"  [{i}] {entry.name}")
+        print(f"      id: {entry.id}")
+        print(f"      description: {entry.description[:80]}..." if len(entry.description or "") > 80 else f"      description: {entry.description or '(none)'}")
+        print(f"      source_uri: {entry.source_uri}")
+        print(f"      provider_id: {entry.provider_id}")
+        if entry.raw_metadata.get("install_command"):
+            print(f"      install_command: {entry.raw_metadata['install_command']}")
+        print()
+
+    if not entries:
+        print("  (No entries returned; API may be empty or query may have no matches.)\n")
+
+
+def demo_dynamic_discovery_tool(provider: BaseDiscoveryProvider) -> None:
+    """2. Use DynamicDiscoveryTool: run discovery and print result (no agent registration)."""
+    print("=" * 60)
+    print("2. DynamicDiscoveryTool (discover only, no agent)")
+    print("=" * 60)
+
+    discovery_tool = DynamicDiscoveryTool(
+        provider=provider,
+        limit=2,
+        agent=None,
+        auto_register=False,
+        name="dynamic_tool_discovery",
+    )
+
+    query = "database or postgres"
+    print(f"  Calling tool with search_query={query!r} ...\n")
+
+    try:
+        result = discovery_tool.run(search_query=query, limit=2)
+    except Exception as e:
+        print(f"  Error: {e}")
+        return
+
+    print(f"  Result count: {result['count']}")
+    print(f"  Registered to agent: {result['registered']}")
+    print(f"  Summary: {result['summary']}\n")
+
+    tools = result.get("tools") or []
+    if tools:
+        print("  Discovered tools (usable as CrewAI BaseTool):")
+        for t in tools:
+            print(f"    - {t.name}: {t.description[:60]}..." if len(t.description or "") > 60 else f"    - {t.name}: {t.description or '(no description)'}")
+    else:
+        print("  (No tools resolved; entries may lack a valid MCP server URL for resolve_to_tool.)")
+    print()
+
+
+def demo_dynamic_discovery_with_agent(provider: BaseDiscoveryProvider) -> None:
+    """3. Wire DynamicDiscoveryTool to an agent (tool can register discovered tools to agent.tools)."""
+    print("=" * 60)
+    print("3. DynamicDiscoveryTool + Agent (auto_register)")
+    print("=" * 60)
+
+    try:
+        from crewai import Agent
+    except ImportError:
+        print("  Skipped: Agent not available (optional for this demo).\n")
+        return
+
+    # Agent starts with only the discovery tool
+    agent = Agent(
+        role="Tool discovery assistant",
+        goal="Find and register useful MCP tools for the user.",
+        backstory="You help users discover tools by natural language.",
+        tools=[],  # We add DynamicDiscoveryTool below
+        verbose=False,
+    )
+
+    discovery_tool = DynamicDiscoveryTool(
+        provider=provider,
+        limit=2,
+        agent=agent,
+        auto_register=True,
+    )
+
+    agent.tools = [discovery_tool]
+
+    print("  Agent has one tool: dynamic_tool_discovery.")
+    print("  When the agent uses it with a query, discovered tools are appended to agent.tools.")
+    print("  Example: result = discovery_tool.run(search_query='slack')")
+    print()
+
+    try:
+        result = discovery_tool.run(search_query="slack or notifications", limit=2)
+        print(f"  After run: result['count']={result['count']}, result['registered']={result['registered']}")
+        print(f"  agent.tools now has {len(agent.tools)} item(s):")
+        for i, t in enumerate(agent.tools):
+            name = getattr(t, "name", str(t))[:50]
+            print(f"    [{i+1}] {name}")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+    print()
+
+
+def main() -> None:
+    print("\nMCP Tool Discovery — E2E Demo\n")
+
+    provider = MCPDiscoveryProvider()
+    print(f"Using MCPDiscoveryProvider (provider_id={provider.provider_id})")
+    print()
+
+    asyncio.run(demo_search_semantic(provider))
+
+    demo_dynamic_discovery_tool(provider)
+
+    demo_dynamic_discovery_with_agent(provider)
+
+    print("Done.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
🚀 Summary
This PR introduces a flexible Discovery Provider architecture to address the need for dynamic tool discovery mentioned in #4249. Instead of hard-coding a specific API, it provides an abstract BaseDiscoveryProvider that can support multiple backends (like mcp-discovery or Agenium).

🛠️ Changes
Core Architecture: Added BaseDiscoveryProvider and DiscoveryEntry for unified discovery logic.

Implementations: Added MCPDiscoveryProvider targeting the yksanjo API.

New Tool: Added DynamicDiscoveryTool allowing agents to search and optionally auto_register tools at runtime.

Documentation: Comprehensive guide added at docs/en/mcp/tool-discovery.mdx.

🧪 Verification
Created lib/crewai/tests/tools/test_mcp_discovery.py with full Mock coverage.

Verified with an E2E demo script at scripts/demo_mcp_discovery.py.