### PR TITLE
fix: load MCP tools when agent has no explicit tools

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1695,11 +1695,15 @@ class Agent(BaseAgent):
         # Process platform apps and MCP tools
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
-            if platform_tools and self.tools is not None:
+            if platform_tools:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(platform_tools)
         if self.mcps:
             mcps = self.get_mcp_tools(self.mcps)
-            if mcps and self.tools is not None:
+            if mcps:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(mcps)
 
         # Prepare tools


### PR DESCRIPTION
## Problem

When an agent is configured with `mcps` but no explicit `tools`, `self.tools` is `None`. The condition on line 1702:

```python
if mcps and self.tools is not None:
    self.tools.extend(mcps)
```

…skips extending because `self.tools is not None` evaluates to `False`. MCP tools are silently ignored.

Fixes #4568

## Fix

Initialize `self.tools` to `[]` when it is `None` before extending with MCP tools.

## Changes

- `lib/crewai/src/crewai/agent/core.py`: Changed the `mcps` loading block to initialize `self.tools = []` when None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool list initialization during kickoff; low chance of side effects beyond ensuring expected tools are available.
> 
> **Overview**
> Fixes standalone agent kickoff tool loading so *platform apps* and *MCP* tools are appended even when `self.tools` is `None`.
> 
> `_prepare_kickoff()` now initializes `self.tools` to an empty list before extending, preventing silently skipped tool integration when only `apps`/`mcps` are configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84738fc837fb3e1e63ab6bb6cfe47a3c11cd1d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->