### PR TITLE
Make sys.stdout/stderr filtering opt-in

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -175,10 +175,10 @@ class FilteredStream(io.TextIOBase):
 
 def enable_litellm_filtering() -> None:
     """Enable filtering of LiteLLM debug output from stdout/stderr.
-    
+
     This wraps sys.stdout and sys.stderr with FilteredStream to suppress
     noisy LiteLLM banners and debug messages.
-    
+
     Can also be enabled via environment variable: CREWAI_FILTER_LITELLM_OUTPUT=1
     """
     if not isinstance(sys.stdout, FilteredStream):

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -173,13 +173,26 @@ class FilteredStream(io.TextIOBase):
         return True
 
 
+def enable_litellm_filtering() -> None:
+    """Enable filtering of LiteLLM debug output from stdout/stderr.
+    
+    This wraps sys.stdout and sys.stderr with FilteredStream to suppress
+    noisy LiteLLM banners and debug messages.
+    
+    Can also be enabled via environment variable: CREWAI_FILTER_LITELLM_OUTPUT=1
+    """
+    if not isinstance(sys.stdout, FilteredStream):
+        sys.stdout = FilteredStream(sys.stdout)
+    if not isinstance(sys.stderr, FilteredStream):
+        sys.stderr = FilteredStream(sys.stderr)
+
+
 # Apply the filtered stream globally so that any subsequent writes containing the filtered
 # keywords (e.g., "litellm") are hidden from terminal output. We guard against double
 # wrapping to ensure idempotency in environments where this module might be reloaded.
-if not isinstance(sys.stdout, FilteredStream):
-    sys.stdout = FilteredStream(sys.stdout)
-if not isinstance(sys.stderr, FilteredStream):
-    sys.stderr = FilteredStream(sys.stderr)
+# This is now opt-in via CREWAI_FILTER_LITELLM_OUTPUT environment variable.
+if os.environ.get("CREWAI_FILTER_LITELLM_OUTPUT", "").lower() in ("1", "true", "yes"):
+    enable_litellm_filtering()
 
 
 MIN_CONTEXT: Final[int] = 1024


### PR DESCRIPTION
## Description

Fixes #3000 - Stop hijacking sys.stdout and sys.stderr

## Problem

The FilteredStream was unconditionally wrapping sys.stdout and sys.stderr at module import time, affecting all code that imports crewai.llm. This is a global side effect that library code should not impose on users.

As noted in Python docs for contextlib.redirect_stdout:
> Note that the global side effect on sys.stdout means that this context manager is not suitable for use in library code

## Solution

Make the filtering opt-in:
- Added environment variable CREWAI_FILTER_LITELLM_OUTPUT (set to 1/true/yes to enable)
- Added enable_litellm_filtering() helper for programmatic use
- Users who want the old behavior can set the env var

## Changes

- Filtering now requires explicit opt-in
- Added enable_litellm_filtering() public helper function
- Maintained backward compatibility for users who set the env var