### PR TITLE
fix: MCP tools not loading when tools is None

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1156,11 +1156,15 @@ class Agent(BaseAgent):
         # Process platform apps and MCP tools
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
-            if platform_tools and self.tools is not None:
+            if platform_tools:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(platform_tools)
         if self.mcps:
             mcps = self.get_mcp_tools(self.mcps)
-            if mcps and self.tools is not None:
+            if mcps:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(mcps)
 
         # Prepare tools


### PR DESCRIPTION
## Description

Fixes #4568 - When I use mcps but tools is None, it will not load mcp tools

## Problem

When using the `mcps` parameter without setting `tools`, the MCP tools were not being loaded because the code checked:

```python
if mcps and self.tools is not None:
    self.tools.extend(mcps)
```

This means users who only want to use MCP tools (without any other tools) couldn't do so.

## Solution

Initialize `self.tools` to an empty list when it's None and MCP/platform tools are provided:

```python
if mcps:
    if self.tools is None:
        self.tools = []
    self.tools.extend(mcps)
```

## Changes

- Modified `lib/crewai/src/crewai/agent/core.py` to initialize `self.tools = []` when None and tools need to be added

## Testing

Now this works:
```python
agent = Agent(
    role='...',
    goal='...',
    backstory='...',
    mcps=[MCPServerHTTP(url='http://localhost:8022/mcp')]
)
```