### PR TITLE
Fail closed on unsafe code execution without explicit policy and pre-execution confirmation

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -186,6 +186,10 @@ class Agent(BaseAgent):
     allow_code_execution: bool | None = Field(
         default=False, description="Enable code execution for the agent."
     )
+    allow_unsafe_code_execution: bool = Field(
+        default=False,
+        description="Explicit policy opt-in required to allow unsafe code execution mode.",
+    )
     respect_context_window: bool = Field(
         default=True,
         description="Keep messages under the context window size by summarizing content.",

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -190,6 +190,13 @@ class Agent(BaseAgent):
         default=False,
         description="Explicit policy opt-in required to allow unsafe code execution mode.",
     )
+    unsafe_code_execution_confirmation: Any | None = Field(
+        default=None,
+        description=(
+            "Callable confirmation gate executed before unsafe code tools are enabled. "
+            "Must return True to allow execution."
+        ),
+    )
     respect_context_window: bool = Field(
         default=True,
         description="Keep messages under the context window size by summarizing content.",

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1423,10 +1423,25 @@ class Crew(FlowTrackable, BaseModel):
                 "Set allow_unsafe_code_execution=True to opt in."
             )
 
-        if not getattr(task, "human_input", False):
+        confirmation_gate = getattr(agent, "unsafe_code_execution_confirmation", None)
+        if not callable(confirmation_gate):
             raise ValueError(
-                "Unsafe code execution requires task.human_input=True "
-                "for explicit operator confirmation."
+                "Unsafe code execution requires agent.unsafe_code_execution_confirmation "
+                "to be a callable that returns True before execution."
+            )
+
+        try:
+            confirmed = bool(confirmation_gate(task))
+        except TypeError:
+            confirmed = bool(confirmation_gate())
+        except Exception as exc:
+            raise ValueError(
+                "Unsafe code execution confirmation gate raised an exception."
+            ) from exc
+
+        if not confirmed:
+            raise ValueError(
+                "Unsafe code execution confirmation gate must return True."
             )
 
     def _add_memory_tools(self, tools: list[BaseTool], memory: Any) -> list[BaseTool]:

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1282,6 +1282,7 @@ class Crew(FlowTrackable, BaseModel):
         if hasattr(agent, "allow_code_execution") and getattr(
             agent, "allow_code_execution", False
         ):
+            self._validate_code_execution_safety_policy(agent, task)
             tools = self._add_code_execution_tools(agent, tools)
 
         if (
@@ -1410,9 +1411,25 @@ class Crew(FlowTrackable, BaseModel):
             return self._merge_tools(tools, cast(list[BaseTool], code_tools))
         return tools
 
-    def _add_memory_tools(
-        self, tools: list[BaseTool], memory: Any
-    ) -> list[BaseTool]:
+    @staticmethod
+    def _validate_code_execution_safety_policy(agent: BaseAgent, task: Task) -> None:
+        code_execution_mode = getattr(agent, "code_execution_mode", "safe")
+        if code_execution_mode != "unsafe":
+            return
+
+        if not getattr(agent, "allow_unsafe_code_execution", False):
+            raise ValueError(
+                "Unsafe code execution is disabled by default. "
+                "Set allow_unsafe_code_execution=True to opt in."
+            )
+
+        if not getattr(task, "human_input", False):
+            raise ValueError(
+                "Unsafe code execution requires task.human_input=True "
+                "for explicit operator confirmation."
+            )
+
+    def _add_memory_tools(self, tools: list[BaseTool], memory: Any) -> list[BaseTool]:
         """Add recall and remember tools when memory is available.
 
         Args:

--- a/lib/crewai/src/crewai/project/crew_base.py
+++ b/lib/crewai/src/crewai/project/crew_base.py
@@ -75,6 +75,7 @@ class AgentConfig(TypedDict, total=False):
 
     # Code execution
     allow_code_execution: bool
+    allow_unsafe_code_execution: bool
     code_execution_mode: Literal["safe", "unsafe"]
 
     # Context and performance

--- a/lib/crewai/src/crewai/project/crew_base.py
+++ b/lib/crewai/src/crewai/project/crew_base.py
@@ -76,6 +76,7 @@ class AgentConfig(TypedDict, total=False):
     # Code execution
     allow_code_execution: bool
     allow_unsafe_code_execution: bool
+    unsafe_code_execution_confirmation: Any
     code_execution_mode: Literal["safe", "unsafe"]
 
     # Context and performance


### PR DESCRIPTION
## Problem
Unsafe code execution can be routed into crew task execution without strict, pre-execution confirmation guarantees, creating permissive high-risk tool behavior.

## Why now
Issue #4593 asks for fail-closed unsafe tool execution defaults as crew autonomy scales and safety boundaries must be explicit.

## What changed
- Added explicit agent policy flag: `allow_unsafe_code_execution` (default `False`).
- Added explicit pre-execution confirmation gate: `unsafe_code_execution_confirmation` callable.
- Added fail-closed guard in crew tool preparation for unsafe code execution mode.
- Unsafe mode now errors unless:
  - `allow_unsafe_code_execution=True`, and
  - `unsafe_code_execution_confirmation` is callable and returns `True` before tool injection.
- Added tests for missing allow policy, missing confirmation gate, negative confirmation result, and allowed path.

## Validation
- `uv run ruff format lib/crewai/src/crewai/agent/core.py lib/crewai/src/crewai/crew.py lib/crewai/src/crewai/project/crew_base.py lib/crewai/tests/test_crew.py` (pass)
- `uv run ruff check lib/crewai/src/crewai/agent/core.py lib/crewai/src/crewai/crew.py lib/crewai/src/crewai/project/crew_base.py lib/crewai/tests/test_crew.py` (pass)
- `uv run pytest lib/crewai/tests/test_crew.py -k 'code_execution_flag_adds_code_tool_upon_kickoff or unsafe_code_execution_requires_explicit_allow_policy or unsafe_code_execution_requires_confirmation_setting or unsafe_code_execution_requires_positive_confirmation or unsafe_code_execution_allowed_with_policy_and_confirmation_gate'` (pass)

Refs #4593
