### PR TITLE
docs: add litellm dependency note for non-native LLM providers

### DIFF
--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -111,7 +111,7 @@ There are different places in CrewAI code where you can specify the model to use
 
   All other providers are powered by **LiteLLM**. If you plan to use any of them, add it as a dependency to your project:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
 </Info>
 
@@ -287,7 +287,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -588,7 +588,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -788,7 +788,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -808,7 +808,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -899,7 +899,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -944,7 +944,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -970,7 +970,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -997,7 +997,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1015,7 +1015,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1035,7 +1035,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1055,7 +1055,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1074,7 +1074,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1102,7 +1102,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1132,7 +1132,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1159,7 +1159,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -1186,7 +1186,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/en/learn/llm-connections.mdx
+++ b/docs/en/learn/llm-connections.mdx
@@ -44,7 +44,7 @@ For a complete and up-to-date list of supported providers, please refer to the [
 <Info>
   To use any provider not covered by a native integration, add LiteLLM as a dependency to your project:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
   Native providers (OpenAI, Anthropic, Google Gemini, Azure, AWS Bedrock) use their own SDK extras — see the [Provider Configuration Examples](/en/concepts/llms#provider-configuration-examples).
 </Info>

--- a/docs/en/observability/tracing.mdx
+++ b/docs/en/observability/tracing.mdx
@@ -35,7 +35,7 @@ Visit [app.crewai.com](https://app.crewai.com) and create your free account. Thi
 If you haven't already, install CrewAI with the CLI tools:
 
 ```bash
-uv add crewai[tools]
+uv add 'crewai[tools]'
 ```
 
 Then authenticate your CLI with your CrewAI AMP account:

--- a/docs/ko/concepts/llms.mdx
+++ b/docs/ko/concepts/llms.mdx
@@ -110,7 +110,7 @@ CrewAI 코드 내에는 사용할 모델을 지정할 수 있는 여러 위치�
 
   그 외 모든 제공자는 **LiteLLM**을 통해 지원됩니다. 이를 사용하려면 프로젝트에 의존성으로 추가하세요:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
 </Info>
 
@@ -226,7 +226,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -371,7 +371,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -461,7 +461,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -481,7 +481,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -572,7 +572,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -617,7 +617,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -643,7 +643,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -670,7 +670,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -688,7 +688,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -708,7 +708,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -728,7 +728,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -747,7 +747,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -775,7 +775,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -805,7 +805,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -832,7 +832,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -859,7 +859,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/ko/learn/llm-connections.mdx
+++ b/docs/ko/learn/llm-connections.mdx
@@ -44,7 +44,7 @@ LiteLLM은 다음을 포함하되 이에 국한되지 않는 다양한 프로바
 <Info>
   네이티브 통합에서 지원하지 않는 제공자를 사용하려면 LiteLLM을 프로젝트에 의존성으로 추가하세요:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
   네이티브 제공자(OpenAI, Anthropic, Google Gemini, Azure, AWS Bedrock)는 자체 SDK extras를 사용합니다 — [공급자 구성 예시](/ko/concepts/llms#공급자-구성-예시)를 참조하세요.
 </Info>

--- a/docs/ko/observability/tracing.mdx
+++ b/docs/ko/observability/tracing.mdx
@@ -35,7 +35,7 @@ crewai login
 아직 설치하지 않았다면 CLI 도구와 함께 CrewAI를 설치하세요:
 
 ```bash
-uv add crewai[tools]
+uv add 'crewai[tools]'
 ```
 
 그런 다음 CrewAI AMP 계정으로 CLI를 인증하세요:

--- a/docs/pt-BR/concepts/llms.mdx
+++ b/docs/pt-BR/concepts/llms.mdx
@@ -110,7 +110,7 @@ Existem diferentes locais no código do CrewAI onde você pode especificar o mod
 
   Todos os outros provedores são alimentados pelo **LiteLLM**. Se você planeja usar algum deles, adicione-o como dependência ao seu projeto:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
 </Info>
 
@@ -226,7 +226,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -371,7 +371,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -460,7 +460,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -480,7 +480,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -571,7 +571,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -616,7 +616,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -642,7 +642,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -669,7 +669,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -687,7 +687,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -707,7 +707,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -727,7 +727,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -746,7 +746,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -774,7 +774,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -804,7 +804,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 
@@ -831,7 +831,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
     ```bash
-    uv add litellm
+    uv add 'crewai[litellm]'
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/pt-BR/learn/llm-connections.mdx
+++ b/docs/pt-BR/learn/llm-connections.mdx
@@ -43,7 +43,7 @@ Para uma lista completa e sempre atualizada dos provedores suportados, consulte 
 <Info>
   Para usar qualquer provedor não coberto por uma integração nativa, adicione o LiteLLM como dependência ao seu projeto:
   ```bash
-  uv add litellm
+  uv add 'crewai[litellm]'
   ```
   Provedores nativos (OpenAI, Anthropic, Google Gemini, Azure, AWS Bedrock) usam seus próprios extras de SDK — consulte os [Exemplos de Configuração de Provedores](/pt-BR/concepts/llms#exemplos-de-configuração-de-provedores).
 </Info>

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -427,7 +427,7 @@ class LLM(BaseLLM):
                 f"installed.\n\n"
                 f"To fix this, either:\n"
                 f"  1. Install LiteLLM for broad model support: "
-                f"uv add litellm\n"
+                f"uv add 'crewai[litellm]'\n"
                 f"or\n"
                 f"pip install litellm\n\n"
                 f"For more details, see: "


### PR DESCRIPTION
## Summary

- Added an `<Info>` callout in the "Setting up your LLM" section of `docs/en/concepts/llms.mdx` explaining the native vs. LiteLLM provider split and that `uv add litellm` is needed for non-native providers
- Added a `**Note:** This provider uses LiteLLM. Add it as a dependency...` block to all 16 non-native provider accordions (Meta-Llama, Google Vertex AI, Amazon SageMaker, Mistral, Nvidia NIM, Local NVIDIA NIM, Groq, IBM watsonx.ai, Ollama, Fireworks AI, Perplexity AI, Hugging Face, SambaNova, Cerebras, Open Router, Nebius AI Studio)
- Updated the opening paragraph of `docs/en/learn/llm-connections.mdx` to accurately reflect the native + LiteLLM fallback architecture
- Added an `<Info>` callout with `uv add litellm` install instruction in the "Connect to Any LLM" learn page

## Test plan

- [ ] Run docs dev server (`mintlify dev` from `docs/`) and verify the Info callout appears in the "Setting up your LLM" section
- [ ] Open each non-native provider accordion and confirm the LiteLLM note appears at the bottom
- [ ] Verify native provider accordions (OpenAI, Anthropic, Google Gemini, Azure, Bedrock) still only show their own `crewai[...]` install notes
- [ ] Check the "Connect to Any LLM" page for the updated intro paragraph and new callout

Closes ENG-1716