### PR TITLE
Preserve full UUID entropy for executor instance IDs

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -200,7 +200,8 @@ class AgentExecutor(Flow[AgentReActState], CrewAgentExecutorMixin):
         self._has_been_invoked: bool = False
         self._flow_initialized: bool = False
 
-        self._instance_id = str(uuid4())[:8]
+        # Keep full UUID entropy for collision resistance across concurrent runs.
+        self._instance_id = str(uuid4())
 
         self.before_llm_call_hooks: list[
             BeforeLLMCallHookType | BeforeLLMCallHookCallable

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -5,6 +5,7 @@ flow methods, routing logic, and error handling.
 """
 
 import time
+import uuid
 from unittest.mock import Mock, patch
 
 import pytest
@@ -97,6 +98,13 @@ class TestAgentExecutor:
         assert executor.crew == mock_dependencies["crew"]
         assert executor.max_iter == 10
         assert executor.use_stop_words is True
+
+    def test_executor_instance_id_uses_full_uuid(self, mock_dependencies):
+        """Executor instance ids should keep full UUID entropy."""
+        executor = AgentExecutor(**mock_dependencies)
+
+        parsed = uuid.UUID(executor._instance_id)
+        assert str(parsed) == executor._instance_id
 
     def test_initialize_reasoning(self, mock_dependencies):
         """Test flow entry point."""


### PR DESCRIPTION
## Problem
`AgentExecutor` currently truncates UUIDs to 8 characters for `_instance_id`, which materially increases collision risk in concurrent/multi-run contexts.

## Why now
Issue #4607 targets collision-resistant execution identifiers for task/crew/flow orchestration paths.

## What changed
- Updated `AgentExecutor` to retain full UUID string entropy for `_instance_id`.
- Added regression coverage in `lib/crewai/tests/agents/test_agent_executor.py` to assert `_instance_id` is a full UUID.

## Validation
- `cd lib/crewai && uv run pytest tests/agents/test_agent_executor.py -k 'executor_initialization or executor_instance_id_uses_full_uuid'`

Refs #4607
