### PR TITLE
fix: load MCP tools even when agent's tools is None

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1703,11 +1703,15 @@ class Agent(BaseAgent):
         # Process platform apps and MCP tools
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
-            if platform_tools and self.tools is not None:
+            if platform_tools:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(platform_tools)
         if self.mcps:
             mcps = self.get_mcp_tools(self.mcps)
-            if mcps and self.tools is not None:
+            if mcps:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(mcps)
 
         # Prepare tools

--- a/lib/crewai/tests/agents/test_lite_agent.py
+++ b/lib/crewai/tests/agents/test_lite_agent.py
@@ -694,6 +694,54 @@ def test_agent_kickoff_with_mcp_tools(mock_get_mcp_tools):
     mock_get_mcp_tools.assert_called_once_with("https://mcp.exa.ai/mcp?api_key=test_exa_key&profile=research")
 
 
+
+def test_agent_mcp_tools_loaded_when_tools_is_none():
+    """Test that MCP tools are loaded even when the agent's tools attribute is None.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4568
+    When tools is None (e.g. set after init or via a subclass), MCP tools
+    should still be appended instead of being silently dropped.
+    """
+
+    class MockMCPTool(BaseTool):
+        name: str = "mcp_tool"
+        description: str = "A mock MCP tool"
+
+        def _run(self, query: str) -> str:
+            return "result"
+
+    mock_mcp_tool = MockMCPTool()
+
+    agent = Agent(
+        role="Test Agent",
+        goal="Test goal",
+        backstory="Test backstory",
+        llm=LLM(model="gpt-4o-mini"),
+        mcps=["https://example.com/mcp"],
+    )
+
+    # Force tools to None to simulate the reported scenario where
+    # self.tools ends up as None at kickoff time.
+    agent.__dict__["tools"] = None
+    assert agent.tools is None
+
+    # Patch get_mcp_tools at the class level to return our mock tool
+    with patch.object(Agent, "get_mcp_tools", return_value=[mock_mcp_tool]) as mock_get:
+        # Call the internal method that processes MCP tools.
+        # It may fail downstream (LLM setup, etc.), but the MCP tool
+        # loading happens at the top of the method.
+        try:
+            agent._prepare_kickoff("test query")
+        except Exception:
+            pass
+
+        mock_get.assert_called_once_with(["https://example.com/mcp"])
+
+    # The key assertion: tools should no longer be None and should contain the MCP tool
+    assert agent.tools is not None
+    assert mock_mcp_tool in agent.tools
+
+
 # ============================================================================
 # Tests for LiteAgent inside Flow (magic auto-async pattern)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Fixes the bug where MCP tools are silently dropped when `self.tools` is `None` on an agent
- Initializes `self.tools` to an empty list before extending with MCP/platform tools
- Applies the same defensive fix to the `platform_tools` code path which had the identical bug pattern
- Adds a regression test to verify MCP tools load correctly when `tools` is `None`

Closes #4568

## Changes

In `lib/crewai/src/crewai/agent/core.py`, the `_prepare_kickoff` method had:

```python
if mcps and self.tools is not None:
    self.tools.extend(mcps)
```

When a user creates an Agent with `mcps` but doesn't explicitly pass `tools` (or `tools` ends up as `None`), this condition fails silently and MCP tools never get added. The fix initializes `self.tools = []` when it is `None` before calling `.extend()`.

## Test plan

- [x] Added regression test `test_agent_mcp_tools_loaded_when_tools_is_none` that verifies MCP tools are loaded when `self.tools` is `None`
- [x] All 30 existing tests in `test_lite_agent.py` continue to pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, targeted defensive change in kickoff tool preparation plus a regression test; main impact is tool list initialization where `tools` was unexpectedly `None`.
> 
> **Overview**
> Ensures `_prepare_kickoff` no longer silently skips adding platform or MCP tools when `Agent.tools` is `None` by initializing it to an empty list before extending.
> 
> Adds a regression test (`test_agent_mcp_tools_loaded_when_tools_is_none`) to verify MCP tools are appended and `tools` becomes non-`None` in this scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7c896a96ec3487ad261fd4f30c1d9235f57732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->