### PR TITLE
fix: initialize tools list when None before extending with MCP tools

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1156,11 +1156,15 @@ class Agent(BaseAgent):
         # Process platform apps and MCP tools
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
-            if platform_tools and self.tools is not None:
+            if platform_tools:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(platform_tools)
         if self.mcps:
             mcps = self.get_mcp_tools(self.mcps)
-            if mcps and self.tools is not None:
+            if mcps:
+                if self.tools is None:
+                    self.tools = []
                 self.tools.extend(mcps)
 
         # Prepare tools


### PR DESCRIPTION
## Summary
- Fixes a bug where MCP tools are not loaded when `tools` parameter is not explicitly passed to Agent
- The condition `self.tools is not None` prevented MCP tools from being added when `self.tools` defaults to `None`
- Initializes `self.tools` to an empty list before extending with MCP/platform tools

Fixes #4568

## Test plan
- [ ] Create an Agent with `mcps` but without `tools` parameter and verify MCP tools are loaded
- [ ] Create an Agent with both `mcps` and `tools=[]` and verify both are loaded
- [ ] Create an Agent with `tools=[some_tool]` and `mcps` and verify both are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)