### PR TITLE
fix: add type guard in process_config for non-dict input

### DIFF
--- a/lib/crewai/src/crewai/utilities/config.py
+++ b/lib/crewai/src/crewai/utilities/config.py
@@ -15,6 +15,9 @@ def process_config(
     Returns:
         The updated values dictionary.
     """
+    if not isinstance(values, dict):
+        return values
+
     config = values.get("config", {})
     if not config:
         return values


### PR DESCRIPTION
## Summary
- Adds a type guard at the start of `process_config()` to handle non-dict input gracefully
- When `Task(agent="string")` is passed, Pydantic's `mode='before'` validator forwards the raw string to `process_config()`, which calls `.get()` on it, causing an `AttributeError`
- The fix returns non-dict values unchanged, allowing Pydantic's type validation to produce a proper `ValidationError`

Fixes #4419

## Test plan
- [ ] Verify `Task(agent="string")` raises a clear Pydantic `ValidationError` instead of `AttributeError`
- [ ] Verify normal dict-based config processing still works correctly
- [ ] Verify `Task(agent=Agent(...))` continues to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)