### PR TITLE
fix: add Anthropic error pattern for context window detection

### DIFF
--- a/lib/crewai/src/crewai/utilities/exceptions/context_window_exceeding_exception.py
+++ b/lib/crewai/src/crewai/utilities/exceptions/context_window_exceeding_exception.py
@@ -10,6 +10,7 @@ CONTEXT_LIMIT_ERRORS: Final[list[str]] = [
     "too many tokens",
     "input is too long",
     "exceeds token limit",
+    "prompt is too long",
 ]
 
 


### PR DESCRIPTION
## Summary
- Adds `"prompt is too long"` to the `CONTEXT_LIMIT_ERRORS` list to recognize Anthropic's context window error format
- Anthropic returns `"prompt is too long: 210094 tokens > 200000 maximum"` which was not matched by any existing pattern
- This enables `respect_context_window=True` to work correctly with Anthropic/Claude models

Fixes #4381

## Test plan
- [ ] Verify `_is_context_limit_error` returns `True` for Anthropic's error message format
- [ ] Verify existing OpenAI-style error patterns still match correctly
- [ ] Test `respect_context_window=True` with an Anthropic model that exceeds context

🤖 Generated with [Claude Code](https://claude.com/claude-code)