### PR TITLE
fix: reset executor state between sequential task executions

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -214,6 +214,10 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         Returns:
             Dictionary with agent output.
         """
+        # Reset execution state for fresh execution
+        self.messages = []
+        self.iterations = 0
+
         self._setup_messages(inputs)
 
         self._inject_multimodal_files(inputs)
@@ -1111,6 +1115,10 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         Returns:
             Dictionary with agent output.
         """
+        # Reset execution state for fresh execution
+        self.messages = []
+        self.iterations = 0
+
         self._setup_messages(inputs)
 
         await self._ainject_multimodal_files(inputs)


### PR DESCRIPTION
## Summary
- Resets `self.messages` and `self.iterations` at the start of `invoke()` and `ainvoke()` in `CrewAgentExecutor`
- When one agent handles multiple sequential tasks, the executor is reused, causing messages from Task 1 to leak into Task 2's LLM context
- This also prevents premature max iterations limits from carrying over
- Matches the behavior already implemented in the experimental `AgentExecutor`

Fixes #4389

## Test plan
- [ ] Create a Crew with one agent assigned to two sequential tasks
- [ ] Verify Task 2's LLM context only contains messages relevant to Task 2
- [ ] Verify iterations reset to 0 for each new task
- [ ] Verify single-task execution still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)