### PR TITLE
fix: parse pydantic output before first guardrail invocation

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -597,12 +597,9 @@ class Task(BaseModel):
                 else:
                     pydantic_output = None
                     json_output = None
-            elif not self._guardrails and not self._guardrail:
-                raw = result
-                pydantic_output, json_output = self._export_output(result)
             else:
                 raw = result
-                pydantic_output, json_output = None, None
+                pydantic_output, json_output = self._export_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,
@@ -711,12 +708,9 @@ class Task(BaseModel):
                 else:
                     pydantic_output = None
                     json_output = None
-            elif not self._guardrails and not self._guardrail:
-                raw = result
-                pydantic_output, json_output = self._export_output(result)
             else:
                 raw = result
-                pydantic_output, json_output = None, None
+                pydantic_output, json_output = self._export_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,


### PR DESCRIPTION
## Summary
- Fixes `TaskOutput.pydantic` being `None` on the first guardrail call but populated on retries
- `_export_output()` was intentionally skipped when guardrails were present, causing inconsistent behavior
- Now `_export_output()` is always called, so guardrail functions receive consistent `TaskOutput` with pydantic data on every invocation
- Fixed in both sync (`_execute_core`) and async (`_aexecute_core`) paths

Fixes #4369

## Test plan
- [ ] Create a Task with `output_pydantic` and a guardrail function
- [ ] Verify `task_output.pydantic` is populated on the first guardrail invocation
- [ ] Verify retry attempts still have `task_output.pydantic` populated
- [ ] Verify tasks without guardrails still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)