### PR TITLE
fix: prepare MCP tools in execute_task for delegated agents

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -334,6 +334,15 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
+        # Ensure MCP tools are resolved for delegated agents that haven't
+        # gone through the full kickoff preparation path.
+        if self.mcps and self._mcp_resolver is None:
+            mcp_tools = self.get_mcp_tools(self.mcps)
+            if mcp_tools:
+                if self.tools is None:
+                    self.tools = []
+                self.tools.extend(mcp_tools)
+
         handle_reasoning(self, task)
         self._inject_date_to_task(task)
 


### PR DESCRIPTION
## Summary
- Fixes MCP tools not being available when a sub-agent receives a delegated task
- MCP tools are only resolved during the kickoff preparation path, but `execute_task()` (used for delegation) never triggers MCP resolution
- Adds MCP tool resolution at the start of `execute_task()` when the resolver hasn't been initialized yet, ensuring delegated agents have access to their MCP tools

Fixes #4571

## Test plan
- [ ] Create a main agent with delegation and a sub-agent with MCP servers
- [ ] Verify the sub-agent can use MCP tools when receiving delegated tasks
- [ ] Verify agents that go through normal kickoff still work correctly (idempotent check)
- [ ] Verify agents without MCP servers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)