### PR TITLE
fix: relax opentelemetry dependency constraints to allow newer versions

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.34.0,<2",
+    "opentelemetry-sdk>=1.34.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers~=0.20.3",


### PR DESCRIPTION
## Summary
- Relaxes opentelemetry dependency constraints from `~=1.34.0` (pinned to `>=1.34.0,<1.35.0`) to `>=1.34.0,<2`
- The tight pinning prevented users from using newer opentelemetry versions (e.g., 1.39.1) required by other tools like Langfuse
- Still protects against major version breaking changes with the `<2` upper bound

Fixes #4511

## Test plan
- [ ] Verify crewai installs successfully with opentelemetry 1.34.x
- [ ] Verify crewai installs successfully with opentelemetry 1.39.x
- [ ] Verify telemetry functionality works with both versions
- [ ] Verify no dependency conflicts with common companion packages (langfuse, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)