### PR TITLE
docs: sync Composio tool docs across locales

### DIFF
--- a/docs/en/tools/automation/composiotool.mdx
+++ b/docs/en/tools/automation/composiotool.mdx
@@ -28,7 +28,7 @@ After the installation is complete, set your Composio API key as `COMPOSIO_API_K
 
 The following example demonstrates how to initialize the tool and execute a github action:
 
-1. Initialize Composio with CrewAI
+1. Initialize Composio with CrewAI Provider
 
 ```python Code
 from composio_crewai import ComposioProvider

--- a/docs/ko/tools/automation/composiotool.mdx
+++ b/docs/ko/tools/automation/composiotool.mdx
@@ -28,7 +28,7 @@ pip install crewai
 
 다음 예시는 도구를 초기화하고 GitHub 액션을 실행하는 방법을 보여줍니다:
 
-1. CrewAI와 함께 Composio 초기화
+1. CrewAI Provider와 함께 Composio 초기화
 
 ```python Code
 from composio_crewai import ComposioProvider
@@ -50,9 +50,9 @@ tools = session.tools()
 세션 및 사용자 관리에 대한 자세한 내용은 [여기](https://docs.composio.dev/docs/configuring-sessions)를 참고하세요.
 </CodeGroup>
 
-3. 사용자 수동 인증
+3. 사용자 수동 인증하기
 
-Composio는 세션을 기반으로 사용자를 자동 인증합니다. 하지만 `authorize` 메서드를 호출해 수동으로 인증할 수도 있습니다.
+Composio는 에이전트 채팅 세션 중에 사용자를 자동으로 인증합니다. 하지만 `authorize` 메서드를 호출해 사용자를 수동으로 인증할 수도 있습니다.
 ```python Code
 connection_request = session.authorize("github")
 print(f"Open this URL to authenticate: {connection_request.redirect_url}")

--- a/docs/pt-BR/tools/automation/composiotool.mdx
+++ b/docs/pt-BR/tools/automation/composiotool.mdx
@@ -28,7 +28,7 @@ Após concluir a instalação, defina sua chave de API do Composio como `COMPOSI
 
 O exemplo a seguir demonstra como inicializar a ferramenta e executar uma ação do GitHub:
 
-1. Inicialize o Composio com CrewAI
+1. Inicialize o Composio com o Provider do CrewAI
 
 ```python Code
 from composio_crewai import ComposioProvider
@@ -50,9 +50,9 @@ tools = session.tools()
 Leia mais sobre sessões e gerenciamento de usuários [aqui](https://docs.composio.dev/docs/configuring-sessions)
 </CodeGroup>
 
-3. Autenticação manual do usuário
+3. Autenticação manual dos usuários
 
-O Composio autentica automaticamente o usuário com base na sessão. No entanto, você também pode autenticar o usuário manualmente chamando o método `authorize`.
+O Composio autentica automaticamente os usuários durante a sessão de chat do agente. No entanto, você também pode autenticar o usuário manualmente chamando o método `authorize`.
 ```python Code
 connection_request = session.authorize("github")
 print(f"Open this URL to authenticate: {connection_request.redirect_url}")


### PR DESCRIPTION
## Summary
- update the Composio automation docs in `pt-BR` and `ko` to match the new English session-based integration flow
- align installation steps, API key setup, manual authorization example, and toolkit reference links across locales
- keep code examples consistent with the new `ComposioProvider` + `Composio` + `session.tools()` usage

## Test plan
- [x] verify markdown syntax and rendering structure in all three locale files
- [x] run lints for edited docs files (no issues)
- [ ] docs preview in site build (optional)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that change examples/links but do not affect runtime code.
> 
> **Overview**
> Updates the Composio automation docs (EN/KO/PT-BR) to the new session-based integration flow using `ComposioProvider` + `Composio`, creating a session via `composio.create(...)` and retrieving tools via `session.tools()`.
> 
> Refreshes setup guidance by adding the base `composio` install, switching API key instructions/link to `platform.composio.dev`, replacing the old `composio add`/action-filtering examples with a manual `session.authorize("github")` snippet, and pointing the “tool list” link to `docs.composio.dev/toolkits` (plus minor wording/translation fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cb177b57f286622cdb6f2f09d1d0880714071aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->