### PR TITLE
fix: upgrade pypdf 4.x → 6.7.4 to resolve Dependabot alerts

### DIFF
--- a/lib/crewai-files/pyproject.toml
+++ b/lib/crewai-files/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "Pillow~=12.1.1",
-    "pypdf~=4.0.0",
+    "pypdf~=6.7.4",
     "python-magic>=0.4.27",
     "aiocache~=0.12.3",
     "aiofiles~=24.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1276,7 +1276,7 @@ requires-dist = [
     { name = "aiofiles", specifier = "~=24.1.0" },
     { name = "av", specifier = "~=13.0.0" },
     { name = "pillow", specifier = "~=12.1.1" },
-    { name = "pypdf", specifier = "~=4.0.0" },
+    { name = "pypdf", specifier = "~=6.7.4" },
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "tinytag", specifier = "~=1.10.0" },
 ]
@@ -6169,11 +6169,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "4.0.2"
+version = "6.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/de/5ee74158c3090ec99eae9f90c9e9c18f207fa5c722b0e95d6fa7faebcdf8/pypdf-4.0.2.tar.gz", hash = "sha256:3316d9ddfcff5df67ae3cdfe8b945c432aa43e7f970bae7c2a4ab4fe129cd937", size = 280173, upload-time = "2024-02-18T15:45:10.729Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/dc/f52deef12797ad58b88e4663f097a343f53b9361338aef6573f135ac302f/pypdf-6.7.4.tar.gz", hash = "sha256:9edd1cd47938bb35ec87795f61225fd58a07cfaf0c5699018ae1a47d6f8ab0e3", size = 5304821, upload-time = "2026-02-27T10:44:39.395Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/87/30f8a2963247fd7b1267e600379c5e3f51c9849a07d042398e4485b7415c/pypdf-4.0.2-py3-none-any.whl", hash = "sha256:a62daa2a24d5a608ba1b6284dde185317ce3644f89b9ebe5314d0c5d1c9f257d", size = 283953, upload-time = "2024-02-18T15:45:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/be/cded021305f5c81b47265b8c5292b99388615a4391c21ff00fd538d34a56/pypdf-6.7.4-py3-none-any.whl", hash = "sha256:527d6da23274a6c70a9cb59d1986d93946ba8e36a6bc17f3f7cce86331492dda", size = 331496, upload-time = "2026-02-27T10:44:37.527Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Upgrade pypdf from ~=4.0.0 to ~=6.7.4 to resolve 11 open Dependabot alerts for DoS vulnerabilities via crafted PDF streams.

## Key Changes
- **pypdf** 4.0.2 → 6.7.4 in `crewai-files`
- Fixes: FlateDecode RAM exhaustion, LZWDecode RAM exhaustion, RunLengthDecode RAM exhaustion, XFA stream exhaustion, TreeObject infinite loop, outlines/bookmarks infinite loop, inline DCT image infinite loop, malformed startxref long runtimes, circular /Prev entries infinite loop
- Only basic `PdfReader`/`PdfWriter` APIs are used — none were affected by the 5.0 or 6.0 breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it upgrades `pypdf` across major versions, which may introduce runtime/API behavior differences in PDF chunking/page counting code paths.
> 
> **Overview**
> Upgrades the `crewai-files` dependency on `pypdf` from `~4.0.0` to `~6.7.4` to address reported PDF-related DoS vulnerabilities.
> 
> Updates `uv.lock` accordingly, including the new `pypdf` version metadata and its conditional `typing-extensions` dependency for older Python versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c17e4f35999fc9e47bb07426fdfb266ba08ae443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->