### PR TITLE
fix: inject tool errors as observations and resolve name collisions

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -23,7 +23,7 @@ from pydantic import (
 )
 from typing_extensions import TypeIs
 
-from crewai.tools.structured_tool import CrewStructuredTool
+from crewai.tools.structured_tool import CrewStructuredTool, build_schema_hint
 from crewai.utilities.printer import Printer
 from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.string_utils import sanitize_tool_name
@@ -167,8 +167,9 @@ class BaseTool(BaseModel, ABC):
                 validated = self.args_schema.model_validate(kwargs)
                 return validated.model_dump()
             except Exception as e:
+                hint = build_schema_hint(self.args_schema)
                 raise ValueError(
-                    f"Tool '{self.name}' arguments validation failed: {e}"
+                    f"Tool '{self.name}' arguments validation failed: {e}{hint}"
                 ) from e
         return kwargs
 

--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -2,6 +2,7 @@
 # https://github.com/un33k/python-slugify
 # MIT License
 
+import hashlib
 import re
 from typing import Any, Final
 import unicodedata
@@ -40,7 +41,9 @@ def sanitize_tool_name(name: str, max_length: int = _MAX_TOOL_NAME_LENGTH) -> st
     name = name.strip("_")
 
     if len(name) > max_length:
-        name = name[:max_length].rstrip("_")
+        name_hash = hashlib.sha256(name.encode()).hexdigest()[:8]
+        suffix = f"_{name_hash}"
+        name = name[: max_length - len(suffix)].rstrip("_") + suffix
 
     return name
 

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1184,7 +1184,7 @@ class TestNativeToolCallingJsonParseError:
         executor = self._make_executor([tool])
 
         from crewai.utilities.agent_utils import convert_tools_to_openai_schema
-        _, available_functions = convert_tools_to_openai_schema([tool])
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
 
         malformed_json = '{"code": "print("hello")"}'
 
@@ -1212,7 +1212,7 @@ class TestNativeToolCallingJsonParseError:
         executor = self._make_executor([tool])
 
         from crewai.utilities.agent_utils import convert_tools_to_openai_schema
-        _, available_functions = convert_tools_to_openai_schema([tool])
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
 
         valid_json = '{"code": "print(1)"}'
 
@@ -1239,7 +1239,7 @@ class TestNativeToolCallingJsonParseError:
         executor = self._make_executor([tool])
 
         from crewai.utilities.agent_utils import convert_tools_to_openai_schema
-        _, available_functions = convert_tools_to_openai_schema([tool])
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
 
         result = executor._execute_single_native_tool_call(
             call_id="call_789",
@@ -1265,7 +1265,7 @@ class TestNativeToolCallingJsonParseError:
         executor = self._make_executor([tool])
 
         from crewai.utilities.agent_utils import convert_tools_to_openai_schema
-        _, available_functions = convert_tools_to_openai_schema([tool])
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
 
         result = executor._execute_single_native_tool_call(
             call_id="call_schema",

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -80,7 +80,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_converts_single_tool(self) -> None:
         """Test converting a single tool to OpenAI schema."""
         tools = [CalculatorTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         assert len(schemas) == 1
         assert len(functions) == 1
@@ -95,7 +95,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_converts_multiple_tools(self) -> None:
         """Test converting multiple tools to OpenAI schema."""
         tools = [CalculatorTool(), SearchTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         assert len(schemas) == 2
         assert len(functions) == 2
@@ -113,7 +113,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_functions_dict_contains_callables(self) -> None:
         """Test that the functions dict maps names to callable run methods."""
         tools = [CalculatorTool(), SearchTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         assert "calculator" in functions
         assert "web_search" in functions
@@ -123,14 +123,14 @@ class TestConvertToolsToOpenaiSchema:
     def test_function_can_be_called(self) -> None:
         """Test that the returned function can be called."""
         tools = [CalculatorTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         result = functions["calculator"](expression="2 + 2")
         assert result == "4"
 
     def test_empty_tools_list(self) -> None:
         """Test with an empty tools list."""
-        schemas, functions = convert_tools_to_openai_schema([])
+        schemas, functions, _ = convert_tools_to_openai_schema([])
 
         assert schemas == []
         assert functions == {}
@@ -138,7 +138,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_schema_has_required_fields(self) -> None:
         """Test that the schema includes required fields information."""
         tools = [SearchTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         schema = schemas[0]
         params = schema["function"]["parameters"]
@@ -158,7 +158,7 @@ class TestConvertToolsToOpenaiSchema:
                 return "done"
 
         tools = [MinimalTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         assert len(schemas) == 1
         schema = schemas[0]
@@ -169,7 +169,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_schema_structure_matches_openai_format(self) -> None:
         """Test that the schema structure matches OpenAI's expected format."""
         tools = [CalculatorTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         schema = schemas[0]
 
@@ -194,7 +194,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_removes_redundant_schema_fields(self) -> None:
         """Test that redundant title and description are removed from parameters."""
         tools = [CalculatorTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         # Title should be removed as it's redundant with function name
@@ -203,7 +203,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_preserves_field_descriptions(self) -> None:
         """Test that field descriptions are preserved in the schema."""
         tools = [SearchTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         query_prop = params["properties"]["query"]
@@ -215,7 +215,7 @@ class TestConvertToolsToOpenaiSchema:
     def test_preserves_default_values(self) -> None:
         """Test that default values are preserved in the schema."""
         tools = [SearchTool()]
-        schemas, functions = convert_tools_to_openai_schema(tools)
+        schemas, functions, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         max_results_prop = params["properties"]["max_results"]
@@ -265,7 +265,7 @@ class TestOptionalFieldsPreserveNull:
         """Optional[str] fields should include null in the schema so the LLM
         can send null instead of being forced to guess a value."""
         tools = [MCPStyleTool()]
-        schemas, _ = convert_tools_to_openai_schema(tools)
+        schemas, _, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         page_id_prop = params["properties"]["page_id"]
@@ -278,7 +278,7 @@ class TestOptionalFieldsPreserveNull:
     def test_optional_literal_allows_null(self) -> None:
         """Optional[Literal[...]] fields should include null."""
         tools = [MCPStyleTool()]
-        schemas, _ = convert_tools_to_openai_schema(tools)
+        schemas, _, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         filter_prop = params["properties"]["filter_type"]
@@ -290,7 +290,7 @@ class TestOptionalFieldsPreserveNull:
     def test_required_field_stays_non_null(self) -> None:
         """Required fields without Optional should NOT have null."""
         tools = [MCPStyleTool()]
-        schemas, _ = convert_tools_to_openai_schema(tools)
+        schemas, _, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         query_prop = params["properties"]["query"]
@@ -301,7 +301,7 @@ class TestOptionalFieldsPreserveNull:
     def test_all_fields_in_required_for_strict_mode(self) -> None:
         """All fields (including optional) must be in required for strict mode."""
         tools = [MCPStyleTool()]
-        schemas, _ = convert_tools_to_openai_schema(tools)
+        schemas, _, _ = convert_tools_to_openai_schema(tools)
 
         params = schemas[0]["function"]["parameters"]
         assert "query" in params["required"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes tool name sanitization and native tool-call execution/error handling, which can affect tool lookup, caching keys, and agent control flow when tools fail or names collide.
> 
> **Overview**
> **Improves native tool calling robustness and debuggability.** `convert_tools_to_openai_schema` now returns a sanitized-name→original-tool mapping and auto-disambiguates name collisions by suffixing (`_2`, `_3`, …); both `CrewAgentExecutor` and the experimental `AgentExecutor` use this mapping to correctly associate tool calls back to the right original/structured tool.
> 
> **Better failure behavior and errors.** Tool execution failures are captured and surfaced as tool results/observations (including in parallel batches) rather than raising, invalid native tool-call payloads return a structured error result, and argument-validation errors now append a schema-derived hint of expected/required fields. Tool name truncation in `sanitize_tool_name` now adds a short hash suffix to reduce collisions when exceeding provider length limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89a31c1fc496fbe8ec304384e4c9453d3cc6602c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->