### PR TITLE
fix(cli): memory leak in Repository.is_git_repo() due to @lru_cache

### DIFF
--- a/lib/crewai/src/crewai/cli/git.py
+++ b/lib/crewai/src/crewai/cli/git.py
@@ -1,10 +1,10 @@
-from functools import lru_cache
 import subprocess
 
 
 class Repository:
     def __init__(self, path: str = ".") -> None:
         self.path = path
+        self._is_git_repo_cache: bool | None = None
 
         if not self.is_git_installed():
             raise ValueError("Git is not installed or not found in your PATH.")
@@ -40,22 +40,25 @@ class Repository:
             encoding="utf-8",
         ).strip()
 
-    @lru_cache(maxsize=None)  # noqa: B019
     def is_git_repo(self) -> bool:
         """Check if the current directory is a git repository.
 
-        Notes:
-          - TODO: This method is cached to avoid redundant checks, but using lru_cache on methods can lead to memory leaks
+        Uses an instance-level cache to avoid redundant subprocess calls
+        without the memory leak caused by @lru_cache on instance methods.
         """
+        if self._is_git_repo_cache is not None:
+            return self._is_git_repo_cache
         try:
             subprocess.check_output(
                 ["git", "rev-parse", "--is-inside-work-tree"],  # noqa: S607
                 cwd=self.path,
                 encoding="utf-8",
             )
-            return True
+            result = True
         except subprocess.CalledProcessError:
-            return False
+            result = False
+        self._is_git_repo_cache = result
+        return result
 
     def has_uncommitted_changes(self) -> bool:
         """Check if the repository has uncommitted changes."""

--- a/lib/crewai/tests/cli/test_git.py
+++ b/lib/crewai/tests/cli/test_git.py
@@ -99,3 +99,39 @@ def test_origin_url(fp, repository):
         stdout="https://github.com/user/repo.git\n",
     )
     assert repository.origin_url() == "https://github.com/user/repo.git"
+
+
+def test_is_git_repo_caches_result(fp):
+    """Calling is_git_repo multiple times should only invoke subprocess once."""
+    fp.register(["git", "--version"], stdout="git version 2.30.0\n")
+    fp.register(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        stdout="true\n",
+        occurrences=1,
+    )
+    fp.register(["git", "fetch"], stdout="")
+
+    repo = Repository(path=".")
+    # __init__ already called is_git_repo once (1 subprocess call)
+    assert repo.is_git_repo() is True
+    assert repo.is_git_repo() is True
+
+    # The rev-parse command should have been invoked exactly once (during __init__);
+    # subsequent calls must return the cached value without a new subprocess.
+    assert fp.call_count(["git", "rev-parse", "--is-inside-work-tree"]) == 1
+
+
+def test_is_git_repo_no_global_cache_leak(fp):
+    """Repository instances must be garbage-collectable (no global lru_cache holding refs)."""
+    import gc
+    import weakref
+
+    fp.register(["git", "--version"], stdout="git version 2.30.0\n")
+    fp.register(["git", "rev-parse", "--is-inside-work-tree"], stdout="true\n")
+    fp.register(["git", "fetch"], stdout="")
+
+    repo = Repository(path=".")
+    weak = weakref.ref(repo)
+    del repo
+    gc.collect()
+    assert weak() is None, "Repository instance was not garbage collected"


### PR DESCRIPTION
## Summary

Fixes #4210

`@lru_cache(maxsize=None)` on the instance method `Repository.is_git_repo()` holds a strong reference to `self` in the global cache, preventing garbage collection of `Repository` instances.

## Changes

- **`lib/crewai/src/crewai/cli/git.py`**: Replaced `@lru_cache(maxsize=None)` with a manual instance-level `_is_git_repo_cache` attribute initialized in `__init__`. The cache is checked at the start of `is_git_repo()` and populated on first call.
- **`lib/crewai/tests/cli/test_git.py`**: Added two tests:
  - `test_is_git_repo_caches_result` — verifies the cached value is reused.
  - `test_is_git_repo_no_global_cache_leak` — verifies `Repository` instances are garbage collected (uses `weakref` + `gc.collect()`).

## Why this approach

Using an instance attribute instead of `@lru_cache`:
- Eliminates the memory leak (no global reference to `self`)
- Preserves caching behavior (subprocess only called once per instance)
- Cache lifetime is tied to instance lifetime — cleaned up automatically on GC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `Repository.is_git_repo()` caching semantics plus targeted tests; main risk is stale cache if repository state changes during the instance lifetime.
> 
> **Overview**
> Fixes a potential memory leak in the CLI `Repository` helper by replacing the `@lru_cache`-decorated `is_git_repo()` with an **instance-scoped** `_is_git_repo_cache`, avoiding a global cache holding strong references to `self`.
> 
> Adds tests ensuring `git rev-parse` is only executed once per `Repository` instance and that instances can be garbage collected (no cache-based retention).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb68e1733bb44bdb68a3684e2f6ce3b16e9b6da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->