### PR TITLE
security: add RestrictedUnpickler to PickleHandler (CWE-502)

### DIFF
--- a/lib/crewai/src/crewai/utilities/file_handler.py
+++ b/lib/crewai/src/crewai/utilities/file_handler.py
@@ -122,6 +122,46 @@ class FileHandler:
             raise ValueError(f"Failed to log message: {e!s}") from e
 
 
+class _SafeUnpickler(pickle.Unpickler):
+    """Restricted unpickler that only allows safe built-in types.
+
+    Prevents arbitrary code execution via crafted pickle payloads (CWE-502).
+    The PickleHandler is used for training data persistence, which only requires
+    basic Python types (dicts, lists, strings, numbers).
+    """
+
+    _ALLOWED_CLASSES: frozenset[tuple[str, str]] = frozenset({
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "bytearray"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+        ("datetime", "datetime"),
+        ("datetime", "date"),
+        ("datetime", "time"),
+        ("datetime", "timedelta"),
+        ("datetime", "timezone"),
+        ("collections", "OrderedDict"),
+        ("collections", "defaultdict"),
+        ("collections", "deque"),
+    })
+
+    def find_class(self, module: str, name: str) -> type:
+        if (module, name) in self._ALLOWED_CLASSES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to unpickle '{module}.{name}': class not in allowlist"
+        )
+
+
 class PickleHandler:
     """Handler for saving and loading data using pickle.
 
@@ -159,6 +199,9 @@ class PickleHandler:
     def load(self) -> Any:
         """Load the data from the specified file using pickle.
 
+        Uses a restricted unpickler that only allows safe built-in types,
+        preventing arbitrary code execution from tampered pickle files.
+
         Returns:
             The data loaded from the file.
         """
@@ -167,7 +210,7 @@ class PickleHandler:
 
         with open(self.file_path, "rb") as file:
             try:
-                return pickle.load(file)  # noqa: S301
+                return _SafeUnpickler(file).load()
             except EOFError:
                 return {}  # Return an empty dictionary if the file is empty or corrupted
             except Exception:

--- a/lib/crewai/tests/utilities/test_file_handler.py
+++ b/lib/crewai/tests/utilities/test_file_handler.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import unittest
 import uuid
 
@@ -47,3 +48,39 @@ class TestPickleHandler(unittest.TestCase):
 
         assert str(exc.value) == "pickle data was truncated"
         assert "<class '_pickle.UnpicklingError'>" == str(exc.type)
+
+    def test_load_rejects_unsafe_class(self):
+        """Verify that RestrictedUnpickler blocks arbitrary code execution.
+
+        A tampered .pkl file could contain a payload that executes arbitrary
+        code (e.g., os.system, eval, subprocess.Popen) when loaded with
+        unrestricted pickle.load(). The SafeUnpickler should reject any
+        class not in its allowlist.
+        """
+        class _Exploit:
+            def __reduce__(self):
+                return (eval, ("1+1",))
+
+        payload = pickle.dumps(_Exploit())
+
+        with open(self.file_path, "wb") as f:
+            f.write(payload)
+
+        with pytest.raises(pickle.UnpicklingError, match="not in allowlist"):
+            self.handler.load()
+
+    def test_load_allows_safe_types(self):
+        """Verify that common safe data types can still be loaded."""
+        from collections import OrderedDict
+        from datetime import datetime
+
+        data = {
+            "strings": ["a", "b", "c"],
+            "numbers": [1, 2.5, True, None],
+            "nested": {"key": (1, 2, 3)},
+            "ordered": OrderedDict([("x", 1), ("y", 2)]),
+            "timestamp": datetime(2026, 1, 1, 12, 0, 0),
+        }
+        self.handler.save(data)
+        loaded = self.handler.load()
+        assert loaded == data


### PR DESCRIPTION
## Summary

`PickleHandler.load()` in `utilities/file_handler.py` uses bare `pickle.load()` without restrictions, which allows **arbitrary code execution** if a `.pkl` file is tampered with ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)).

The `# noqa: S301` comment on that line indicates the team is aware of Bandit's warning but has suppressed it rather than mitigating the risk.

### Attack scenario

`PickleHandler` stores files in `os.getcwd()` with predictable names (e.g., `trained_agents_data.pkl` used by `CrewTrainingHandler`). An attacker who can write to the working directory — via a path traversal in another component, a shared filesystem, or a supply chain attack on training data — can replace the `.pkl` file with a crafted payload that executes arbitrary code when `load()` is called.

### Fix

This PR adds a `_SafeUnpickler` (subclass of `pickle.Unpickler`) that restricts deserialization to a strict allowlist of safe built-in types:
- **builtins:** dict, list, set, frozenset, tuple, str, bytes, bytearray, int, float, complex, bool, NoneType
- **datetime:** datetime, date, time, timedelta, timezone
- **collections:** OrderedDict, defaultdict, deque

Any class not in the allowlist is rejected with a clear `UnpicklingError`. This is the [recommended mitigation](https://docs.python.org/3/library/pickle.html#restricting-globals) from the Python docs.

### Backward compatibility

All existing training data (dicts, lists, strings, numbers, timestamps) loads correctly. Only payloads referencing dangerous classes (os.system, eval, subprocess.Popen, etc.) are blocked. No API changes.

## Test plan

- [x] `test_load_rejects_unsafe_class` — verifies a crafted payload using `eval` is rejected
- [x] `test_load_allows_safe_types` — verifies dicts, lists, OrderedDict, datetime still load
- [x] Existing `test_save_and_load`, `test_load_empty_file`, `test_load_corrupted_file` — unchanged, still pass

## References

- [Python docs: Restricting Globals for pickle](https://docs.python.org/3/library/pickle.html#restricting-globals)
- [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)
- [OWASP: Deserialization](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how persisted training data is deserialized; while it mitigates RCE risk, it may break loading of previously-saved pickle files that contain custom/non-allowlisted types.
> 
> **Overview**
> Mitigates pickle deserialization RCE (CWE-502) by replacing `pickle.load()` in `PickleHandler.load()` with a new `_SafeUnpickler` that only allows an explicit allowlist of common built-in/container types plus select `datetime` and `collections` types.
> 
> Adds tests ensuring malicious payloads are rejected with `pickle.UnpicklingError` and that typical persisted training data structures still round-trip correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db4e25fd5308bf4924e1c4fb994c34cc2eb5fc9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->