### PR TITLE
docs: add Spanish (es) translations for documentation

### DIFF
--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -1,0 +1,76 @@
+---
+title: "Documentación de CrewAI"
+description: "Construye agentes de IA colaborativos, crews y flujos — listos para producción desde el primer día."
+icon: "house"
+mode: "wide"
+---
+
+<div
+  style={{
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 20,
+    textAlign: 'center',
+    padding: '48px 24px',
+    borderRadius: 16,
+    background: 'linear-gradient(180deg, rgba(235,102,88,0.12) 0%, rgba(201,76,60,0.08) 100%)',
+    border: '1px solid rgba(235,102,88,0.18)'
+  }}
+>
+  <img src="/images/crew_only_logo.png" alt="CrewAI" width="250" height="100" />
+  <div style={{ maxWidth: 720 }}>
+    <h1 style={{ marginBottom: 12 }}>Despliega sistemas multi-agente con confianza</h1>
+    <p style={{ color: 'var(--mint-text-2)' }}>
+      Diseña agentes, orquesta crews y automatiza flujos con guardrails, memoria, conocimiento y observabilidad integrados.
+    </p>
+  </div>
+
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
+    <a className="button button-primary" href="/es/quickstart">Comenzar</a>
+    <a className="button" href="/en/changelog">Ver changelog</a>
+    <a className="button" href="/en/api-reference/introduction">Referencia de API</a>
+  </div>
+
+</div>
+
+<div style={{ marginTop: 32 }} />
+
+## Primeros pasos
+
+<CardGroup cols={3}>
+  <Card title="Introducción" href="/es/introduction" icon="sparkles">
+    Descripción general de los conceptos, la arquitectura y lo que puedes construir con agentes, crews y flujos de CrewAI.
+  </Card>
+  <Card title="Instalación" href="/en/installation" icon="wrench">
+    Instala con `uv`, configura claves de API y prepara el CLI para desarrollo local.
+  </Card>
+  <Card title="Inicio rápido" href="/es/quickstart" icon="rocket">
+    Crea tu primer crew en minutos. Aprende el runtime principal, la estructura del proyecto y el ciclo de desarrollo.
+  </Card>
+</CardGroup>
+
+## Construye lo básico
+
+<CardGroup cols={3}>
+  <Card title="Agentes" href="/en/concepts/agents" icon="users">
+    Compone agentes con herramientas, memoria, conocimiento y salidas estructuradas usando Pydantic. Incluye plantillas y mejores prácticas.
+  </Card>
+  <Card title="Flujos" href="/en/concepts/flows" icon="arrow-progress">
+    Orquesta pasos start/listen/router, gestiona estado, persiste ejecuciones y reanuda workflows de larga duración.
+  </Card>
+  <Card title="Tareas y Procesos" href="/en/concepts/tasks" icon="check">
+    Define procesos secuenciales, jerárquicos o híbridos con guardrails, callbacks y triggers human-in-the-loop.
+  </Card>
+</CardGroup>
+
+## Mantente conectado
+
+<CardGroup cols={2}>
+  <Card title="Danos una estrella en GitHub" href="https://github.com/crewAIInc/crewAI" icon="star">
+    Si CrewAI te ayuda a desarrollar más rápido, danos una estrella y comparte tus proyectos con la comunidad.
+  </Card>
+  <Card title="Únete a la comunidad" href="https://community.crewai.com" icon="comments">
+    Haz preguntas, muestra tus workflows y solicita funcionalidades junto con otros desarrolladores.
+  </Card>
+</CardGroup>

--- a/docs/es/introduction.mdx
+++ b/docs/es/introduction.mdx
@@ -1,0 +1,144 @@
+---
+title: Introducción
+description: Construye equipos de agentes de IA que trabajan juntos para resolver tareas complejas
+icon: handshake
+mode: "wide"
+---
+
+# ¿Qué es CrewAI?
+
+**CrewAI es el principal framework open-source para orquestar agentes de IA autónomos y construir workflows complejos.**
+
+Permite a los desarrolladores crear sistemas multi-agente listos para producción, combinando la inteligencia colaborativa de los **Crews** con el control preciso de los **Flows**.
+
+- **[CrewAI Flows](/en/guides/flows/first-flow)**: La columna vertebral de tu aplicación de IA. Los Flows te permiten crear workflows estructurados y basados en eventos que gestionan el estado y controlan la ejecución. Proporcionan la estructura para que tus agentes de IA trabajen.
+- **[CrewAI Crews](/en/guides/crews/first-crew)**: Las unidades de trabajo dentro de tu Flow. Los Crews son equipos de agentes autónomos que colaboran para resolver tareas específicas delegadas por el Flow.
+
+Con más de 100,000 desarrolladores certificados a través de nuestros cursos comunitarios, CrewAI es el estándar para automatización de IA a nivel empresarial.
+
+## La Arquitectura de CrewAI
+
+La arquitectura de CrewAI está diseñada para equilibrar autonomía con control.
+
+### 1. Flows: La Columna Vertebral
+
+<Note>
+  Piensa en un Flow como el "gerente" o la "definición de proceso" de tu aplicación. Define los pasos, la lógica y cómo los datos fluyen a través de tu sistema.
+</Note>
+
+<Frame caption="Descripción general del Framework CrewAI">
+  <img src="/images/flows.png" alt="Descripción general del Framework CrewAI" />
+</Frame>
+
+Los Flows proporcionan:
+- **Gestión de Estado**: Persiste datos entre pasos y ejecuciones.
+- **Ejecución Basada en Eventos**: Dispara acciones basadas en eventos o entradas externas.
+- **Flujo de Control**: Usa lógica condicional, bucles y ramificaciones.
+
+### 2. Crews: La Inteligencia
+
+<Note>
+  Los Crews son los "equipos" que hacen el trabajo pesado. Dentro de un Flow, puedes activar un Crew para abordar un problema complejo que requiere creatividad y colaboración.
+</Note>
+
+<Frame caption="Descripción general del Framework CrewAI">
+  <img src="/images/crews.png" alt="Descripción general del Framework CrewAI" />
+</Frame>
+
+Los Crews proporcionan:
+- **Agentes con Roles**: Agentes especializados con objetivos y herramientas específicas.
+- **Colaboración Autónoma**: Los agentes trabajan juntos para resolver tareas.
+- **Delegación de Tareas**: Las tareas se asignan y ejecutan según las capacidades de cada agente.
+
+## Cómo Funciona Todo Junto
+
+1.  **El Flow** dispara un evento o inicia un proceso.
+2.  **El Flow** gestiona el estado y decide qué hacer a continuación.
+3.  **El Flow** delega una tarea compleja a un **Crew**.
+4.  Los agentes del **Crew** colaboran para completar la tarea.
+5.  **El Crew** devuelve el resultado al **Flow**.
+6.  **El Flow** continúa la ejecución basándose en el resultado.
+
+## Características Principales
+
+<CardGroup cols={2}>
+  <Card title="Flows de Grado Producción" icon="arrow-progress">
+    Construye workflows confiables y con estado que pueden manejar procesos de larga duración y lógica compleja.
+  </Card>
+  <Card title="Crews Autónomos" icon="users">
+    Despliega equipos de agentes que pueden planificar, ejecutar y colaborar para lograr objetivos de alto nivel.
+  </Card>
+  <Card title="Herramientas Flexibles" icon="screwdriver-wrench">
+    Conecta tus agentes a cualquier API, base de datos o herramienta local.
+  </Card>
+  <Card title="Seguridad Empresarial" icon="lock">
+    Diseñado con seguridad y cumplimiento normativo para implementaciones empresariales.
+  </Card>
+</CardGroup>
+
+## Cuándo Usar Crews vs. Flows
+
+**La respuesta corta: Usa ambos.**
+
+Para cualquier aplicación lista para producción, **comienza con un Flow**.
+
+- **Usa un Flow** para definir la estructura general, el estado y la lógica de tu aplicación.
+- **Usa un Crew** dentro de un paso del Flow cuando necesites un equipo de agentes para realizar una tarea específica y compleja que requiere autonomía.
+
+| Caso de Uso | Arquitectura |
+| :--- | :--- |
+| **Automatización Simple** | Un solo Flow con tareas en Python |
+| **Investigación Compleja** | Flow gestionando estado -> Crew realizando investigación |
+| **Backend de Aplicación** | Flow manejando peticiones API -> Crew generando contenido -> Flow guardando en BD |
+
+## ¿Por Qué Elegir CrewAI?
+
+- 🧠 **Operación Autónoma**: Los agentes toman decisiones inteligentes basadas en sus roles y herramientas disponibles
+- 📝 **Interacción Natural**: Los agentes se comunican y colaboran como miembros de un equipo humano
+- 🛠️ **Diseño Extensible**: Fácil de agregar nuevas herramientas, roles y capacidades
+- 🚀 **Listo para Producción**: Construido para confiabilidad y escalabilidad en aplicaciones del mundo real
+- 🔒 **Enfocado en Seguridad**: Diseñado con requisitos de seguridad empresarial en mente
+- 💰 **Eficiente en Costos**: Optimizado para minimizar el uso de tokens y llamadas a APIs
+
+## ¿Listo para Empezar a Construir?
+
+<CardGroup cols={2}>
+  <Card
+    title="Construye Tu Primer Flow"
+    icon="diagram-project"
+    href="/en/guides/flows/first-flow"
+  >
+    Aprende a crear workflows estructurados y basados en eventos con control preciso sobre la ejecución.
+  </Card>
+  <Card
+    title="Construye Tu Primer Crew"
+    icon="users-gear"
+    href="/en/guides/crews/first-crew"
+  >
+    Tutorial paso a paso para crear un equipo de IA colaborativo que trabaja junto para resolver problemas complejos.
+  </Card>
+</CardGroup>
+
+<CardGroup cols={3}>
+  <Card
+    title="Instalar CrewAI"
+    icon="wrench"
+    href="/en/installation"
+  >
+    Comienza con CrewAI en tu entorno de desarrollo.
+  </Card>
+  <Card
+    title="Inicio Rápido"
+    icon="bolt"
+    href="/es/quickstart"
+  >
+    Sigue nuestra guía de inicio rápido para crear tu primer agente y obtener experiencia práctica.
+  </Card>
+  <Card
+    title="Únete a la Comunidad"
+    icon="comments"
+    href="https://community.crewai.com"
+  >
+    Conéctate con otros desarrolladores, obtén ayuda y comparte tus experiencias con CrewAI.
+  </Card>
+</CardGroup>

--- a/docs/es/quickstart.mdx
+++ b/docs/es/quickstart.mdx
@@ -1,0 +1,213 @@
+---
+title: Inicio Rápido
+description: Construye tu primer agente de IA con CrewAI en menos de 5 minutos.
+icon: rocket
+mode: "wide"
+---
+
+## Construye tu primer Agente con CrewAI
+
+Vamos a crear un crew simple que nos ayudará a `investigar` y `reportar` sobre los `últimos desarrollos en IA` para un tema dado.
+
+Antes de continuar, asegúrate de haber terminado de instalar CrewAI.
+Si aún no lo has instalado, puedes hacerlo siguiendo la [guía de instalación](/en/installation).
+
+¡Sigue los pasos a continuación para empezar! 🚣‍♂️
+
+<Steps>
+  <Step title="Crea tu crew">
+  Crea un nuevo proyecto de crew ejecutando el siguiente comando en tu terminal.
+  Esto creará un nuevo directorio llamado `latest-ai-development` con la estructura básica para tu crew.
+    <CodeGroup>
+      ```shell Terminal
+      crewai create crew latest-ai-development
+      ```
+    </CodeGroup>
+  </Step>
+  <Step title="Navega a tu nuevo proyecto de crew">
+    <CodeGroup>
+      ```shell Terminal
+      cd latest_ai_development
+      ```
+    </CodeGroup>
+  </Step>
+  <Step title="Modifica tu archivo `agents.yaml`">
+  <Tip>
+  También puedes modificar los agentes según sea necesario para tu caso de uso o copiar y pegar tal cual en tu proyecto.
+  Cualquier variable interpolada en tus archivos `agents.yaml` y `tasks.yaml` como `{topic}` será reemplazada por el valor de la variable en el archivo `main.py`.
+  </Tip>
+    ```yaml agents.yaml
+    # src/latest_ai_development/config/agents.yaml
+    researcher:
+      role: >
+        {topic} Investigador Senior de Datos
+      goal: >
+        Descubrir desarrollos de vanguardia en {topic}
+      backstory: >
+        Eres un investigador experimentado con habilidad para descubrir los
+        últimos desarrollos en {topic}. Conocido por tu capacidad de encontrar
+        la información más relevante y presentarla de manera clara y concisa.
+
+    reporting_analyst:
+      role: >
+        Analista de Reportes de {topic}
+      goal: >
+        Crear reportes detallados basados en el análisis de datos e investigación de {topic}
+      backstory: >
+        Eres un analista meticuloso con ojo agudo para los detalles. Eres conocido
+        por tu capacidad de convertir datos complejos en reportes claros y concisos,
+        facilitando que otros entiendan y actúen sobre la información que proporcionas.
+    ```
+
+  </Step>
+  <Step title="Modifica tu archivo `tasks.yaml`">
+    ```yaml tasks.yaml
+    # src/latest_ai_development/config/tasks.yaml
+    research_task:
+      description: >
+        Realiza una investigación exhaustiva sobre {topic}.
+        Asegúrate de encontrar información interesante y relevante dado
+        que el año actual es 2025.
+      expected_output: >
+        Una lista con 10 puntos de la información más relevante sobre {topic}
+      agent: researcher
+
+    reporting_task:
+      description: >
+        Revisa el contexto que obtuviste y expande cada tema en una sección completa para un reporte.
+        Asegúrate de que el reporte sea detallado y contenga toda la información relevante.
+      expected_output: >
+        Un reporte completo con los temas principales, cada uno con una sección completa de información.
+        Formateado como markdown sin '```'
+      agent: reporting_analyst
+      output_file: report.md
+    ```
+
+  </Step>
+  <Step title="Modifica tu archivo `crew.py`">
+    ```python crew.py
+    # src/latest_ai_development/crew.py
+    from crewai import Agent, Crew, Process, Task
+    from crewai.project import CrewBase, agent, crew, task
+    from crewai_tools import SerperDevTool
+    from crewai.agents.agent_builder.base_agent import BaseAgent
+    from typing import List
+
+    @CrewBase
+    class LatestAiDevelopmentCrew():
+      """Crew de LatestAiDevelopment"""
+
+      agents: List[BaseAgent]
+      tasks: List[Task]
+
+      @agent
+      def researcher(self) -> Agent:
+        return Agent(
+          config=self.agents_config['researcher'], # type: ignore[index]
+          verbose=True,
+          tools=[SerperDevTool()]
+        )
+
+      @agent
+      def reporting_analyst(self) -> Agent:
+        return Agent(
+          config=self.agents_config['reporting_analyst'], # type: ignore[index]
+          verbose=True
+        )
+
+      @task
+      def research_task(self) -> Task:
+        return Task(
+          config=self.tasks_config['research_task'], # type: ignore[index]
+        )
+
+      @task
+      def reporting_task(self) -> Task:
+        return Task(
+          config=self.tasks_config['reporting_task'], # type: ignore[index]
+          output_file='output/report.md'
+        )
+
+      @crew
+      def crew(self) -> Crew:
+        """Crea el crew de LatestAiDevelopment"""
+        return Crew(
+          agents=self.agents,
+          tasks=self.tasks,
+          process=Process.sequential,
+          verbose=True,
+        )
+    ```
+
+  </Step>
+  <Step title="Pasa entradas personalizadas a tu crew">
+    ```python main.py
+    #!/usr/bin/env python
+    # src/latest_ai_development/main.py
+    import sys
+    from latest_ai_development.crew import LatestAiDevelopmentCrew
+
+    def run():
+      """
+      Ejecuta el crew.
+      """
+      inputs = {
+        'topic': 'Agentes de IA'
+      }
+      LatestAiDevelopmentCrew().crew().kickoff(inputs=inputs)
+    ```
+
+  </Step>
+  <Step title="Configura tus variables de entorno">
+  Antes de ejecutar tu crew, asegúrate de tener las siguientes claves configuradas como variables de entorno en tu archivo `.env`:
+    - Una clave API de [Serper.dev](https://serper.dev/): `SERPER_API_KEY=TU_CLAVE_AQUI`
+    - La configuración para tu modelo elegido, como una clave API. Consulta la
+        [guía de configuración de LLM](/en/concepts/llms#setting-up-your-llm) para aprender cómo configurar modelos de cualquier proveedor.
+  </Step>
+  <Step title="Bloquea e instala las dependencias">
+      <CodeGroup>
+        ```shell Terminal
+        crewai install
+        ```
+      </CodeGroup>
+  </Step>
+  <Step title="Ejecuta tu crew">
+      <CodeGroup>
+        ```bash Terminal
+        crewai run
+        ```
+      </CodeGroup>
+  </Step>
+</Steps>
+
+<Check>
+¡Felicidades!
+
+¡Has configurado exitosamente tu proyecto de crew y estás listo para empezar a construir tus propios workflows con agentes!
+
+</Check>
+
+### Nota sobre Consistencia en Nombres
+
+Los nombres que uses en tus archivos YAML (`agents.yaml` y `tasks.yaml`) deben coincidir con los nombres de los métodos en tu código Python.
+Por ejemplo, puedes referenciar el agente para tareas específicas desde el archivo `tasks.yaml`.
+Esta consistencia en nombres permite a CrewAI vincular automáticamente tus configuraciones con tu código.
+
+## Desplegando Tu Crew
+
+La forma más fácil de desplegar tu crew en producción es a través de [CrewAI AMP](http://app.crewai.com).
+
+<CardGroup cols={2}>
+  <Card title="Despliega en Enterprise" icon="rocket" href="http://app.crewai.com">
+    Comienza con CrewAI AMP y despliega tu crew en un entorno de producción
+    con solo unos clics.
+  </Card>
+  <Card
+    title="Únete a la Comunidad"
+    icon="comments"
+    href="https://community.crewai.com"
+  >
+    Únete a nuestra comunidad open source para discutir ideas, compartir tus proyectos
+    y conectar con otros desarrolladores de CrewAI.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

This PR adds Spanish (es) translations for the CrewAI documentation, joining the existing Korean (ko) and Portuguese (pt-BR) translations.

### Pages translated:
- `docs/es/index.mdx` - Documentation landing page
- `docs/es/introduction.mdx` - Introduction (What is CrewAI?)
- `docs/es/quickstart.mdx` - Quickstart guide

### Why?
Spanish is the second most spoken native language globally. Adding Spanish translations makes CrewAI more accessible to the large Spanish-speaking developer community in Latin America and Spain.

All translations maintain the same structure and links as the English originals, with natural Mexican Spanish localization (not machine-translated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Spanish MDX documentation pages only, with no runtime or API behavior changes. Primary risk is broken/incorrect links or rendering issues in the new content.
> 
> **Overview**
> Adds initial Spanish (`es`) docs content by introducing new MDX pages for the Spanish landing page (`docs/es/index.mdx`), `Introducción` (`docs/es/introduction.mdx`), and `Inicio Rápido` (`docs/es/quickstart.mdx`).
> 
> The new pages mirror the existing docs structure with localized copy and CTAs, and include code/config examples translated to Spanish while largely linking back to existing English routes where Spanish equivalents aren’t provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 022198e9e785ecf20bde6c4086b243cd6b1584ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->