### PR TITLE
fix(gemini): group parallel function_response parts in a single Content object

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -634,19 +634,11 @@ class GeminiCompletion(BaseLLM):
                 function_response_part = types.Part.from_function_response(
                     name=tool_name, response=response_data
                 )
-                # Gemini requires all parallel function responses in a single
-                # Content object.  When the previous Content already holds
-                # function_response parts, merge into it instead of creating
-                # a new Content.
                 if (
                     contents
                     and contents[-1].role == "user"
                     and contents[-1].parts
-                    and all(
-                        hasattr(p, "function_response")
-                        and p.function_response is not None
-                        for p in contents[-1].parts
-                    )
+                    and contents[-1].parts[-1].function_response is not None
                 ):
                     contents[-1].parts.append(function_response_part)
                 else:


### PR DESCRIPTION
When Gemini makes N parallel tool calls, the API requires all N function_response parts in one Content object. Previously each tool result created a separate Content, causing 400 INVALID_ARGUMENT errors. Merge consecutive function_response parts into the existing Content instead of appending new ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Gemini request formatting for tool results by mutating the last `Content` instead of always appending a new one, which could affect downstream assumptions about message boundaries but is limited to tool-response packaging.
> 
> **Overview**
> Fixes Gemini tool-response formatting by **grouping consecutive `function_response` parts** into the same trailing `Content(role="user")` instead of creating a new `Content` per tool result.
> 
> This aligns with Gemini’s requirement for parallel tool call outputs (multiple `function_response` parts in one `Content`) and avoids `400 INVALID_ARGUMENT` errors when multiple tool responses are returned back-to-back.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c797ccbe84212ca3b407f6faac596b739ba27d0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->