### PR TITLE
docs: add crewai-tool-agentwallet to community tools

### DIFF
--- a/lib/crewai-tools/README.md
+++ b/lib/crewai-tools/README.md
@@ -227,3 +227,13 @@ Join our rapidly growing community and receive real-time support:
 - [Open an Issue](https://github.com/crewAIInc/crewAI/issues)
 
 Build smarter, faster, and more powerful AI solutions—powered by CrewAI Tools.
+---
+
+## Community Tools
+
+Third-party tools built by the community:
+
+| Tool | PyPI | Description |
+|------|------|-------------|
+| [crewai-tool-agentwallet](https://github.com/agentwallet-sdk/crewai-tool-agentwallet) | [PyPI](https://pypi.org/project/crewai-tool-agentwallet/) | Non-custodial wallet — EVM transfers, x402 payments, 17-chain CCTP bridge, on-chain spend limits |
+


### PR DESCRIPTION
Adds crewai-tool-agentwallet to a Community Tools section.

PyPI: https://pypi.org/project/crewai-tool-agentwallet/
GitHub: https://github.com/agentwallet-sdk/crewai-tool-agentwallet
License: MIT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new entry to the README; no runtime code or behavior is affected.
> 
> **Overview**
> Adds a new **Community Tools** section to `lib/crewai-tools/README.md`, listing the third-party `crewai-tool-agentwallet` project with links to its GitHub repo and PyPI package plus a short capability description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fca1106413c6fb9f084370f786a9380e8bb8c75b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->