### PR TITLE
fix(memory): handle thread pool shutdown and future errors in Encodin…

### DIFF
--- a/lib/crewai/src/crewai/memory/encoding_flow.py
+++ b/lib/crewai/src/crewai/memory/encoding_flow.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
+import logging
 import math
 from typing import Any
 from uuid import uuid4
@@ -26,6 +27,9 @@ from crewai.memory.analyze import (
     analyze_for_save,
 )
 from crewai.memory.types import MemoryConfig, MemoryRecord, embed_texts
+
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +276,15 @@ class EncodingFlow(Flow[EncodingState]):
 
             # Collect field-resolution results
             for i, future in save_futures.items():
-                analysis = future.result()
+                try:
+                    analysis = future.result()
+                except Exception as e:
+                    _logger.warning("Field resolution failed for item %d, falling back to defaults: %s", i, e)
+                    self._apply_defaults(items[i])
+                    items[i].plan = ConsolidationPlan(actions=[], insert_new=True)
+                    # Skip consolidation for this item since field resolution failed
+                    consol_futures.pop(i, None)
+                    continue
                 item = items[i]
                 item.resolved_scope = item.scope or analysis.suggested_scope or "/"
                 item.resolved_categories = (
@@ -301,9 +313,13 @@ class EncodingFlow(Flow[EncodingState]):
 
             # Collect consolidation results
             for i, future in consol_futures.items():
-                items[i].plan = future.result()
+                try:
+                    items[i].plan = future.result()
+                except Exception as e:
+                    _logger.warning("Consolidation analysis failed for item %d, inserting as new: %s", i, e)
+                    items[i].plan = ConsolidationPlan(actions=[], insert_new=True)
         finally:
-            pool.shutdown(wait=False)
+            pool.shutdown(wait=True)
 
     def _apply_defaults(self, item: ItemState) -> None:
         """Apply caller values with config defaults (fast path)."""


### PR DESCRIPTION
…gFlow

Two issues in `parallel_analyze()`:

1. `pool.shutdown(wait=False)` could discard still-running LLM futures, silently losing analysis results. Changed to `wait=True`.

2. `future.result()` had no exception handling — a single LLM call failure would crash the entire batch. Now each future is wrapped in try/except: failed field-resolution items fall back to caller defaults, failed consolidation items are inserted as new records.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and error handling in the memory encoding pipeline; failures now degrade to default inserts instead of aborting, which can affect consolidation/update behavior if LLM calls are flaky.
> 
> **Overview**
> Improves robustness of `EncodingFlow.parallel_analyze()` by **catching exceptions from LLM futures** and continuing the batch instead of failing the whole run.
> 
> On field-resolution failures it now falls back to caller/config defaults and forces an insert plan (skipping consolidation); on consolidation failures it inserts as new, and the executor now uses `pool.shutdown(wait=True)` to avoid dropping in-flight work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2c86ff7989eeed460d4194a9f19c64cddc7c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->