### PR TITLE
fix(mcp): add timeout to cleanup and handle running event loop

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -94,10 +94,30 @@ class MCPToolResolver:
         async def _disconnect_all() -> None:
             for client in self._clients:
                 if client and hasattr(client, "connected") and client.connected:
-                    await client.disconnect()
+                    try:
+                        await asyncio.wait_for(
+                            client.disconnect(), timeout=MCP_CONNECTION_TIMEOUT
+                        )
+                    except asyncio.TimeoutError:
+                        self._logger.log(
+                            "warning",
+                            "MCP client disconnect timed out, forcing cleanup",
+                        )
+                    except Exception as e:
+                        self._logger.log(
+                            "debug", f"Error disconnecting MCP client: {e}"
+                        )
 
         try:
-            asyncio.run(_disconnect_all())
+            try:
+                asyncio.get_running_loop()
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(asyncio.run, _disconnect_all())
+                    future.result(timeout=MCP_CONNECTION_TIMEOUT * len(self._clients) + 5)
+            except RuntimeError:
+                asyncio.run(_disconnect_all())
         except Exception as e:
             self._logger.log("error", f"Error during MCP client cleanup: {e}")
         finally:


### PR DESCRIPTION
The `cleanup()` method had two issues:

1. `client.disconnect()` had no timeout — if an MCP server was unresponsive, agent shutdown would hang indefinitely.
2. `asyncio.run()` was called unconditionally, which raises `RuntimeError` when called from within an existing event loop (e.g. during async agent execution or in Jupyter).

Add `asyncio.wait_for()` with `MCP_CONNECTION_TIMEOUT` per client, and detect a running loop to dispatch via `ThreadPoolExecutor` (matching the pattern already used in `_resolve_native()`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent shutdown/cleanup behavior and adds cross-thread async execution, which can affect resource teardown timing and error handling in async environments.
> 
> **Overview**
> Prevents MCP tool cleanup from hanging by wrapping each `client.disconnect()` in `asyncio.wait_for(..., timeout=MCP_CONNECTION_TIMEOUT)` and logging timeouts/cleanup errors.
> 
> Updates `MCPToolResolver.cleanup()` to avoid calling `asyncio.run()` inside an existing event loop by dispatching the disconnect coroutine via a `ThreadPoolExecutor` when a loop is already running, with an overall timeout based on client count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 771861851feb86a26e4d88eeb354a8f58b355727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->