### PR TITLE
fix: serialize Memory objects for telemetry span attributes

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -279,7 +279,11 @@ class Telemetry:
             self._add_attribute(span, "python_version", platform.python_version())
             add_crew_attributes(span, crew, self._add_attribute)
             self._add_attribute(span, "crew_process", crew.process)
-            self._add_attribute(span, "crew_memory", crew.memory)
+            self._add_attribute(
+                span,
+                "crew_memory",
+                crew.memory if isinstance(crew.memory, bool) else type(crew.memory).__name__,
+            )
             self._add_attribute(span, "crew_number_of_tasks", len(crew.tasks))
             self._add_attribute(span, "crew_number_of_agents", len(crew.agents))
 

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -1,6 +1,6 @@
 import os
 import threading
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from crewai import Agent, Crew, Task
@@ -159,3 +159,46 @@ def test_no_signal_handler_traceback_in_non_main_thread():
     mock_holder["logger"].debug.assert_any_call(
         "Skipping signal handler registration: not running in main thread"
     )
+
+
+@pytest.mark.parametrize(
+    "memory_input,expected_value",
+    [
+        (True, True),
+        (False, False),
+        pytest.param(
+            type("FakeMemory", (), {})(),
+            "FakeMemory",
+            id="custom_memory_instance",
+        ),
+    ],
+)
+def test_crew_creation_serializes_memory_for_telemetry(memory_input, expected_value):
+    """crew_memory span attribute must be OTel-serializable for any memory value.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4703
+    """
+    telemetry = Telemetry()
+    telemetry.ready = True
+
+    captured: dict[str, object] = {}
+    original = telemetry._add_attribute
+
+    def spy(span, key, value):
+        captured[key] = value
+        original(span, key, value)
+
+    agent = Agent(role="r", goal="g", backstory="b", llm="gpt-4o-mini")
+    task = Task(description="d", expected_output="e", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task], memory=memory_input)
+
+    with (
+        patch.object(telemetry, "_add_attribute", side_effect=spy),
+        patch.object(telemetry, "_safe_telemetry_operation", side_effect=lambda op: op()),
+        patch("crewai.telemetry.telemetry.trace") as mock_trace,
+    ):
+        mock_trace.get_tracer.return_value.start_span.return_value = MagicMock()
+        telemetry.crew_creation(crew, None)
+
+    assert captured["crew_memory"] == expected_value
+    assert isinstance(captured["crew_memory"], (bool, str, bytes, int, float))


### PR DESCRIPTION
## Summary

Fixes #4703

When `crew.memory` is a custom `Memory` instance (rather than a `bool`), OpenTelemetry rejects it as a span attribute value since it only accepts primitives (`bool`, `str`, `bytes`, `int`, `float`). This causes a runtime error during crew initialization:

```
Invalid type Memory for attribute 'crew_memory' value.
Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

**Fix:** In `crew_creation()` in `telemetry.py`, convert the `crew.memory` value before setting it as a span attribute -- booleans pass through unchanged, while any other type (e.g. a `Memory` instance) is converted to its class name string.

The `isinstance(crew.memory, bool)` check is intentional: since `bool` is a subclass of `int` in Python, checking `bool` first ensures `True`/`False` are preserved as booleans rather than being converted to `"bool"` string.

## Test Plan

- Added parametrized test covering `memory=True`, `memory=False`, and a custom memory instance
- Each case asserts the captured `crew_memory` attribute matches the expected value
- Each case verifies the value is an OTel-serializable type

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to telemetry span attribute formatting; primary risk is minor downstream impact on analytics expecting the previous `crew_memory` value shape.
> 
> **Overview**
> Prevents OpenTelemetry span creation from failing when `crew.memory` is a custom object by serializing the `crew_memory` attribute to an OTel-accepted primitive (booleans preserved; other types recorded as their class name).
> 
> Adds a regression test to ensure `Telemetry.crew_creation()` always emits an OTel-serializable `crew_memory` value for both boolean and custom memory instances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894f5e75e66ef9bc55d579b198b59811ec2c7ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->