### PR TITLE
fix(flow): use specific exception types in state management

### DIFF
--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -1472,7 +1472,8 @@ class Flow(Generic[T], metaclass=FlowMeta):
                     state_dict = self._state.model_dump()
                     model_class = type(self._state)
                     return model_class(**state_dict)
-                except Exception:
+                except (ValidationError, ValueError, TypeError):
+                    # Fallback to shallow copy if model reconstruction fails
                     return self._state.model_copy(deep=False)
         else:
             try:
@@ -2253,7 +2254,8 @@ class Flow(Generic[T], metaclass=FlowMeta):
         if isinstance(state_copy, BaseModel):
             try:
                 return state_copy.model_dump(mode="json")
-            except Exception:
+            except (ValueError, TypeError):
+                # Fallback to regular dump if JSON serialization fails
                 return state_copy.model_dump()
         else:
             return state_copy


### PR DESCRIPTION
Replace bare 'except Exception:' with specific exception types in state copying and serialization methods:

- In _copy_state: catch ValidationError, ValueError, TypeError for model reconstruction failures
- In _copy_and_serialize_state: catch ValueError, TypeError for JSON serialization failures

This improves error handling clarity and makes debugging easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to exception handling in state copying/serialization paths, with explicit fallbacks preserved. Main risk is some previously swallowed unexpected exceptions may now surface during flow event emission.
> 
> **Overview**
> **Flow state handling now catches narrower exception types.** In `Flow._copy_state`, bare reconstruction failures are limited to `ValidationError`/`ValueError`/`TypeError`, falling back to a shallow `model_copy`.
> 
> **State serialization fallbacks are more explicit.** In `Flow._copy_and_serialize_state`, JSON-mode `model_dump` failures now only catch `ValueError`/`TypeError` and fall back to a regular `model_dump`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88834f53184de046ecd1652e41339f0a749e096e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->