### PR TITLE
fix(memory): use specific exception types in recall_flow

### DIFF
--- a/lib/crewai/src/crewai/memory/recall_flow.py
+++ b/lib/crewai/src/crewai/memory/recall_flow.py
@@ -301,7 +301,8 @@ class RecallFlow(Flow[RecallState]):
                     "extraction": response,
                     "results": finding["results"],
                 })
-            except Exception:
+            except (ValueError, TypeError, RuntimeError) as e:
+                # LLM call failed - continue with empty extraction
                 enhanced.append({
                     "scope": finding["scope"],
                     "extraction": "",


### PR DESCRIPTION
Replace bare 'except Exception:' with specific exception types to improve error handling clarity. The LLM call can raise ValueError, TypeError, or RuntimeError, so we catch those specifically instead of all exceptions.

This makes the error handling more explicit and helps with debugging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime behavior by no longer swallowing all exceptions during `recursive_exploration`, which could surface previously-hidden errors and fail recalls in edge cases.
> 
> **Overview**
> **Tightens exception handling in memory recall’s deep-extraction loop.** In `RecallFlow.recursive_exploration` (`recall_flow.py`), the LLM call now catches only `ValueError`, `TypeError`, and `RuntimeError` (adding a clarifying comment) while still falling back to an empty extraction for those failures, instead of swallowing all exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d3b6511c76711cc97c66307193ceaf6247c8ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->