### PR TITLE
fix(utilities): use specific exception types in serialization and par…

### DIFF
--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -315,7 +315,7 @@ def format_answer(answer: str) -> AgentAction | AgentFinish:
     """
     try:
         return parse(answer)
-    except Exception:
+    except OutputParserError:
         return AgentFinish(
             thought="Failed to parse LLM response",
             output=answer,

--- a/lib/crewai/src/crewai/utilities/serialization.py
+++ b/lib/crewai/src/crewai/utilities/serialization.py
@@ -89,7 +89,7 @@ def to_serializable(
                 _current_depth=_current_depth + 1,
                 _ancestors=new_ancestors,
             )
-        except Exception:
+        except (ValueError, TypeError, AttributeError):
             try:
                 return {
                     _to_serializable_key(k): to_serializable(
@@ -101,7 +101,7 @@ def to_serializable(
                     for k, v in obj.__dict__.items()
                     if k not in (exclude or set())
                 }
-            except Exception:
+            except (ValueError, TypeError, AttributeError):
                 return repr(obj)
     return repr(obj)
 


### PR DESCRIPTION
…sing

Replace bare 'except Exception:' with specific exception types:

- In serialization.py: catch ValueError, TypeError, AttributeError for model dumping and dict access failures
- In agent_utils.py: catch OutputParserError specifically when parsing LLM responses

This improves error handling clarity and makes it easier to debug issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrowing `except Exception` to specific error types can cause previously swallowed unexpected failures to propagate, potentially changing runtime behavior in parsing/serialization paths.
> 
> **Overview**
> Improves error-handling specificity in utilities by replacing broad `except Exception` blocks with targeted exceptions.
> 
> `format_answer` in `agent_utils.py` now only falls back to an `AgentFinish` on `OutputParserError`, and `to_serializable` in `serialization.py` only suppresses `ValueError`/`TypeError`/`AttributeError` during Pydantic model dumping and `__dict__` fallback, allowing other unexpected exceptions to surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b8041bbb47cd92be8fc75519ce53f40e6e8ebfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->