### PR TITLE
fix(cli): use specific exception types in version command

### DIFF
--- a/lib/crewai/src/crewai/cli/cli.py
+++ b/lib/crewai/src/crewai/cli/cli.py
@@ -101,7 +101,7 @@ def version(tools):
     """Show the installed version of crewai."""
     try:
         crewai_version = get_version("crewai")
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         crewai_version = "unknown version"
     click.echo(f"crewai version: {crewai_version}")
 
@@ -109,7 +109,7 @@ def version(tools):
         try:
             tools_version = get_version("crewai")
             click.echo(f"crewai tools version: {tools_version}")
-        except Exception:
+        except (ImportError, ModuleNotFoundError):
             click.echo("crewai tools not installed")
 
 


### PR DESCRIPTION
Replace bare 'except Exception:' with specific exception types (ImportError, ModuleNotFoundError) when checking for package versions.

This makes the error handling more explicit and only catches the expected exceptions when a package is not installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes error handling for `importlib.metadata.version` lookups in the CLI, reducing the chance of masking unrelated runtime errors.
> 
> **Overview**
> The `crewai version` command now catches only `ImportError`/`ModuleNotFoundError` when querying package versions, instead of swallowing all exceptions.
> 
> This makes version reporting fail *only* in the expected “package not installed” cases and lets unexpected errors surface during `crewai`/tools version checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6de03b190e3882a929dfb288dfcc81f2f6ff4ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->