### PR TITLE
Harden vulnerability reporting workflow and policy (#4610)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,19 @@ title: "[BUG]"
 labels: ["bug"]
 assignees: []
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Security Notice
+        If your report includes a potential security vulnerability, do **not** continue with this public issue form.
+        Please use private reporting instead: https://github.com/crewAIInc/crewAI/security/advisories/new or security@crewai.com.
+  - type: checkboxes
+    id: non-security-confirmation
+    attributes:
+      label: Public disclosure confirmation
+      options:
+        - label: I confirm this issue does not contain vulnerability details, exploit code, or other sensitive security information.
+          required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/crewAIInc/crewAI/security/advisories/new
+    about: Use private reporting only for vulnerabilities. If needed, email security@crewai.com.
+  - name: Security policy
+    url: https://github.com/crewAIInc/crewAI/security/policy
+    about: Review the full vulnerability disclosure process and response commitments.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,7 +15,8 @@ Issues affecting clearly unaffiliated third-party services or user-generated con
 ### How to Report
 
 - **Please do not** disclose vulnerabilities via public GitHub issues, pull requests, or social media.
-- Email detailed reports to **security@crewai.com** with the subject line `Security Report`.
+- Submit a private advisory through GitHub Security Advisories: **https://github.com/crewAIInc/crewAI/security/advisories/new**.
+- You can also email detailed reports to **security@crewai.com** with the subject line `Security Report`.
 - If you need to share large files or sensitive artifacts, mention it in your email and we will coordinate a secure transfer method.
 
 ### What to Include
@@ -34,6 +35,14 @@ Providing comprehensive information enables us to validate the issue quickly:
 - **Communication:** We will keep you informed about triage results, remediation progress, and planned release timelines.
 - **Resolution:** Confirmed vulnerabilities will be prioritized based on severity and fixed as quickly as possible.
 - **Recognition:** We currently do not run a bug bounty program; any rewards or recognition are issued at CrewAI's discretion.
+
+### Escalation If You Do Not Hear Back
+
+If you do not receive an acknowledgement within two business days:
+
+- Reply to your original report and include `[FOLLOW-UP]` in the subject line.
+- If reported through GHSA, add a comment to the same private advisory thread.
+- If there is still no response after five business days, open a **public** GitHub issue that contains only the advisory identifier and a request for contact. Do **not** include exploit details or sensitive technical information.
 
 ### Coordinated Disclosure
 

--- a/lib/crewai/tests/security/test_security_reporting_templates.py
+++ b/lib/crewai/tests/security/test_security_reporting_templates.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ISSUE_TEMPLATES_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+
+    assert isinstance(data, dict), f"Expected YAML object in {path}"
+    return data
+
+
+def test_security_policy_is_in_supported_location() -> None:
+    assert (REPO_ROOT / ".github" / "SECURITY.md").exists()
+
+
+def test_security_policy_documents_escalation_window() -> None:
+    policy = (REPO_ROOT / ".github" / "SECURITY.md").read_text(encoding="utf-8")
+
+    assert "Acknowledgement" in policy
+    assert "two business days" in policy
+    assert "Escalation If You Do Not Hear Back" in policy
+    assert "five business days" in policy
+
+
+def test_issue_template_config_exposes_private_security_contact() -> None:
+    config = _load_yaml(ISSUE_TEMPLATES_DIR / "config.yml")
+    contact_links = config.get("contact_links")
+
+    assert isinstance(contact_links, list)
+
+    security_link = next(
+        (
+            link
+            for link in contact_links
+            if isinstance(link, dict)
+            and "security" in str(link.get("name", "")).lower()
+            and "advisories/new" in str(link.get("url", ""))
+        ),
+        None,
+    )
+
+    assert isinstance(security_link, dict)
+    assert security_link["url"] == (
+        "https://github.com/crewAIInc/crewAI/security/advisories/new"
+    )
+    assert "security@crewai.com" in str(security_link.get("about", ""))
+
+
+def test_bug_report_template_requires_non_security_confirmation() -> None:
+    bug_report = _load_yaml(ISSUE_TEMPLATES_DIR / "bug_report.yml")
+    body = bug_report.get("body")
+
+    assert isinstance(body, list)
+
+    security_warning_present = any(
+        isinstance(item, dict)
+        and item.get("type") == "markdown"
+        and "security vulnerability"
+        in str((item.get("attributes") or {}).get("value", "")).lower()
+        for item in body
+    )
+    assert security_warning_present
+
+    confirmation_block = next(
+        (
+            item
+            for item in body
+            if isinstance(item, dict)
+            and item.get("type") == "checkboxes"
+            and item.get("id") == "non-security-confirmation"
+        ),
+        None,
+    )
+
+    assert isinstance(confirmation_block, dict)
+    options = (confirmation_block.get("attributes") or {}).get("options")
+    assert isinstance(options, list)
+    assert options
+
+    first_option = options[0]
+    assert isinstance(first_option, dict)
+    assert first_option.get("required") is True
+
+    label = str(first_option.get("label", "")).lower()
+    assert "vulnerability" in label
+    assert "sensitive security information" in label


### PR DESCRIPTION
## Summary
This PR implements issue #4610.

- Scope: [SECURITY] Critical Vulnerability Disclosure
- Source branch: yuweuii:codex/issue-4610
- Commit: f9dea9bd

## Linked Issue
Closes #4610

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/template changes plus lightweight tests; main risk is CI failures if template text/paths change unexpectedly.
> 
> **Overview**
> Strengthens public-facing vulnerability reporting guidance by adding a **security notice** and mandatory non-security confirmation checkbox to the `bug_report.yml` issue template, and by exposing private security reporting links via `.github/ISSUE_TEMPLATE/config.yml`.
> 
> Updates `.github/SECURITY.md` to explicitly direct reporters to GitHub Security Advisories and to document an escalation window if acknowledgements are delayed.
> 
> Adds `test_security_reporting_templates.py` to assert the security policy is present, mentions acknowledgement/escalation timelines, and that the issue templates/config include the expected private security contact information.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb1fa5dec8be543dc7fd23d3fa725eecde4493d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->