### PR TITLE
fix(deps): bump gitpython to >=3.1.41 for CVE path traversal fix

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -108,7 +108,7 @@ stagehand = [
     "stagehand>=0.4.1",
 ]
 github = [
-    "gitpython==3.1.38",
+    "gitpython>=3.1.41,<4",
     "PyGithub==1.59.1",
 ]
 rag = [

--- a/uv.lock
+++ b/uv.lock
@@ -1426,7 +1426,7 @@ requires-dist = [
     { name = "docker", specifier = "~=7.1.0" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
-    { name = "gitpython", marker = "extra == 'github'", specifier = "==3.1.38" },
+    { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.41,<4" },
     { name = "hyperbrowser", marker = "extra == 'hyperbrowser'", specifier = ">=0.18.0" },
     { name = "langchain-apify", marker = "extra == 'apify'", specifier = ">=0.1.2,<1.0.0" },
     { name = "linkup-sdk", marker = "extra == 'linkup-sdk'", specifier = ">=0.2.2" },
@@ -2201,14 +2201,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.38"
+version = "3.1.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/45/cee7af549b6fa33f04531e402693a772b776cd9f845a2cbeca99cfac3331/GitPython-3.1.38.tar.gz", hash = "sha256:4d683e8957c8998b58ddb937e3e6cd167215a180e1ffd4da769ab81c620a89fe", size = 200632, upload-time = "2023-10-17T06:09:52.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/ae/044453eacd5a526d3f242ccd77e38ee8219c65e0b132562b551bd67c61a4/GitPython-3.1.38-py3-none-any.whl", hash = "sha256:9e98b672ffcb081c2c8d5aa630d4251544fb040fb158863054242f24a2a2ba30", size = 190573, upload-time = "2023-10-17T06:09:50.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `gitpython` from pinned `==3.1.38` to `>=3.1.41,<4` to resolve high-severity path traversal vulnerability (dependabot alert #1)
- Updates lockfile (resolved to 3.1.46)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency update limited to the optional `github` extra, but it may subtly affect Git operations for integrations relying on GitPython.
> 
> **Overview**
> Updates the optional `github` extra in `lib/crewai-tools/pyproject.toml` to stop pinning `gitpython==3.1.38` and instead require `gitpython>=3.1.41,<4` to pick up the path traversal security fix.
> 
> Refreshes `uv.lock` accordingly, resolving GitPython to `3.1.46` and updating the locked sdist/wheel metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bdc5c0f333ab07e154db85d8220f4c884adba41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->