### PR TITLE
fix(tools): preserve LF when generating tool.specs.json on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,8 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        # Force LF line endings cross-platform to keep tool.specs.json stable on Windows.
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 

--- a/lib/crewai-tools/tests/test_generate_tool_specs.py
+++ b/lib/crewai-tools/tests/test_generate_tool_specs.py
@@ -192,3 +192,13 @@ def test_save_to_json(extractor, tmp_path):
     assert len(data["tools"]) == 1
     assert data["tools"][0]["humanized_name"] == "Test Tool"
     assert data["tools"][0]["run_params_schema"][0]["name"] == "param1"
+
+
+def test_save_to_json_uses_lf_newlines(extractor):
+    extractor.tools_spec = [{"name": "TestTool"}]
+
+    m = mock.mock_open()
+    with mock.patch("builtins.open", m):
+        extractor.save_to_json("tool.specs.json")
+
+    m.assert_called_once_with("tool.specs.json", "w", encoding="utf-8", newline="\n")


### PR DESCRIPTION
## Summary
Fixes CRLF churn in `tool.specs.json` when running `generate_tool_specs.py` on Windows.

## What changed
- Updated `ToolSpecExtractor.save_to_json` to open files with `newline="\n"`.
- Added a unit test to assert the file is opened with LF newline policy.

## Why
Issue #4737 reports that Windows text-mode writes produce `\r\n`, causing noisy full-file diffs even when content is unchanged. For this generated artifact we want deterministic LF output across platforms.

## Notes on validation
- This environment does not have full project test dependencies (`crewai` and `vcr` plugins), so full pytest execution wasn’t possible here.
- Change is localized and low-risk (single write path + assertion test).

Closes #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes file-opening parameters for a generated JSON artifact and adds a targeted test; output content/structure is unchanged.
> 
> **Overview**
> Ensures generated `tool.specs.json` is stable on Windows by opening the output file with `newline="\n"` in `ToolSpecExtractor.save_to_json`, preventing CRLF churn.
> 
> Adds a unit test that mocks `open()` to assert the LF newline policy is applied when writing the specs file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b7855f1ce60efdb2bc94482bd0b620a03f5418d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->