### PR TITLE
fix: CRLF line endings, JSON fence fallback, corrupted JSON handling

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -18,6 +18,16 @@ from crewai.memory.types import MemoryRecord, ScopeInfo
 
 _logger = logging.getLogger(__name__)
 
+
+def _safe_json_loads(value: str | None, default: Any) -> Any:
+    """Parse JSON string, returning default on failure."""
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return default
+
 # Default embedding vector dimensionality (matches OpenAI text-embedding-3-small).
 # Used when creating new tables and for zero-vector placeholder scans.
 # Callers can override via the ``vector_dim`` constructor parameter.
@@ -296,8 +306,8 @@ class LanceDBStorage:
             id=str(row["id"]),
             content=str(row["content"]),
             scope=str(row["scope"]),
-            categories=json.loads(row["categories_str"]) if row.get("categories_str") else [],
-            metadata=json.loads(row["metadata_str"]) if row.get("metadata_str") else {},
+            categories=_safe_json_loads(row.get("categories_str"), []),
+            metadata=_safe_json_loads(row.get("metadata_str"), {}),
             importance=float(row.get("importance", 0.5)),
             created_at=_parse_dt(row.get("created_at")),
             last_accessed=_parse_dt(row.get("last_accessed")),

--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -65,7 +65,25 @@ class Converter(OutputConverter):
                 if isinstance(response, BaseModel):
                     result = response
                 else:
-                    result = self.model.model_validate_json(response)
+                    try:
+                        result = self.model.model_validate_json(response)
+                    except ValidationError:
+                        # LLM may return markdown-wrapped JSON even with function calling
+                        result = handle_partial_json(
+                            result=response,
+                            model=self.model,
+                            is_json_output=False,
+                            agent=None,
+                        )
+                        if not isinstance(result, BaseModel):
+                            if isinstance(result, dict):
+                                result = self.model.model_validate(result)
+                            elif isinstance(result, str):
+                                result = self.model.model_validate_json(result)
+                            else:
+                                raise ConverterError(
+                                    "handle_partial_json returned an unexpected type."
+                                ) from None
             else:
                 response = self.llm.call(
                     [


### PR DESCRIPTION
## Summary

- **CRLF in tool.specs.json (#4737):** `generate_tool_specs.py` opens output file without `newline=""`, causing `\r\n` on Windows. Added `newline=""` to `open()` call.

- **Pydantic validation error with markdown-wrapped JSON (#4509):** When a function-calling LLM returns JSON wrapped in markdown fences (` ```json ... ``` `), `model_validate_json()` fails. Added fallback to `handle_partial_json()` which extracts JSON from markdown fences via regex.

- **Corrupted JSON in lancedb_storage:** `_row_to_record()` calls `json.loads()` on `categories_str` / `metadata_str` without error handling. If stored data is malformed, the entire recall/search operation crashes. Added `_safe_json_loads()` helper that returns default value on parse failure.

## Test plan

- [x] All 13 converter tests pass (1 pre-existing unrelated failure in `test_get_conversion_instructions_non_gpt`)
- [ ] Verify `tool.specs.json` uses LF line endings on Windows after regeneration
- [ ] Verify converter handles ` ```json {"key": "value"} ``` ` response from LLM
- [ ] Verify `_row_to_record` gracefully handles malformed JSON in categories/metadata columns

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how LLM outputs and stored memory metadata are parsed, which could mask bad data or alter error behavior in core conversion/recall paths.
> 
> **Overview**
> Fixes Windows CRLF in generated `tool.specs.json` by forcing LF newlines when writing from `generate_tool_specs.py`.
> 
> Improves resilience to malformed/markdown-wrapped JSON: `Converter.to_pydantic()` now falls back to `handle_partial_json()` (and re-validates dict/string outputs) when `model_validate_json()` fails even under function-calling, and `LanceDBStorage._row_to_record()` now uses a `_safe_json_loads()` helper to tolerate corrupted `categories_str`/`metadata_str` without crashing recall/search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e420e0d331af5db8423e0a3ee3ccc24524ca9a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->