### PR TITLE
fix(tools): force LF newlines when generating tool.specs.json

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 

--- a/lib/crewai-tools/tests/test_generate_tool_specs.py
+++ b/lib/crewai-tools/tests/test_generate_tool_specs.py
@@ -192,3 +192,14 @@ def test_save_to_json(extractor, tmp_path):
     assert len(data["tools"]) == 1
     assert data["tools"][0]["humanized_name"] == "Test Tool"
     assert data["tools"][0]["run_params_schema"][0]["name"] == "param1"
+
+
+def test_save_to_json_uses_lf_newlines(extractor):
+    extractor.tools_spec = []
+
+    with mock.patch("crewai_tools.generate_tool_specs.open", mock.mock_open()) as mocked_open:
+        extractor.save_to_json("tool.specs.json")
+
+    mocked_open.assert_called_once_with(
+        "tool.specs.json", "w", encoding="utf-8", newline="\n"
+    )


### PR DESCRIPTION
## Summary
- write `tool.specs.json` with explicit `newline="\n"` in `generate_tool_specs.py`
- add a unit test to assert `save_to_json` opens files with LF newlines

## Why
Running the generator on Windows can otherwise rewrite the file with CRLF line endings and create noisy diffs.
