### PR TITLE
docs: fix typos in Oxylabs scraper docs

### DIFF
--- a/docs/en/tools/web-scraping/oxylabsscraperstool.mdx
+++ b/docs/en/tools/web-scraping/oxylabsscraperstool.mdx
@@ -4,7 +4,7 @@ description: >
   Oxylabs Scrapers allow to easily access the information from the respective sources. Please see the list of available sources below:
     - `Amazon Product`
     - `Amazon Search`
-    - `Google Seach`
+    - `Google Search`
     - `Universal`
 icon: globe
 mode: "wide"
@@ -87,7 +87,7 @@ print(result)
 ### Parameters
 
 - `query` - Amazon search term.
-- `domain` - Domain localization for Bestbuy.
+- `domain` - Domain localization for Amazon.
 - `start_page` - starting page number.
 - `pages` - number of pages to retrieve.
 - `geo_location` - the _Deliver to_ location.


### PR DESCRIPTION
## Summary
- fix `Google Seach` -> `Google Search` in the source list
- fix the `domain` parameter description to reference Amazon (not Bestbuy)

## Why
These are user-facing docs typos in the Oxylabs scraper page and can confuse setup/usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that correct wording and do not affect runtime behavior.
> 
> **Overview**
> Corrects a typo in the Oxylabs Scrapers source list (`Google Seach` → `Google Search`).
> 
> Fixes the `domain` parameter description under `OxylabsAmazonSearchScraperTool` to reference Amazon rather than Bestbuy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ba5e495e834e41009db0eb8c83f57dedc38dc71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->