### PR TITLE
feat: create action for nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     name: Build nightly packages
     needs: check
-    if: needs.check.outputs.has_changes == 'true'
+    if: needs.check.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,6 +62,11 @@ jobs:
             sed -i "s/__version__ = .*/__version__ = \"${NIGHTLY}\"/" "$init_file"
             echo "$init_file: $CURRENT -> $NIGHTLY"
           done
+
+          # Update cross-package dependency pins to nightly versions
+          sed -i "s/\"crewai-tools==[^\"]*\"/\"crewai-tools==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          sed -i "s/\"crewai==[^\"]*\"/\"crewai==${NIGHTLY}\"/" lib/crewai-tools/pyproject.toml
+          echo "Updated cross-package dependency pins to ${NIGHTLY}"
 
       - name: Build packages
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds automated nightly builds and PyPI publishing, which can inadvertently publish incorrect versions or dependencies if the stamping/publish logic misbehaves. Risk is limited to release automation (no runtime code changes) but impacts external package distribution.
> 
> **Overview**
> Adds a new `Nightly Canary Release` GitHub Actions workflow that runs daily (or manually) and **skips execution unless there were commits in the last 24 hours**.
> 
> The workflow stamps nightly `.devYYYYMMDD` versions into the three package `__init__.py` files, updates cross-package dependency pins in `pyproject.toml`, builds all packages with `uv`, uploads the `dist/` artifacts, and then publishes each artifact to PyPI (skipping `crewai_devtools`) with failure aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b8b7b74a2624aeaaa8d56dd021a5c917ba9c65d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->