### PR TITLE
fix: Use LF line endings in generate_tool_specs.py on Windows (fixes #4737)

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -185,7 +185,8 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        # Use newline="\n" to ensure LF line endings on all platforms (fixes Windows CRLF issues)
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
## Problem

Running `generate_tool_specs.py` on Windows regenerates `tool.specs.json` with `\r\n` line endings instead of `\n`, causing every line to appear modified in git diff.

## Solution

Add `newline="\n"` to the `open()` call to ensure consistent LF line endings across all platforms.

## Changes

- `lib/crewai-tools/src/crewai_tools/generate_tool_specs.py`: Add `newline="\n"` parameter

## Testing

- The change is minimal and only affects line ending behavior
- On Windows, this now produces LF endings matching the committed file
- On Unix/Linux/macOS, this is a no-op (already uses LF)

Fixes #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes file-writing newline behavior to avoid Windows CRLF diffs; no schema/content generation logic is modified.
> 
> **Overview**
> Ensures `generate_tool_specs.py` writes `tool.specs.json` using **LF line endings** on all platforms by opening the output file with `newline="\n"`.
> 
> This prevents Windows runs from regenerating the JSON with CRLF and causing full-file diffs, without changing the generated JSON structure/content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 465f746c093265191b35d56a216f50ce32f4f6aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->