### PR TITLE
docs: Add crewai-soul as community memory backend

### DIFF
--- a/docs/en/concepts/memory.mdx
+++ b/docs/en/concepts/memory.mdx
@@ -763,7 +763,7 @@ memory = Memory(
 
 ## Community Memory Backends
 
-The CrewAI community has built alternative memory backends for specific use cases.
+The CrewAI community has built alternative memory backends. These are maintained independently and may have different APIs or storage patterns.
 
 ### crewai-soul (Markdown-Native Memory)
 
@@ -781,18 +781,14 @@ The CrewAI community has built alternative memory backends for specific use case
 pip install crewai-soul
 ```
 
-**Usage:**
+**Standalone usage:**
 
 ```python
-from crewai import Crew
 from crewai_soul import SoulMemory
 
-# Drop-in replacement for Memory
-crew = Crew(
-    agents=[researcher, writer],
-    tasks=[...],
-    memory=SoulMemory(),
-)
+memory = SoulMemory()
+memory.remember("We decided to use PostgreSQL.")
+matches = memory.recall("database decision")
 ```
 
 After running, check `MEMORY.md`:
@@ -800,8 +796,8 @@ After running, check `MEMORY.md`:
 ```markdown
 # Memory Log
 
-## 2026-03-06 18:30:15 UTC
-We decided to use PostgreSQL for the user database.
+## YYYY-MM-DD HH:MM:SS UTC
+We decided to use PostgreSQL.
 ```
 
 **Features:**
@@ -814,7 +810,6 @@ We decided to use PostgreSQL for the user database.
 **Links:**
 - [GitHub](https://github.com/menonpg/crewai-soul)
 - [PyPI](https://pypi.org/project/crewai-soul/)
-- [Comparison: crewai-soul vs CrewAI Memory](https://menonlab-blog-production.up.railway.app/blog/crewai-soul-vs-crewai-memory)
 
 
 ## Discovery


### PR DESCRIPTION
## Summary

Adds **crewai-soul** to the Memory documentation as a community backend option for users who prefer markdown-based, git-versionable memory storage.

## What is crewai-soul?

A drop-in memory backend that stores agent memories in human-readable markdown files (`SOUL.md` + `MEMORY.md`).

**Why users might prefer it:**
- **Human-readable** — See exactly what agents remember
- **Git-versionable** — Track memory evolution with commits
- **Editable** — Fix wrong memories by editing files
- **No database** — Just markdown files

**Built on:**
- [soul-agent](https://github.com/menonpg/soul.py) — RAG + RLM hybrid retrieval
- [soul-schema](https://github.com/menonpg/soul-schema) — Database semantic layers

## Links

- PyPI: https://pypi.org/project/crewai-soul/
- GitHub: https://github.com/menonpg/crewai-soul
- Comparison article: https://menonlab-blog-production.up.railway.app/blog/crewai-soul-vs-crewai-memory

## Changes

- Added "Community Memory Backends" section to `docs/en/concepts/memory.mdx`
- Documented installation, usage, and when to choose crewai-soul over default Memory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a new **Community Memory Backends** section to `docs/en/concepts/memory.mdx` introducing `crewai-soul` as an alternative, community-maintained memory backend.
> 
> Documents when to use it, how to install it, a minimal standalone usage example, and links to its GitHub/PyPI plus a short feature list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1df2d78f59ec53a6a42e3d9ffd0a5cc8d803363. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->