### PR TITLE
fix: extract Bedrock tool arguments from 'input' field correctly

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,15 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            # Check for OpenAI-style arguments first, then Bedrock-style input.
+            # Use sentinel to distinguish "key absent" from "key is empty string".
+            _sentinel = object()
+            _raw_args = func_info.get("arguments", _sentinel)
+            if _raw_args is _sentinel or (isinstance(_raw_args, str) and _raw_args in ("", "{}")):
+                # No valid OpenAI arguments — try Bedrock's input field
+                func_args = tool_call.get("input", _raw_args if _raw_args is not _sentinel else "{}")
+            else:
+                func_args = _raw_args
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Problem

When using AWS Bedrock models, all tool calls receive empty arguments `{}` regardless of what the LLM provides.

The bug is in `crew_agent_executor.py`:
```python
func_args = func_info.get('arguments', '{}') or tool_call.get('input', {})
```

`.get('arguments', '{}')` returns the string `'{}'` when the key is absent. Since `'{}'` is truthy, the `or` operator never evaluates `tool_call.get('input', {})`, so Bedrock's `input` field is always ignored.

## Solution

Use a sentinel object to distinguish "key absent" from "key is empty string". Only fall back to Bedrock's `input` field when no valid OpenAI-style arguments are present.

Fixes #4748

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change isolated to native tool-call parsing; behavior only differs when OpenAI-style `function.arguments` is absent/empty, enabling Bedrock `input` to be used instead.
> 
> **Overview**
> Fixes native tool-call argument extraction for Bedrock-style responses so tools receive the actual payload from the `input` field when OpenAI-style `function.arguments` is missing or effectively empty.
> 
> Updates `_parse_native_tool_call` to use a sentinel to distinguish “key absent” from default `'{}'`, preventing the previous truthy default from masking Bedrock arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a1c00f221ac7d4fd89befbf31ae39c74346855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->