### PR TITLE
fix: group multiple Bedrock tool results into single user message

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -1815,21 +1815,33 @@ class BedrockCompletion(BaseLLM):
             elif role == "tool":
                 if not tool_call_id:
                     raise ValueError("Tool message missing required tool_call_id")
-                converse_messages.append(
-                    {
-                        "role": "user",
+                tool_result_block = {
+                    "toolResult": {
+                        "toolUseId": tool_call_id,
                         "content": [
-                            {
-                                "toolResult": {
-                                    "toolUseId": tool_call_id,
-                                    "content": [
-                                        {"text": str(content) if content else ""}
-                                    ],
-                                }
-                            }
+                            {"text": str(content) if content else ""}
                         ],
                     }
-                )
+                }
+                # Bedrock requires all toolResult blocks for a single assistant
+                # turn to be grouped in one user message.  If the previous
+                # converse message is already a user message containing
+                # toolResult blocks, append to it instead of creating a new one.
+                if (
+                    converse_messages
+                    and converse_messages[-1].get("role") == "user"
+                    and converse_messages[-1].get("content")
+                    and isinstance(converse_messages[-1]["content"], list)
+                    and any(
+                        "toolResult" in block
+                        for block in converse_messages[-1]["content"]
+                    )
+                ):
+                    converse_messages[-1]["content"].append(tool_result_block)
+                else:
+                    converse_messages.append(
+                        {"role": "user", "content": [tool_result_block]}
+                    )
             else:
                 # Convert to Converse API format with proper content structure
                 if isinstance(content, list):


### PR DESCRIPTION
## Problem

When a Bedrock model makes multiple tool calls in a single response, CrewAI sends each tool result as a separate user message:
```
Message 0: user (prompt)
Message 1: assistant (toolUse A, toolUse B)
Message 2: user (toolResult A)  ← Separate message
Message 3: user (toolResult B)  ← Separate message — causes ValidationException
```

Bedrock's Converse API requires all tool results for a given assistant message to be grouped in one user message.

## Solution

When converting tool messages to Bedrock format, check if the previous converse message is already a user message containing `toolResult` blocks. If so, append the new `toolResult` to it instead of creating a new message:
```
Message 0: user (prompt)
Message 1: assistant (toolUse A, toolUse B)
Message 2: user (toolResult A, toolResult B)  ← Grouped correctly
```

Fixes #4749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how tool responses are serialized into the Bedrock conversation history, which can affect multi-tool-call flows and message alternation edge cases.
> 
> **Overview**
> Prevents Bedrock Converse `ValidationException` when a model returns multiple tool calls in one assistant turn by **grouping all corresponding `toolResult` blocks into a single subsequent `user` message**.
> 
> Updates `_format_messages_for_converse` so consecutive `tool` role messages append their `toolResult` blocks onto the previous `user` message (when it already contains tool results) instead of emitting multiple separate `user` turns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3840574252e41735ba5d125fc54a20bd3a6496d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->