### PR TITLE
fix: ensure memory drain in akickoff async method

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -937,6 +937,9 @@ class Crew(FlowTrackable, BaseModel):
             )
             raise
         finally:
+            # Ensure all background memory saves complete before returning
+            if self._memory is not None and hasattr(self._memory, "drain_writes"):
+                self._memory.drain_writes()
             clear_files(self.id)
             detach(token)
 


### PR DESCRIPTION
## Summary

The sync `kickoff()` method includes a `drain_writes()` call in its `finally` block to ensure all background memory saves complete before returning:

```python
# kickoff() finally block (line 744)
if self._memory is not None and hasattr(self._memory, "drain_writes"):
    self._memory.drain_writes()
```

The async `akickoff()` method is missing this call, which means memory writes may be lost when using async execution. This was likely a copy-paste oversight when `akickoff` was added.

## Fix

Added the same `drain_writes()` guard to `akickoff()`'s finally block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity change, but it adds a blocking `drain_writes()` call to an async code path, which could impact latency or surface exceptions during shutdown.
> 
> **Overview**
> `Crew.akickoff()` now mirrors `kickoff()` by draining pending background memory writes in its `finally` block (guarded by `hasattr(self._memory, "drain_writes")`) before clearing files and detaching context.
> 
> This prevents async executions from returning before queued memory saves complete, reducing the chance of dropped memories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46f07369aec4a0f2bd80b484757625e628f7fffa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->