### PR TITLE
fix: extract Bedrock tool arguments from input field

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", "{}")
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

Fixes #4748.

When using AWS Bedrock models, tool calls always receive empty arguments `{}` because the fallback to Bedrock's `input` field never executes.

**Root cause:** `func_info.get("arguments", "{}")` returns the string `"{}"` (truthy) when no `arguments` key exists, so the `or` branch for `tool_call.get("input", {})` is never evaluated.

## Fix

```python
# Before (broken):
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})

# After (fixed):
func_args = func_info.get("arguments") or tool_call.get("input", "{}")
```

Using `None` as the default for `get("arguments")` makes the `or` fallback work correctly. The `"{}"` default is moved to the Bedrock `input` fallback as the final default.

**`lib/crewai/src/crewai/agents/crew_agent_executor.py`** line 850 — one-line fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small, isolated change to native tool-call parsing; risk is limited to how tool arguments are extracted for dict-style (Bedrock) tool calls.
> 
> **Overview**
> Fixes native tool-call argument extraction for Bedrock-style responses by changing `_parse_native_tool_call` to only use `function.arguments` when it exists, otherwise falling back to the tool call’s `input` field (defaulting to the JSON string `{}`). This prevents missing `arguments` from incorrectly short-circuiting the fallback and producing empty tool args.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd59c902c1270f57e3c0ed220b52733280f2f77e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->