### PR TITLE
fix: write tool specs with LF line endings on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
## Summary

Fixes #4737.

On Windows, `generate_tool_specs.py` writes `tool.specs.json` with CRLF (`\r\n`) line endings because Python's `open()` in text mode uses OS-native line endings. The committed file uses LF, so every line shows as modified in git diff.

## Fix

Add `newline="\n"` to the `open()` call in `save_to_json()` to force LF line endings on all platforms:

```python
# Before:
with open(output_path, "w", encoding="utf-8") as f:

# After:
with open(output_path, "w", encoding="utf-8", newline="\n") as f:
```

**`lib/crewai-tools/src/crewai_tools/generate_tool_specs.py`** — one-line fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to file writing settings to make generated `tool.specs.json` use consistent LF newlines across platforms, without affecting schema contents.
> 
> **Overview**
> Ensures the tool-spec generation script writes `tool.specs.json` with **LF line endings** on all platforms by opening the output file with `newline="\n"`, preventing noisy CRLF-only diffs on Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9985fa3754044787f618db52e5a666d2725a0dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->