### PR TITLE
fix: convert Memory object to string for OpenTelemetry attribute

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -279,7 +279,8 @@ class Telemetry:
             self._add_attribute(span, "python_version", platform.python_version())
             add_crew_attributes(span, crew, self._add_attribute)
             self._add_attribute(span, "crew_process", crew.process)
-            self._add_attribute(span, "crew_memory", crew.memory)
+            crew_memory = crew.memory if isinstance(crew.memory, (bool, str, int, float)) else type(crew.memory).__name__
+            self._add_attribute(span, "crew_memory", crew_memory)
             self._add_attribute(span, "crew_number_of_tasks", len(crew.tasks))
             self._add_attribute(span, "crew_number_of_agents", len(crew.agents))
 


### PR DESCRIPTION
## Summary

Fixes #4703.

When `crew.memory` is a custom `Memory` instance (instead of `True`), passing it directly to `self._add_attribute()` crashes with:

```
Invalid type Memory for attribute 'crew_memory' value.
Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

## Fix

Convert non-primitive `crew.memory` values to the class name string before setting the telemetry attribute:

```python
# Before:
self._add_attribute(span, "crew_memory", crew.memory)

# After:
crew_memory = crew.memory if isinstance(crew.memory, (bool, str, int, float)) else type(crew.memory).__name__
self._add_attribute(span, "crew_memory", crew_memory)
```

This preserves backward compatibility with `memory=True` while allowing custom `Memory` instances to be tracked as `"Memory"` in telemetry.

**`lib/crewai/src/crewai/telemetry/telemetry.py`** — one-line fix at line 282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to telemetry metadata: it only alters how `crew_memory` is recorded to avoid invalid OpenTelemetry attribute types.
> 
> **Overview**
> Fixes a telemetry crash during `Telemetry.crew_creation` when `crew.memory` is a custom object by coercing non-primitive values to the class name string before setting the `crew_memory` span attribute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f58a788741d690ade9e47c318d1cee38fe515dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->