### PR TITLE
fix: group consecutive tool results into single Bedrock user message

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -1815,21 +1815,35 @@ class BedrockCompletion(BaseLLM):
             elif role == "tool":
                 if not tool_call_id:
                     raise ValueError("Tool message missing required tool_call_id")
-                converse_messages.append(
-                    {
-                        "role": "user",
+                tool_result_block = {
+                    "toolResult": {
+                        "toolUseId": tool_call_id,
                         "content": [
-                            {
-                                "toolResult": {
-                                    "toolUseId": tool_call_id,
-                                    "content": [
-                                        {"text": str(content) if content else ""}
-                                    ],
-                                }
-                            }
+                            {"text": str(content) if content else ""}
                         ],
                     }
-                )
+                }
+                # Group consecutive tool results into a single user message.
+                # Bedrock requires all toolResult blocks for a given assistant
+                # turn to be in one user message, not separate messages.
+                if (
+                    converse_messages
+                    and converse_messages[-1]["role"] == "user"
+                    and converse_messages[-1]["content"]
+                    and any(
+                        "toolResult" in block
+                        for block in converse_messages[-1]["content"]
+                        if isinstance(block, dict)
+                    )
+                ):
+                    converse_messages[-1]["content"].append(tool_result_block)
+                else:
+                    converse_messages.append(
+                        {
+                            "role": "user",
+                            "content": [tool_result_block],
+                        }
+                    )
             else:
                 # Convert to Converse API format with proper content structure
                 if isinstance(content, list):

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -967,3 +967,147 @@ def test_bedrock_agent_kickoff_structured_output_with_tools():
     assert result.pydantic.result == 42, f"Expected result 42 but got {result.pydantic.result}"
     assert result.pydantic.operation, "Operation should not be empty"
     assert result.pydantic.explanation, "Explanation should not be empty"
+
+
+def test_bedrock_groups_consecutive_tool_results():
+    """
+    Test that consecutive tool result messages are grouped into a single
+    user message. Bedrock's Converse API requires all toolResult blocks
+    for a given assistant turn to appear in one user message.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4749
+    """
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    # Simulate: user prompt -> assistant makes 2 tool calls -> 2 tool results
+    test_messages = [
+        {"role": "user", "content": "Calculate 25 + 17 AND 10 * 5"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_add",
+                    "function": {
+                        "name": "add_tool",
+                        "arguments": '{"a": 25, "b": 17}',
+                    },
+                },
+                {
+                    "id": "call_mul",
+                    "function": {
+                        "name": "multiply_tool",
+                        "arguments": '{"a": 10, "b": 5}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_add",
+            "content": "42",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_mul",
+            "content": "50",
+        },
+    ]
+
+    formatted, system_msg = llm._format_messages_for_converse(test_messages)
+
+    # Should produce exactly 3 messages: user, assistant, user (with both results)
+    assert len(formatted) == 3, (
+        f"Expected 3 messages (user, assistant, user-with-results), got {len(formatted)}: "
+        + str([m['role'] for m in formatted])
+    )
+
+    assert formatted[0]["role"] == "user"
+    assert formatted[1]["role"] == "assistant"
+    assert formatted[2]["role"] == "user"
+
+    # The user message must contain both toolResult blocks
+    tool_result_msg = formatted[2]
+    assert len(tool_result_msg["content"]) == 2, (
+        f"Expected 2 toolResult blocks in one message, got {len(tool_result_msg['content'])}"
+    )
+
+    # Verify both tool results are present with correct IDs
+    result_ids = {
+        block["toolResult"]["toolUseId"]
+        for block in tool_result_msg["content"]
+        if "toolResult" in block
+    }
+    assert result_ids == {"call_add", "call_mul"}, f"Unexpected tool result IDs: {result_ids}"
+
+
+def test_bedrock_single_tool_result_still_works():
+    """
+    Verify that a single tool result still produces a correct message.
+    """
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    test_messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_weather",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_weather",
+            "content": "Sunny, 72F",
+        },
+    ]
+
+    formatted, _ = llm._format_messages_for_converse(test_messages)
+
+    assert len(formatted) == 3
+    assert formatted[2]["role"] == "user"
+    assert len(formatted[2]["content"]) == 1
+    assert "toolResult" in formatted[2]["content"][0]
+    assert formatted[2]["content"][0]["toolResult"]["toolUseId"] == "call_weather"
+
+
+def test_bedrock_groups_three_tool_results():
+    """
+    Verify that three consecutive tool results are grouped into one message.
+    """
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    test_messages = [
+        {"role": "user", "content": "Run all three tools"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "t1", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "t2", "arguments": "{}"}},
+                {"id": "c3", "function": {"name": "t3", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "r1"},
+        {"role": "tool", "tool_call_id": "c2", "content": "r2"},
+        {"role": "tool", "tool_call_id": "c3", "content": "r3"},
+    ]
+
+    formatted, _ = llm._format_messages_for_converse(test_messages)
+
+    assert len(formatted) == 3
+    tool_result_msg = formatted[2]
+    assert tool_result_msg["role"] == "user"
+    assert len(tool_result_msg["content"]) == 3
+    result_ids = {
+        block["toolResult"]["toolUseId"]
+        for block in tool_result_msg["content"]
+    }
+    assert result_ids == {"c1", "c2", "c3"}


### PR DESCRIPTION
## Summary

Fixes #4749

When a Bedrock model makes multiple tool calls in one assistant response, CrewAI sends each tool result as a separate `user` message. Bedrock's Converse API requires all `toolResult` blocks for a given assistant turn to be grouped in a **single** user message, causing a `ValidationException`.

## Problem

**Before (broken) — each tool result is a separate message:**
```
Message 0: user     → "Calculate 25+17 AND 10*5"
Message 1: assistant → [toolUse: add_tool, toolUse: multiply_tool]
Message 2: user     → [toolResult: add_tool]       ← separate message
Message 3: user     → [toolResult: multiply_tool]   ← separate message — ERROR
```

Bedrock rejects this with:
```
ValidationException: Expected toolResult blocks at messages.2.content
for the following Ids: tooluse_xxx, tooluse_yyy
```

**After (fixed) — consecutive tool results grouped into one message:**
```
Message 0: user     → "Calculate 25+17 AND 10*5"
Message 1: assistant → [toolUse: add_tool, toolUse: multiply_tool]
Message 2: user     → [toolResult: add_tool, toolResult: multiply_tool]  ← single message
```

## Changes

**`lib/crewai/src/crewai/llms/providers/bedrock/completion.py`**

In `_format_messages_for_converse()`, the `role == "tool"` handler previously called `converse_messages.append(...)` for every tool result. Now it checks whether the previous message is already a user message containing `toolResult` blocks, and if so, appends the new `toolResult` block to that existing message instead of creating a new one.

**`lib/crewai/tests/llms/bedrock/test_bedrock.py`**

Added three test cases:
- `test_bedrock_groups_consecutive_tool_results` — two parallel tool calls produce one user message with two `toolResult` blocks
- `test_bedrock_single_tool_result_still_works` — single tool call still works correctly (regression guard)
- `test_bedrock_groups_three_tool_results` — three parallel tool calls produce one user message with three `toolResult` blocks

## Test plan

- [x] New unit tests pass for 1, 2, and 3 parallel tool results
- [x] Single tool call behavior unchanged
- [x] No changes to non-tool message handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bedrock request formatting for tool-calling conversations, which could affect downstream tool execution/continuation if edge cases exist, but coverage is added via new regression tests for 1/2/3 tool results.
> 
> **Overview**
> Fixes Bedrock Converse formatting when an assistant issues multiple tool calls by **grouping consecutive `tool` messages into one `user` message** that contains multiple `toolResult` blocks (instead of emitting one `user` message per tool result).
> 
> Adds Bedrock unit tests to lock in the expected grouping behavior for **single**, **two**, and **three** consecutive tool results (regression for #4749).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a3ee8c2fec0561cb73cdc98cb54dffb27ff7528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->