### PR TITLE
fix: parse JSON string config in Mem0Storage

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/mem0_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/mem0_storage.py
@@ -1,0 +1,272 @@
+from collections import defaultdict
+from collections.abc import Iterable
+import json
+import os
+import re
+from typing import Any
+
+from mem0 import Memory, MemoryClient  # type: ignore[import-untyped,import-not-found]
+
+from crewai.memory.storage.interface import Storage
+from crewai.rag.chromadb.utils import _sanitize_collection_name
+
+
+MAX_AGENT_ID_LENGTH_MEM0 = 255
+
+
+class Mem0Storage(Storage):
+    """
+    Extends Storage to handle embedding and searching across entities using Mem0.
+    """
+
+    def __init__(self, type, crew=None, config=None):
+        super().__init__()
+
+        self._validate_type(type)
+        self.memory_type = type
+        self.crew = crew
+        self.config = self._parse_config(config)
+
+        self._extract_config_values()
+        self._initialize_memory()
+
+    def _validate_type(self, type):
+        supported_types = {"short_term", "long_term", "entities", "external"}
+        if type not in supported_types:
+            raise ValueError(
+                f"Invalid type '{type}' for Mem0Storage. "
+                f"Must be one of: {', '.join(supported_types)}"
+            )
+
+    @staticmethod
+    def _parse_config(config):
+        """Parse config into a dict, handling JSON strings, dicts, and None.
+
+        This handles the common case where config is loaded from environment
+        variables, config files, or CLI arguments as a JSON string rather
+        than a dict.
+
+        Args:
+            config: Configuration as a dict, JSON string, or None.
+
+        Returns:
+            dict: Parsed configuration dictionary.
+
+        Raises:
+            TypeError: If config is not a dict, JSON string, or None, or if
+                       a JSON string decodes to a non-dict type.
+            ValueError: If config is a string but not valid JSON.
+        """
+        if config is None:
+            return {}
+        if isinstance(config, dict):
+            return config
+        if isinstance(config, str):
+            try:
+                parsed = json.loads(config)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Mem0Storage config string is not valid JSON: {exc}"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise TypeError(
+                    f"Mem0Storage config JSON must decode to a dict, "
+                    f"got {type(parsed).__name__}"
+                )
+            return parsed
+        raise TypeError(
+            f"Mem0Storage config must be a dict or JSON string, "
+            f"got {type(config).__name__}"
+        )
+
+    def _extract_config_values(self):
+        self.mem0_run_id = self.config.get("run_id")
+        self.includes = self.config.get("includes")
+        self.excludes = self.config.get("excludes")
+        self.custom_categories = self.config.get("custom_categories")
+        self.infer = self.config.get("infer", True)
+
+    def _initialize_memory(self):
+        api_key = self.config.get("api_key") or os.getenv("MEM0_API_KEY")
+        org_id = self.config.get("org_id")
+        project_id = self.config.get("project_id")
+        local_config = self.config.get("local_mem0_config")
+
+        if api_key:
+            self.memory = (
+                MemoryClient(api_key=api_key, org_id=org_id, project_id=project_id)
+                if org_id and project_id
+                else MemoryClient(api_key=api_key)
+            )
+            if self.custom_categories:
+                self.memory.update_project(custom_categories=self.custom_categories)
+        else:
+            self.memory = (
+                Memory.from_config(local_config)
+                if local_config and len(local_config)
+                else Memory()
+            )
+
+    def _create_filter_for_search(self):
+        """
+        Returns:
+            dict: A filter dictionary containing AND conditions for querying data.
+                - Includes user_id and agent_id if both are present.
+                - Includes user_id if only user_id is present.
+                - Includes agent_id if only agent_id is present.
+                - Includes run_id if memory_type is 'short_term' and
+                  mem0_run_id is present.
+        """
+        filter = defaultdict(list)
+
+        if self.memory_type == "short_term" and self.mem0_run_id:
+            filter["AND"].append({"run_id": self.mem0_run_id})
+        else:
+            user_id = self.config.get("user_id", "")
+            agent_id = self.config.get("agent_id", "")
+
+            if user_id and agent_id:
+                filter["OR"].append({"user_id": user_id})
+                filter["OR"].append({"agent_id": agent_id})
+            elif user_id:
+                filter["AND"].append({"user_id": user_id})
+            elif agent_id:
+                filter["AND"].append({"agent_id": agent_id})
+
+        return filter
+
+    def save(self, value: Any, metadata: dict[str, Any]) -> None:
+        def _last_content(messages: Iterable[dict[str, Any]], role: str) -> str:
+            return next(
+                (
+                    m.get("content", "")
+                    for m in reversed(list(messages))
+                    if m.get("role") == role
+                ),
+                "",
+            )
+
+        conversations = []
+        messages = metadata.pop("messages", None)
+        if messages:
+            last_user = _last_content(messages, "user")
+            last_assistant = _last_content(messages, "assistant")
+
+            if user_msg := self._get_user_message(last_user):
+                conversations.append({"role": "user", "content": user_msg})
+
+            if assistant_msg := self._get_assistant_message(last_assistant):
+                conversations.append({"role": "assistant", "content": assistant_msg})
+        else:
+            conversations.append({"role": "assistant", "content": value})
+
+        user_id = self.config.get("user_id", "")
+
+        base_metadata = {
+            "short_term": "short_term",
+            "long_term": "long_term",
+            "entities": "entity",
+            "external": "external",
+        }
+
+        # Shared base params
+        params: dict[str, Any] = {
+            "metadata": {"type": base_metadata[self.memory_type], **metadata},
+            "infer": self.infer,
+        }
+
+        # MemoryClient-specific overrides
+        if isinstance(self.memory, MemoryClient):
+            params["includes"] = self.includes
+            params["excludes"] = self.excludes
+            params["output_format"] = "v1.1"
+            params["version"] = "v2"
+
+        if self.memory_type == "short_term" and self.mem0_run_id:
+            params["run_id"] = self.mem0_run_id
+
+        if user_id:
+            params["user_id"] = user_id
+
+        if agent_id := self.config.get("agent_id", self._get_agent_name()):
+            params["agent_id"] = agent_id
+
+        self.memory.add(conversations, **params)
+
+    def search(
+        self, query: str, limit: int = 5, score_threshold: float = 0.6
+    ) -> list[Any]:
+        params = {
+            "query": query,
+            "limit": limit,
+            "version": "v2",
+            "output_format": "v1.1",
+        }
+
+        if user_id := self.config.get("user_id", ""):
+            params["user_id"] = user_id
+
+        memory_type_map = {
+            "short_term": {"type": "short_term"},
+            "long_term": {"type": "long_term"},
+            "entities": {"type": "entity"},
+            "external": {"type": "external"},
+        }
+
+        if self.memory_type in memory_type_map:
+            params["metadata"] = memory_type_map[self.memory_type]
+            if self.memory_type == "short_term":
+                params["run_id"] = self.mem0_run_id
+
+        # Discard the filters for now since we create the filters
+        # automatically when the crew is created.
+
+        params["filters"] = self._create_filter_for_search()
+        params["threshold"] = score_threshold
+
+        if isinstance(self.memory, Memory):
+            del params["metadata"], params["version"], params["output_format"]
+            if params.get("run_id"):
+                del params["run_id"]
+
+        results = self.memory.search(**params)
+
+        # This makes it compatible for Contextual Memory to retrieve
+        for result in results["results"]:
+            result["content"] = result["memory"]
+
+        return [r for r in results["results"]]
+
+    def reset(self):
+        if self.memory:
+            self.memory.reset()
+
+    def _sanitize_role(self, role: str) -> str:
+        """
+        Sanitizes agent roles to ensure valid directory names.
+        """
+        return role.replace("\n", "").replace(" ", "_").replace("/", "_")
+
+    def _get_agent_name(self) -> str:
+        if not self.crew:
+            return ""
+
+        agents = self.crew.agents
+        agents = [self._sanitize_role(agent.role) for agent in agents]
+        agents = "_".join(agents)
+        return _sanitize_collection_name(
+            name=agents, max_collection_length=MAX_AGENT_ID_LENGTH_MEM0
+        )
+
+    def _get_assistant_message(self, text: str) -> str:
+        marker = "Final Answer:"
+        if marker in text:
+            return text.split(marker, 1)[1].strip()
+        return text
+
+    def _get_user_message(self, text: str) -> str:
+        pattern = r"User message:\s*(.*)"
+        match = re.search(pattern, text)
+        if match:
+            return match.group(1).strip()
+        return text

--- a/lib/crewai/tests/storage/test_mem0_storage_config.py
+++ b/lib/crewai/tests/storage/test_mem0_storage_config.py
@@ -1,0 +1,61 @@
+"""Tests for Mem0Storage._parse_config JSON string handling.
+
+Verifies the fix for https://github.com/crewAIInc/crewAI/issues/4423
+"""
+
+import json
+
+import pytest
+
+from crewai.memory.storage.mem0_storage import Mem0Storage
+
+
+class TestParseConfig:
+    """Unit tests for Mem0Storage._parse_config (static method)."""
+
+    def test_none_returns_empty_dict(self):
+        assert Mem0Storage._parse_config(None) == {}
+
+    def test_dict_passes_through(self):
+        cfg = {"user_id": "u1", "agent_id": "a1"}
+        assert Mem0Storage._parse_config(cfg) is cfg
+
+    def test_json_string_parsed(self):
+        raw = '{"user_id": "u1", "agent_id": "a1"}'
+        result = Mem0Storage._parse_config(raw)
+        assert result == {"user_id": "u1", "agent_id": "a1"}
+        assert isinstance(result, dict)
+
+    def test_nested_json_string_parsed(self):
+        raw = json.dumps({
+            "user_id": "u1",
+            "local_mem0_config": {"vector_store": {"provider": "qdrant"}},
+        })
+        result = Mem0Storage._parse_config(raw)
+        assert result["local_mem0_config"]["vector_store"]["provider"] == "qdrant"
+
+    def test_invalid_json_string_raises_value_error(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            Mem0Storage._parse_config("{bad json}")
+
+    def test_json_array_raises_type_error(self):
+        with pytest.raises(TypeError, match="must decode to a dict"):
+            Mem0Storage._parse_config("[1, 2, 3]")
+
+    def test_json_scalar_raises_type_error(self):
+        with pytest.raises(TypeError, match="must decode to a dict"):
+            Mem0Storage._parse_config('"just a string"')
+
+    def test_integer_raises_type_error(self):
+        with pytest.raises(TypeError, match="must be a dict"):
+            Mem0Storage._parse_config(42)
+
+    def test_list_raises_type_error(self):
+        with pytest.raises(TypeError, match="must be a dict"):
+            Mem0Storage._parse_config([1, 2])
+
+    def test_empty_json_object_string(self):
+        assert Mem0Storage._parse_config("{}") == {}
+
+    def test_empty_dict(self):
+        assert Mem0Storage._parse_config({}) == {}


### PR DESCRIPTION
## Summary

Fixes #4423.

`Mem0Storage.__init__()` calls `self.config.get()` which crashes with `AttributeError: 'str' object has no attribute 'get'` when `config` is a JSON string — a common scenario when configs are loaded from environment variables, config files, or CLI arguments.

### Changes

- **`lib/crewai/src/crewai/memory/storage/mem0_storage.py`**: Add `_parse_config()` static method that auto-parses JSON strings via `json.loads()`, passes dicts through unchanged, returns `{}` for `None`, and raises clear `TypeError`/`ValueError` for invalid inputs. Replace `self.config = config or {}` with `self.config = self._parse_config(config)`.
- **`lib/crewai/tests/storage/test_mem0_storage_config.py`**: Unit tests covering dict passthrough, JSON string parsing, nested configs, invalid JSON, non-dict JSON, and wrong types.

### Before
```python
Mem0Storage(type="external", config='{"agent_id":"agent-123"}')
# AttributeError: 'str' object has no attribute 'get'
```

### After
```python
Mem0Storage(type="external", config='{"agent_id":"agent-123"}')
# Works — JSON string is auto-parsed to dict
```

> **Note:** `mem0_storage.py` was removed from `main` in the unified memory system refactor (#4420). This PR restores the file with the fix applied, matching the version in the 1.9.3 release. If Mem0 integration is no longer planned for future releases, this issue can be closed as won't-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces the `Mem0Storage` integration and adds tests that import `mem0`, which could impact environments where the optional dependency or legacy storage interface isn’t available. Logic changes are otherwise localized to config parsing and error handling.
> 
> **Overview**
> Restores/adds `Mem0Storage` and fixes initialization to accept `config` as a JSON string (in addition to `dict`/`None`), with clear `TypeError`/`ValueError` failures for invalid inputs.
> 
> Adds focused unit tests for `_parse_config()` covering JSON parsing (including nested objects) and error cases, preventing regressions for configs provided via env/CLI/config files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72d603622468de6bfab86e530c28c4624d801d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->