### PR TITLE
fix: replace empty message content to prevent Anthropic API 400 error

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -591,14 +591,14 @@ class AnthropicCompletion(BaseLLM):
                         list[dict[str, Any]],
                         [
                             *self.previous_thinking_blocks,
-                            {"type": "text", "text": content if content else ""},
+                            {"type": "text", "text": content if content else " "},
                         ],
                     )
                     formatted_messages.append(
                         LLMMessage(role="assistant", content=structured_content)
                     )
                 else:
-                    content_str = content if content is not None else ""
+                    content_str = content if content else " "
                     formatted_messages.append(
                         LLMMessage(role="assistant", content=content_str)
                     )
@@ -614,7 +614,7 @@ class AnthropicCompletion(BaseLLM):
                 if isinstance(content, list):
                     formatted_messages.append({"role": role_str, "content": content})
                 else:
-                    content_str = content if content is not None else ""
+                    content_str = content if content else " "
                     formatted_messages.append(
                         LLMMessage(role=role_str, content=content_str)
                     )

--- a/lib/crewai/tests/llms/anthropic/test_empty_content.py
+++ b/lib/crewai/tests/llms/anthropic/test_empty_content.py
@@ -1,0 +1,119 @@
+"""Tests for empty message content handling in AnthropicCompletion.
+
+The Anthropic API rejects messages with empty string content ("") with a
+400 error. This can happen in pipelines where one agent's empty output
+becomes the next agent's input. These tests verify that empty content is
+replaced with a single space before sending to the API.
+
+See: https://github.com/crewAIInc/crewAI/issues/4427
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+
+@pytest.fixture(autouse=True)
+def mock_anthropic_api_key():
+    """Automatically mock ANTHROPIC_API_KEY for all tests."""
+    if "ANTHROPIC_API_KEY" not in os.environ:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            yield
+    else:
+        yield
+
+
+class TestEmptyContentHandling:
+    """Verify that empty message content is replaced before hitting the API."""
+
+    def _get_completion(self) -> AnthropicCompletion:
+        return AnthropicCompletion(model="claude-3-5-sonnet-20241022")
+
+    def test_empty_user_message_content_replaced(self):
+        """Empty string user content should become a single space."""
+        completion = self._get_completion()
+        messages = [{"role": "user", "content": ""}]
+        formatted, _ = completion._format_messages_for_anthropic(messages)
+
+        user_msgs = [m for m in formatted if m.get("role") == "user"]
+        assert len(user_msgs) >= 1
+        # The last user message (which came from our input) must not be empty
+        assert user_msgs[-1]["content"] != ""
+        assert user_msgs[-1]["content"] == " "
+
+    def test_none_user_message_content_replaced(self):
+        """None user content should also become a single space."""
+        completion = self._get_completion()
+        messages = [{"role": "user", "content": None}]
+        formatted, _ = completion._format_messages_for_anthropic(messages)
+
+        user_msgs = [m for m in formatted if m.get("role") == "user"]
+        assert len(user_msgs) >= 1
+        assert user_msgs[-1]["content"] == " "
+
+    def test_nonempty_user_message_unchanged(self):
+        """Non-empty user content should pass through unchanged."""
+        completion = self._get_completion()
+        messages = [{"role": "user", "content": "Hello, world!"}]
+        formatted, _ = completion._format_messages_for_anthropic(messages)
+
+        user_msgs = [m for m in formatted if m.get("role") == "user"]
+        assert user_msgs[-1]["content"] == "Hello, world!"
+
+    def test_empty_assistant_message_content_replaced(self):
+        """Empty string assistant content should become a single space."""
+        completion = self._get_completion()
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Continue"},
+        ]
+        formatted, _ = completion._format_messages_for_anthropic(messages)
+
+        assistant_msgs = [m for m in formatted if m.get("role") == "assistant"]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == " "
+
+    def test_pipeline_empty_output_scenario(self):
+        """Simulate a pipeline where agent A returns empty output to agent B.
+
+        This is the exact scenario from issue #4427: one agent produces
+        empty output that becomes the next agent's user message.
+        """
+        completion = self._get_completion()
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": ""},  # Empty output from previous agent
+        ]
+        formatted, system_msg = completion._format_messages_for_anthropic(messages)
+
+        assert system_msg == "You are a helpful assistant."
+        user_msgs = [m for m in formatted if m.get("role") == "user"]
+        assert len(user_msgs) >= 1
+        # Must not be empty — Anthropic API would reject ""
+        for msg in user_msgs:
+            content = msg.get("content")
+            if isinstance(content, str):
+                assert content != "", (
+                    "Empty string content would cause Anthropic API 400 error"
+                )
+
+    def test_multiple_empty_messages_all_replaced(self):
+        """All empty messages in a conversation should be sanitized."""
+        completion = self._get_completion()
+        messages = [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": ""},
+        ]
+        formatted, _ = completion._format_messages_for_anthropic(messages)
+
+        for msg in formatted:
+            content = msg.get("content")
+            if isinstance(content, str):
+                assert content != "", (
+                    f"Message with role={msg.get('role')} has empty content"
+                )


### PR DESCRIPTION
## Summary

Fixes #4427

`AnthropicCompletion._format_messages_for_anthropic()` forwards empty string content (`""`) verbatim to the Anthropic API, which rejects it with a 400 error. This happens in pipelines where one agent's empty output becomes the next agent's user message.

## Changes

- **`lib/crewai/src/crewai/llms/providers/anthropic/completion.py`**: Replace empty/`None` content with a single space (`" "`) for user messages, assistant messages, and thinking-block text content in `_format_messages_for_anthropic()`. Changed `content if content is not None else ""` to `content if content else " "` — this catches both `None` and empty string `""` in one expression.

- **`lib/crewai/tests/llms/anthropic/test_empty_content.py`**: Added test suite covering:
  - Empty string user message content
  - `None` user message content
  - Non-empty content passes through unchanged
  - Empty assistant message content
  - Pipeline scenario (empty agent output → next agent input)
  - Multiple empty messages in a conversation

## Root cause

Lines 601 and 617 in `_format_messages_for_anthropic()` used `content if content is not None else ""`, which preserved empty strings. The Anthropic Messages API requires all text content blocks to be non-empty.

## Test plan

- [ ] `pytest lib/crewai/tests/llms/anthropic/test_empty_content.py` — new unit tests pass
- [ ] Existing anthropic tests unaffected
- [ ] Manual: run a pipeline where agent A returns empty output to agent B with an Anthropic model — no longer crashes with 400 error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to sanitizing empty/`None` message content before calling Anthropic; behavior only differs when content is falsy and could subtly affect downstream prompts in those edge cases.
> 
> **Overview**
> Prevents Anthropic 400s by ensuring `_format_messages_for_anthropic()` never emits empty string content: empty/`None` user and assistant message strings (including the text block appended after `previous_thinking_blocks`) are replaced with a single space.
> 
> Adds a focused unit test suite covering empty/`None` content for user/assistant messages, a pipeline handoff scenario, and multiple empty messages to ensure all formatted messages avoid `""`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7418031d0652e7607b51c8a2033fb57f2eb947d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->