### PR TITLE
fix(bedrock): group parallel tool results in single user message

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -1781,6 +1781,7 @@ class BedrockCompletion(BaseLLM):
 
         converse_messages: list[LLMMessage] = []
         system_message: str | None = None
+        pending_tool_results: list[dict[str, Any]] = []
 
         for message in formatted_messages:
             role = message.get("role")
@@ -1794,68 +1795,56 @@ class BedrockCompletion(BaseLLM):
                     system_message += f"\n\n{content}"
                 else:
                     system_message = cast(str, content)
-            elif role == "assistant" and tool_calls:
-                # Convert OpenAI-style tool_calls to Bedrock toolUse format
-                bedrock_content = []
-                for tc in tool_calls:
-                    func = tc.get("function", {})
-                    tool_use_block = {
-                        "toolUse": {
-                            "toolUseId": tc.get("id", f"call_{id(tc)}"),
-                            "name": func.get("name", ""),
-                            "input": func.get("arguments", {})
-                            if isinstance(func.get("arguments"), dict)
-                            else json.loads(func.get("arguments", "{}") or "{}"),
-                        }
-                    }
-                    bedrock_content.append(tool_use_block)
-                converse_messages.append(
-                    {"role": "assistant", "content": bedrock_content}
-                )
             elif role == "tool":
                 if not tool_call_id:
                     raise ValueError("Tool message missing required tool_call_id")
-                # Buffer tool results — Bedrock requires all tool results
-                # for a given assistant message grouped in a single user message.
-                tool_result_block = {
-                    "toolResult": {
-                        "toolUseId": tool_call_id,
-                        "content": [
-                            {"text": str(content) if content else ""}
-                        ],
-                    }
-                }
-                # If the previous message is already a user message with
-                # toolResult blocks, append to it (parallel tool calls).
-                if (
-                    converse_messages
-                    and converse_messages[-1].get("role") == "user"
-                    and converse_messages[-1].get("content")
-                    and isinstance(converse_messages[-1]["content"], list)
-                    and any(
-                        "toolResult" in block
-                        for block in converse_messages[-1]["content"]
-                    )
-                ):
-                    converse_messages[-1]["content"].append(tool_result_block)
-                else:
-                    converse_messages.append(
-                        {
-                            "role": "user",
-                            "content": [tool_result_block],
+                pending_tool_results.append(
+                    {
+                        "toolResult": {
+                            "toolUseId": tool_call_id,
+                            "content": [{"text": str(content) if content else ""}],
                         }
-                    )
+                    }
+                )
             else:
-                # Convert to Converse API format with proper content structure
-                if isinstance(content, list):
-                    # Already formatted as multimodal content blocks
-                    converse_messages.append({"role": role, "content": content})
-                else:
-                    # String content - wrap in text block
-                    text_content = content if content else ""
+                if pending_tool_results:
                     converse_messages.append(
-                        {"role": role, "content": [{"text": text_content}]}
+                        {"role": "user", "content": pending_tool_results}
                     )
+                    pending_tool_results = []
+
+                if role == "assistant" and tool_calls:
+                    # Convert OpenAI-style tool_calls to Bedrock toolUse format
+                    bedrock_content = []
+                    for tc in tool_calls:
+                        func = tc.get("function", {})
+                        tool_use_block = {
+                            "toolUse": {
+                                "toolUseId": tc.get("id", f"call_{id(tc)}"),
+                                "name": func.get("name", ""),
+                                "input": func.get("arguments", {})
+                                if isinstance(func.get("arguments"), dict)
+                                else json.loads(func.get("arguments", "{}") or "{}"),
+                            }
+                        }
+                        bedrock_content.append(tool_use_block)
+                    converse_messages.append(
+                        {"role": "assistant", "content": bedrock_content}
+                    )
+                else:
+                    # Convert to Converse API format with proper content structure
+                    if isinstance(content, list):
+                        # Already formatted as multimodal content blocks
+                        converse_messages.append({"role": role, "content": content})
+                    else:
+                        # String content - wrap in text block
+                        text_content = content if content else ""
+                        converse_messages.append(
+                            {"role": role, "content": [{"text": text_content}]}
+                        )
+
+        if pending_tool_results:
+            converse_messages.append({"role": "user", "content": pending_tool_results})
 
         # CRITICAL: Handle model-specific conversation requirements
         # Cohere and some other models require conversation to end with user message

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -967,41 +967,72 @@ def test_bedrock_agent_kickoff_structured_output_with_tools():
     assert result.pydantic.result == 42, f"Expected result 42 but got {result.pydantic.result}"
     assert result.pydantic.operation, "Operation should not be empty"
     assert result.pydantic.explanation, "Explanation should not be empty"
-  def test_bedrock_groups_three_tool_results():
-      """Three parallel tool calls must be grouped into one user message."""
-      llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
 
-      messages = [
-          {"role": "user", "content": "Run all three tools"},
-          {
-              "role": "assistant",
-              "content": "",
-              "tool_calls": [
-                  {"id": "c1", "type": "function", "function": {"name": "t1", "arguments": "{}"}},
-                  {"id": "c2", "type": "function", "function": {"name": "t2", "arguments": "{}"}},
-                  {"id": "c3", "type": "function", "function": {"name": "t3", "arguments": "{}"}},
-              ],
-          },
-          {"role": "tool", "tool_call_id": "c1", "content": "r1"},
-          {"role": "tool", "tool_call_id": "c2", "content": "r2"},
-          {"role": "tool", "tool_call_id": "c3", "content": "r3"},
-      ]
 
-      converse_msgs, _ = llm._format_messages_for_converse(messages)
+def test_bedrock_groups_three_tool_results():
+    """Consecutive tool results should be grouped into one Bedrock user message."""
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
 
-      tool_result_messages = [
-          m for m in converse_msgs
-          if m.get("role") == "user"
-          and any("toolResult" in b for b in m.get("content", []))
-      ]
+    messages = [
+        {"role": "user", "content": "Use all three tools, then continue."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "tool-1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_weather",
+                        "arguments": '{"location": "New York"}',
+                    },
+                },
+                {
+                    "id": "tool-2",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_news",
+                        "arguments": '{"topic": "AI"}',
+                    },
+                },
+                {
+                    "id": "tool-3",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_stock",
+                        "arguments": '{"ticker": "AMZN"}',
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tool-1", "content": "72F and sunny"},
+        {"role": "tool", "tool_call_id": "tool-2", "content": "AI news summary"},
+        {"role": "tool", "tool_call_id": "tool-3", "content": "AMZN up 1.2%"},
+    ]
 
-      assert len(tool_result_messages) == 1
-      assert len(tool_result_messages[0]["content"]) == 3
-      tool_use_ids = {
-          block["toolResult"]["toolUseId"]
-          for block in tool_result_messages[0]["content"]
-      }
-      assert tool_use_ids == {"c1", "c2", "c3"}
+    formatted_messages, system_message = llm._format_messages_for_converse(messages)
+
+    assert system_message is None
+    assert [message["role"] for message in formatted_messages] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert len(formatted_messages[1]["content"]) == 3
+
+    tool_results = formatted_messages[2]["content"]
+    assert len(tool_results) == 3
+    assert [block["toolResult"]["toolUseId"] for block in tool_results] == [
+        "tool-1",
+        "tool-2",
+        "tool-3",
+    ]
+    assert [block["toolResult"]["content"][0]["text"] for block in tool_results] == [
+        "72F and sunny",
+        "AI news summary",
+        "AMZN up 1.2%",
+    ]
+
 
 def test_bedrock_parallel_tool_results_grouped():
     """Regression test for issue #4749.


### PR DESCRIPTION
## What does this PR do?

Fixes parallel tool call results not being grouped in a single user message for AWS Bedrock's Converse API.

### Problem

When an assistant message contains multiple parallel tool calls (`toolUse` blocks), Bedrock requires all corresponding `toolResult` blocks to be sent back in a **single** user message. Previously, each tool result was emitted as a separate user message:

```
Message 0: user (prompt)
Message 1: assistant (toolUse A, toolUse B)
Message 2: user (toolResult A)  ← Separate message
Message 3: user (toolResult B)  ← Separate message → ValidationException
```

This caused: `ValidationException: Expected toolResult blocks at messages.2.content`

### Fix

When processing consecutive `role == "tool"` messages in `_format_messages_for_converse()`, the fix checks if the previous converse message is already a user message containing `toolResult` blocks. If so, it appends the new `toolResult` to that existing message instead of creating a new one:

```
Message 0: user (prompt)
Message 1: assistant (toolUse A, toolUse B)
Message 2: user (toolResult A, toolResult B)  ← Grouped in single message ✅
```

### Tests Added

3 regression tests:
- `test_bedrock_parallel_tool_results_grouped` — 2 parallel tool calls → single grouped user message
- `test_bedrock_single_tool_result_still_works` — single tool call still works correctly
- `test_bedrock_tool_results_not_merged_across_assistant_messages` — tool results from different assistant turns remain separate

All 28 existing bedrock tests pass (1 pre-existing failure in `test_bedrock_raises_error_when_model_not_found`, unrelated).

Fixes #4749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Bedrock tool-calling message serialization, which can affect downstream Converse API validation and tool execution flows, though coverage is improved with targeted regression tests.
> 
> **Overview**
> Fixes AWS Bedrock Converse message formatting so **consecutive `role: "tool"` results are buffered and emitted as a single `role: "user"` message containing multiple `toolResult` blocks**, matching Bedrock’s requirement for parallel tool calls.
> 
> Adds regression tests covering grouped multi-tool results, ensuring single-tool behavior remains correct, and verifying tool results are not merged across separate assistant turns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61f61c6a5e23dfb0a52876acf2b949d72c4bcaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->