### PR TITLE
Fix delegation bug in hierarchical process: manager agent cannot dele…

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1480,7 +1480,8 @@ class Crew(FlowTrackable, BaseModel):
     ) -> list[BaseTool]:
         if self.manager_agent:
             if task.agent:
-                tools = self._inject_delegation_tools(tools, task.agent, [task.agent])
+                other_agents = [agent for agent in self.agents if agent != task.agent]
+                tools = self._inject_delegation_tools(tools, task.agent, other_agents)
             else:
                 tools = self._inject_delegation_tools(
                     tools, self.manager_agent, self.agents


### PR DESCRIPTION
…gate to other agents

## Description
Fix a critical bug in CrewAI's hierarchical process where manager agents cannot delegate tasks to other agents due to incorrect delegation tool configuration.

## Problem
In hierarchical process mode, when a manager agent is dynamically created (which happens when `manager_agent` is not pre-set), the delegation tools were incorrectly configured to only allow delegation to the manager agent itself, making delegation impossible.

### Root Cause
In `_update_manager_tools()` method, line 1486 was passing `[task.agent]` as the agents list for delegation, which means the manager could only "delegate" to itself:

# Before (buggy)
tools = self._inject_delegation_tools(tools, task.agent, [task.agent])


Impact
✅ Fixes delegation functionality in hierarchical process
✅ Allows manager agents to properly coordinate and delegate tasks to worker agents 
✅ No breaking changes to existing APIs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hierarchical delegation tool injection so a manager can delegate to all other agents; incorrect agent lists here could impact task routing during hierarchical runs.
> 
> **Overview**
> Fixes a hierarchical-process delegation bug where a manager running a task could only "delegate" back to itself.
> 
> In `Crew._update_manager_tools()`, delegation tools are now injected with all *other* crew agents (excluding the current `task.agent`) instead of a single-item list, enabling the manager to hand off work to worker agents as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adb12364915e44b88a3a9a1ccb4b8575f4ef7f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->