### PR TITLE
feat(tools): Add MoltsPayTool - crypto payments for AI agents

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -176,6 +176,7 @@ from crewai_tools.tools.youtube_channel_search_tool.youtube_channel_search_tool 
     YoutubeChannelSearchTool,
 )
 from crewai_tools.tools.youtube_video_search_tool.youtube_video_search_tool import (
+from crewai_tools.tools.moltspay_tool.moltspay_tool import MoltsPayTool
     YoutubeVideoSearchTool,
 )
 from crewai_tools.tools.zapier_action_tool.zapier_action_tool import ZapierActionTools
@@ -270,5 +271,6 @@ __all__ = [
     "XMLSearchTool",
     "YoutubeChannelSearchTool",
     "YoutubeVideoSearchTool",
+    "MoltsPayTool",
     "ZapierActionTools",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/README.md
@@ -1,0 +1,61 @@
+# MoltsPay Tool
+
+Pay for AI services using USDC (gasless) via the x402 protocol.
+
+## Description
+
+MoltsPayTool enables CrewAI agents to autonomously pay for and use AI services from other agents or providers. It uses the x402 protocol for HTTP-native payments - no gas fees, pay-for-success model.
+
+## Installation
+
+```bash
+pip install moltspay
+```
+
+## Setup
+
+1. Initialize a MoltsPay wallet:
+```bash
+npx moltspay init --chain base
+```
+
+2. Fund your wallet with USDC on Base network
+
+## Usage
+
+```python
+from crewai_tools import MoltsPayTool
+
+# Initialize the tool
+moltspay = MoltsPayTool()
+
+# Use in an agent
+agent = Agent(
+    role="Content Creator",
+    goal="Generate engaging video content",
+    tools=[moltspay]
+)
+
+# The agent can now pay for services
+# Example: Generate a video ($0.99 USDC)
+result = moltspay.run(
+    provider_url="https://juai8.com/zen7",
+    service_id="text-to-video", 
+    prompt="A cat dancing on a rainbow"
+)
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| provider_url | str | Yes | Service provider URL |
+| service_id | str | Yes | Service identifier (e.g., "text-to-video") |
+| prompt | str | No | Text prompt for the service |
+| image_path | str | No | Path to image file for image-based services |
+
+## Links
+
+- [MoltsPay Documentation](https://docs.moltspay.com)
+- [x402 Protocol](https://www.x402.org)
+- [Available Services](https://moltspay.com/services)

--- a/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/__init__.py
@@ -1,0 +1,3 @@
+from .moltspay_tool import MoltsPayTool
+
+__all__ = ["MoltsPayTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/moltspay_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/moltspay_tool/moltspay_tool.py
@@ -1,0 +1,146 @@
+"""
+MoltsPay Tool for CrewAI
+
+Pay for AI services using USDC (gasless) via the x402 protocol.
+Enables AI agents to autonomously purchase services from other agents.
+"""
+
+import os
+from typing import Any, Optional, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class MoltsPayToolSchema(BaseModel):
+    """Input schema for MoltsPayTool."""
+
+    provider_url: str = Field(
+        ..., 
+        description="Provider URL (e.g., 'https://example.com/api')"
+    )
+    service_id: str = Field(
+        ..., 
+        description="Service ID to call (e.g., 'text-to-video', 'image-generation')"
+    )
+    prompt: Optional[str] = Field(
+        default=None,
+        description="Prompt or instructions for the service"
+    )
+    image_path: Optional[str] = Field(
+        default=None,
+        description="Path to image file for image-to-video or image processing services"
+    )
+
+
+class MoltsPayTool(BaseTool):
+    """
+    MoltsPayTool - Pay for AI services using crypto (USDC) via x402 protocol.
+
+    This tool allows CrewAI agents to:
+    - Discover AI services that accept MoltsPay
+    - Pay for services using USDC (gasless, no ETH needed)
+    - Execute paid AI services (video generation, image processing, etc.)
+
+    The x402 protocol ensures pay-for-success: payment only completes if 
+    the service delivers results.
+
+    Dependencies:
+        - moltspay (pip install moltspay)
+
+    Environment Variables:
+        - MOLTSPAY_WALLET_PATH: Path to wallet JSON file (optional, auto-creates)
+
+    Example:
+        ```python
+        from crewai_tools import MoltsPayTool
+
+        tool = MoltsPayTool()
+        result = tool.run(
+            provider_url="https://juai8.com/zen7",
+            service_id="text-to-video",
+            prompt="A cat dancing on a rainbow"
+        )
+        ```
+    """
+
+    name: str = "MoltsPay"
+    description: str = (
+        "Pay for AI services using USDC cryptocurrency (gasless). "
+        "Use this to purchase video generation, image processing, transcription, "
+        "and other AI services from providers that accept MoltsPay. "
+        "Requires provider_url and service_id. Optional: prompt, image_path."
+    )
+    args_schema: Type[BaseModel] = MoltsPayToolSchema
+    
+    _client: Any = None
+
+    def __init__(self, wallet_path: Optional[str] = None, **kwargs):
+        """
+        Initialize MoltsPayTool.
+
+        Args:
+            wallet_path: Path to MoltsPay wallet JSON file. 
+                        If not provided, uses MOLTSPAY_WALLET_PATH env var
+                        or default ~/.moltspay/wallet.json
+        """
+        super().__init__(**kwargs)
+        self._wallet_path = wallet_path or os.environ.get(
+            "MOLTSPAY_WALLET_PATH", 
+            os.path.expanduser("~/.moltspay/wallet.json")
+        )
+
+    def _get_client(self):
+        """Lazy-load MoltsPay client."""
+        if self._client is None:
+            try:
+                from moltspay import MoltsPay
+                self._client = MoltsPay(wallet_path=self._wallet_path)
+            except ImportError:
+                raise ImportError(
+                    "MoltsPay is required for this tool. "
+                    "Install with: pip install moltspay"
+                )
+        return self._client
+
+    def _run(
+        self,
+        provider_url: str,
+        service_id: str,
+        prompt: Optional[str] = None,
+        image_path: Optional[str] = None,
+        **kwargs
+    ) -> str:
+        """
+        Execute a paid AI service via MoltsPay.
+
+        Args:
+            provider_url: The service provider's base URL
+            service_id: The specific service to call
+            prompt: Text prompt for the service
+            image_path: Path to image file (for image-based services)
+
+        Returns:
+            Service response (URL to result, or result data)
+        """
+        try:
+            client = self._get_client()
+            
+            # Build request params
+            params = {}
+            if prompt:
+                params["prompt"] = prompt
+            if image_path:
+                params["image"] = image_path
+            
+            # Execute x402 payment + service call
+            result = client.x402(
+                url=f"{provider_url.rstrip('/')}/v1/{service_id}",
+                method="POST",
+                data=params
+            )
+            
+            return str(result)
+            
+        except Exception as e:
+            return f"MoltsPay error: {str(e)}"


### PR DESCRIPTION
## Summary

This PR adds **MoltsPayTool** to crewai-tools, enabling CrewAI agents to pay for AI services using USDC via the [x402 protocol](https://www.x402.org).

## Features

- 💰 **Gasless payments** - No ETH needed, just USDC on Base
- ✅ **Pay-for-success** - Payment only completes if service delivers
- 🤖 **Agent-to-agent commerce** - Agents can autonomously purchase services
- 🎬 **Multiple services** - Video generation, image processing, transcription, etc.

## Usage

```python
from crewai_tools import MoltsPayTool

tool = MoltsPayTool()
result = tool.run(
    provider_url="https://juai8.com/zen7",
    service_id="text-to-video",
    prompt="A cat dancing on a rainbow"
)
```

## Setup

```bash
pip install moltspay
npx moltspay init --chain base  # one-time wallet setup
```

## Links

- [MoltsPay Documentation](https://docs.moltspay.com)
- [x402 Protocol](https://www.x402.org)
- [PyPI Package](https://pypi.org/project/moltspay/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new external-payment integration and updates the central `tools/__init__.py` export list; the current import placement appears to introduce a syntax error that could break importing `crewai_tools.tools` entirely.
> 
> **Overview**
> Adds a new `MoltsPayTool` (with Pydantic args schema and lazy `moltspay` client initialization via `MOLTSPAY_WALLET_PATH`) that performs an x402-paid `POST` to `provider_url/v1/{service_id}` with optional `prompt`/`image` params.
> 
> Exports the tool from `crewai_tools.tools` and adds a dedicated README, but the `MoltsPayTool` import is currently inserted inside the parenthesized `YoutubeVideoSearchTool` import block in `tools/__init__.py`, which likely causes a syntax error at import time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e10a7369bfd67a93c6a41a8bbeff9b38ce53366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->