### PR TITLE
fix: prioritize tool calls over text when available_functions is None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,17 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # This must be checked before returning text_response, because some LLMs
+        # (e.g., Anthropic via OpenRouter/Bedrock) return both text and tool_calls
+        # in the same response. The tool calls should take priority so the executor
+        # can execute them instead of treating the text as a final answer.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1253,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
## Summary

Fixes #4788 - Native tool calls are discarded if LLM returns a text response alongside them.

When an LLM (e.g., Anthropic via OpenRouter/Bedrock) returns **both** a text response and tool calls in the same message, the previous logic in `_handle_non_streaming_response` returned the text response instead of the tool calls when `available_functions` was `None`. This caused the CrewAgentExecutor to treat the text as a final answer, silently discarding the tool calls that should have been executed.

## Root cause

The condition at step 5 was:
```python
if (not tool_calls or not available_functions) and text_response:
    return text_response
```

When `tool_calls` is truthy (tool calls exist), `not available_functions` is True (executor passes None), and `text_response` is truthy, this condition matches and returns the text — never reaching step 6 which would return the tool calls.

## Fix

Swap the order of steps 5 and 6 so that tool calls are returned first when `available_functions` is `None`, before falling back to text response. The new step 6 now only returns text when there are genuinely no tool calls (`not tool_calls`).

This is a minimal, focused change (4 lines of logic) that preserves all existing behavior for:
- Responses with only text (no tool calls) — still returns text
- Responses with tool calls and `available_functions` provided — still executes tools
- Responses with no text and no tool calls — falls through to step 8

## Test plan

- [ ] Verify LLM responses with both text + tool calls return tool calls when `available_functions=None`
- [ ] Verify text-only responses still work correctly
- [ ] Verify tool execution still works when `available_functions` is provided
- [ ] Run existing test suite: `pytest lib/crewai/tests/test_llm.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM response selection logic and could affect downstream callers that previously received text in mixed text+tool responses, though the change is small and narrowly scoped to the `available_functions=None` case.
> 
> **Overview**
> Fixes non-streaming LLM response handling so that when a provider returns *both* `tool_calls` and text in the same message and `available_functions` is `None`, the method returns the `tool_calls` instead of prematurely treating the text as the final answer.
> 
> This reorders the decision logic in `_handle_non_streaming_response` to give tool calls priority (enabling executors to run native tools) while preserving the existing paths for text-only responses and for executing tools when `available_functions` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10cdfd6d0f8d465b9352b51b36319d0eb71507da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->