### PR TITLE
fix: extract Bedrock tool arguments from input field correctly

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

Fixes #4748 - AWS Bedrock tool calls extract empty arguments due to wrong default value in `get()`.

All AWS Bedrock models (Nova Pro, Nova Lite, Claude via Bedrock, etc.) receive empty `{}` arguments for every tool call, regardless of what the LLM actually provides. This causes tools to fail or return incorrect results.

## Root cause

In `CrewAgentExecutor._parse_native_tool_call()` (line 850):

```python
# BEFORE (buggy)
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
```

`func_info.get("arguments", "{}")` returns the string `"{}"` when `"arguments"` is absent (Bedrock format). Since `"{}"` is truthy, Python's `or` operator **never evaluates** `tool_call.get("input", {})`, which is where Bedrock stores its arguments.

The correct pattern already exists in `utilities/agent_utils.py` line 1155:
```python
func_args = func_info.get("arguments") or tool_call.get("input") or {}
```

## Fix

One-line change: remove the default value `"{}"` from `get("arguments")` so it returns `None` when absent, allowing the `or`-chain to fall through to Bedrock's `"input"` field:

```python
# AFTER (fixed)
func_args = func_info.get("arguments") or tool_call.get("input") or {}
```

## Test plan

- [ ] Verify Bedrock tool call format `{"name": "search_tool", "input": {"query": "test"}}` correctly extracts arguments
- [ ] Verify OpenAI tool call format `{"function": {"name": "search_tool", "arguments": {"query": "test"}}}` still works
- [ ] Verify empty tool calls (no arguments in either format) default to `{}`
- [ ] Run existing test suite: `pytest lib/crewai/tests/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool-call argument extraction used during agent execution; while the change is small and targeted, it can affect tool invocation behavior across providers when `arguments` is absent or empty.
> 
> **Overview**
> Fixes native tool-call parsing for dict-based providers (notably AWS Bedrock) by no longer defaulting missing `function.arguments` to the truthy string `"{}"`, allowing `_parse_native_tool_call()` to fall through to `tool_call["input"]` and correctly pass real tool arguments.
> 
> This changes the default behavior for tool calls with no provided args to return an empty dict (`{}`) rather than a stringified empty object, improving consistency across provider formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d8f15f4284bcfa659f486cb404bca8b716f9be0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->