### PR TITLE
fix(bedrock): extract tool arguments from Bedrock input field

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

Fixes #4748

AWS Bedrock tool calls use `tool_call["input"]` for arguments, but CrewAI only extracts from `tool_call["function"]["arguments"]`. The `or` fallback never fires because `func_info.get("arguments", "{}")` returns the truthy string `"{}"`.

## Fix

Changed the default from `"{}"` to `None` (by removing the default), matching the pattern already used in `agent_utils.py` line 1155:

```python
# Before
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})

# After  
func_args = func_info.get("arguments") or tool_call.get("input") or {}
```

## Test Plan

- [x] Verified the bug exists at the exact line described in the issue
- [x] The fix matches an existing correct pattern in `agent_utils.py`
- [x] OpenAI-format tool calls are unaffected (they have truthy `arguments`)
- [x] Ruff lint passes

This contribution was developed with AI assistance (Claude Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to tool-call argument extraction that only affects native tool calling for dict-shaped (e.g., Bedrock) tool calls.
> 
> **Overview**
> Fixes native tool-call parsing to **actually fall back** from `tool_call["function"]["arguments"]` to `tool_call["input"]` when `arguments` is missing/empty, avoiding the previous truthy default (`"{}"`) that prevented Bedrock tool arguments from being read.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f3fa5898a4d2f0a717ab619905d562cc23f6468. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->