### PR TITLE
fix(llm): prevent text response from overriding native tool calls

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1248,8 +1248,8 @@ class LLM(BaseLLM):
             )
             return tool_calls
 
-        # --- 6) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 6) If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1387,7 +1387,8 @@ class LLM(BaseLLM):
             )
             return tool_calls
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1239,6 +1239,13 @@ class LLM(BaseLLM):
         # Must be checked before the text-return path so that tool calls are not
         # silently discarded when the LLM also returns a text response.
         if tool_calls and not available_functions:
+            self._handle_emit_call_events(
+                response=tool_calls,
+                call_type=LLMCallType.TOOL_CALL,
+                from_task=from_task,
+                from_agent=from_agent,
+                messages=params["messages"],
+            )
             return tool_calls
 
         # --- 6) If no tool calls or no available functions, return the text response directly as long as there is a text response
@@ -1366,6 +1373,20 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # Must be checked before the text-return path so that tool calls are not
+        # silently discarded when the LLM also returns a text response.
+        if tool_calls and not available_functions:
+            self._handle_emit_call_events(
+                response=tool_calls,
+                call_type=LLMCallType.TOOL_CALL,
+                from_task=from_task,
+                from_agent=from_agent,
+                messages=params["messages"],
+            )
+            return tool_calls
+
         if (not tool_calls or not available_functions) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
@@ -1375,11 +1396,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,7 +1234,14 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # Must be checked before the text-return path so that tool calls are not
+        # silently discarded when the LLM also returns a text response.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls or no available functions, return the text response directly as long as there is a text response
         if (not tool_calls or not available_functions) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
@@ -1244,11 +1251,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
## Summary
- When the LLM returns both a text response and `tool_calls`, the executor passes `available_functions=None`. The existing condition `(not tool_calls or not available_functions) and text_response` at step 5 matched because `not available_functions` was `True`, so the text response was returned and tool calls were silently discarded.
- Fix: reorder the checks so that "tool_calls present but no available_functions" is evaluated **before** the text-return path. This ensures tool calls are returned to the caller (executor) for handling.
- No new dependencies or breaking changes.

## Test plan
- [ ] Verify with an LLM that returns both text and tool_calls when `available_functions=None` -- tool calls should be returned, not text
- [ ] Verify that when only text is returned (no tool_calls), behavior is unchanged
- [ ] Verify that when `available_functions` is provided, tool execution still works normally

Fixes #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM non-streaming return-path precedence so responses with `tool_calls` no longer fall back to text when `available_functions` is `None`, which may alter what downstream callers receive in this edge case.
> 
> **Overview**
> Prevents native `tool_calls` from being silently dropped when the LLM returns both text and tool calls but `available_functions` is not provided.
> 
> Reorders the non-streaming and async non-streaming response handling to **return `tool_calls` first** (and emit `LLMCallType.TOOL_CALL` completion events) before the text-return path, while keeping existing behavior when there are no tool calls or when tool execution is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33985614e0a5b973d7fea32b678408e3e5a3eaa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->