### PR TITLE
fix(tools): prevent Pydantic validation error with security_context in MCP tools

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -320,19 +320,22 @@ class ToolUsage:
 
                     if calling.arguments:
                         try:
+                            enriched = self._add_fingerprint_metadata(
+                                dict(calling.arguments)
+                            )
                             acceptable_args = tool.args_schema.model_json_schema()[
                                 "properties"
                             ].keys()
                             arguments = {
                                 k: v
-                                for k, v in calling.arguments.items()
+                                for k, v in enriched.items()
                                 if k in acceptable_args
                             }
-                            arguments = self._add_fingerprint_metadata(arguments)
                             result = await tool.ainvoke(input=arguments)
                         except Exception:
-                            arguments = calling.arguments
-                            arguments = self._add_fingerprint_metadata(arguments)
+                            arguments = self._add_fingerprint_metadata(
+                                dict(calling.arguments)
+                            )
                             result = await tool.ainvoke(input=arguments)
                     else:
                         arguments = self._add_fingerprint_metadata({})
@@ -552,19 +555,22 @@ class ToolUsage:
 
                     if calling.arguments:
                         try:
+                            enriched = self._add_fingerprint_metadata(
+                                dict(calling.arguments)
+                            )
                             acceptable_args = tool.args_schema.model_json_schema()[
                                 "properties"
                             ].keys()
                             arguments = {
                                 k: v
-                                for k, v in calling.arguments.items()
+                                for k, v in enriched.items()
                                 if k in acceptable_args
                             }
-                            arguments = self._add_fingerprint_metadata(arguments)
                             result = tool.invoke(input=arguments)
                         except Exception:
-                            arguments = calling.arguments
-                            arguments = self._add_fingerprint_metadata(arguments)
+                            arguments = self._add_fingerprint_metadata(
+                                dict(calling.arguments)
+                            )
                             result = tool.invoke(input=arguments)
                     else:
                         arguments = self._add_fingerprint_metadata({})


### PR DESCRIPTION
## Summary
- `_add_fingerprint_metadata` injects `security_context` into tool arguments **after** the `acceptable_args` filtering, so it bypasses the filter and causes `Pydantic ValidationError` on strict MCP tool schemas that don't declare `security_context` as a valid field.
- Fix: move the `_add_fingerprint_metadata` call to **before** the `acceptable_args` filtering in both the sync and async code paths. The existing filter naturally strips any keys not in the tool's schema, so `security_context` is only passed to tools that explicitly declare it.
- No new dependencies or breaking changes.

## Test plan
- [ ] Use an MCP tool with a strict Pydantic schema that does not include `security_context` -- should no longer raise `ValidationError`
- [ ] Use a tool that declares `security_context` in its schema -- should still receive the field
- [ ] Verify fingerprint metadata is still injected correctly for tools that accept it

Fixes #4796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool argument preparation that mainly affects whether extra metadata keys are forwarded; minimal behavioral risk outside of tools that relied on previously unfiltered metadata.
> 
> **Overview**
> Prevents strict-schema (e.g., MCP) tools from failing Pydantic validation by changing when fingerprint metadata is injected into tool call arguments.
> 
> In both sync and async tool execution paths, `_add_fingerprint_metadata` now runs *before* filtering against `tool.args_schema` properties, so injected keys like `security_context` are stripped unless explicitly allowed; the exception fallback also copies arguments before enrichment to avoid mutating the original input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef8ac3c4b66ff61e537ef9d2c069e26eb993800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->