### PR TITLE
fix(tools): write LF newlines in tool.specs.json on all platforms

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,8 +180,9 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
+            f.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `generate_tool_specs.py` uses `open()` in text mode, which writes OS-native line endings. On Windows this produces CRLF, causing spurious diffs when the file is committed on Linux/macOS.
- Fix: add `newline="\n"` to the `open()` call to force LF on all platforms. Also adds a trailing newline for POSIX convention.
- Note: PR #4753 addresses the same issue but is still open. This PR takes a similar approach and also adds the trailing newline.

## Test plan
- [ ] Run `generate_tool_specs.py` on Windows and verify the output file contains LF line endings
- [ ] Run on Linux/macOS and verify behavior is unchanged
- [ ] Verify the output file ends with a trailing newline

Fixes #4737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to how a generated JSON file is written; minimal behavioral impact beyond line-ending normalization.
> 
> **Overview**
> Ensures generated `tool.specs.json` is stable across platforms by forcing LF line endings when writing from `generate_tool_specs.py`.
> 
> The JSON writer now opens the output with `newline="\n"` and explicitly appends a trailing newline after `json.dump`, avoiding CRLF on Windows and reducing spurious diffs when the file is committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03f906672b8ba808b998bbe0e92fe23bfcaa5b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->