### PR TITLE
fix: replace deprecated asyncio.get_event_loop with get_running_loop

### DIFF
--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -263,7 +263,7 @@ class CrewStructuredTool:
             # Run sync functions in a thread pool
             import asyncio
 
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.func(**parsed_args, **kwargs)
             )
         except Exception:


### PR DESCRIPTION
## Description

`asyncio.get_event_loop()` has been deprecated since Python 3.10 and emits a `DeprecationWarning` when there is no current event loop. Since `avoke` is an async method, a running event loop is always guaranteed, making `asyncio.get_running_loop()` the correct API to use.

## Changes

- **lib/crewai/src/crewai/tools/structured_tool.py**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in the `avoke` method

## Testing

- No behavioral change — `get_running_loop()` returns the same loop when called within an async context
- Eliminates the deprecation warning on Python 3.10+

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line update to asyncio loop retrieval in an already-async path, intended to remove Python 3.10+ deprecation warnings without changing behavior.
> 
> **Overview**
> Updates `CrewStructuredTool.ainvoke` to use `asyncio.get_running_loop()` instead of the deprecated `get_event_loop()` when dispatching synchronous tool functions via `run_in_executor`, eliminating deprecation warnings in Python 3.10+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 945fff96c65da0fc8c69617c7f6cd1db9ddfde56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->