### PR TITLE
docs: update changelog and version for v1.10.2a1

### DIFF
--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,39 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Mar 11, 2026">
+  ## v1.10.2a1
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2a1)
+
+  ## What's Changed
+
+  ### Features
+  - Add support for tool search, saving tokens, and dynamically injecting appropriate tools during execution for Anthropics.
+  - Introduce more Brave Search tools.
+  - Create action for nightly releases.
+
+  ### Bug Fixes
+  - Fix LockException under concurrent multi-process execution.
+  - Resolve issues with grouping parallel tool results in a single user message.
+  - Address MCP tools resolutions and eliminate all shared mutable connections.
+  - Update LLM parameter handling in the human_feedback function.
+  - Add missing list/dict methods to LockedListProxy and LockedDictProxy.
+  - Propagate contextvars context to parallel tool call threads.
+  - Bump gitpython dependency to >=3.1.41 to resolve CVE path traversal vulnerability.
+
+  ### Refactoring
+  - Refactor memory classes to be serializable.
+
+  ### Documentation
+  - Update changelog and version for v1.10.1.
+
+  ## Contributors
+
+  @akaKuruma, @github-actions[bot], @giulio-leone, @greysonlalonde, @joaomdmoura, @jonathansampson, @lorenzejay, @lucasgomide, @mattatcha
+
+</Update>
+
 <Update label="Mar 04, 2026">
   ## v1.10.1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,39 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 3월 11일">
+  ## v1.10.2a1
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2a1)
+
+  ## 변경 사항
+
+  ### 기능
+  - Anthropics에 대한 도구 검색 지원 추가, 토큰 저장, 실행 중 적절한 도구를 동적으로 주입하는 기능 추가.
+  - 더 많은 Brave Search 도구 도입.
+  - 야간 릴리스를 위한 액션 생성.
+
+  ### 버그 수정
+  - 동시 다중 프로세스 실행 중 LockException 수정.
+  - 단일 사용자 메시지에서 병렬 도구 결과 그룹화 문제 해결.
+  - MCP 도구 해상도 문제 해결 및 모든 공유 가변 연결 제거.
+  - human_feedback 함수에서 LLM 매개변수 처리 업데이트.
+  - LockedListProxy 및 LockedDictProxy에 누락된 list/dict 메서드 추가.
+  - 병렬 도구 호출 스레드에 contextvars 컨텍스트 전파.
+  - CVE 경로 탐색 취약점을 해결하기 위해 gitpython 의존성을 >=3.1.41로 업데이트.
+
+  ### 리팩토링
+  - 메모리 클래스를 직렬화 가능하도록 리팩토링.
+
+  ### 문서
+  - v1.10.1에 대한 변경 로그 및 버전 업데이트.
+
+  ## 기여자
+
+  @akaKuruma, @github-actions[bot], @giulio-leone, @greysonlalonde, @joaomdmoura, @jonathansampson, @lorenzejay, @lucasgomide, @mattatcha
+
+</Update>
+
 <Update label="2026년 3월 4일">
   ## v1.10.1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,39 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="11 mar 2026">
+  ## v1.10.2a1
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2a1)
+
+  ## O que mudou
+
+  ### Recursos
+  - Adicionar suporte para busca de ferramentas, salvamento de tokens e injeção dinâmica de ferramentas apropriadas durante a execução para Anthropics.
+  - Introduzir mais ferramentas de Busca Brave.
+  - Criar ação para lançamentos noturnos.
+
+  ### Correções de Bugs
+  - Corrigir LockException durante a execução concorrente de múltiplos processos.
+  - Resolver problemas com a agrupação de resultados de ferramentas paralelas em uma única mensagem de usuário.
+  - Abordar resoluções de ferramentas MCP e eliminar todas as conexões mutáveis compartilhadas.
+  - Atualizar o manuseio de parâmetros LLM na função human_feedback.
+  - Adicionar métodos de lista/dicionário ausentes a LockedListProxy e LockedDictProxy.
+  - Propagar o contexto de contextvars para as threads de chamada de ferramentas paralelas.
+  - Atualizar a dependência gitpython para >=3.1.41 para resolver a vulnerabilidade de travessia de diretórios CVE.
+
+  ### Refatoração
+  - Refatorar classes de memória para serem serializáveis.
+
+  ### Documentação
+  - Atualizar o changelog e a versão para v1.10.1.
+
+  ## Contribuidores
+
+  @akaKuruma, @github-actions[bot], @giulio-leone, @greysonlalonde, @joaomdmoura, @jonathansampson, @lorenzejay, @lucasgomide, @mattatcha
+
+</Update>
+
 <Update label="04 mar 2026">
   ## v1.10.1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that appends release notes; no runtime or build logic is modified.
> 
> **Overview**
> Adds a new **v1.10.2a1** changelog entry (dated Mar 11, 2026) to the localized `changelog.mdx` pages (`docs/en`, `docs/ko`, `docs/pt-BR`), including the GitHub release link, categorized highlights (features/bug fixes/refactoring/docs), and the contributor list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e82b4fe5139bd0b382b636de5d64c37ed49f15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->