### PR TITLE
fix(mcp): use extra='ignore' in _json_schema_to_pydantic to allow CrewAI-injected security_context

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -15,6 +15,8 @@ import time
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
 
+from pydantic import ConfigDict
+
 from crewai.mcp.client import MCPClient
 from crewai.mcp.config import (
     MCPServerConfig,
@@ -585,8 +587,13 @@ class MCPToolResolver:
         from crewai.utilities.pydantic_schema_utils import create_model_from_schema
 
         model_name = f"{tool_name.replace('-', '_').replace(' ', '_')}Schema"
+        # Use extra="ignore" so that CrewAI-injected fields like `security_context`
+        # (added by tool_usage.py before validation) do not cause a Pydantic
+        # "Extra inputs are not permitted" ValidationError on MCP tools whose
+        # inputSchema was generated without that field.
         return create_model_from_schema(
             json_schema,
             model_name=model_name,
             enrich_descriptions=True,
+            __config__=ConfigDict(extra="ignore"),
         )


### PR DESCRIPTION
## Problem

CrewAI's `tool_usage.py` injects a `security_context` field into every tool call's arguments before Pydantic validation (lines 1024-1045). MCP tools build their argument schema from the MCP server's `inputSchema` via `create_model_from_schema()`, which defaults to `ConfigDict(extra='forbid')`.

Since the MCP server's schema never includes `security_context`, validation raises (closes #4796):

```
pydantic_core.ValidationError: Extra inputs are not permitted
  security_context
    Extra inputs are not permitted [type=extra_forbidden, ...]
```

## Root cause

`MCPToolResolver._json_schema_to_pydantic()` calls `create_model_from_schema()` without overriding the default `ConfigDict(extra='forbid')`.

## Fix

Pass `ConfigDict(extra='ignore')` explicitly when building the schema model for MCP tools:

```python
return create_model_from_schema(
    json_schema,
    model_name=model_name,
    enrich_descriptions=True,
    __config__=ConfigDict(extra="ignore"),   # ← allow security_context to pass through
)
```

Framework-injected fields are silently dropped before the model sees only the fields it declared. The MCP tool's own validation is unaffected.

Closes #4796

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes Pydantic validation for MCP tool arguments by ignoring unknown fields, which could mask unexpected/typoed inputs but is scoped to MCP-derived schemas and prevents runtime failures from framework-injected metadata.
> 
> **Overview**
> Fixes MCP tool argument validation failures by generating Pydantic models with `extra="ignore"` in `MCPToolResolver._json_schema_to_pydantic`, allowing CrewAI-injected fields like `security_context` to pass through without raising `extra_forbidden` errors.
> 
> This changes MCP tool schemas created via `create_model_from_schema` to silently drop unknown keys instead of rejecting them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81037f4c585f6011586a2e6de1aad983c9e72f34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->