### PR TITLE
fix: replace deprecated asyncio.get_event_loop with get_running_loop

### DIFF
--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -263,7 +263,7 @@ class CrewStructuredTool:
             # Run sync functions in a thread pool
             import asyncio
 
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.func(**parsed_args, **kwargs)
             )
         except Exception:


### PR DESCRIPTION
## Description

`asyncio.get_event_loop()` has been deprecated since Python 3.10 and emits a `DeprecationWarning` when there is no current event loop. Since `avoke` is an async method, a running event loop is always guaranteed, making `asyncio.get_running_loop()` the correct API to use.

## Changes

- **lib/crewai/src/crewai/tools/structured_tool.py**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in the `avoke` method

## Testing

- No behavioral change — `get_running_loop()` returns the same loop when called within an async context
- Eliminates the deprecation warning on Python 3.10+

Fixes #4812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API swap inside an async-only code path; behavior should be unchanged aside from eliminating `DeprecationWarning` on newer Python versions.
> 
> **Overview**
> Updates `CrewStructuredTool.ainvoke` to call `asyncio.get_running_loop().run_in_executor(...)` instead of the deprecated `asyncio.get_event_loop()` when running sync tool functions in a thread pool, avoiding `DeprecationWarning` on Python 3.10+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3d9cbf51273a1d1d318839ae93c25840e87856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->