### PR TITLE
Fix generate_tool_specs line endings on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
This pull request updates the `generate_tool_specs.py` helper so that it always writes `tool.specs.json` with Unix (`LF`) line endings, even when executed on Windows.

Previously, Python's text-mode `open()` call used the platform default line endings. On Windows this resulted in `CRLF` being written to `tool.specs.json`, which in turn caused large, noisy diffs whenever the file was regenerated.

The change is minimal and aligns with the behavior suggested in the issue:

- Open the output file with `newline="\n"` while preserving UTF-8 encoding.

Closes #4737.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how `tool.specs.json` is written to disk by forcing `LF` newlines, without altering schema extraction or JSON content.
> 
> **Overview**
> Ensures `generate_tool_specs.py` always writes `tool.specs.json` with Unix (`LF`) line endings by opening the output file with `newline="\n"`, preventing noisy `CRLF`-only diffs when the generator is run on Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efe113dc3c6292603a93ca424fb7f9388544d16c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->