### PR TITLE
Fix LiteLLM response_model and native tool call handling

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1150,7 +1150,8 @@ class LLM(BaseLLM):
             str: The response text
         """
         # --- 1) Handle response_model with InternalInstructor for LiteLLM
-        if response_model and self.is_litellm:
+        # Only use this path when no native tools are being passed.
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])
@@ -1234,8 +1235,13 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If there are no tool calls, fall back to returning the text response (if any)
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1250,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1290,7 +1291,7 @@ class LLM(BaseLLM):
         Returns:
             str: The response text
         """
-        if response_model and self.is_litellm:
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])
@@ -1364,7 +1365,12 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        if (not tool_calls) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1373,11 +1379,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
This pull request fixes two related bugs in the LiteLLM integration used by the `LLM` wrapper:

- When `supports_function_calling()` is true and a `response_model` is provided, the internal instructor path was used even when native tools were also passed. This caused custom agent tools to be ignored in favor of the structured output model.
- Native tool calls could be dropped when the LLM returned both text and tool calls in the same response. In that case, the text branch won and the tool calls were never surfaced back to the executor.

Key changes:

1. Only route through `InternalInstructor` when no tools are being passed.
   This ensures that when tools are provided, the call behaves like a normal tool-enabled completion and agent tools are preserved.

2. Prefer tool calls over plain text when both are present.
   The non-streaming response handlers now return tool calls first when they exist, and only fall back to text when there are no tool calls.

These changes are applied to both the synchronous and asynchronous non-streaming handlers so that behavior is consistent across code paths.

Closes #4697.
Closes #4788.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LiteLLM non-streaming return semantics around `response_model` and tool-calling, which can affect downstream executors that previously received plain text instead of tool call objects. Risk is moderate due to altered control flow in a core LLM wrapper, but scoped to LiteLLM non-streaming sync/async handlers.
> 
> **Overview**
> Fixes LiteLLM non-streaming handling so `response_model` routing through `InternalInstructor` is **skipped when native `tools` are provided**, preserving tool-enabled completions.
> 
> Adjusts both sync and async non-streaming response handlers to **prefer returning `tool_calls`** when present but `available_functions` isn’t supplied (so callers can execute tools), and only fall back to returning text when no tool calls exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f647049aa545f74414ca9e6e1475fab0aaa99728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->