### PR TITLE
Fix Bedrock native tool call argument extraction

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,9 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments")
+            if func_args is None:
+                func_args = tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
This pull request fixes argument extraction for native tool calls coming from AWS Bedrock models.

When Bedrock returns tool calls via the Converse API, the payload uses the `input` field instead of
`function.arguments`. Our dictionary-based parser path in `CrewAgentExecutor._parse_native_tool_call()`
always pulled from `function.arguments` with a default of the string "{}", which meant the Bedrock
`input` field was never considered and tools consistently received empty arguments.

**What changed**

In the dictionary branch of `_parse_native_tool_call`:

- Stop using `func_info.get("arguments", "{}") or tool_call.get("input", {})`.
- Instead, first look for `function.arguments` and only fall back to `tool_call["input"]`
  when `arguments` is missing:

  ```python
  func_args = func_info.get("arguments")
  if func_args is None:
      func_args = tool_call.get("input", {})
  ```

This preserves the existing OpenAI-style behaviour (where `function.arguments` is present),
while correctly handling Bedrock-style tool calls where the arguments live under `input`.

**Result**

- OpenAI / Anthropic (OpenAI-style) tool calls continue to work as before, since they populate
  `function.arguments`.
- AWS Bedrock tool calls now correctly forward the structured `input` payload to tools, so
  tools receive the expected parameters instead of `{}`.

Closes #4748.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native tool-call parsing, which directly affects tool execution inputs across providers; while the change is small and guarded, it could alter behavior for dict-shaped tool call payloads.
> 
> **Overview**
> Fixes `CrewAgentExecutor._parse_native_tool_call()` for dict-shaped native tool calls by **preferring** `function.arguments` when present and **falling back** to Bedrock-style `input` only when `arguments` is missing, preventing tools from receiving empty `{}` arguments in Bedrock Converse responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abb3c9833d354a1ee4e79f1b90d17e5b5bf540e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->