### PR TITLE
fix(llm): return native tool calls before text fallback

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,13 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls, return the text response when present
+        if text_response and not tool_calls:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1249,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1364,7 +1364,12 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        if text_response and not tool_calls:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1373,11 +1378,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from time import sleep
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from crewai.agents.agent_builder.utilities.base_token_process import TokenProcess
 from crewai.events.event_types import (
@@ -650,6 +650,76 @@ def test_handle_streaming_tool_calls_no_tools(mock_emit):
         expected_completed_llm_call=1,
         expected_final_chunk_result=response,
     )
+
+
+def test_non_streaming_prefers_tool_calls_when_text_also_present():
+    llm = LLM(model="openai/gpt-4o-mini", stream=False, is_litellm=True)
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"query":"weather"}'},
+        }
+    ]
+
+    with patch("litellm.completion") as mocked_completion:
+        mock_message = MagicMock()
+        mock_message.content = "I can help with that."
+        mock_message.tool_calls = tool_calls
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = {
+            "prompt_tokens": 5,
+            "completion_tokens": 5,
+            "total_tokens": 10,
+        }
+        mocked_completion.return_value = mock_response
+
+        result = llm.call(
+            [{"role": "user", "content": "Use tool"}],
+            available_functions=None,
+        )
+
+    assert result == tool_calls
+
+
+@pytest.mark.asyncio
+async def test_async_non_streaming_prefers_tool_calls_when_text_also_present():
+    llm = LLM(model="openai/gpt-4o-mini", stream=False, is_litellm=True)
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"query":"weather"}'},
+        }
+    ]
+
+    mock_message = MagicMock()
+    mock_message.content = "I can help with that."
+    mock_message.tool_calls = tool_calls
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = {
+        "prompt_tokens": 5,
+        "completion_tokens": 5,
+        "total_tokens": 10,
+    }
+
+    with patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
+        result = await llm.acall(
+            [{"role": "user", "content": "Use tool"}],
+            available_functions=None,
+        )
+
+    assert result == tool_calls
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Summary
- prioritize returning native `tool_calls` when `available_functions=None`, even if the model also emits text
- keep existing text-path behavior when no tool calls are present
- add sync + async tests covering mixed text+tool_calls responses

## Why
`crew_agent_executor` intentionally calls the LLM with `available_functions=None` for native tool execution.
When an LLM emits both text and tool calls, the previous condition returned text and dropped tool calls.

## Validation
- Added unit tests in `lib/crewai/tests/test_llm.py` for sync/async non-streaming paths
- Local test execution is blocked in this environment because the repo test harness requires Python >=3.10 while this host only has Python 3.9

Closes #4788

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM return behavior in non-streaming sync/async paths, which may affect callers expecting a text string when models emit both text and tool calls. Scope is limited and covered by new unit tests.
> 
> **Overview**
> Ensures non-streaming LLM calls *preserve native tool invocation intent*: when the model returns both `tool_calls` and text, and `available_functions` is not provided, the LLM now returns `tool_calls` instead of falling back to the text response.
> 
> Adds sync and async unit tests validating this mixed-response behavior, and updates mocks to use `AsyncMock` for the async path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9decddd4ac97cd617ef5b9f0b00b3f8c306e69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->