### PR TITLE
fix: propagate ContextVars into async task and streaming threads

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 from concurrent.futures import Future
 from copy import copy as shallow_copy
 import datetime
@@ -524,10 +525,11 @@ class Task(BaseModel):
     ) -> Future[TaskOutput]:
         """Execute the task asynchronously."""
         future: Future[TaskOutput] = Future()
+        ctx = contextvars.copy_context()
         threading.Thread(
             daemon=True,
-            target=self._execute_task_async,
-            args=(agent, context, tools, future),
+            target=ctx.run,
+            args=(self._execute_task_async, agent, context, tools, future),
         ).start()
         return future
 

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator, Callable, Iterator
+import contextvars
 import queue
 import threading
 from typing import Any, NamedTuple
@@ -240,7 +241,8 @@ def create_chunk_generator(
     Yields:
         StreamChunk objects as they arrive.
     """
-    thread = threading.Thread(target=run_func, daemon=True)
+    ctx = contextvars.copy_context()
+    thread = threading.Thread(target=ctx.run, args=(run_func,), daemon=True)
     thread.start()
 
     try:


### PR DESCRIPTION
## Summary

Fixes the same root cause as #4823 — `threading.Thread()` does not inherit the parent thread's `contextvars.Context`, causing ContextVar-based state (OpenTelemetry spans, Langfuse trace IDs, and any other request-scoped vars) to be silently dropped.

This PR extends the fix to **two locations** that #4823 explicitly flagged but did not address:

1. **`task.py` — `execute_async()`** (same as #4823)
2. **`src/crewai/utilities/streaming.py` — `create_chunk_generator()`** (additional fix)

The streaming path was called out in #4823's review checklist as a known gap:
> *"Consider whether other `threading.Thread` callsites... (e.g. `streaming.py`) also need context propagation — this PR only addresses `task.py`"*

## Changes

**`src/crewai/task.py`**
```python
# Before
threading.Thread(
    daemon=True,
    target=self._execute_task_async,
    args=(agent, context, tools, future),
).start()

# After
ctx = contextvars.copy_context()
threading.Thread(
    daemon=True,
    target=ctx.run,
    args=(self._execute_task_async, agent, context, tools, future),
).start()
```

**`src/crewai/utilities/streaming.py`**
```python
# Before
thread = threading.Thread(target=run_func, daemon=True)

# After
ctx = contextvars.copy_context()
thread = threading.Thread(target=ctx.run, args=(run_func,), daemon=True)
```

## Why this matters

Without this fix, OpenTelemetry spans, Langfuse trace IDs, and any ContextVar-scoped state are silently lost in both async task execution and streaming execution paths. `contextvars.copy_context()` is the standard Python mechanism for this (same pattern used by `asyncio.to_thread()` internally) and has negligible overhead.

## Relationship to #4823

#4823 fixes `task.py` only. This PR includes that same fix plus the `streaming.py` fix. If the maintainers prefer to fold the streaming fix into #4823, happy to close this and comment there instead.

Co-Authored-By: Alex De Angelis <alexdeangelis@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to thread startup that only affects propagation of `contextvars` state (e.g., tracing) without altering task/streaming control flow.
> 
> **Overview**
> Preserves request-scoped `contextvars` state when work is offloaded to background threads.
> 
> `Task.execute_async()` and streaming `create_chunk_generator()` now wrap their thread targets with `contextvars.copy_context().run(...)`, ensuring tracing/telemetry context is not silently dropped when executing tasks or streaming output in a new `threading.Thread`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0926625ba5d33c4ee2fd4d9353f3ec71bcdbe706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->