### PR TITLE
fix: use LF line endings in generate_tool_specs.py on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
## Description

Fixes #4737

When running `generate_tool_specs.py` on Windows, the script generates `tool.specs.json` with CRLF line endings (`\r\n`) instead of LF (`\n`), causing spurious git diffs across the entire file.

## Root Cause

Python's `open()` function in text mode uses the operating system's native line endings:
- **Windows**: CRLF (`\r\n`)
- **Unix/Linux/macOS**: LF (`\n`)

Since the repository uses LF line endings, running the script on Windows causes every line in the generated JSON file to appear as modified in git diff.

## Solution

Add the `newline='\n'` parameter to the `open()` call in the `save_to_json` method to explicitly force LF line endings on all platforms.

### Before
```python
with open(output_path, "w", encoding="utf-8") as f:
    json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
```

### After
```python
with open(output_path, "w", encoding="utf-8", newline="\n") as f:
    json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Manual testing on Windows 11, Python 3.13.1
- [x] Verified generated file matches repository format
- [x] No spurious diffs in `git status`
- [x] No behavior change on Unix systems (already using LF)

### Test Steps
1. Run `python lib/crewai-tools/src/crewai_tools/generate_tool_specs.py` on Windows
2. Check `git diff lib/crewai-tools/tool.specs.json`
3. Verify no diffs appear (unless tool specs actually changed)
4. Run `file lib/crewai-tools/tool.specs.json` - should show "with LF line terminators"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A - simple one-line fix)
- [x] I have made corresponding changes to the documentation (N/A - no doc changes needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A - manual testing sufficient for this fix)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Impact Analysis

### Cross-Platform Compatibility
✅ **Improved**: Now works correctly on Windows without creating spurious diffs

### Backward Compatibility
✅ **Maintained**: No breaking changes
- Unix systems: No change (already using LF)
- Windows systems: Now generates correct LF endings

### Performance
✅ **No impact**: One-line fix, no performance implications

## Security Considerations

✅ **No security concerns**:
- No sensitive data handling changes
- No new dependencies
- No security vulnerabilities introduced

## Additional Context

This is a common issue when developing on Windows with git repositories that use LF line endings. The Python documentation recommends explicitly specifying `newline` parameter when consistent line endings are required across platforms.

Reference: [Python open() documentation](https://docs.python.org/3/library/functions.html#open)

## AI-Assisted Development

This fix was developed with assistance from CodeBuddy (AI coding assistant) for:
- Issue analysis
- Solution identification
- Documentation drafting

All code has been reviewed and tested by the contributor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to file writing that only affects newline normalization, not the generated JSON content.
> 
> **Overview**
> Ensures the `generate_tool_specs.py` output is **platform-stable** by opening the JSON output file with `newline="\n"`, preventing Windows from emitting CRLF line endings and causing whole-file diffs in `tool.specs.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbc87961f90ba0feab213c99e955f26cd1b25196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->