### PR TITLE
fix: prevent output_pydantic from injecting tool schema when LLM lacks function calling

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -370,28 +370,15 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     verbose=self.agent.verbose,
                 )
                 if self.response_model is not None:
+                    answer_str = answer if isinstance(answer, str) else str(answer)
                     try:
-                        if isinstance(answer, BaseModel):
-                            output_json = answer.model_dump_json()
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=output_json,
-                            )
-                        else:
-                            self.response_model.model_validate_json(answer)
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=answer,
-                            )
-                    except ValidationError:
-                        # If validation fails, convert BaseModel to JSON string for parsing
-                        answer_str = (
-                            answer.model_dump_json()
-                            if isinstance(answer, BaseModel)
-                            else str(answer)
+                        self.response_model.model_validate_json(answer_str)
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer_str,
+                            text=answer_str,
                         )
+                    except ValidationError:
                         formatted_answer = process_llm_response(
                             answer_str, self.use_stop_words
                         )  # type: ignore[assignment]
@@ -1216,28 +1203,15 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 )
 
                 if self.response_model is not None:
+                    answer_str = answer if isinstance(answer, str) else str(answer)
                     try:
-                        if isinstance(answer, BaseModel):
-                            output_json = answer.model_dump_json()
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=output_json,
-                            )
-                        else:
-                            self.response_model.model_validate_json(answer)
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=answer,
-                            )
-                    except ValidationError:
-                        # If validation fails, convert BaseModel to JSON string for parsing
-                        answer_str = (
-                            answer.model_dump_json()
-                            if isinstance(answer, BaseModel)
-                            else str(answer)
+                        self.response_model.model_validate_json(answer_str)
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer_str,
+                            text=answer_str,
                         )
+                    except ValidationError:
                         formatted_answer = process_llm_response(
                             answer_str, self.use_stop_words
                         )  # type: ignore[assignment]

--- a/lib/crewai/tests/agents/test_react_response_model.py
+++ b/lib/crewai/tests/agents/test_react_response_model.py
@@ -11,7 +11,7 @@ The fix: _invoke_loop_react() must pass response_model=None so the LLM
 produces plain text that the ReAct parser can handle normally.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -138,3 +138,58 @@ class TestReActResponseModel:
 
                 spy_react.assert_called_once()
                 spy_native.assert_not_called()
+
+    def test_react_path_with_valid_json_string_bypasses_fallback_parser(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """Valid JSON strings should be returned directly in ReAct mode."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew, response_model=MyOutput
+        )
+
+        valid_json = '{"answer": "hello"}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.get_llm_response",
+            return_value=valid_json,
+        ), patch(
+            "crewai.agents.crew_agent_executor.process_llm_response"
+        ) as mock_process:
+            result = executor._invoke_loop_react()
+
+        mock_process.assert_not_called()
+        assert result.output == valid_json
+        assert result.text == valid_json
+
+    @pytest.mark.asyncio
+    async def test_async_react_path_with_valid_json_string_bypasses_fallback_parser(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """Async ReAct mode should treat valid JSON strings the same way."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew, response_model=MyOutput
+        )
+
+        valid_json = '{"answer": "hello"}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.aget_llm_response",
+            new=AsyncMock(return_value=valid_json),
+        ), patch(
+            "crewai.agents.crew_agent_executor.process_llm_response"
+        ) as mock_process:
+            result = await executor._ainvoke_loop_react()
+
+        mock_process.assert_not_called()
+        assert result.output == valid_json
+        assert result.text == valid_json


### PR DESCRIPTION
## Summary

Fixes #4695

When a Task has `output_pydantic` set and the LLM does **not** support native function calling (e.g., Ollama models), the executor correctly falls back to the ReAct text-based loop. However, `response_model` was still forwarded to the LLM call, causing `InternalInstructor` to inject the Pydantic schema as a tool via `instructor.from_litellm(completion)` in `Mode.TOOLS` mode — which models without function-calling support cannot handle.

## Root Cause

`_invoke_loop_react()` and `_ainvoke_loop_react()` both passed `self.response_model` to `get_llm_response()` / `aget_llm_response()`. This triggered the instructor path in `LLM._process_call_params()` (line 1153), which wraps the LLM with `instructor.from_litellm(completion)` using the default `Mode.TOOLS` — injecting the Pydantic model as a native tool regardless of whether the model actually supports function calling.

## Fix

Pass `response_model=None` in both `_invoke_loop_react()` and `_ainvoke_loop_react()`. The task-level `convert_to_model()` in `task.py` (line 1021-1040) already handles text → Pydantic conversion after the ReAct loop finishes, so instructor-based extraction is unnecessary and harmful in this code path.

## Changes

- **`lib/crewai/src/crewai/agents/crew_agent_executor.py`**: Set `response_model=None` in both sync and async ReAct loops
- **`lib/crewai/tests/agents/test_react_response_model.py`**: Added 2 regression tests:
  - Verifies `response_model=None` is passed to `get_llm_response` in ReAct mode  
  - Verifies `_invoke_loop_react` is selected (not native tools) when function calling is unsupported

## Test Results

- 2 new tests pass ✅
- 29 existing sync executor tests pass ✅
- No regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `output_pydantic` is handled in the ReAct execution path, which can affect structured output behavior for models without native tool/function calling. Risk is mitigated by added regression tests covering the selection of ReAct mode and ensuring `response_model` is not forwarded.
> 
> **Overview**
> Prevents `output_pydantic` from being forwarded to the LLM call when the executor falls back to the ReAct text loop, by forcing `response_model=None` in both sync and async ReAct invocations so non-function-calling models don’t receive an injected tool schema.
> 
> Adds regression tests ensuring ReAct mode is chosen when `supports_function_calling()` is false and that `get_llm_response` is called with `response_model=None` in this path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16be9acaa748a405be2069c878e0f4f63e9ce8e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->