### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -591,10 +591,10 @@ class BrightDataDatasetTool(BaseTool):
                 )
             )
         except TimeoutError as e:
-            return f"Timeout Exception occured in method : get_dataset_data_async. Details - {e!s}"
+            return f"Timeout Exception occurred in method : get_dataset_data_async. Details - {e!s}"
         except BrightDataDatasetToolException as e:
             return (
-                f"Exception occured in method : get_dataset_data_async. Details - {e!s}"
+                f"Exception occurred in method : get_dataset_data_async. Details - {e!s}"
             )
         except Exception as e:
             return f"Bright Data API error: {e!s}"


### PR DESCRIPTION
Fixed typo in brightdata_dataset.py

```diff
- Timeout Exception occured
+ Timeout Exception occurred

- Exception occured
+ Exception occurred
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust typoed strings in exception return messages, with no behavioral or API changes.
> 
> **Overview**
> Fixes a typo in `BrightDataDatasetTool._run` error handling, changing `occured` to `occurred` in the returned messages for `TimeoutError` and `BrightDataDatasetToolException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb239f63b3e53723ac68a58722301f9affbb2f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->