### PR TITLE
fix(tools): write LF newlines in tool.specs.json on all platforms

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,8 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="
+") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
## Summary

On Windows, `open()` defaults to CRLF line endings which causes spurious diffs in `tool.specs.json`. This is because the file gets written with platform-specific line endings, creating inconsistencies across different development environments.

## Changes

Pass `newline='\n'` to `open()` to ensure consistent LF output across all platforms.

Fixes #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects how `tool.specs.json` is written by forcing consistent LF newlines, with no behavioral changes to tool schema extraction.
> 
> **Overview**
> Ensures `tool.specs.json` is written with consistent LF line endings across platforms by passing `newline='\n'` when opening the output file in `ToolSpecExtractor.save_to_json()` to avoid Windows CRLF-driven diffs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92076b0cbdd709b3be45143348a8c8d7f041286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->