### PR TITLE
fix: prevent tool_calls from being silently discarded when LLM also returns text

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,15 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # Must be checked before the text fallback so that tool_calls are not
+        # silently discarded when the LLM also returns text content.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1251,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1364,7 +1366,15 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # Must be checked before the text fallback so that tool_calls are not
+        # silently discarded when the LLM also returns text content.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1373,11 +1383,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
When the LLM response contains both text and tool_calls with available_functions=None, the condition incorrectly returns only text. Reorder checks so tool_calls always take priority. Applied to both sync and async code paths. Fixes #4788

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes return behavior of non-streaming LLM calls: callers that previously received a text `str` may now receive `tool_calls` when the model returns both, which could affect downstream type/flow assumptions.
> 
> **Overview**
> Ensures `tool_calls` are not silently dropped when an LLM response includes both text and tool invocations but `available_functions` is `None`.
> 
> Reorders the non-streaming sync and async response handling to return `tool_calls` first in that scenario, leaving tool execution to the caller instead of falling back to the text content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0960d2cc152c185614cb1930a3aa142a159b454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->