### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/lib/crewai/src/crewai/cli/memory_tui.py
+++ b/lib/crewai/src/crewai/cli/memory_tui.py
@@ -367,7 +367,7 @@ class MemoryTUI(App[None]):
                 if self._selected_scope != "/"
                 else None
             )
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             matches = await loop.run_in_executor(
                 None,
                 lambda: self._memory.recall(

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -263,7 +263,7 @@ class CrewStructuredTool:
             # Run sync functions in a thread pool
             import asyncio
 
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.func(**parsed_args, **kwargs)
             )
         except Exception:

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -181,7 +181,7 @@ def create_streaming_state(
 
     if use_async:
         async_queue = asyncio.Queue()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
     handler = _create_stream_handler(current_task_info, sync_queue, async_queue, loop)
     crewai_event_bus.register_handler(LLMStreamChunkEvent, handler)


### PR DESCRIPTION
asyncio.get_event_loop() is deprecated since Python 3.10 and emits DeprecationWarning in Python 3.12+. Replace all occurrences with asyncio.get_running_loop() in memory_tui.py, structured_tool.py, and streaming.py. Since these call sites are always within an async context, get_running_loop() is the correct API. Fixes #4812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical change that only affects how the current event loop is retrieved inside async code paths; behavior should be unchanged unless these functions are called without a running loop.
> 
> **Overview**
> Replaces deprecated `asyncio.get_event_loop()` calls with `asyncio.get_running_loop()` in async execution paths, including the memory TUI recall worker, `CrewStructuredTool.ainvoke()` threadpool execution, and async streaming state setup.
> 
> This removes Python 3.12+ `DeprecationWarning`s while keeping the existing `run_in_executor`/queue behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 110a308f51b2aa442431817606e33a5b263c4479. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->