### PR TITLE
fix: add extra='ignore' to MCP tool resolver Pydantic model

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -607,7 +607,14 @@ class MCPToolResolver:
 
     @staticmethod
     def _json_schema_to_pydantic(tool_name: str, json_schema: dict[str, Any]) -> type:
-        """Convert JSON Schema to a Pydantic model for tool arguments."""
+        """Convert JSON Schema to a Pydantic model for tool arguments.
+
+        Uses extra='ignore' so that MCP servers injecting non-standard
+        properties (e.g. security_context) do not cause Pydantic
+        validation errors.
+        """
+        from pydantic import ConfigDict
+
         from crewai.utilities.pydantic_schema_utils import create_model_from_schema
 
         model_name = f"{tool_name.replace('-', '_').replace(' ', '_')}Schema"
@@ -615,4 +622,5 @@ class MCPToolResolver:
             json_schema,
             model_name=model_name,
             enrich_descriptions=True,
+            __config__=ConfigDict(extra="ignore"),
         )


### PR DESCRIPTION
MCP servers may inject non-standard properties (e.g. security_context) into tool schemas. The generated Pydantic model uses extra='forbid' by default, causing validation errors for these extra fields. Add ConfigDict(extra='ignore') to the dynamically created model so non-standard properties are silently dropped instead of raising errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP tool argument validation to silently drop unknown fields, which could mask schema/argument mismatches but is limited to dynamically generated MCP tool models.
> 
> **Overview**
> Fixes MCP tool argument model generation to tolerate MCP servers that inject non-standard schema properties.
> 
> `MCPToolResolver._json_schema_to_pydantic` now builds dynamic Pydantic models with `extra="ignore"` (via `ConfigDict`) instead of the default `extra="forbid"`, preventing validation failures when unexpected fields (e.g. `security_context`) appear in tool schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 485537941ff671ff8701ddc1dc8aff4fe76d6a0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->