### PR TITLE
fix: propagate ContextVar state to async_execution worker threads

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import logging
 from pathlib import Path
+import contextvars
 import threading
 from typing import (
     Any,
@@ -524,10 +525,13 @@ class Task(BaseModel):
     ) -> Future[TaskOutput]:
         """Execute the task asynchronously."""
         future: Future[TaskOutput] = Future()
+        # Copy the current context so ContextVar values propagate to the
+        # worker thread (e.g. tracing spans, tenant IDs, etc.).
+        ctx = contextvars.copy_context()
         threading.Thread(
             daemon=True,
-            target=self._execute_task_async,
-            args=(agent, context, tools, future),
+            target=ctx.run,
+            args=(self._execute_task_async, agent, context, tools, future),
         ).start()
         return future
 


### PR DESCRIPTION
Task.execute_async() spawns a new threading.Thread for background execution, but threading.Thread does not inherit the parent's contextvars.Context. This causes ContextVar values (e.g. tracing spans, tenant IDs, session state) to be lost in the worker thread. Use contextvars.copy_context() to snapshot the current context and run the worker function inside it via ctx.run(). Fixes #4822

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async task execution by changing how worker threads are started, which could affect any code relying on thread startup semantics. The change is small but impacts tracing/tenant context propagation across all `Task.execute_async` calls.
> 
> **Overview**
> **Fixes lost `ContextVar` state in async task execution.** `Task.execute_async()` now snapshots the current `contextvars` context and starts the background thread via `ctx.run(...)`, ensuring context-local values (e.g., tracing/tenant/session data) propagate into the worker thread.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06973d3b0ab71fbeedcc38e03db025266c90c54c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->