### PR TITLE
fix: escape single quotes in LanceDB delete() to prevent SQL injection

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -461,7 +461,8 @@ class LanceDBStorage:
                 if not to_delete:
                     return 0
                 before = self._table.count_rows()
-                ids_expr = ", ".join(f"'{rid}'" for rid in to_delete)
+                safe_ids = [str(rid).replace("'", "''") for rid in to_delete]
+                ids_expr = ", ".join(f"'{rid}'" for rid in safe_ids)
                 self._do_write("delete", f"id IN ({ids_expr})")
                 return before - self._table.count_rows()
             conditions = []

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -438,7 +438,8 @@ class LanceDBStorage:
         with self._write_lock, self._file_lock():
             if record_ids and not (categories or metadata_filter):
                 before = self._table.count_rows()
-                ids_expr = ", ".join(f"'{rid}'" for rid in record_ids)
+                safe_ids = [str(rid).replace("'", "''") for rid in record_ids]
+                ids_expr = ", ".join(f"'{rid}'" for rid in safe_ids)
                 self._do_write("delete", f"id IN ({ids_expr})")
                 return before - self._table.count_rows()
             if categories or metadata_filter:


### PR DESCRIPTION
In LanceDBStorage.delete(), the fast-path for record_ids directly interpolates IDs into the SQL expression without escaping single quotes. A record ID containing a single quote would break SQL syntax or allow injection. The touch_records() method already correctly escapes with replace("'", "''"). Apply the same escaping in delete(). Fixes #4850

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to escaping of record IDs in `LanceDBStorage.delete()` to prevent malformed queries/SQL injection; behavior should only differ for IDs containing single quotes.
> 
> **Overview**
> **Hardens LanceDB memory deletions against injection/syntax errors.** In `LanceDBStorage.delete()`, the `record_ids` fast-path and the category/metadata deletion path now escape single quotes in IDs (matching `touch_records()`/`update()`) before building the `id IN (...)` predicate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dcb6be1e16aafb3e2c47224d7faa06b331308a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->