### PR TITLE
fix: remove spurious repair_json call in _validate_tool_input that could skip Attempt 3

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -882,8 +882,7 @@ class ToolUsage:
             if isinstance(arguments, dict):
                 return arguments
         except (ValueError, SyntaxError):
-            repaired_input = repair_json(tool_input)
-            # Continue to the next parsing attempt
+            pass  # Continue to the next parsing attempt
 
         # Attempt 3: Parse as JSON5
         try:


### PR DESCRIPTION
In _validate_tool_input(), Attempt 2 (ast.literal_eval) has an except branch that calls repair_json(tool_input). This variable is never read before Attempt 4 reassigns it, making it dead code. Worse, if repair_json itself raises, Attempt 3 (json5) is skipped entirely. Replace with pass. Fixes #4851

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small control-flow change limited to tool argument parsing; it mainly prevents an unnecessary `repair_json` invocation from skipping the JSON5 parse path if it raised.
> 
> **Overview**
> **Fixes tool input parsing control flow.** In `ToolUsage._validate_tool_input`, the `ast.literal_eval` failure path no longer calls `repair_json` (dead code), so failures proceed cleanly to the JSON5 parse attempt before the final JSON repair step.
> 
> This avoids `repair_json` exceptions prematurely bypassing Attempt 3 and makes parsing behavior more predictable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb62b7ca3987c5327442bbbb3427e9903d47e7a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->