### PR TITLE
docs: update changelog and version for v1.10.2rc1

### DIFF
--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,30 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Mar 13, 2026">
+  ## v1.10.2rc1
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc1)
+
+  ## What's Changed
+
+  ### Features
+  - Add release command and trigger PyPI publish
+
+  ### Bug Fixes
+  - Fix cross-process and thread-safe locking to unprotected I/O
+  - Propagate contextvars across all thread and executor boundaries
+  - Propagate ContextVars into async task threads
+
+  ### Documentation
+  - Update changelog and version for v1.10.2a1
+
+  ## Contributors
+
+  @danglies007, @greysonlalonde
+
+</Update>
+
 <Update label="Mar 11, 2026">
   ## v1.10.2a1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,30 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 3월 13일">
+  ## v1.10.2rc1
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc1)
+
+  ## 변경 사항
+
+  ### 기능
+  - 릴리스 명령 추가 및 PyPI 게시 트리거
+
+  ### 버그 수정
+  - 보호되지 않은 I/O에 대한 프로세스 간 및 스레드 안전 잠금 수정
+  - 모든 스레드 및 실행기 경계를 넘는 contextvars 전파
+  - async 작업 스레드로 ContextVars 전파
+
+  ### 문서
+  - v1.10.2a1에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @danglies007, @greysonlalonde
+
+</Update>
+
 <Update label="2026년 3월 11일">
   ## v1.10.2a1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,30 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="13 mar 2026">
+  ## v1.10.2rc1
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc1)
+
+  ## O que Mudou
+
+  ### Funcionalidades
+  - Adicionar comando de lançamento e acionar publicação no PyPI
+
+  ### Correções de Bugs
+  - Corrigir bloqueio seguro entre processos e threads para I/O não protegido
+  - Propagar contextvars através de todos os limites de thread e executor
+  - Propagar ContextVars para threads de tarefas assíncronas
+
+  ### Documentação
+  - Atualizar changelog e versão para v1.10.2a1
+
+  ## Contribuidores
+
+  @danglies007, @greysonlalonde
+
+</Update>
+
 <Update label="11 mar 2026">
   ## v1.10.2a1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating localized changelogs; no runtime behavior or dependencies are modified.
> 
> **Overview**
> Adds a new `v1.10.2rc1` section dated Mar 13, 2026 to the localized changelogs (`docs/en`, `docs/ko`, `docs/pt-BR`), including the GitHub release link, summarized features/bug fixes/docs notes, and contributor credits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37f92bf7efe5ee83624ce913ec7fd6af5e4fd867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->