### PR TITLE
fix: correct Bedrock tool call argument extraction field name

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

Fixes #4748

- **Bug**: In `crew_agent_executor.py` line 850, `func_info.get("arguments", "{}")` returns the truthy string `"{}"` when the key is absent, preventing the `or` operator from ever falling through to Bedrock's `input` field. This causes all AWS Bedrock tool calls to receive empty arguments `{}`.
- **Fix**: Use `func_info.get("arguments")` (returning `None` when absent) so the `or` correctly falls through to `tool_call.get("input")`. This matches the already-correct pattern in `agent_utils.py` line 1157.

## Change

```diff
- func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+ func_args = func_info.get("arguments") or tool_call.get("input") or {}
```

## Why this works

- When `tool_call` is an OpenAI-format dict with `function.arguments`, `func_info.get("arguments")` returns the arguments (truthy), so it is used directly.
- When `tool_call` is a Bedrock-format dict with `input`, `func_info.get("arguments")` returns `None` (falsy), so the `or` falls through to `tool_call.get("input")` which returns the Bedrock arguments.
- The trailing `or {}` provides a safe empty-dict default if neither field is present.

## Test plan

- [ ] Verify existing OpenAI-format tool calls still work (arguments extracted from `function.arguments`)
- [ ] Verify Bedrock-format tool calls now correctly extract arguments from `input` field
- [ ] Run existing test suite: `pytest lib/crewai/tests/agents/test_native_tool_calling.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, one-line change in native tool-call parsing to fix argument extraction for Bedrock-formatted tool calls; limited to how tool call payloads are interpreted.
> 
> **Overview**
> Fixes native tool-call argument extraction in `CrewAgentExecutor._parse_native_tool_call` by removing the default `"{}"` fallback for `function.arguments`, allowing the logic to correctly fall through to Bedrock’s `input` field (and finally `{}`) when `arguments` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13486723ecc0386f5ba87f93eda2ccc7d64311cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->