### PR TITLE
fix: prevent custom tools from being discarded when output_pydantic is set

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1150,7 +1150,11 @@ class LLM(BaseLLM):
             str: The response text
         """
         # --- 1) Handle response_model with InternalInstructor for LiteLLM
-        if response_model and self.is_litellm:
+        # Only use InternalInstructor when there are no tools to call.
+        # When tools are present, we must go through the normal litellm.completion
+        # path so that both tools and response_model are sent together, allowing
+        # the LLM to call tools before returning structured output. (fixes #4697)
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])
@@ -1290,7 +1294,10 @@ class LLM(BaseLLM):
         Returns:
             str: The response text
         """
-        if response_model and self.is_litellm:
+        # Only use InternalInstructor when there are no tools to call.
+        # When tools are present, we must go through the normal litellm.completion
+        # path so that both tools and response_model are sent together. (fixes #4697)
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])


### PR DESCRIPTION
## Summary

Fixes #4697

When `supports_function_calling()` returns `True` and `output_pydantic` is set on a task, the agent's custom tools are silently discarded. The LLM only sees the `output_pydantic` schema as a tool and is forced to return structured output immediately without calling any of the agent's actual tools.

**Root cause:** In `_handle_non_streaming_response` and `_ahandle_non_streaming_response` (in `llm.py`), when `response_model` and `self.is_litellm` are both truthy, the method short-circuits into `InternalInstructor` which creates a **separate** `litellm.completion` call containing only the `response_model` -- completely ignoring the `tools` that were already prepared in `params`.

**Fix:** Add a `not params.get("tools")` guard to the `InternalInstructor` short-circuit path. When tools are present in `params`, the code falls through to the normal `litellm.completion(**params)` path which correctly passes both `tools` and `response_model` together, allowing the LLM to call tools before returning structured output.

### Changes

- `lib/crewai/src/crewai/llm.py`:
  - `_handle_non_streaming_response`: Changed condition from `if response_model and self.is_litellm` to `if response_model and self.is_litellm and not params.get("tools")`
  - `_ahandle_non_streaming_response`: Same fix applied

## Test plan

- [ ] Verify agent with custom tools + `output_pydantic` sends both tool specs and response model to the LLM
- [ ] Verify agent with `output_pydantic` but no tools still uses the `InternalInstructor` path (no regression)
- [ ] Verify streaming path behavior is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LiteLLM non-streaming (sync/async) response handling to avoid bypassing tool-calling when `response_model` is set, which could subtly affect structured-output behavior for tasks relying on `InternalInstructor`. Scope is small but touches core LLM execution flow.
> 
> **Overview**
> Fixes LiteLLM non-streaming calls so `response_model` no longer short-circuits into `InternalInstructor` when `params` includes `tools`, ensuring both *tools* and *structured output* configuration are sent in the same `litellm.completion`/`acompletion` request (addresses #4697).
> 
> The `InternalInstructor` path is now only used when `response_model` is set **and** no tools are present, applied consistently in `_handle_non_streaming_response` and `_ahandle_non_streaming_response`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4ab69b73415b631c45cc23a3e93833b84d199ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->