### PR TITLE
fix: Bedrock tool calls return empty arguments due to truthy default

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 
@@ -895,9 +895,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             ToolUsageStartedEvent,
         )
 
-        args_dict, parse_error = parse_tool_call_args(
-            func_args, func_name, call_id, original_tool
-        )
+        args_dict, parse_error = parse_tool_call_args(func_args, func_name, call_id, original_tool)
         if parse_error is not None:
             return parse_error
 


### PR DESCRIPTION
## Summary

Fixes #4748

AWS Bedrock tool calls always receive empty arguments `{}` because `_extract_tool_call_info_from_dict` in `crew_agent_executor.py` uses a truthy default that prevents fallthrough to Bedrock's `input` field.

**Bug:** `func_info.get("arguments", "{}")` returns the string `"{}"` (truthy) when the key is absent, so the `or` operator never evaluates `tool_call.get("input", {})`.

**Fix:** Changed to `func_info.get("arguments") or tool_call.get("input") or {}` — using `None` as the default sentinel so the `or` fallthrough works correctly. This matches the pattern already used in `agent_utils.py:extract_tool_call_info` (line 1157).

### Before (broken)
```python
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
#                                      ^^^^
# Returns truthy string "{}" — or never reaches Bedrock input field
```

### After (fixed)
```python
func_args = func_info.get("arguments") or tool_call.get("input") or {}
#           Returns None when absent — or correctly falls through to input
```

**Reference:** [AWS Bedrock ToolUseBlock API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html) — tool arguments are in the `input` field, not `function.arguments`.

## Test plan

- [ ] Verify Bedrock tool calls with `input` field now receive correct arguments
- [ ] Verify OpenAI tool calls with `function.arguments` still work correctly
- [ ] Verify edge case: tool call with neither `arguments` nor `input` defaults to `{}`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, targeted bug fix in native tool-call parsing that only affects how tool arguments are extracted for dict-style (e.g., Bedrock) tool calls.
> 
> **Overview**
> Fixes native tool-call argument extraction for dict-based tool calls (notably AWS Bedrock) by no longer defaulting missing `function.arguments` to the truthy string `"{}"`, allowing fallback to the provider’s `input` field and finally to `{}`.
> 
> Also applies a small formatting change to the `parse_tool_call_args` invocation with no functional impact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f64b3846cadb3df7dbb32292898ef6929fd7bbf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->