### PR TITLE
fix(tools): force LF line endings in generate_tool_specs.py

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,8 +180,9 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
+            f.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Pass `newline="\n"` to `open()` in `save_to_json()` so the generated `tool.specs.json` always uses LF line endings, regardless of platform
- Add a trailing newline to the JSON output for POSIX convention

## Problem

On Windows, `open()` in text mode writes `\r\n` (CRLF) line endings. This causes `generate_tool_specs.py` to produce a `tool.specs.json` with CRLF, making every line appear modified in `git diff` even when the content hasn't changed.

## Fix

A one-line change: add `newline="\n"` to the `open()` call in `ToolSpecExtractor.save_to_json()`. This forces LF line endings on all platforms.

Fixes #4737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how `tool.specs.json` is written (line endings and trailing newline) without affecting the schema/content generation logic.
> 
> **Overview**
> Ensures `ToolSpecExtractor.save_to_json()` writes `tool.specs.json` with consistent **LF** line endings on all platforms by opening the file with `newline="\n"`.
> 
> Also appends a trailing newline after `json.dump(...)` to follow POSIX conventions and reduce noisy diffs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 602e4fdb30206212d501b62ff03776ffdc09f833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->