### PR TITLE
perf(crewai-tools): set a timeout on generate crewai automation tool HTTP calls

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/generate_crewai_automation_tool/generate_crewai_automation_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/generate_crewai_automation_tool/generate_crewai_automation_tool.py
@@ -52,6 +52,7 @@ class GenerateCrewaiAutomationTool(BaseTool):
             f"{self.crewai_enterprise_url}/crewai_plus/api/v1/studio",
             headers=self._get_headers(input_data.organization_id),
             json={"prompt": input_data.prompt},
+            timeout=10.0,
         )
 
         response.raise_for_status()


### PR DESCRIPTION
Add a timeout parameter to the HTTP request in generate_crewai_automation_tool.py to avoid indefinite hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile lib/crewai-tools/src/crewai_tools/tools/generate_crewai_automation_tool/generate_crewai_automation_tool.py`.

Context: py-http-timeout at lib/crewai-tools/src/crewai_tools/tools/generate_crewai_automation_tool/generate_crewai_automation_tool.py:51.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `timeout=10.0` to a single `requests.post` call to prevent indefinite hangs; main behavior change is that slow/unresponsive requests will now fail after 10 seconds.
> 
> **Overview**
> Adds a 10-second timeout to the `requests.post` call in `GenerateCrewaiAutomationTool._run` when creating a CrewAI Studio project, preventing workers from hanging indefinitely on stalled network requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2c81d68d9cff559759bba399906dae588c8d590. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->