### PR TITLE
fix: Bedrock tool calls extract empty arguments due to truthy default

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 
@@ -895,9 +895,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             ToolUsageStartedEvent,
         )
 
-        args_dict, parse_error = parse_tool_call_args(
-            func_args, func_name, call_id, original_tool
-        )
+        args_dict, parse_error = parse_tool_call_args(func_args, func_name, call_id, original_tool)
         if parse_error is not None:
             return parse_error
 


### PR DESCRIPTION
## Summary

- Fixes AWS Bedrock tool calls always receiving empty arguments `{}` regardless of what the LLM provides
- Root cause: `func_info.get("arguments", "{}")` returns the truthy string `"{}"` when the key is absent, preventing the `or` operator from falling through to Bedrock's `input` field
- Fix: remove the default value so `.get("arguments")` returns `None` (falsy), allowing correct fallthrough to `tool_call.get("input", {})`

Fixes #4748

## Test plan

- [ ] Verify OpenAI-format tool calls still work (arguments in `function.arguments`)
- [ ] Verify Bedrock-format tool calls now receive correct arguments (arguments in `input`)
- [ ] Verify edge case where both `arguments` and `input` are absent returns `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly changes argument extraction for dict-based native tool calls so Bedrock-style `input` is used when `function.arguments` is absent; could only affect edge cases where callers relied on the previous incorrect empty-args behavior.
> 
> **Overview**
> Fixes dict-based native tool call parsing to **no longer default missing `function.arguments` to the truthy string `"{}"`**, allowing proper fallback to Bedrock-style `input` so tools receive the LLM-provided arguments.
> 
> Also includes a minor formatting-only change to the `parse_tool_call_args(...)` invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d997b6320f84d59d5e79836013160455ae18a2b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->