### PR TITLE
fix: guard output_pydantic injection when LLM lacks function calling

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -314,6 +314,18 @@ class Agent(BaseAgent):
             and len(tools) > 0
         )
 
+    def _llm_supports_function_calling(self) -> bool:
+        """Check if the LLM supports native function calling.
+
+        Returns:
+            True if the LLM supports function calling.
+        """
+        return (
+            hasattr(self.llm, "supports_function_calling")
+            and callable(getattr(self.llm, "supports_function_calling", None))
+            and self.llm.supports_function_calling()
+        )
+
     def execute_task(
         self,
         task: Task,
@@ -850,7 +862,13 @@ class Agent(BaseAgent):
                 request_within_rpm_limit=rpm_limit_fn,
                 callbacks=[TokenCalcHandler(self._token_process)],
                 response_model=(
-                    task.response_model or task.output_pydantic or task.output_json
+                    task.response_model
+                    or (
+                        (task.output_pydantic or task.output_json)
+                        if use_native_tool_calling
+                        or self._llm_supports_function_calling()
+                        else None
+                    )
                 )
                 if task
                 else None,
@@ -883,7 +901,14 @@ class Agent(BaseAgent):
         self.agent_executor.tools_names = get_tool_names(tools)
         self.agent_executor.tools_description = render_text_description_and_args(tools)
         self.agent_executor.response_model = (
-            (task.response_model or task.output_pydantic or task.output_json)
+            (
+                task.response_model
+                or (
+                    (task.output_pydantic or task.output_json)
+                    if self._llm_supports_function_calling()
+                    else None
+                )
+            )
             if task
             else None
         )


### PR DESCRIPTION
## Summary

Fixes #4695

When a Task has `output_pydantic` set and the LLM does not support function calling (e.g., Ollama models via LiteLLM), the pydantic schema is incorrectly injected as a native tool via `response_model`. This forces the LLM to produce structured output immediately via `tool_choice` without first gathering data through the agent's tools, resulting in empty/placeholder values.

### Changes

- Added `_llm_supports_function_calling()` helper method on `Agent` to check LLM function calling support without requiring a tools list
- Modified `create_agent_executor()` to only pass `output_pydantic`/`output_json` as `response_model` when the LLM supports function calling
- Modified `_update_executor_parameters()` with the same guard
- `task.response_model` (explicit user override) is always respected regardless of function calling support

### How it works

When `supports_function_calling()` returns `False`:
- `response_model` is set to `None` (unless `task.response_model` is explicitly set)
- The agent uses the ReAct loop (Action/Action Input/Observation) to gather data with tools
- After execution, the existing text-based conversion path in `converter.py` handles converting the result to the pydantic model

When `supports_function_calling()` returns `True`:
- Behavior is unchanged -- `output_pydantic`/`output_json` is passed as `response_model`

## Test plan

- [ ] Run with an Ollama model (no function calling) + `output_pydantic` task + agent tools -- verify the agent uses ReAct loop and tools before producing structured output
- [ ] Run with an OpenAI model (function calling supported) + `output_pydantic` -- verify existing behavior is unchanged
- [ ] Verify `task.response_model` is always passed through regardless of function calling support
- [ ] Run existing test suite to ensure no regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `response_model` is set for task execution, which can alter structured-output and tool-calling behavior across LLM providers. Risk is moderate because it affects agent executor configuration but is narrowly scoped to guarding schema injection based on function-calling support.
> 
> **Overview**
> Prevents `Task.output_pydantic`/`output_json` from being passed as `response_model` when the underlying LLM does **not** support native function calling, avoiding forced structured output that can bypass tool usage.
> 
> Adds an `Agent._llm_supports_function_calling()` helper and updates both `create_agent_executor()` and `_update_executor_parameters()` to only set `response_model` from `output_pydantic`/`output_json` when function calling is supported (while always honoring an explicit `task.response_model`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca3977af332ede2549eb363765eb9604986566b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->