### PR TITLE
docs: update changelog and version for v1.10.2rc2

### DIFF
--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,25 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Mar 14, 2026">
+  ## v1.10.2rc2
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc2)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Remove exclusive locks from read-only storage operations
+
+  ### Documentation
+  - Update changelog and version for v1.10.2rc1
+
+  ## Contributors
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="Mar 13, 2026">
   ## v1.10.2rc1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,25 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 3월 14일">
+  ## v1.10.2rc2
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc2)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - 읽기 전용 스토리지 작업에서 독점 잠금 제거
+
+  ### 문서
+  - v1.10.2rc1에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="2026년 3월 13일">
   ## v1.10.2rc1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,25 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="14 mar 2026">
+  ## v1.10.2rc2
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.10.2rc2)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Remover bloqueios exclusivos de operações de armazenamento somente leitura
+
+  ### Documentação
+  - Atualizar changelog e versão para v1.10.2rc1
+
+  ## Contribuidores
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="13 mar 2026">
   ## v1.10.2rc1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding new release notes across multiple locales; no runtime code is modified.
> 
> **Overview**
> Adds a new `v1.10.2rc2` release entry to the changelog pages in English, Korean, and Portuguese (Brazil), including the GitHub release link, summarized bullet points (notably the read-only storage lock fix), and contributor attribution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a40ff74d7e89f998c60c9b5351c26edc772b32e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->