### PR TITLE
Fix telemetry crash when crew.memory is a Memory instance

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -279,7 +279,11 @@ class Telemetry:
             self._add_attribute(span, "python_version", platform.python_version())
             add_crew_attributes(span, crew, self._add_attribute)
             self._add_attribute(span, "crew_process", crew.process)
-            self._add_attribute(span, "crew_memory", crew.memory)
+            self._add_attribute(
+                span,
+                "crew_memory",
+                crew.memory if isinstance(crew.memory, bool) else bool(crew.memory),
+            )
             self._add_attribute(span, "crew_number_of_tasks", len(crew.tasks))
             self._add_attribute(span, "crew_number_of_agents", len(crew.agents))
 


### PR DESCRIPTION
## Summary

Fixes #4703

When `crew.memory` is set to a `Memory` instance (e.g., with a custom LanceDB storage backend) instead of a plain boolean, the telemetry module crashes with:

```
Invalid type Memory for attribute 'crew_memory' value.
Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This happens because `span.set_attribute()` in OpenTelemetry only accepts primitive types, and the `Memory` object is passed directly.

## Fix

In `crew_creation()`, the `crew_memory` attribute is now coerced to `bool` when it is not already a boolean. This preserves the original `True`/`False` value for standard usage, while converting `Memory` instances to `True` (since a non-None Memory object is truthy and indicates memory is enabled).

**Before:**
```python
self._add_attribute(span, "crew_memory", crew.memory)
```

**After:**
```python
self._add_attribute(
    span,
    "crew_memory",
    crew.memory if isinstance(crew.memory, bool) else bool(crew.memory),
)
```

## Test plan

- [ ] Pass `memory=True` — telemetry records `crew_memory=True` (unchanged behavior)
- [ ] Pass `memory=False` — telemetry records `crew_memory=False` (unchanged behavior)
- [ ] Pass `memory=Memory(storage=LanceDBStorage(...))` — telemetry records `crew_memory=True` instead of crashing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small telemetry-only change that coerces `crew.memory` to a primitive `bool` to satisfy OpenTelemetry attribute type requirements and avoid runtime crashes.
> 
> **Overview**
> Prevents telemetry from crashing when `crew.memory` is a non-boolean (e.g., a `Memory` instance) by coercing the `crew_memory` span attribute to a `bool` in `Telemetry.crew_creation()` while preserving existing `True`/`False` behavior for boolean inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d52284010d153d13e6d3ded14676d8d64ec5a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->