### PR TITLE
fix: ignore extra inputs on MCP tool args schema

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/adapters/mcp_adapter.py
+++ b/lib/crewai-tools/src/crewai_tools/adapters/mcp_adapter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from crewai.tools import BaseTool
 from crewai.utilities.pydantic_schema_utils import create_model_from_schema
 from crewai.utilities.string_utils import sanitize_tool_name
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from crewai_tools.adapters.tool_collection import ToolCollection
 
@@ -51,7 +51,10 @@ try:
             """
             tool_name = sanitize_tool_name(mcp_tool.name)
             tool_description = mcp_tool.description or ""
-            args_model = create_model_from_schema(mcp_tool.inputSchema)
+            args_model = create_model_from_schema(
+                mcp_tool.inputSchema,
+                __config__=ConfigDict(extra="ignore"),
+            )
 
             class CrewAIMCPTool(BaseTool):
                 name: str = tool_name


### PR DESCRIPTION
## Summary

Fixes #4796

MCP tools fail with `Extra inputs are not permitted` because CrewAI's tool execution framework injects a `security_context` parameter into tool call arguments, but the dynamically created Pydantic args model uses `extra='forbid'` (the default from `create_model_from_schema`), causing validation to reject the unknown field.

## Changes

- **`lib/crewai-tools/src/crewai_tools/adapters/mcp_adapter.py`**: Pass `__config__=ConfigDict(extra='ignore')` to `create_model_from_schema()` so that internally-added fields like `security_context` are silently discarded instead of raising a validation error.
- Added `ConfigDict` to the pydantic import.

## Root cause

`create_model_from_schema()` defaults to `ConfigDict(extra="forbid")`. When CrewAI injects `security_context` (containing `agent_fingerprint` and `metadata`) during parameter validation — before `_run` is called — the strict schema rejects it.

## Test plan

- [x] Verified that `create_model_from_schema` accepts `__config__` as an override parameter
- [ ] MCP tool calls with `security_context` injection no longer raise `extra_forbidden` validation errors
- [ ] MCP tools still correctly validate their declared input parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Loosens Pydantic validation for MCP-adapted tool inputs by ignoring unknown fields, which could mask unexpected/typoed parameters but is scoped to the MCP adapter path.
> 
> **Overview**
> Prevents MCP tool calls from failing validation when CrewAI injects internal arguments by creating the MCP tool `args_schema` with `ConfigDict(extra="ignore")`.
> 
> This updates `mcp_adapter.py` to pass a custom Pydantic config into `create_model_from_schema` (and imports `ConfigDict`), so extra fields like `security_context` are silently dropped instead of raising `extra_forbidden` errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c7ab51ad308cb98cf35e85aa09c347f9b7f7fcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->