### PR TITLE
fix(llm): prioritize tool calls over text when available_functions is None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,16 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls.
+        # This must be checked before the text-return path so that tool calls
+        # are not silently discarded when the LLM also produces a text response
+        # (e.g. Claude models often return explanatory text alongside tool calls).
+        # See: https://github.com/crewAIInc/crewAI/issues/4788
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If there are no tool calls, return the text response
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1252,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1364,7 +1367,15 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If there are tool calls but no available functions, return the tool calls.
+        # This must be checked before the text-return path so that tool calls
+        # are not silently discarded when the LLM also produces a text response.
+        # See: https://github.com/crewAIInc/crewAI/issues/4788
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # If there are no tool calls, return the text response
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1373,11 +1384,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
## Summary

Fixes #4788 — Native tool calls are silently discarded when the LLM returns both text content and tool calls, and `available_functions` is `None`.

**Root cause:** In `_handle_non_streaming_response` (and its async counterpart), the check at step 5 used `(not tool_calls or not available_functions) and text_response`, which matched when `available_functions=None` even if `tool_calls` were present — returning the text response and discarding the tool calls.

**Fix:** Reorder the conditional checks so that the "tool calls without available_functions" path is evaluated **before** the text-return path. The condition for returning text is also tightened from `(not tool_calls or not available_functions)` to just `not tool_calls`, making the logic clearer and eliminating the ambiguity.

Both sync (`_handle_non_streaming_response`) and async (`_ahandle_non_streaming_response`) code paths are fixed.

## Changes

- **`lib/crewai/src/crewai/llm.py`**: Swap steps 5 and 6 in both sync and async response handlers so tool calls take precedence over text responses when `available_functions` is `None`.

## How it was before (buggy)

```python
# Step 5 — matches when tool_calls exist but available_functions is None, discarding tool calls
if (not tool_calls or not available_functions) and text_response:
    return text_response  # BUG: tool calls lost

# Step 6 — never reached in the buggy scenario
if tool_calls and not available_functions:
    return tool_calls
```

## How it is now (fixed)

```python
# Step 5 — tool calls without available_functions: return them for external execution
if tool_calls and not available_functions:
    return tool_calls

# Step 6 — no tool calls: return text
if not tool_calls and text_response:
    return text_response
```

## Test plan

- [ ] Verify with an LLM that returns both text + tool calls (e.g. Claude via OpenRouter) that tool calls are properly returned and executed
- [ ] Verify that pure text responses (no tool calls) still work correctly
- [ ] Verify that tool calls with `available_functions` provided still execute normally
- [ ] Run existing test suite: `pytest lib/crewai/tests/`

> **Note:** PR #4806 addresses the same issue. This PR takes a minimal approach — it reorders the checks without adding emit-call-event side effects to the tool-call return path, keeping the behavior change focused on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM response handling to return `tool_calls` instead of text when tool calls are present but `available_functions` is missing, which can change return types for some callers.
> 
> **Overview**
> Fixes non-streaming LLM response handling so native `tool_calls` are no longer dropped when the model returns both text and tool calls but `available_functions` is `None`.
> 
> In both `_handle_non_streaming_response` and `_ahandle_non_streaming_response`, the conditional order is swapped and the text-return condition is tightened to `not tool_calls`, ensuring tool calls are returned for external execution before falling back to the text response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d97a9bfcf9e4d8a2da6312c9ce56721d467bc591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->