### PR TITLE
Use defusedxml in XMLLoader to block entity expansion

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests~=2.32.5",
     "docker~=7.1.0",
     "crewai==1.10.2rc2",
+    "defusedxml>=0.7.1,<0.8",
     "tiktoken~=0.8.0",
     "beautifulsoup4~=4.13.4",
     "python-docx~=1.2.0",

--- a/lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py
@@ -1,5 +1,7 @@
 from typing import Any
-from xml.etree.ElementTree import ParseError, fromstring, parse
+
+from defusedxml.ElementTree import ParseError, fromstring, parse
+from defusedxml.common import DefusedXmlException
 
 from crewai_tools.rag.base_loader import BaseLoader, LoaderResult
 from crewai_tools.rag.loaders.utils import load_from_url
@@ -40,9 +42,9 @@ class XMLLoader(BaseLoader):
     def _parse_xml(self, content: str, source_ref: str) -> LoaderResult:
         try:
             if content.strip().startswith("<"):
-                root = fromstring(content)  # noqa: S314
+                root = fromstring(content)
             else:
-                root = parse(source_ref).getroot()  # noqa: S314
+                root = parse(source_ref).getroot()
 
             text_parts = []
             for text_content in root.itertext():
@@ -51,7 +53,7 @@ class XMLLoader(BaseLoader):
 
             text = "\n".join(text_parts)
             metadata = {"format": "xml", "root_tag": root.tag}
-        except ParseError as e:
+        except (DefusedXmlException, ParseError) as e:
             text = content
             metadata = {"format": "xml", "parse_error": str(e)}
 

--- a/lib/crewai-tools/tests/rag/test_xml_loader_security.py
+++ b/lib/crewai-tools/tests/rag/test_xml_loader_security.py
@@ -1,0 +1,14 @@
+from crewai_tools.rag.loaders.xml_loader import XMLLoader
+from crewai_tools.rag.source_content import SourceContent
+
+
+class TestXMLLoaderSecurity:
+    def test_rejects_internal_entities(self):
+        xml_with_entity = """<!DOCTYPE foo [<!ENTITY xxe "EXPANDED">]>
+<root>&xxe;</root>"""
+
+        result = XMLLoader().load(SourceContent(xml_with_entity))
+
+        assert result.metadata["format"] == "xml"
+        assert "parse_error" in result.metadata
+        assert result.content == xml_with_entity

--- a/uv.lock
+++ b/uv.lock
@@ -1286,6 +1286,7 @@ source = { editable = "lib/crewai-tools" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "crewai" },
+    { name = "defusedxml" },
     { name = "docker" },
     { name = "pymupdf" },
     { name = "python-docx" },
@@ -1423,6 +1424,7 @@ requires-dist = [
     { name = "crewai", editable = "lib/crewai" },
     { name = "cryptography", marker = "extra == 'snowflake'", specifier = ">=43.0.3" },
     { name = "databricks-sdk", marker = "extra == 'databricks-sdk'", specifier = ">=0.46.0" },
+    { name = "defusedxml", specifier = ">=0.7.1,<0.8" },
     { name = "docker", specifier = "~=7.1.0" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },


### PR DESCRIPTION
## Summary
This changes `XMLLoader` to use `defusedxml` instead of the standard library XML parser so entity expansion is rejected by default.

## Problem
The current implementation uses `xml.etree.ElementTree`, which expands internal entities. A malicious XML payload such as `<!DOCTYPE foo [<!ENTITY xxe "EXPANDED">]><root>&xxe;</root>` is therefore parsed into normal output instead of being rejected.

That means the loader does not currently fail closed for unsafe XML input, which is exactly the class of issue called out in #4865.

## Root Cause
`XMLLoader` relied on the standard parser and only handled `ParseError`. Once the parser was switched to `defusedxml`, dangerous entity payloads raised `DefusedXmlException`, which also needed to be handled by the loader's existing parse-error fallback path.

## Fix
- add `defusedxml` as a `crewai-tools` dependency
- switch `XMLLoader` to `defusedxml.ElementTree`
- catch `DefusedXmlException` alongside `ParseError`
- add a regression test that verifies internal entities are rejected instead of expanded

## Validation
- `uv run pytest lib/crewai-tools/tests/rag/test_xml_loader_security.py -q`
- `uv run ruff check lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py lib/crewai-tools/tests/rag/test_xml_loader_security.py`

Closes #4865.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes XML parsing behavior by switching to `defusedxml`, which may reject previously-accepted XML (e.g., documents with DTD/entity declarations) but is scoped to the RAG XML loader and improves security against XXE/entity expansion.
> 
> **Overview**
> **Hardens XML ingestion in RAG.** `XMLLoader` now uses `defusedxml.ElementTree` instead of the stdlib parser and treats `DefusedXmlException` the same as `ParseError`, falling back to returning the raw content with `parse_error` metadata.
> 
> Adds `defusedxml` as a `crewai-tools` dependency (and updates `uv.lock`) and includes a regression test ensuring internal entity declarations are rejected rather than expanded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7880b36fe9a7c421a0c8319cf0cfa771ac3981c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->