### PR TITLE
fix: prioritize tool_calls over text when available_functions is None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,7 +1234,12 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls or no available functions, return the text response directly as long as there is a text response
         if (not tool_calls or not available_functions) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
@@ -1244,11 +1249,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1364,6 +1364,11 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution
+        if tool_calls and not available_functions:
+            return tool_calls
+
         if (not tool_calls or not available_functions) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
@@ -1373,11 +1378,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from time import sleep
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from crewai.agents.agent_builder.utilities.base_token_process import TokenProcess
 from crewai.events.event_types import (
@@ -413,6 +413,67 @@ def test_context_window_exceeded_error_handling():
 
         assert "context length exceeded" in str(excinfo.value).lower()
         assert "8192 tokens" in str(excinfo.value)
+
+
+def test_non_streaming_returns_tool_calls_when_text_and_tool_calls_exist_without_available_functions():
+    llm = LLM(model="gpt-4", is_litellm=True)
+    messages = [{"role": "user", "content": "Calculate 1+1"}]
+    tool_calls = [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression": "1+1"}',
+            },
+        }
+    ]
+
+    with patch("litellm.completion") as mock_completion:
+        mock_message = MagicMock()
+        mock_message.content = "I'll use a tool."
+        mock_message.tool_calls = tool_calls
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+        mock_completion.return_value = mock_response
+
+        result = llm.call(messages, available_functions=None)
+
+    assert result == tool_calls
+
+
+@pytest.mark.asyncio
+async def test_async_non_streaming_returns_tool_calls_when_text_and_tool_calls_exist_without_available_functions():
+    llm = LLM(model="gpt-4", is_litellm=True)
+    messages = [{"role": "user", "content": "Calculate 1+1"}]
+    tool_calls = [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression": "1+1"}',
+            },
+        }
+    ]
+
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_message = MagicMock()
+        mock_message.content = "I'll use a tool."
+        mock_message.tool_calls = tool_calls
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+        mock_acompletion.return_value = mock_response
+
+        result = await llm.acall(messages, available_functions=None)
+
+    assert result == tool_calls
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #4788

## Problem
When LLM returns both text and tool_calls simultaneously, and executor passes available_functions=None to get_llm_response, the current logic returns text instead of tool_calls. This causes native tool calls to be discarded.

## Root Cause
In llm.py, the branch order was:
1. If (no tool_calls OR no available_functions) AND text_response → return text
2. If tool_calls AND no available_functions → return tool_calls

When both text and tool_calls exist with available_functions=None, branch 1 fires first, and branch 2 is never reached.

## Fix
Reorder to prioritize tool_calls:
1. If tool_calls AND no available_functions → return tool_calls  
2. If (no tool_calls OR no available_functions) AND text_response → return text

## Changes
- lib/crewai/src/crewai/llm.py: Reorder return logic in both sync and async paths
- tests/test_llm.py: Add regression tests for this exact scenario

## Testing
Added two unit tests:
- test_non_streaming_returns_tool_calls_when_text_and_tool_calls_exist_without_available_functions
- test_async_non_streaming_returns_tool_calls_when_text_and_tool_calls_exist_without_available_functions

Both verify that tool_calls are returned when available_functions=None, even when text content is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk logic reordering in LiteLLM non-streaming sync/async paths; behavior changes only when responses include both `content` and `tool_calls` and `available_functions` is `None`/empty.
> 
> **Overview**
> Fixes LiteLLM non-streaming response handling so that when an LLM returns both `content` and `tool_calls` and `available_functions` is not provided, the LLM returns the raw `tool_calls` instead of discarding them by returning text.
> 
> Adds sync and async regression tests (mocking `litellm.completion`/`litellm.acompletion`) to assert `LLM.call`/`LLM.acall` prefer `tool_calls` over text in this scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 684de7e6aaaa87ae1f0d4f91cb53082280e269f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->