### PR TITLE
feat(agentcore): enhance Browser & Code Interpreter toolkits with full session config, new tools, and telemetry

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -266,7 +266,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/agentcorecodeinterpretertool"
                         ]
                       },
                       {
@@ -284,6 +285,7 @@
                         "icon": "plug",
                         "pages": [
                           "en/tools/integration/overview",
+                          "en/tools/integration/agentcoreoverview",
                           "en/tools/integration/bedrockinvokeagenttool",
                           "en/tools/integration/crewaiautomationtool",
                           "en/tools/integration/mergeagenthandlertool"
@@ -297,7 +299,8 @@
                           "en/tools/automation/apifyactorstool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
-                          "en/tools/automation/zapieractionstool"
+                          "en/tools/automation/zapieractionstool",
+                          "en/tools/automation/agentcorebrowsertool"
                         ]
                       }
                     ]
@@ -725,7 +728,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/agentcorecodeinterpretertool"
                         ]
                       },
                       {
@@ -743,6 +747,7 @@
                         "icon": "plug",
                         "pages": [
                           "en/tools/integration/overview",
+                          "en/tools/integration/agentcoreoverview",
                           "en/tools/integration/bedrockinvokeagenttool",
                           "en/tools/integration/crewaiautomationtool",
                           "en/tools/integration/mergeagenthandlertool"
@@ -756,7 +761,8 @@
                           "en/tools/automation/apifyactorstool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
-                          "en/tools/automation/zapieractionstool"
+                          "en/tools/automation/zapieractionstool",
+                          "en/tools/automation/agentcorebrowsertool"
                         ]
                       }
                     ]
@@ -2111,7 +2117,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/agentcorecodeinterpretertool"
                         ]
                       },
                       {
@@ -2141,7 +2148,8 @@
                           "ko/tools/automation/apifyactorstool",
                           "ko/tools/automation/composiotool",
                           "ko/tools/automation/multiontool",
-                          "ko/tools/automation/zapieractionstool"
+                          "ko/tools/automation/zapieractionstool",
+                          "ko/tools/automation/agentcorebrowsertool"
                         ]
                       }
                     ]
@@ -2560,7 +2568,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/agentcorecodeinterpretertool"
                         ]
                       },
                       {
@@ -2590,7 +2599,8 @@
                           "ko/tools/automation/apifyactorstool",
                           "ko/tools/automation/composiotool",
                           "ko/tools/automation/multiontool",
-                          "ko/tools/automation/zapieractionstool"
+                          "ko/tools/automation/zapieractionstool",
+                          "ko/tools/automation/agentcorebrowsertool"
                         ]
                       }
                     ]

--- a/docs/en/tools/ai-ml/agentcorecodeinterpretertool.mdx
+++ b/docs/en/tools/ai-ml/agentcorecodeinterpretertool.mdx
@@ -1,0 +1,132 @@
+---
+title: AgentCore Code Interpreter
+description: AWS-managed secure code execution for CrewAI agents with Python, shell commands, and file operations in cloud sandboxes.
+icon: aws
+mode: "wide"
+---
+
+# `CodeInterpreterToolkit`
+
+## Description
+
+The `CodeInterpreterToolkit` from [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) provides AWS-managed code execution for CrewAI agents. Unlike the local Docker-based [`CodeInterpreterTool`](/en/tools/ai-ml/codeinterpretertool), AgentCore runs code in secure cloud sandboxes (MicroVMs) with no local Docker required. Use `CodeInterpreterTool` for quick local tasks when Docker is available; use AgentCore for longer sessions, no-Docker setups, or production workloads.
+
+Key features:
+- **No local Docker required** — code runs in AWS-managed cloud sandboxes
+- **Up to 8-hour sessions** — long-running computations without timeout concerns
+- **Full environment** — Python, shell commands, and file system operations
+- **Multi-agent isolation** — use `thread_id` to give each agent its own sandboxed environment
+
+## Installation
+
+```shell
+pip install 'crewai[tools]' 'crewai-tools[bedrock]'
+```
+
+**Prerequisites:**
+- AWS credentials configured (via environment variables, AWS CLI profile, or IAM role)
+- IAM permissions for `bedrock-agentcore:*`
+- An LLM configured for your agents (if using Amazon Bedrock models, pass `llm=LLM(model="bedrock/...", region_name="us-west-2")` to your Agent — see [LLM connections](/en/learn/llm-connections))
+
+## Example
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.code_interpreter import create_code_interpreter_toolkit
+
+# Create the code interpreter toolkit
+toolkit, code_tools = create_code_interpreter_toolkit(region="us-west-2")
+
+# Create an agent with code interpreter tools
+developer_agent = Agent(
+    role="Python Developer",
+    goal="Write and execute Python code to solve problems",
+    backstory="You're a skilled Python developer with expertise in data analysis.",
+    tools=code_tools,
+)
+
+# Create a task
+coding_task = Task(
+    description="Write a Python function that calculates the factorial of a number and test it with values 1 through 10.",
+    expected_output="The factorial values for numbers 1 through 10.",
+    agent=developer_agent,
+)
+
+# Run the crew
+crew = Crew(agents=[developer_agent], tasks=[coding_task])
+result = crew.kickoff()
+
+# Always clean up code interpreter sessions when done
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
+asyncio.run(toolkit.cleanup())
+```
+
+## Available Tools
+
+The toolkit provides nine code execution and file management tools:
+
+| Tool | Description |
+| :--- | :---------- |
+| `execute_code` | Execute code in various languages (primarily Python) |
+| `execute_command` | Run shell commands in the code interpreter environment |
+| `read_files` | Read content of files in the environment |
+| `list_files` | List files in directories in the environment |
+| `delete_files` | Remove files from the environment |
+| `write_files` | Create or update files in the environment |
+| `start_command_execution` | Start long-running commands asynchronously |
+| `get_task` | Check status of async tasks |
+| `stop_task` | Stop running tasks |
+
+## Arguments
+
+| Argument | Type | Description |
+| :------- | :--- | :---------- |
+| `region` | `str` | AWS region for the code interpreter service (default: `us-west-2`) |
+
+## Multi-Agent Usage
+
+Use `thread_id` to give each agent its own isolated code interpreter session. Each thread gets a separate sandbox with its own file system and execution context.
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.code_interpreter import create_code_interpreter_toolkit
+
+toolkit, code_tools = create_code_interpreter_toolkit(region="us-west-2")
+
+# Both agents share the toolkit but can use different thread_ids
+# to maintain separate sandbox environments
+data_agent = Agent(
+    role="Data Analyst",
+    goal="Analyze datasets and produce insights",
+    backstory="You specialize in data analysis with pandas and matplotlib.",
+    tools=code_tools,
+)
+
+test_agent = Agent(
+    role="Test Engineer",
+    goal="Write and run test suites",
+    backstory="You specialize in writing comprehensive test cases.",
+    tools=code_tools,
+)
+```
+
+## Cleanup
+
+Always clean up code interpreter sessions when your crew finishes to release cloud resources. Unlike the Browser toolkit, Code Interpreter cleanup is async-only. CrewAI may leave a running event loop after `crew.kickoff()`, so call `nest_asyncio.apply()` before using `asyncio.run()`.
+
+```python Code
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
+
+# From synchronous code (e.g., after crew.kickoff())
+asyncio.run(toolkit.cleanup())
+
+# From async code
+await toolkit.cleanup()
+
+# Clean up a specific thread's session only
+asyncio.run(toolkit.cleanup(thread_id="specific-thread"))
+```

--- a/docs/en/tools/ai-ml/overview.mdx
+++ b/docs/en/tools/ai-ml/overview.mdx
@@ -38,7 +38,9 @@ These tools integrate with AI and machine learning services to enhance your agen
     Execute Python code and perform data analysis.
   </Card>
 
-
+  <Card title="AgentCore Code Interpreter" icon="aws" href="/en/tools/ai-ml/agentcorecodeinterpretertool">
+    AWS-managed secure code execution in cloud sandboxes with up to 8-hour sessions.
+  </Card>
 </CardGroup>
 
 ## **Common Use Cases**

--- a/docs/en/tools/automation/agentcorebrowsertool.mdx
+++ b/docs/en/tools/automation/agentcorebrowsertool.mdx
@@ -1,0 +1,129 @@
+---
+title: AgentCore Browser
+description: AWS-managed browser automation for CrewAI agents with Playwright-based web interaction in secure cloud sandboxes.
+icon: aws
+mode: "wide"
+---
+
+# `BrowserToolkit`
+
+## Description
+
+The `BrowserToolkit` from [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) provides AWS-managed browser automation for CrewAI agents. Unlike local Docker-based solutions or third-party browser services, AgentCore runs Playwright-based browsers in secure cloud sandboxes with no local setup required.
+
+Key features:
+- **No local infrastructure** — no Docker, no browser installs, no Playwright setup
+- **Secure cloud sandboxes** — each browser session runs in an isolated AWS-managed environment
+- **Playwright-based** — full Playwright browser automation capabilities (navigation, clicking, text extraction)
+- **Multi-agent isolation** — use `thread_id` to give each agent its own independent browser session
+
+## Installation
+
+```shell
+pip install 'crewai[tools]' 'crewai-tools[bedrock]'
+```
+
+**Prerequisites:**
+- AWS credentials configured (via environment variables, AWS CLI profile, or IAM role)
+- IAM permissions for `bedrock-agentcore:*`
+- An LLM configured for your agents (if using Amazon Bedrock models, pass `llm=LLM(model="bedrock/...", region_name="us-west-2")` to your Agent — see [LLM connections](/en/learn/llm-connections))
+
+## Example
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.browser import create_browser_toolkit
+
+# Create the browser toolkit
+toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
+
+# Create an agent with browser tools
+research_agent = Agent(
+    role="Web Researcher",
+    goal="Research and summarize web content",
+    backstory="You're an expert at finding information online.",
+    tools=browser_tools,
+)
+
+# Create a task
+research_task = Task(
+    description="Navigate to https://example.com and extract all text content. Summarize the main points.",
+    expected_output="A summary of the main content on example.com.",
+    agent=research_agent,
+)
+
+# Run the crew
+crew = Crew(agents=[research_agent], tasks=[research_task])
+result = crew.kickoff()
+
+# Always clean up browser sessions when done
+toolkit.sync_cleanup()
+```
+
+## Available Tools
+
+The toolkit provides seven browser tools:
+
+| Tool | Description |
+| :--- | :---------- |
+| `navigate_browser` | Navigate a browser to the specified URL |
+| `click_element` | Click on an element with the given CSS selector |
+| `extract_text` | Extract all the text on the current webpage |
+| `extract_hyperlinks` | Extract all hyperlinks on the current webpage |
+| `get_elements` | Get elements from the webpage using a CSS selector |
+| `navigate_back` | Navigate back to the previous page |
+| `current_webpage` | Get information about the current webpage |
+
+## Arguments
+
+| Argument | Type | Description |
+| :------- | :--- | :---------- |
+| `region` | `str` | AWS region for the browser service (default: `us-west-2`) |
+
+## Multi-Agent Usage
+
+Use `thread_id` to isolate browser sessions across concurrent agents. Each thread gets its own independent browser instance.
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.browser import create_browser_toolkit
+
+toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
+
+# Both agents share the toolkit but can use different thread_ids
+# to maintain separate browser sessions
+news_agent = Agent(
+    role="News Researcher",
+    goal="Find the latest tech news",
+    backstory="You specialize in technology news.",
+    tools=browser_tools,
+)
+
+finance_agent = Agent(
+    role="Finance Researcher",
+    goal="Find current market data",
+    backstory="You specialize in financial markets.",
+    tools=browser_tools,
+)
+
+# You can also assign specific tools to specific agents
+tools_by_name = toolkit.get_tools_by_name()
+navigate_only_agent = Agent(
+    role="Navigator",
+    goal="Navigate to specified URLs",
+    backstory="You navigate to web pages.",
+    tools=[tools_by_name["navigate_browser"], tools_by_name["extract_text"]],
+)
+```
+
+## Cleanup
+
+Always clean up browser sessions when your crew finishes to release cloud resources.
+
+```python Code
+# From synchronous code
+toolkit.sync_cleanup()
+
+# From async code
+await toolkit.cleanup()
+```

--- a/docs/en/tools/automation/overview.mdx
+++ b/docs/en/tools/automation/overview.mdx
@@ -25,6 +25,10 @@ These tools enable your agents to automate workflows, integrate with external pl
   <Card title="Zapier Actions Adapter" icon="bolt" href="/en/tools/automation/zapieractionstool">
     Expose Zapier Actions as CrewAI tools for automation across thousands of apps.
   </Card>
+
+  <Card title="AgentCore Browser" icon="aws" href="/en/tools/automation/agentcorebrowsertool">
+    AWS-managed browser automation in secure cloud sandboxes with Playwright.
+  </Card>
 </CardGroup>
 
 ## **Common Use Cases**

--- a/docs/en/tools/integration/agentcoreoverview.mdx
+++ b/docs/en/tools/integration/agentcoreoverview.mdx
@@ -1,0 +1,87 @@
+---
+title: AgentCore Overview
+description: AWS-managed tools and runtime for CrewAI — browser automation, code execution, knowledge retrieval, and cloud deployment via Amazon Bedrock AgentCore.
+icon: aws
+mode: "wide"
+---
+
+# Amazon Bedrock AgentCore
+
+[Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) provides AWS-managed infrastructure for CrewAI agents. Instead of running tools locally or managing your own servers, AgentCore handles browser sessions, code sandboxes, knowledge bases, agent invocation, and production deployment in the cloud.
+
+## Available Integrations
+
+<CardGroup cols={2}>
+  <Card title="AgentCore Browser" icon="globe" href="/en/tools/automation/agentcorebrowsertool">
+    Playwright-based browser automation in secure cloud sandboxes — no local Docker or browser installs.
+  </Card>
+
+  <Card title="AgentCore Code Interpreter" icon="code" href="/en/tools/ai-ml/agentcorecodeinterpretertool">
+    Python and shell execution in cloud sandboxes with up to 8-hour sessions — no local Docker required.
+  </Card>
+
+  <Card title="Bedrock Invoke Agent" icon="robot" href="/en/tools/integration/bedrockinvokeagenttool">
+    Call Amazon Bedrock Agents from your crews, reuse AWS guardrails, and stream responses back.
+  </Card>
+
+  <Card title="Bedrock KB Retriever" icon="database" href="/en/tools/cloud-storage/bedrockkbretriever">
+    Query Amazon Bedrock Knowledge Bases for RAG-powered retrieval within your agent workflows.
+  </Card>
+</CardGroup>
+
+## Installation
+
+All AgentCore tool integrations share the same install:
+
+```shell
+pip install 'crewai[tools]' 'crewai-tools[bedrock]'
+```
+
+**Prerequisites:**
+- AWS credentials configured (environment variables, AWS CLI profile, or IAM role)
+- IAM permissions for `bedrock-agentcore:*`
+- An LLM configured for your agents — see [LLM connections](/en/learn/llm-connections)
+
+## Quick Start
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.browser import create_browser_toolkit
+from crewai_tools.aws.bedrock.code_interpreter import create_code_interpreter_toolkit
+
+# Cloud browser — no local setup needed
+browser_toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
+
+# Cloud code sandbox — no local Docker needed
+ci_toolkit, code_tools = create_code_interpreter_toolkit(region="us-west-2")
+
+researcher = Agent(
+    role="Web Researcher",
+    goal="Find information online and analyze it with code",
+    backstory="You research topics on the web and use Python to analyze findings.",
+    tools=browser_tools + code_tools,
+)
+
+task = Task(
+    description="Navigate to https://example.com, extract the page text, then write Python code to count the words.",
+    expected_output="The word count of the page content.",
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+
+# Always clean up cloud resources
+browser_toolkit.sync_cleanup()
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
+asyncio.run(ci_toolkit.cleanup())
+```
+
+## What's Next
+
+- **[Browser Toolkit](/en/tools/automation/agentcorebrowsertool)** — full tool reference, multi-agent usage, cleanup patterns
+- **[Code Interpreter Toolkit](/en/tools/ai-ml/agentcorecodeinterpretertool)** — full tool reference, async commands, file operations
+- **[Bedrock Invoke Agent](/en/tools/integration/bedrockinvokeagenttool)** — session management, multi-agent workflows
+- **[Bedrock KB Retriever](/en/tools/cloud-storage/bedrockkbretriever)** — knowledge base queries for RAG

--- a/docs/en/tools/integration/overview.mdx
+++ b/docs/en/tools/integration/overview.mdx
@@ -21,6 +21,10 @@ Integration tools let your agents hand off work to other automation platforms an
   <Card title="Bedrock Invoke Agent Tool" icon="aws" href="/en/tools/integration/bedrockinvokeagenttool">
     Call Amazon Bedrock Agents from your crews, reuse AWS guardrails, and stream responses back into the workflow.
   </Card>
+
+  <Card title="AgentCore Overview" icon="aws" href="/en/tools/integration/agentcoreoverview">
+    AWS-managed tools and runtime for browser automation, code execution, knowledge retrieval, and cloud deployment.
+  </Card>
 </CardGroup>
 
 ## **Common Use Cases**

--- a/docs/ko/tools/ai-ml/agentcorecodeinterpretertool.mdx
+++ b/docs/ko/tools/ai-ml/agentcorecodeinterpretertool.mdx
@@ -1,0 +1,132 @@
+---
+title: AgentCore 코드 인터프리터
+description: AWS 관리형 클라우드 샌드박스에서 Python, 셸 명령, 파일 작업을 안전하게 실행하는 CrewAI 에이전트용 코드 실행 도구입니다.
+icon: aws
+mode: "wide"
+---
+
+# `CodeInterpreterToolkit`
+
+## 설명
+
+[Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)의 `CodeInterpreterToolkit`은 CrewAI 에이전트에 AWS 관리형 코드 실행 환경을 제공합니다. 로컬 Docker 기반 [`CodeInterpreterTool`](/ko/tools/ai-ml/codeinterpretertool)과 달리, AgentCore는 로컬 Docker 없이 보안 클라우드 샌드박스(MicroVM)에서 코드를 실행합니다. Docker를 사용할 수 있는 빠른 로컬 작업에는 `CodeInterpreterTool`을, 장시간 세션이나 Docker 없는 환경, 또는 프로덕션 워크로드에는 AgentCore를 사용하세요.
+
+주요 기능:
+- **로컬 Docker 불필요** — AWS 관리형 클라우드 샌드박스에서 코드 실행
+- **최대 8시간 세션** — 타임아웃 걱정 없이 장시간 연산 수행
+- **완전한 실행 환경** — Python, 셸 명령, 파일 시스템 작업 지원
+- **멀티 에이전트 격리** — `thread_id`로 각 에이전트에 독립 샌드박스 환경 제공
+
+## 설치
+
+```shell
+pip install 'crewai[tools]' 'crewai-tools[bedrock]'
+```
+
+**사전 요구사항:**
+- AWS 자격 증명 구성 (환경 변수, AWS CLI 프로필, 또는 IAM 역할)
+- `bedrock-agentcore:*` IAM 권한
+- 에이전트용 LLM 구성 (Amazon Bedrock 모델 사용 시 `llm=LLM(model="bedrock/...", region_name="us-west-2")`을 Agent에 전달 — [LLM 연결](/en/learn/llm-connections) 참조)
+
+## 사용 예시
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.code_interpreter import create_code_interpreter_toolkit
+
+# 코드 인터프리터 툴킷 생성
+toolkit, code_tools = create_code_interpreter_toolkit(region="us-west-2")
+
+# 코드 인터프리터 도구를 사용하는 에이전트 생성
+developer_agent = Agent(
+    role="Python Developer",
+    goal="Write and execute Python code to solve problems",
+    backstory="You're a skilled Python developer with expertise in data analysis.",
+    tools=code_tools,
+)
+
+# 태스크 생성
+coding_task = Task(
+    description="Write a Python function that calculates the factorial of a number and test it with values 1 through 10.",
+    expected_output="The factorial values for numbers 1 through 10.",
+    agent=developer_agent,
+)
+
+# 크루 실행
+crew = Crew(agents=[developer_agent], tasks=[coding_task])
+result = crew.kickoff()
+
+# 완료 후 항상 코드 인터프리터 세션 정리
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
+asyncio.run(toolkit.cleanup())
+```
+
+## 사용 가능한 도구
+
+툴킷은 9개의 코드 실행 및 파일 관리 도구를 제공합니다:
+
+| 도구 | 설명 |
+| :--- | :---------- |
+| `execute_code` | 다양한 언어(주로 Python)로 코드를 실행합니다 |
+| `execute_command` | 코드 인터프리터 환경에서 셸 명령을 실행합니다 |
+| `read_files` | 환경 내 파일의 내용을 읽습니다 |
+| `list_files` | 환경 내 디렉토리의 파일을 나열합니다 |
+| `delete_files` | 환경에서 파일을 삭제합니다 |
+| `write_files` | 환경에서 파일을 생성하거나 업데이트합니다 |
+| `start_command_execution` | 장시간 실행 명령을 비동기적으로 시작합니다 |
+| `get_task` | 비동기 작업의 상태를 확인합니다 |
+| `stop_task` | 실행 중인 작업을 중지합니다 |
+
+## 파라미터
+
+| 파라미터 | 타입 | 설명 |
+| :------- | :--- | :---------- |
+| `region` | `str` | 코드 인터프리터 서비스의 AWS 리전 (기본값: `us-west-2`) |
+
+## 멀티 에이전트 사용
+
+`thread_id`를 사용하여 각 에이전트에 격리된 코드 인터프리터 세션을 제공할 수 있습니다. 각 스레드는 자체 파일 시스템과 실행 컨텍스트를 가진 별도의 샌드박스를 갖습니다.
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.code_interpreter import create_code_interpreter_toolkit
+
+toolkit, code_tools = create_code_interpreter_toolkit(region="us-west-2")
+
+# 두 에이전트가 툴킷을 공유하지만 서로 다른 thread_id로
+# 별도의 샌드박스 환경을 유지할 수 있습니다
+data_agent = Agent(
+    role="Data Analyst",
+    goal="Analyze datasets and produce insights",
+    backstory="You specialize in data analysis with pandas and matplotlib.",
+    tools=code_tools,
+)
+
+test_agent = Agent(
+    role="Test Engineer",
+    goal="Write and run test suites",
+    backstory="You specialize in writing comprehensive test cases.",
+    tools=code_tools,
+)
+```
+
+## 정리
+
+크루 실행이 완료되면 항상 코드 인터프리터 세션을 정리하여 클라우드 리소스를 해제하세요. 브라우저 툴킷과 달리 코드 인터프리터 정리는 비동기 전용입니다. CrewAI는 `crew.kickoff()` 이후 이벤트 루프를 실행 상태로 남길 수 있으므로, `asyncio.run()` 사용 전에 `nest_asyncio.apply()`를 호출하세요.
+
+```python Code
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
+
+# 동기 코드에서 (예: crew.kickoff() 이후)
+asyncio.run(toolkit.cleanup())
+
+# 비동기 코드에서
+await toolkit.cleanup()
+
+# 특정 스레드의 세션만 정리
+asyncio.run(toolkit.cleanup(thread_id="specific-thread"))
+```

--- a/docs/ko/tools/ai-ml/overview.mdx
+++ b/docs/ko/tools/ai-ml/overview.mdx
@@ -37,6 +37,10 @@ mode: "wide"
   <Card title="Code Interpreter 도구" icon="code" href="/ko/tools/ai-ml/codeinterpretertool">
     Python 코드를 실행하고 데이터 분석을 수행합니다.
   </Card>
+
+  <Card title="AgentCore 코드 인터프리터" icon="aws" href="/ko/tools/ai-ml/agentcorecodeinterpretertool">
+    AWS 관리형 클라우드 샌드박스에서 최대 8시간 세션으로 안전한 코드 실행을 제공합니다.
+  </Card>
 </CardGroup>
 
 ## **일반적인 사용 사례**

--- a/docs/ko/tools/automation/agentcorebrowsertool.mdx
+++ b/docs/ko/tools/automation/agentcorebrowsertool.mdx
@@ -1,0 +1,129 @@
+---
+title: AgentCore 브라우저
+description: AWS 관리형 클라우드 샌드박스에서 Playwright 기반 웹 상호작용을 제공하는 CrewAI 에이전트용 브라우저 자동화 도구입니다.
+icon: aws
+mode: "wide"
+---
+
+# `BrowserToolkit`
+
+## 설명
+
+[Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)의 `BrowserToolkit`은 CrewAI 에이전트에 AWS 관리형 브라우저 자동화 기능을 제공합니다. 로컬 Docker 기반 솔루션이나 서드파티 브라우저 서비스와 달리, AgentCore는 보안 클라우드 샌드박스에서 Playwright 기반 브라우저를 실행하므로 로컬 설정이 필요 없습니다.
+
+주요 기능:
+- **로컬 인프라 불필요** — Docker, 브라우저 설치, Playwright 설정 없음
+- **보안 클라우드 샌드박스** — 각 브라우저 세션이 격리된 AWS 관리형 환경에서 실행
+- **Playwright 기반** — 탐색, 클릭, 텍스트 추출 등 완전한 브라우저 자동화
+- **멀티 에이전트 격리** — `thread_id`로 각 에이전트에 독립 브라우저 세션 제공
+
+## 설치
+
+```shell
+pip install 'crewai[tools]' 'crewai-tools[bedrock]'
+```
+
+**사전 요구사항:**
+- AWS 자격 증명 구성 (환경 변수, AWS CLI 프로필, 또는 IAM 역할)
+- `bedrock-agentcore:*` IAM 권한
+- 에이전트용 LLM 구성 (Amazon Bedrock 모델 사용 시 `llm=LLM(model="bedrock/...", region_name="us-west-2")`을 Agent에 전달 — [LLM 연결](/en/learn/llm-connections) 참조)
+
+## 사용 예시
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.browser import create_browser_toolkit
+
+# 브라우저 툴킷 생성
+toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
+
+# 브라우저 도구를 사용하는 에이전트 생성
+research_agent = Agent(
+    role="Web Researcher",
+    goal="Research and summarize web content",
+    backstory="You're an expert at finding information online.",
+    tools=browser_tools,
+)
+
+# 태스크 생성
+research_task = Task(
+    description="Navigate to https://example.com and extract all text content. Summarize the main points.",
+    expected_output="A summary of the main content on example.com.",
+    agent=research_agent,
+)
+
+# 크루 실행
+crew = Crew(agents=[research_agent], tasks=[research_task])
+result = crew.kickoff()
+
+# 완료 후 항상 브라우저 세션 정리
+toolkit.sync_cleanup()
+```
+
+## 사용 가능한 도구
+
+툴킷은 7개의 브라우저 도구를 제공합니다:
+
+| 도구 | 설명 |
+| :--- | :---------- |
+| `navigate_browser` | 지정된 URL로 브라우저를 이동합니다 |
+| `click_element` | 주어진 CSS 선택자로 요소를 클릭합니다 |
+| `extract_text` | 현재 웹페이지의 모든 텍스트를 추출합니다 |
+| `extract_hyperlinks` | 현재 웹페이지의 모든 하이퍼링크를 추출합니다 |
+| `get_elements` | CSS 선택자를 사용하여 웹페이지에서 요소를 가져옵니다 |
+| `navigate_back` | 이전 페이지로 돌아갑니다 |
+| `current_webpage` | 현재 웹페이지 정보를 가져옵니다 |
+
+## 파라미터
+
+| 파라미터 | 타입 | 설명 |
+| :------- | :--- | :---------- |
+| `region` | `str` | 브라우저 서비스의 AWS 리전 (기본값: `us-west-2`) |
+
+## 멀티 에이전트 사용
+
+`thread_id`를 사용하여 동시에 실행되는 에이전트 간 브라우저 세션을 격리할 수 있습니다. 각 스레드는 독립적인 브라우저 인스턴스를 갖습니다.
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools.aws.bedrock.browser import create_browser_toolkit
+
+toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
+
+# 두 에이전트가 툴킷을 공유하지만 서로 다른 thread_id로
+# 별도의 브라우저 세션을 유지할 수 있습니다
+news_agent = Agent(
+    role="News Researcher",
+    goal="Find the latest tech news",
+    backstory="You specialize in technology news.",
+    tools=browser_tools,
+)
+
+finance_agent = Agent(
+    role="Finance Researcher",
+    goal="Find current market data",
+    backstory="You specialize in financial markets.",
+    tools=browser_tools,
+)
+
+# 특정 도구만 특정 에이전트에 할당할 수도 있습니다
+tools_by_name = toolkit.get_tools_by_name()
+navigate_only_agent = Agent(
+    role="Navigator",
+    goal="Navigate to specified URLs",
+    backstory="You navigate to web pages.",
+    tools=[tools_by_name["navigate_browser"], tools_by_name["extract_text"]],
+)
+```
+
+## 정리
+
+크루 실행이 완료되면 항상 브라우저 세션을 정리하여 클라우드 리소스를 해제하세요.
+
+```python Code
+# 동기 코드에서
+toolkit.sync_cleanup()
+
+# 비동기 코드에서
+await toolkit.cleanup()
+```

--- a/docs/ko/tools/automation/overview.mdx
+++ b/docs/ko/tools/automation/overview.mdx
@@ -25,6 +25,10 @@ mode: "wide"
   <Card title="Zapier Actions Adapter" icon="bolt" href="/ko/tools/automation/zapieractionstool">
     수천 개의 앱을 자동화할 수 있도록 Zapier Actions를 CrewAI 도구로 제공합니다.
   </Card>
+
+  <Card title="AgentCore 브라우저" icon="aws" href="/ko/tools/automation/agentcorebrowsertool">
+    AWS 관리형 보안 클라우드 샌드박스에서 Playwright 기반 브라우저 자동화를 제공합니다.
+  </Card>
 </CardGroup>
 
 ## **일반적인 사용 사례**

--- a/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_session_manager.py
+++ b/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_session_manager.py
@@ -76,6 +76,23 @@ class BrowserSessionManager:
         self._sync_playwrights: dict[str, SyncPlaywright] = {}
         self._creating: dict[str, threading.Event] = {}
 
+    def _build_start_kwargs(self) -> dict[str, Any]:
+        """Build kwargs dict for BrowserClient.start() from session config."""
+        kwargs: dict[str, Any] = {}
+        if self.identifier is not None:
+            kwargs["identifier"] = self.identifier
+        if self.session_timeout_seconds is not None:
+            kwargs["session_timeout_seconds"] = self.session_timeout_seconds
+        if self.viewport is not None:
+            kwargs["viewport"] = self.viewport
+        if self.proxy_configuration is not None:
+            kwargs["proxy_configuration"] = self.proxy_configuration
+        if self.extensions is not None:
+            kwargs["extensions"] = self.extensions
+        if self.profile_configuration is not None:
+            kwargs["profile_configuration"] = self.profile_configuration
+        return kwargs
+
     async def get_async_browser(self, thread_id: str) -> AsyncBrowser:
         """Get or create an async browser for the specified thread.
 
@@ -157,20 +174,7 @@ class BrowserSessionManager:
         )
 
         try:
-            start_kwargs: dict[str, Any] = {}
-            if self.identifier is not None:
-                start_kwargs["identifier"] = self.identifier
-            if self.session_timeout_seconds is not None:
-                start_kwargs["session_timeout_seconds"] = self.session_timeout_seconds
-            if self.viewport is not None:
-                start_kwargs["viewport"] = self.viewport
-            if self.proxy_configuration is not None:
-                start_kwargs["proxy_configuration"] = self.proxy_configuration
-            if self.extensions is not None:
-                start_kwargs["extensions"] = self.extensions
-            if self.profile_configuration is not None:
-                start_kwargs["profile_configuration"] = self.profile_configuration
-            browser_client.start(**start_kwargs)
+            browser_client.start(**self._build_start_kwargs())
 
             ws_url, headers = browser_client.generate_ws_headers()
 
@@ -226,20 +230,7 @@ class BrowserSessionManager:
         )
 
         try:
-            start_kwargs: dict[str, Any] = {}
-            if self.identifier is not None:
-                start_kwargs["identifier"] = self.identifier
-            if self.session_timeout_seconds is not None:
-                start_kwargs["session_timeout_seconds"] = self.session_timeout_seconds
-            if self.viewport is not None:
-                start_kwargs["viewport"] = self.viewport
-            if self.proxy_configuration is not None:
-                start_kwargs["proxy_configuration"] = self.proxy_configuration
-            if self.extensions is not None:
-                start_kwargs["extensions"] = self.extensions
-            if self.profile_configuration is not None:
-                start_kwargs["profile_configuration"] = self.profile_configuration
-            browser_client.start(**start_kwargs)
+            browser_client.start(**self._build_start_kwargs())
 
             ws_url, headers = browser_client.generate_ws_headers()
 
@@ -318,9 +309,21 @@ class BrowserSessionManager:
             with self._lock:
                 self._sync_playwrights[thread_id] = pw
 
-        browser = pw.chromium.connect_over_cdp(
-            endpoint_url=ws_url, headers=headers, timeout=30000
-        )
+        try:
+            browser = pw.chromium.connect_over_cdp(
+                endpoint_url=ws_url, headers=headers, timeout=30000
+            )
+        except Exception:
+            # Remove the dead session and stop the AWS browser session
+            # to avoid leaking a remote session that runs up to 8 hours.
+            with self._lock:
+                self._sync_sessions.pop(thread_id, None)
+                self._sync_playwrights.pop(thread_id, None)
+            try:
+                browser_client.stop()
+            except Exception:
+                logger.debug("Failed to stop browser client during reconnect cleanup", exc_info=True)
+            raise
         logger.info(f"Successfully reconnected sync browser for thread {thread_id}")
 
         with self._lock:
@@ -367,9 +370,21 @@ class BrowserSessionManager:
             with self._lock:
                 self._async_playwrights[thread_id] = pw
 
-        browser = await pw.chromium.connect_over_cdp(
-            endpoint_url=ws_url, headers=headers, timeout=30000
-        )
+        try:
+            browser = await pw.chromium.connect_over_cdp(
+                endpoint_url=ws_url, headers=headers, timeout=30000
+            )
+        except Exception:
+            # Remove the dead session and stop the AWS browser session
+            # to avoid leaking a remote session that runs up to 8 hours.
+            with self._lock:
+                self._async_sessions.pop(thread_id, None)
+                self._async_playwrights.pop(thread_id, None)
+            try:
+                await browser_client.async_stop()
+            except Exception:
+                logger.debug("Failed to stop browser client during reconnect cleanup", exc_info=True)
+            raise
         logger.info(f"Successfully reconnected async browser for thread {thread_id}")
 
         with self._lock:

--- a/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_session_manager.py
+++ b/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_session_manager.py
@@ -4,13 +4,21 @@ import asyncio
 import contextvars
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 
 if TYPE_CHECKING:
     from bedrock_agentcore.tools.browser_client import BrowserClient
+    from bedrock_agentcore.tools.config import (
+        BrowserExtension,
+        ProfileConfiguration,
+        ProxyConfiguration,
+        ViewportConfiguration,
+    )
     from playwright.async_api import Browser as AsyncBrowser
+    from playwright.async_api import Playwright as AsyncPlaywright
     from playwright.sync_api import Browser as SyncBrowser
+    from playwright.sync_api import Playwright as SyncPlaywright
 
 logger = logging.getLogger(__name__)
 
@@ -26,16 +34,46 @@ class BrowserSessionManager:
     blocking unrelated callers or wasting resources on duplicate sessions.
     """
 
-    def __init__(self, region: str = "us-west-2"):
+    def __init__(
+        self,
+        region: str = "us-west-2",
+        identifier: str | None = None,
+        session_timeout_seconds: int | None = None,
+        viewport: ViewportConfiguration | dict[str, int] | None = None,
+        proxy_configuration: ProxyConfiguration | dict | None = None,
+        extensions: list[BrowserExtension | dict] | None = None,
+        profile_configuration: ProfileConfiguration | dict | None = None,
+    ):
         """Initialize the browser session manager.
 
         Args:
             region: AWS region for browser client
+            identifier: Browser sandbox identifier. Defaults to the system browser.
+                Use a custom browser ID from create_browser() for custom configurations.
+            session_timeout_seconds: Session timeout in seconds (1-28800). Defaults to
+                3600 (1 hour) if not specified.
+            viewport: Viewport dimensions. Accepts a ``ViewportConfiguration`` instance
+                (e.g. ``ViewportConfiguration.desktop_hd()``) or a plain dict
+                (e.g. ``{"width": 1920, "height": 1080}``).
+            proxy_configuration: Proxy routing configuration. Accepts a
+                ``ProxyConfiguration`` instance or a plain dict matching the SDK shape.
+            extensions: List of browser extensions. Each element can be a
+                ``BrowserExtension`` instance or a plain dict matching the SDK shape.
+            profile_configuration: Profile for persisting browser state across sessions.
+                Accepts a ``ProfileConfiguration`` instance or a plain dict.
         """
         self.region = region
+        self.identifier = identifier
+        self.session_timeout_seconds = session_timeout_seconds
+        self.viewport = viewport
+        self.proxy_configuration = proxy_configuration
+        self.extensions = extensions
+        self.profile_configuration = profile_configuration
         self._lock = threading.Lock()
         self._async_sessions: dict[str, tuple[BrowserClient, AsyncBrowser]] = {}
         self._sync_sessions: dict[str, tuple[BrowserClient, SyncBrowser]] = {}
+        self._async_playwrights: dict[str, AsyncPlaywright] = {}
+        self._sync_playwrights: dict[str, SyncPlaywright] = {}
         self._creating: dict[str, threading.Event] = {}
 
     async def get_async_browser(self, thread_id: str) -> AsyncBrowser:
@@ -113,10 +151,26 @@ class BrowserSessionManager:
         """
         from bedrock_agentcore.tools.browser_client import BrowserClient
 
-        browser_client = BrowserClient(region=self.region)
+        browser_client = BrowserClient(
+            region=self.region,
+            integration_source="crewai",
+        )
 
         try:
-            browser_client.start()
+            start_kwargs: dict[str, Any] = {}
+            if self.identifier is not None:
+                start_kwargs["identifier"] = self.identifier
+            if self.session_timeout_seconds is not None:
+                start_kwargs["session_timeout_seconds"] = self.session_timeout_seconds
+            if self.viewport is not None:
+                start_kwargs["viewport"] = self.viewport
+            if self.proxy_configuration is not None:
+                start_kwargs["proxy_configuration"] = self.proxy_configuration
+            if self.extensions is not None:
+                start_kwargs["extensions"] = self.extensions
+            if self.profile_configuration is not None:
+                start_kwargs["profile_configuration"] = self.profile_configuration
+            browser_client.start(**start_kwargs)
 
             ws_url, headers = browser_client.generate_ws_headers()
 
@@ -126,13 +180,16 @@ class BrowserSessionManager:
 
             from playwright.async_api import async_playwright
 
-            playwright = await async_playwright().start()
-            browser = await playwright.chromium.connect_over_cdp(
+            pw = await async_playwright().start()
+            browser = await pw.chromium.connect_over_cdp(
                 endpoint_url=ws_url, headers=headers, timeout=30000
             )
             logger.info(
                 f"Successfully connected to async browser for thread {thread_id}"
             )
+
+            with self._lock:
+                self._async_playwrights[thread_id] = pw
 
             return browser_client, browser
 
@@ -163,10 +220,26 @@ class BrowserSessionManager:
         """
         from bedrock_agentcore.tools.browser_client import BrowserClient
 
-        browser_client = BrowserClient(region=self.region)
+        browser_client = BrowserClient(
+            region=self.region,
+            integration_source="crewai",
+        )
 
         try:
-            browser_client.start()
+            start_kwargs: dict[str, Any] = {}
+            if self.identifier is not None:
+                start_kwargs["identifier"] = self.identifier
+            if self.session_timeout_seconds is not None:
+                start_kwargs["session_timeout_seconds"] = self.session_timeout_seconds
+            if self.viewport is not None:
+                start_kwargs["viewport"] = self.viewport
+            if self.proxy_configuration is not None:
+                start_kwargs["proxy_configuration"] = self.proxy_configuration
+            if self.extensions is not None:
+                start_kwargs["extensions"] = self.extensions
+            if self.profile_configuration is not None:
+                start_kwargs["profile_configuration"] = self.profile_configuration
+            browser_client.start(**start_kwargs)
 
             ws_url, headers = browser_client.generate_ws_headers()
 
@@ -176,8 +249,8 @@ class BrowserSessionManager:
 
             from playwright.sync_api import sync_playwright
 
-            playwright = sync_playwright().start()
-            browser = playwright.chromium.connect_over_cdp(
+            pw = sync_playwright().start()
+            browser = pw.chromium.connect_over_cdp(
                 endpoint_url=ws_url, headers=headers, timeout=30000
             )
             logger.info(
@@ -185,6 +258,7 @@ class BrowserSessionManager:
             )
 
             with self._lock:
+                self._sync_playwrights[thread_id] = pw
                 self._sync_sessions[thread_id] = (browser_client, browser)
 
             return browser
@@ -202,6 +276,121 @@ class BrowserSessionManager:
 
             raise
 
+    def reconnect_sync_browser(self, thread_id: str) -> SyncBrowser:
+        """Reconnect the Playwright browser for a sync session.
+
+        This is needed after release_control() which invalidates the CDP
+        connection while keeping the BrowserClient session alive.  Reuses the
+        existing Playwright instance to avoid "Sync API inside asyncio loop"
+        errors from starting a second playwright subprocess.
+
+        Args:
+            thread_id: Unique identifier for the thread
+
+        Returns:
+            The reconnected sync browser instance
+
+        Raises:
+            RuntimeError: If no session exists for the thread
+        """
+        with self._lock:
+            if thread_id not in self._sync_sessions:
+                raise RuntimeError(f"No sync session for thread {thread_id}")
+            browser_client, old_browser = self._sync_sessions[thread_id]
+            pw = self._sync_playwrights.get(thread_id)
+
+        # Close old Playwright connection (may already be dead)
+        try:
+            old_browser.close()
+        except Exception:
+            pass
+
+        # Reconnect using existing browser_client (session still active)
+        ws_url, headers = browser_client.generate_ws_headers()
+        logger.info(
+            f"Reconnecting sync browser for thread {thread_id}: {ws_url}"
+        )
+
+        if pw is None:
+            from playwright.sync_api import sync_playwright
+
+            pw = sync_playwright().start()
+            with self._lock:
+                self._sync_playwrights[thread_id] = pw
+
+        browser = pw.chromium.connect_over_cdp(
+            endpoint_url=ws_url, headers=headers, timeout=30000
+        )
+        logger.info(f"Successfully reconnected sync browser for thread {thread_id}")
+
+        with self._lock:
+            self._sync_sessions[thread_id] = (browser_client, browser)
+
+        return browser
+
+    async def reconnect_async_browser(self, thread_id: str) -> AsyncBrowser:
+        """Reconnect the Playwright browser for an async session.
+
+        This is needed after release_control() which invalidates the CDP
+        connection while keeping the BrowserClient session alive.  Reuses the
+        existing Playwright instance to avoid creating a duplicate subprocess.
+
+        Args:
+            thread_id: Unique identifier for the thread
+
+        Returns:
+            The reconnected async browser instance
+
+        Raises:
+            RuntimeError: If no session exists for the thread
+        """
+        with self._lock:
+            if thread_id not in self._async_sessions:
+                raise RuntimeError(f"No async session for thread {thread_id}")
+            browser_client, old_browser = self._async_sessions[thread_id]
+            pw = self._async_playwrights.get(thread_id)
+
+        try:
+            await old_browser.close()
+        except Exception:
+            pass
+
+        ws_url, headers = browser_client.generate_ws_headers()
+        logger.info(
+            f"Reconnecting async browser for thread {thread_id}: {ws_url}"
+        )
+
+        if pw is None:
+            from playwright.async_api import async_playwright
+
+            pw = await async_playwright().start()
+            with self._lock:
+                self._async_playwrights[thread_id] = pw
+
+        browser = await pw.chromium.connect_over_cdp(
+            endpoint_url=ws_url, headers=headers, timeout=30000
+        )
+        logger.info(f"Successfully reconnected async browser for thread {thread_id}")
+
+        with self._lock:
+            self._async_sessions[thread_id] = (browser_client, browser)
+
+        return browser
+
+    def get_browser_client(self, thread_id: str) -> BrowserClient | None:
+        """Get the BrowserClient for a sync session, or None if not started."""
+        with self._lock:
+            if thread_id in self._sync_sessions:
+                return self._sync_sessions[thread_id][0]
+        return None
+
+    async def get_async_browser_client(self, thread_id: str) -> BrowserClient | None:
+        """Get the BrowserClient for an async session, or None if not started."""
+        with self._lock:
+            if thread_id in self._async_sessions:
+                return self._async_sessions[thread_id][0]
+        return None
+
     async def close_async_browser(self, thread_id: str) -> None:
         """Close the async browser session for the specified thread.
 
@@ -214,6 +403,7 @@ class BrowserSessionManager:
                 return
 
             browser_client, browser = self._async_sessions.pop(thread_id)
+            pw = self._async_playwrights.pop(thread_id, None)
 
         if browser:
             try:
@@ -221,6 +411,14 @@ class BrowserSessionManager:
             except Exception as e:
                 logger.warning(
                     f"Error closing async browser for thread {thread_id}: {e}"
+                )
+
+        if pw:
+            try:
+                await pw.stop()
+            except Exception as e:
+                logger.warning(
+                    f"Error stopping async playwright for thread {thread_id}: {e}"
                 )
 
         if browser_client:
@@ -245,6 +443,7 @@ class BrowserSessionManager:
                 return
 
             browser_client, browser = self._sync_sessions.pop(thread_id)
+            pw = self._sync_playwrights.pop(thread_id, None)
 
         if browser:
             try:
@@ -252,6 +451,14 @@ class BrowserSessionManager:
             except Exception as e:
                 logger.warning(
                     f"Error closing sync browser for thread {thread_id}: {e}"
+                )
+
+        if pw:
+            try:
+                pw.stop()
+            except Exception as e:
+                logger.warning(
+                    f"Error stopping sync playwright for thread {thread_id}: {e}"
                 )
 
         if browser_client:

--- a/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_toolkit.py
+++ b/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/browser_toolkit.py
@@ -1,10 +1,20 @@
 """Toolkit for navigating web with AWS browser."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from bedrock_agentcore.tools.config import (
+        BrowserExtension,
+        ProfileConfiguration,
+        ProxyConfiguration,
+        ViewportConfiguration,
+    )
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -483,6 +493,130 @@ class CurrentWebPageTool(BrowserBaseTool):
             return f"Error getting current webpage info: {e!s}"
 
 
+class GenerateLiveViewUrlToolInput(BaseModel):
+    """Input for GenerateLiveViewUrlTool."""
+
+    thread_id: str = Field(
+        default="default", description="Thread ID for the browser session"
+    )
+
+
+class TakeControlToolInput(BaseModel):
+    """Input for TakeControlTool."""
+
+    thread_id: str = Field(
+        default="default", description="Thread ID for the browser session"
+    )
+
+
+class ReleaseControlToolInput(BaseModel):
+    """Input for ReleaseControlTool."""
+
+    thread_id: str = Field(
+        default="default", description="Thread ID for the browser session"
+    )
+
+
+class GenerateLiveViewUrlTool(BrowserBaseTool):
+    """Tool for generating a presigned URL for human oversight of a browser session."""
+
+    name: str = "generate_live_view_url"
+    description: str = "Generate a presigned URL for viewing the browser session in real-time"
+    args_schema: type[BaseModel] = GenerateLiveViewUrlToolInput
+
+    def _run(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = self._session_manager.get_browser_client(thread_id)
+            if not browser_client:
+                return "No browser session found. Navigate to a URL first."
+            url = browser_client.generate_live_view_url()
+            return f"Live view URL: {url}"
+        except Exception as e:
+            logger.error("Failed to generate live view URL: %s", e, exc_info=True)
+            return f"Error generating live view URL: {e!s}"
+
+    async def _arun(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = await self._session_manager.get_async_browser_client(
+                thread_id
+            )
+            if not browser_client:
+                return "No browser session found. Navigate to a URL first."
+            url = browser_client.generate_live_view_url()
+            return f"Live view URL: {url}"
+        except Exception as e:
+            logger.error("Failed to generate live view URL: %s", e, exc_info=True)
+            return f"Error generating live view URL: {e!s}"
+
+
+class TakeControlTool(BrowserBaseTool):
+    """Tool for taking manual control of a browser session (disables automation)."""
+
+    name: str = "take_control"
+    description: str = "Take manual control of the browser session, disabling automation"
+    args_schema: type[BaseModel] = TakeControlToolInput
+
+    def _run(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = self._session_manager.get_browser_client(thread_id)
+            if not browser_client:
+                return "No browser session found. Navigate to a URL first."
+            browser_client.take_control()
+            return "Manual control enabled. Automation is now disabled."
+        except Exception as e:
+            logger.error("Failed to take control: %s", e, exc_info=True)
+            return f"Error taking control: {e!s}"
+
+    async def _arun(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = await self._session_manager.get_async_browser_client(
+                thread_id
+            )
+            if not browser_client:
+                return "No browser session found. Navigate to a URL first."
+            browser_client.take_control()
+            return "Manual control enabled. Automation is now disabled."
+        except Exception as e:
+            logger.error("Failed to take control: %s", e, exc_info=True)
+            return f"Error taking control: {e!s}"
+
+
+class ReleaseControlTool(BrowserBaseTool):
+    """Tool for releasing manual control of a browser session (re-enables automation)."""
+
+    name: str = "release_control"
+    description: str = "Release manual control of the browser session, re-enabling automation"
+    args_schema: type[BaseModel] = ReleaseControlToolInput
+
+    def _run(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = self._session_manager.get_browser_client(thread_id)
+            if not browser_client:
+                return "No browser session found."
+            browser_client.release_control()
+            # Reconnect Playwright — release_control invalidates the CDP connection
+            self._session_manager.reconnect_sync_browser(thread_id)
+            return "Manual control released. Automation is now re-enabled."
+        except Exception as e:
+            logger.error("Failed to release control: %s", e, exc_info=True)
+            return f"Error releasing control: {e!s}"
+
+    async def _arun(self, thread_id: str = "default", **kwargs) -> str:
+        try:
+            browser_client = await self._session_manager.get_async_browser_client(
+                thread_id
+            )
+            if not browser_client:
+                return "No browser session found."
+            browser_client.release_control()
+            # Reconnect Playwright — release_control invalidates the CDP connection
+            await self._session_manager.reconnect_async_browser(thread_id)
+            return "Manual control released. Automation is now re-enabled."
+        except Exception as e:
+            logger.error("Failed to release control: %s", e, exc_info=True)
+            return f"Error releasing control: {e!s}"
+
+
 class BrowserToolkit:
     """Toolkit for navigating web with AWS Bedrock browser.
 
@@ -523,14 +657,86 @@ class BrowserToolkit:
         ```
     """
 
-    def __init__(self, region: str = "us-west-2"):
+    def __init__(
+        self,
+        region: str = "us-west-2",
+        identifier: str | None = None,
+        session_timeout_seconds: int | None = None,
+        viewport: ViewportConfiguration | dict[str, int] | None = None,
+        proxy_configuration: ProxyConfiguration | dict | None = None,
+        extensions: list[BrowserExtension | dict] | None = None,
+        profile_configuration: ProfileConfiguration | dict | None = None,
+    ):
         """Initialize the toolkit.
 
         Args:
             region: AWS region for the browser client
+            identifier: Browser sandbox identifier. Defaults to the system browser.
+                Use a custom browser ID from create_browser() for custom configurations.
+            session_timeout_seconds: Session timeout in seconds (1-28800). Defaults to
+                3600 (1 hour) if not specified.
+            viewport: Viewport dimensions. Accepts a ``ViewportConfiguration`` instance
+                or a plain dict::
+
+                    # Typed (recommended)
+                    from bedrock_agentcore.tools import ViewportConfiguration
+                    viewport=ViewportConfiguration.desktop_hd()   # 1920x1080
+                    viewport=ViewportConfiguration(width=1280, height=720)
+
+                    # Plain dict
+                    viewport={"width": 1920, "height": 1080}
+
+            proxy_configuration: Proxy routing configuration. Accepts a
+                ``ProxyConfiguration`` instance or a plain dict::
+
+                    # Typed (recommended)
+                    from bedrock_agentcore.tools import (
+                        ProxyConfiguration, ExternalProxy, ProxyCredentials, BasicAuth,
+                    )
+                    proxy_configuration=ProxyConfiguration(
+                        proxies=[ExternalProxy(server="proxy.corp.com", port=8080)],
+                        bypass_patterns=[".amazonaws.com"],
+                    )
+
+                    # Plain dict
+                    proxy_configuration={
+                        "proxies": [{"externalProxy": {"server": "proxy.corp.com", "port": 8080}}],
+                        "bypass": {"domainPatterns": [".amazonaws.com"]},
+                    }
+
+            extensions: List of browser extensions stored in S3. Each element can be
+                a ``BrowserExtension`` instance or a plain dict::
+
+                    # Typed (recommended)
+                    from bedrock_agentcore.tools import BrowserExtension, ExtensionS3Location
+                    extensions=[BrowserExtension(s3_location=ExtensionS3Location(
+                        bucket="my-ext", prefix="ublock/",
+                    ))]
+
+                    # Plain dict
+                    extensions=[{"location": {"s3": {"bucket": "my-ext", "prefix": "ublock/"}}}]
+
+            profile_configuration: Profile for persisting browser state (cookies,
+                local storage) across sessions. Accepts a ``ProfileConfiguration``
+                instance or a plain dict::
+
+                    # Typed (recommended)
+                    from bedrock_agentcore.tools import ProfileConfiguration
+                    profile_configuration=ProfileConfiguration(profile_identifier="my-profile")
+
+                    # Plain dict
+                    profile_configuration={"profileIdentifier": "my-profile-id"}
         """
         self.region = region
-        self.session_manager = BrowserSessionManager(region=region)
+        self.session_manager = BrowserSessionManager(
+            region=region,
+            identifier=identifier,
+            session_timeout_seconds=session_timeout_seconds,
+            viewport=viewport,
+            proxy_configuration=proxy_configuration,
+            extensions=extensions,
+            profile_configuration=profile_configuration,
+        )
         self.tools: list[BaseTool] = []
         self._nest_current_loop()
         self._setup_tools()
@@ -559,6 +765,9 @@ class BrowserToolkit:
             ExtractHyperlinksTool(session_manager=self.session_manager),
             GetElementsTool(session_manager=self.session_manager),
             CurrentWebPageTool(session_manager=self.session_manager),
+            GenerateLiveViewUrlTool(session_manager=self.session_manager),
+            TakeControlTool(session_manager=self.session_manager),
+            ReleaseControlTool(session_manager=self.session_manager),
         ]
 
     def get_tools(self) -> list[BaseTool]:
@@ -598,15 +807,41 @@ class BrowserToolkit:
 
 def create_browser_toolkit(
     region: str = "us-west-2",
+    identifier: str | None = None,
+    session_timeout_seconds: int | None = None,
+    viewport: ViewportConfiguration | dict[str, int] | None = None,
+    proxy_configuration: ProxyConfiguration | dict | None = None,
+    extensions: list[BrowserExtension | dict] | None = None,
+    profile_configuration: ProfileConfiguration | dict | None = None,
 ) -> tuple[BrowserToolkit, list[BaseTool]]:
     """Create a BrowserToolkit.
 
     Args:
         region: AWS region for browser client
+        identifier: Browser sandbox identifier. Defaults to the system browser.
+            Use a custom browser ID from create_browser() for custom configurations.
+        session_timeout_seconds: Session timeout in seconds (1-28800). Defaults to
+            3600 (1 hour) if not specified.
+        viewport: Viewport dimensions. Accepts a ``ViewportConfiguration`` instance
+            (e.g. ``ViewportConfiguration.desktop_hd()``) or a plain dict.
+        proxy_configuration: Proxy routing configuration. Accepts a
+            ``ProxyConfiguration`` instance or a plain dict.
+        extensions: List of browser extensions. Each element can be a
+            ``BrowserExtension`` instance or a plain dict.
+        profile_configuration: Profile for persisting browser state. Accepts a
+            ``ProfileConfiguration`` instance or a plain dict.
 
     Returns:
         Tuple of (toolkit, tools)
     """
-    toolkit = BrowserToolkit(region=region)
+    toolkit = BrowserToolkit(
+        region=region,
+        identifier=identifier,
+        session_timeout_seconds=session_timeout_seconds,
+        viewport=viewport,
+        proxy_configuration=proxy_configuration,
+        extensions=extensions,
+        profile_configuration=profile_configuration,
+    )
     tools = toolkit.get_tools()
     return toolkit, tools

--- a/lib/crewai-tools/src/crewai_tools/aws/bedrock/code_interpreter/code_interpreter_toolkit.py
+++ b/lib/crewai-tools/src/crewai_tools/aws/bedrock/code_interpreter/code_interpreter_toolkit.py
@@ -456,6 +456,257 @@ class StopTaskTool(BaseTool):
         return self._run(task_id=task_id, thread_id=thread_id)
 
 
+class UploadFileInput(BaseModel):
+    """Input for UploadFile."""
+
+    path: str = Field(description="Relative path where the file should be saved")
+    content: str = Field(description="File content as a string")
+    description: str = Field(
+        default="", description="Optional semantic description of the file contents"
+    )
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class UploadFilesInput(BaseModel):
+    """Input for UploadFiles."""
+
+    files: list[dict[str, str]] = Field(
+        description="List of dicts with 'path', 'content', and optional 'description'"
+    )
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class InstallPackagesInput(BaseModel):
+    """Input for InstallPackages."""
+
+    packages: list[str] = Field(description="List of package names to install via pip")
+    upgrade: bool = Field(
+        default=False, description="Whether to add --upgrade flag"
+    )
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class DownloadFileInput(BaseModel):
+    """Input for DownloadFile."""
+
+    path: str = Field(description="Path to the file to download")
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class DownloadFilesInput(BaseModel):
+    """Input for DownloadFiles."""
+
+    paths: list[str] = Field(description="List of file paths to download")
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class ClearContextInput(BaseModel):
+    """Input for ClearContext."""
+
+    thread_id: str = Field(
+        default="default", description="Thread ID for the code interpreter session"
+    )
+
+
+class UploadFileTool(BaseTool):
+    """Tool for uploading a file with an optional semantic description."""
+
+    name: str = "upload_file"
+    description: str = "Upload a file to the code interpreter environment with an optional description"
+    args_schema: type[BaseModel] = UploadFileInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(
+        self,
+        path: str,
+        content: str,
+        description: str = "",
+        thread_id: str = "default",
+    ) -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            result = code_interpreter.upload_file(
+                path=path, content=content, description=description
+            )
+            return extract_output_from_stream(result)
+        except Exception as e:
+            logger.error("Failed to upload file: %s", e, exc_info=True)
+            return f"Error uploading file: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
+class UploadFilesTool(BaseTool):
+    """Tool for uploading multiple files at once."""
+
+    name: str = "upload_files"
+    description: str = "Upload multiple files to the code interpreter environment"
+    args_schema: type[BaseModel] = UploadFilesInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(
+        self,
+        files: list[dict[str, str]],
+        thread_id: str = "default",
+    ) -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            result = code_interpreter.upload_files(files=files)
+            return extract_output_from_stream(result)
+        except Exception as e:
+            logger.error("Failed to upload files: %s", e, exc_info=True)
+            return f"Error uploading files: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
+class InstallPackagesTool(BaseTool):
+    """Tool for installing Python packages via pip."""
+
+    name: str = "install_packages"
+    description: str = "Install Python packages via pip in the code interpreter environment"
+    args_schema: type[BaseModel] = InstallPackagesInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(
+        self,
+        packages: list[str],
+        upgrade: bool = False,
+        thread_id: str = "default",
+    ) -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            result = code_interpreter.install_packages(
+                packages=packages, upgrade=upgrade
+            )
+            return extract_output_from_stream(result)
+        except Exception as e:
+            logger.error("Failed to install packages: %s", e, exc_info=True)
+            return f"Error installing packages: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
+class DownloadFileTool(BaseTool):
+    """Tool for downloading a file from the sandbox."""
+
+    name: str = "download_file"
+    description: str = "Download a file from the code interpreter environment"
+    args_schema: type[BaseModel] = DownloadFileInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(self, path: str, thread_id: str = "default") -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            content = code_interpreter.download_file(path=path)
+            if isinstance(content, bytes):
+                return f"[Binary file: {len(content)} bytes]"
+            return content
+        except Exception as e:
+            logger.error("Failed to download file: %s", e, exc_info=True)
+            return f"Error downloading file: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
+class DownloadFilesTool(BaseTool):
+    """Tool for downloading multiple files from the sandbox."""
+
+    name: str = "download_files"
+    description: str = "Download multiple files from the code interpreter environment"
+    args_schema: type[BaseModel] = DownloadFilesInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(self, paths: list[str], thread_id: str = "default") -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            files = code_interpreter.download_files(paths=paths)
+            results = []
+            for file_path, content in files.items():
+                if isinstance(content, bytes):
+                    results.append(f"==== {file_path} [Binary: {len(content)} bytes] ====")
+                else:
+                    results.append(f"==== {file_path} ====\n{content}")
+            return "\n".join(results) if results else "No files found"
+        except Exception as e:
+            logger.error("Failed to download files: %s", e, exc_info=True)
+            return f"Error downloading files: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
+class ClearContextTool(BaseTool):
+    """Tool for clearing all variable state in the Python execution context."""
+
+    name: str = "clear_context"
+    description: str = "Clear all variable state in the Python execution context"
+    args_schema: type[BaseModel] = ClearContextInput
+    toolkit: Any = Field(default=None, exclude=True)
+
+    def __init__(self, toolkit):
+        super().__init__()
+        self.toolkit = toolkit
+
+    def _run(self, thread_id: str = "default") -> str:
+        try:
+            code_interpreter = self.toolkit._get_or_create_interpreter(
+                thread_id=thread_id
+            )
+            code_interpreter.clear_context()
+            return "Python execution context cleared successfully"
+        except Exception as e:
+            logger.error("Failed to clear context: %s", e, exc_info=True)
+            return f"Error clearing context: {e!s}"
+
+    async def _arun(self, **kwargs) -> str:
+        return self._run(**kwargs)
+
+
 class CodeInterpreterToolkit:
     """Toolkit for working with AWS Bedrock code interpreter environment.
 
@@ -470,6 +721,12 @@ class CodeInterpreterToolkit:
     * start_command_execution - Start long-running commands asynchronously
     * get_task - Check status of async tasks
     * stop_task - Stop running tasks
+    * upload_file - Upload a single file to the environment
+    * upload_files - Upload multiple files to the environment
+    * install_packages - Install pip packages in the environment
+    * download_file - Download a single file from the environment
+    * download_files - Download multiple files from the environment
+    * clear_context - Reset the Python execution context
 
     The toolkit lazily initializes the code interpreter session on first use.
     It supports multiple threads by maintaining separate code interpreter sessions for each thread ID.
@@ -509,13 +766,24 @@ class CodeInterpreterToolkit:
         ```
     """
 
-    def __init__(self, region: str = "us-west-2"):
+    def __init__(
+        self,
+        region: str = "us-west-2",
+        identifier: str | None = None,
+        session_timeout_seconds: int | None = None,
+    ):
         """Initialize the toolkit.
 
         Args:
             region: AWS region for the code interpreter
+            identifier: Code interpreter sandbox identifier. Defaults to the system interpreter.
+                Use a custom ID from create_code_interpreter() for custom configurations.
+            session_timeout_seconds: Session timeout in seconds. Defaults to 900
+                (15 minutes) if not specified.
         """
         self.region = region
+        self.identifier = identifier
+        self.session_timeout_seconds = session_timeout_seconds
         self._code_interpreters: dict[str, CodeInterpreter] = {}
         self.tools: list[BaseTool] = []
         self._setup_tools()
@@ -532,6 +800,12 @@ class CodeInterpreterToolkit:
             StartCommandTool(self),
             GetTaskTool(self),
             StopTaskTool(self),
+            UploadFileTool(self),
+            UploadFilesTool(self),
+            InstallPackagesTool(self),
+            DownloadFileTool(self),
+            DownloadFilesTool(self),
+            ClearContextTool(self),
         ]
 
     def _get_or_create_interpreter(self, thread_id: str = "default") -> CodeInterpreter:
@@ -549,8 +823,16 @@ class CodeInterpreterToolkit:
         # Create a new code interpreter for this thread
         from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
 
-        code_interpreter = CodeInterpreter(region=self.region)
-        code_interpreter.start()
+        code_interpreter = CodeInterpreter(
+            region=self.region,
+            integration_source="crewai",
+        )
+        start_kwargs: dict[str, Any] = {}
+        if self.identifier is not None:
+            start_kwargs["identifier"] = self.identifier
+        if self.session_timeout_seconds is not None:
+            start_kwargs["session_timeout_seconds"] = self.session_timeout_seconds
+        code_interpreter.start(**start_kwargs)
         logger.info(
             f"Started code interpreter with session_id:{code_interpreter.session_id} for thread:{thread_id}"
         )
@@ -611,15 +893,25 @@ class CodeInterpreterToolkit:
 
 def create_code_interpreter_toolkit(
     region: str = "us-west-2",
+    identifier: str | None = None,
+    session_timeout_seconds: int | None = None,
 ) -> tuple[CodeInterpreterToolkit, list[BaseTool]]:
     """Create a CodeInterpreterToolkit.
 
     Args:
         region: AWS region for code interpreter
+        identifier: Code interpreter sandbox identifier. Defaults to the system interpreter.
+            Use a custom ID from create_code_interpreter() for custom configurations.
+        session_timeout_seconds: Session timeout in seconds. Defaults to 900
+            (15 minutes) if not specified.
 
     Returns:
         Tuple of (toolkit, tools)
     """
-    toolkit = CodeInterpreterToolkit(region=region)
+    toolkit = CodeInterpreterToolkit(
+        region=region,
+        identifier=identifier,
+        session_timeout_seconds=session_timeout_seconds,
+    )
     tools = toolkit.get_tools()
     return toolkit, tools

--- a/lib/crewai-tools/tests/tools/test_agentcore_browser.py
+++ b/lib/crewai-tools/tests/tools/test_agentcore_browser.py
@@ -1,0 +1,692 @@
+"""Unit tests for AWS Bedrock AgentCore Browser toolkit."""
+
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from crewai_tools.aws.bedrock.browser.browser_session_manager import (
+    BrowserSessionManager,
+)
+from crewai_tools.aws.bedrock.browser.browser_toolkit import (
+    BrowserToolkit,
+    GenerateLiveViewUrlTool,
+    TakeControlTool,
+    ReleaseControlTool,
+    create_browser_toolkit,
+)
+
+
+# --- BrowserSessionManager ---
+
+
+class TestBrowserSessionManager:
+    def test_init_defaults(self):
+        mgr = BrowserSessionManager(region="us-east-1")
+        assert mgr.region == "us-east-1"
+        assert mgr.identifier is None
+
+    def test_init_with_identifier(self):
+        mgr = BrowserSessionManager(region="us-west-2", identifier="vpc-browser")
+        assert mgr.identifier == "vpc-browser"
+
+    def test_integration_source_set_sync(self):
+        """Verify integration_source='crewai' is passed to BrowserClient in sync path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp.return_value = mock_browser
+
+        fake_playwright_module = MagicMock()
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.return_value.start.return_value = mock_playwright_ctx
+        fake_playwright_module.sync_playwright = mock_sync_pw
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.sync_api": fake_playwright_module,
+        }):
+            mgr = BrowserSessionManager(region="us-west-2")
+            mgr._create_sync_browser_session("thread-1")
+
+        MockBC.assert_called_once_with(
+            region="us-west-2",
+            integration_source="crewai",
+        )
+        mock_bc.start.assert_called_once_with()
+
+    def test_identifier_passed_to_start_sync(self):
+        """Verify identifier is passed to start() in sync path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp.return_value = mock_browser
+
+        fake_playwright_module = MagicMock()
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.return_value.start.return_value = mock_playwright_ctx
+        fake_playwright_module.sync_playwright = mock_sync_pw
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.sync_api": fake_playwright_module,
+        }):
+            mgr = BrowserSessionManager(
+                region="us-west-2", identifier="my-vpc-browser"
+            )
+            mgr._create_sync_browser_session("thread-1")
+
+        mock_bc.start.assert_called_once_with(identifier="my-vpc-browser")
+
+    def test_session_config_passed_to_start_sync(self):
+        """Verify all session config is passed to start() in sync path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp.return_value = mock_browser
+
+        fake_playwright_module = MagicMock()
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.return_value.start.return_value = mock_playwright_ctx
+        fake_playwright_module.sync_playwright = mock_sync_pw
+
+        viewport = {"width": 1920, "height": 1080}
+        proxy = {"proxies": [{"externalProxy": {"server": "p.co", "port": 8080}}]}
+        extensions = [{"location": {"s3": {"bucket": "b", "prefix": "e/"}}}]
+        profile = {"profileIdentifier": "prof-1"}
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.sync_api": fake_playwright_module,
+        }):
+            mgr = BrowserSessionManager(
+                region="us-west-2",
+                identifier="custom-id",
+                session_timeout_seconds=7200,
+                viewport=viewport,
+                proxy_configuration=proxy,
+                extensions=extensions,
+                profile_configuration=profile,
+            )
+            mgr._create_sync_browser_session("thread-1")
+
+        mock_bc.start.assert_called_once_with(
+            identifier="custom-id",
+            session_timeout_seconds=7200,
+            viewport=viewport,
+            proxy_configuration=proxy,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+
+    def test_session_config_typed_dataclasses_passed_to_start_sync(self):
+        """Verify SDK typed dataclasses are passed through to start() in sync path."""
+        import sys
+
+        from bedrock_agentcore.tools.config import (
+            BrowserExtension,
+            ExtensionS3Location,
+            ExternalProxy,
+            ProfileConfiguration,
+            ProxyConfiguration,
+            ViewportConfiguration,
+        )
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp.return_value = mock_browser
+
+        fake_playwright_module = MagicMock()
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.return_value.start.return_value = mock_playwright_ctx
+        fake_playwright_module.sync_playwright = mock_sync_pw
+
+        viewport = ViewportConfiguration.desktop_hd()
+        proxy = ProxyConfiguration(
+            proxies=[ExternalProxy(server="proxy.co", port=8080)],
+            bypass_patterns=[".internal.com"],
+        )
+        extensions = [
+            BrowserExtension(
+                s3_location=ExtensionS3Location(bucket="ext-bucket", prefix="ublock/")
+            )
+        ]
+        profile = ProfileConfiguration(profile_identifier="my-profile")
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.sync_api": fake_playwright_module,
+        }):
+            mgr = BrowserSessionManager(
+                region="us-west-2",
+                viewport=viewport,
+                proxy_configuration=proxy,
+                extensions=extensions,
+                profile_configuration=profile,
+            )
+            mgr._create_sync_browser_session("thread-1")
+
+        mock_bc.start.assert_called_once_with(
+            viewport=viewport,
+            proxy_configuration=proxy,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+
+    def test_get_browser_client_returns_none_when_no_session(self):
+        mgr = BrowserSessionManager(region="us-west-2")
+        assert mgr.get_browser_client("nonexistent") is None
+
+    def test_get_browser_client_returns_client(self):
+        mgr = BrowserSessionManager(region="us-west-2")
+        mock_client = MagicMock()
+        mock_browser = MagicMock()
+        mgr._sync_sessions["thread-1"] = (mock_client, mock_browser)
+
+        result = mgr.get_browser_client("thread-1")
+        assert result is mock_client
+
+    @pytest.mark.asyncio
+    async def test_get_async_browser_client_returns_none(self):
+        mgr = BrowserSessionManager(region="us-west-2")
+        result = await mgr.get_async_browser_client("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_async_browser_client_returns_client(self):
+        mgr = BrowserSessionManager(region="us-west-2")
+        mock_client = MagicMock()
+        mock_browser = MagicMock()
+        mgr._async_sessions["thread-1"] = (mock_client, mock_browser)
+
+        result = await mgr.get_async_browser_client("thread-1")
+        assert result is mock_client
+
+    @pytest.mark.asyncio
+    async def test_integration_source_set_async(self):
+        """Verify integration_source='crewai' is passed to BrowserClient in async path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp = AsyncMock(return_value=mock_browser)
+
+        fake_async_pw_module = MagicMock()
+        mock_async_pw = MagicMock()
+        mock_async_pw_start = AsyncMock(return_value=mock_playwright_ctx)
+        mock_async_pw.return_value.start = mock_async_pw_start
+        fake_async_pw_module.async_playwright = mock_async_pw
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.async_api": fake_async_pw_module,
+        }):
+            mgr = BrowserSessionManager(region="us-west-2")
+            await mgr._create_async_browser_session("thread-1")
+
+        MockBC.assert_called_once_with(
+            region="us-west-2",
+            integration_source="crewai",
+        )
+        mock_bc.start.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_identifier_passed_to_start_async(self):
+        """Verify identifier is passed to start() in async path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp = AsyncMock(return_value=mock_browser)
+
+        fake_async_pw_module = MagicMock()
+        mock_async_pw = MagicMock()
+        mock_async_pw_start = AsyncMock(return_value=mock_playwright_ctx)
+        mock_async_pw.return_value.start = mock_async_pw_start
+        fake_async_pw_module.async_playwright = mock_async_pw
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.async_api": fake_async_pw_module,
+        }):
+            mgr = BrowserSessionManager(
+                region="us-west-2", identifier="my-vpc-browser"
+            )
+            await mgr._create_async_browser_session("thread-1")
+
+        mock_bc.start.assert_called_once_with(identifier="my-vpc-browser")
+
+    @pytest.mark.asyncio
+    async def test_session_config_passed_to_start_async(self):
+        """Verify all session config is passed to start() in async path."""
+        import sys
+
+        MockBC = MagicMock()
+        mock_bc = MagicMock()
+        mock_bc.generate_ws_headers.return_value = ("ws://fake", {})
+        MockBC.return_value = mock_bc
+
+        fake_module = MagicMock()
+        fake_module.BrowserClient = MockBC
+
+        mock_playwright_ctx = MagicMock()
+        mock_browser = MagicMock()
+        mock_playwright_ctx.chromium.connect_over_cdp = AsyncMock(return_value=mock_browser)
+
+        fake_async_pw_module = MagicMock()
+        mock_async_pw = MagicMock()
+        mock_async_pw_start = AsyncMock(return_value=mock_playwright_ctx)
+        mock_async_pw.return_value.start = mock_async_pw_start
+        fake_async_pw_module.async_playwright = mock_async_pw
+
+        viewport = {"width": 375, "height": 667}
+        proxy = {"proxies": []}
+        extensions = [{"location": {"s3": {"bucket": "b", "prefix": "e/"}}}]
+        profile = {"profileIdentifier": "mobile-prof"}
+
+        with patch.dict(sys.modules, {
+            "bedrock_agentcore.tools.browser_client": fake_module,
+            "playwright": MagicMock(),
+            "playwright.async_api": fake_async_pw_module,
+        }):
+            mgr = BrowserSessionManager(
+                region="us-west-2",
+                identifier="custom-id",
+                session_timeout_seconds=1800,
+                viewport=viewport,
+                proxy_configuration=proxy,
+                extensions=extensions,
+                profile_configuration=profile,
+            )
+            await mgr._create_async_browser_session("thread-1")
+
+        mock_bc.start.assert_called_once_with(
+            identifier="custom-id",
+            session_timeout_seconds=1800,
+            viewport=viewport,
+            proxy_configuration=proxy,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+
+
+# --- BrowserToolkit ---
+
+
+class TestBrowserToolkit:
+    @patch(
+        "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+    )
+    def test_tool_count(self, MockMgr):
+        """Verify all 10 tools are registered."""
+        toolkit = BrowserToolkit(region="us-west-2")
+        assert len(toolkit.tools) == 10
+
+    @patch(
+        "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+    )
+    def test_identifier_passed_to_session_manager(self, MockMgr):
+        """Verify identifier is forwarded to BrowserSessionManager."""
+        BrowserToolkit(region="us-west-2", identifier="my-id")
+        MockMgr.assert_called_once_with(
+            region="us-west-2",
+            identifier="my-id",
+            session_timeout_seconds=None,
+            viewport=None,
+            proxy_configuration=None,
+            extensions=None,
+            profile_configuration=None,
+        )
+
+    @patch(
+        "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+    )
+    def test_session_config_passed_to_session_manager(self, MockMgr):
+        """Verify all session config is forwarded to BrowserSessionManager."""
+        viewport = {"width": 1920, "height": 1080}
+        proxy = {"proxies": [{"externalProxy": {"server": "p.co", "port": 8080}}]}
+        extensions = [{"location": {"s3": {"bucket": "b", "prefix": "e/"}}}]
+        profile = {"profileIdentifier": "prof-1"}
+
+        BrowserToolkit(
+            region="eu-west-1",
+            identifier="custom-id",
+            session_timeout_seconds=7200,
+            viewport=viewport,
+            proxy_configuration=proxy,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+        MockMgr.assert_called_once_with(
+            region="eu-west-1",
+            identifier="custom-id",
+            session_timeout_seconds=7200,
+            viewport=viewport,
+            proxy_configuration=proxy,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+
+    @patch(
+        "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+    )
+    def test_tool_names(self, MockMgr):
+        """Verify expected tool names are present."""
+        toolkit = BrowserToolkit(region="us-west-2")
+        names = {t.name for t in toolkit.tools}
+        expected = {
+            "navigate_browser",
+            "click_element",
+            "navigate_back",
+            "extract_text",
+            "extract_hyperlinks",
+            "get_elements",
+            "current_webpage",
+            "generate_live_view_url",
+            "take_control",
+            "release_control",
+        }
+        assert names == expected
+
+    def test_create_browser_toolkit_passes_identifier(self):
+        with patch(
+            "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+        ):
+            toolkit, tools = create_browser_toolkit(
+                region="eu-west-1", identifier="vpc-id"
+            )
+        assert len(tools) == 10
+
+    @patch(
+        "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+    )
+    def test_session_config_typed_dataclasses_passed_to_session_manager(self, MockMgr):
+        """Verify SDK typed dataclasses are forwarded to BrowserSessionManager."""
+        from bedrock_agentcore.tools.config import (
+            BrowserExtension,
+            ExtensionS3Location,
+            ProfileConfiguration,
+            ViewportConfiguration,
+        )
+
+        viewport = ViewportConfiguration(width=1280, height=720)
+        extensions = [
+            BrowserExtension(
+                s3_location=ExtensionS3Location(bucket="b", prefix="e/")
+            )
+        ]
+        profile = ProfileConfiguration(profile_identifier="prof-1")
+
+        BrowserToolkit(
+            region="us-west-2",
+            viewport=viewport,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+        MockMgr.assert_called_once_with(
+            region="us-west-2",
+            identifier=None,
+            session_timeout_seconds=None,
+            viewport=viewport,
+            proxy_configuration=None,
+            extensions=extensions,
+            profile_configuration=profile,
+        )
+
+    def test_create_browser_toolkit_passes_session_config(self):
+        with patch(
+            "crewai_tools.aws.bedrock.browser.browser_toolkit.BrowserSessionManager"
+        ) as MockMgr:
+            create_browser_toolkit(
+                region="us-west-2",
+                session_timeout_seconds=3600,
+                viewport={"width": 800, "height": 600},
+                proxy_configuration={"proxies": []},
+                extensions=[],
+                profile_configuration={"profileIdentifier": "p1"},
+            )
+        MockMgr.assert_called_once_with(
+            region="us-west-2",
+            identifier=None,
+            session_timeout_seconds=3600,
+            viewport={"width": 800, "height": 600},
+            proxy_configuration={"proxies": []},
+            extensions=[],
+            profile_configuration={"profileIdentifier": "p1"},
+        )
+
+
+# --- GenerateLiveViewUrlTool ---
+
+
+class TestGenerateLiveViewUrlTool:
+    def test_run_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.generate_live_view_url.return_value = "https://live-view.example.com/abc"
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+
+        mock_mgr.get_browser_client.assert_called_once_with("default")
+        mock_client.generate_live_view_url.assert_called_once()
+        assert "https://live-view.example.com/abc" in result
+
+    def test_run_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_browser_client.return_value = None
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "No browser session found" in result
+
+    def test_run_error(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.generate_live_view_url.side_effect = RuntimeError("auth failed")
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "Error generating live view URL" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.generate_live_view_url.return_value = "https://live.example.com"
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=mock_client)
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+        assert "https://live.example.com" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=None)
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+        assert "No browser session found" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_error(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.generate_live_view_url.side_effect = RuntimeError("auth failed")
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=mock_client)
+
+        tool = GenerateLiveViewUrlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+        assert "Error generating live view URL" in result
+
+
+# --- TakeControlTool ---
+
+
+class TestTakeControlTool:
+    def test_run_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = TakeControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+
+        mock_client.take_control.assert_called_once()
+        assert "Manual control enabled" in result
+
+    def test_run_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_browser_client.return_value = None
+
+        tool = TakeControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "No browser session found" in result
+
+    def test_run_error(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.take_control.side_effect = RuntimeError("control failed")
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = TakeControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "Error taking control" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=mock_client)
+
+        tool = TakeControlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+
+        mock_client.take_control.assert_called_once()
+        assert "Manual control enabled" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=None)
+
+        tool = TakeControlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+        assert "No browser session found" in result
+
+
+# --- ReleaseControlTool ---
+
+
+class TestReleaseControlTool:
+    def test_run_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = ReleaseControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+
+        mock_client.release_control.assert_called_once()
+        mock_mgr.reconnect_sync_browser.assert_called_once_with("default")
+        assert "re-enabled" in result
+
+    def test_run_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_browser_client.return_value = None
+
+        tool = ReleaseControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "No browser session found" in result
+
+    def test_run_error(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_client.release_control.side_effect = RuntimeError("release failed")
+        mock_mgr.get_browser_client.return_value = mock_client
+
+        tool = ReleaseControlTool(session_manager=mock_mgr)
+        result = tool._run(thread_id="default")
+        assert "Error releasing control" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_success(self):
+        mock_mgr = MagicMock()
+        mock_client = MagicMock()
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=mock_client)
+        mock_mgr.reconnect_async_browser = AsyncMock()
+
+        tool = ReleaseControlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+
+        mock_client.release_control.assert_called_once()
+        mock_mgr.reconnect_async_browser.assert_called_once_with("t1")
+        assert "re-enabled" in result
+
+    @pytest.mark.asyncio
+    async def test_arun_no_session(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_async_browser_client = AsyncMock(return_value=None)
+
+        tool = ReleaseControlTool(session_manager=mock_mgr)
+        result = await tool._arun(thread_id="t1")
+        assert "No browser session found" in result

--- a/lib/crewai-tools/tests/tools/test_agentcore_code_interpreter.py
+++ b/lib/crewai-tools/tests/tools/test_agentcore_code_interpreter.py
@@ -1,0 +1,491 @@
+"""Unit tests for AWS Bedrock AgentCore Code Interpreter toolkit."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools.aws.bedrock.code_interpreter.code_interpreter_toolkit import (
+    ClearContextTool,
+    CodeInterpreterToolkit,
+    DownloadFileTool,
+    DownloadFilesTool,
+    ExecuteCodeTool,
+    ExecuteCommandTool,
+    InstallPackagesTool,
+    UploadFileTool,
+    UploadFilesTool,
+    create_code_interpreter_toolkit,
+    extract_output_from_stream,
+)
+
+
+# --- Helpers ---
+
+
+def make_stream_response(text: str) -> dict:
+    """Build a mock code interpreter stream response."""
+    return {
+        "stream": [
+            {
+                "result": {
+                    "content": [{"type": "text", "text": text}]
+                }
+            }
+        ]
+    }
+
+
+def make_resource_response(path: str, text: str) -> dict:
+    """Build a mock code interpreter stream response with a file resource."""
+    return {
+        "stream": [
+            {
+                "result": {
+                    "content": [
+                        {
+                            "type": "resource",
+                            "resource": {"uri": f"file://{path}", "text": text},
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+
+# --- extract_output_from_stream ---
+
+
+class TestExtractOutput:
+    def test_text_content(self):
+        response = make_stream_response("hello world")
+        assert extract_output_from_stream(response) == "hello world"
+
+    def test_resource_content(self):
+        response = make_resource_response("/tmp/data.csv", "a,b\n1,2")
+        output = extract_output_from_stream(response)
+        assert "data.csv" in output
+        assert "a,b" in output
+
+    def test_empty_stream(self):
+        assert extract_output_from_stream({"stream": []}) == ""
+
+    def test_resource_without_text_key(self):
+        """Verify JSON fallback when resource has no 'text' key."""
+        response = {
+            "stream": [
+                {
+                    "result": {
+                        "content": [
+                            {
+                                "type": "resource",
+                                "resource": {"uri": "file:///tmp/out.bin", "size": 1024},
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        output = extract_output_from_stream(response)
+        assert "out.bin" in output
+        assert "1024" in output
+
+    def test_multiple_events_joined(self):
+        """Verify multiple stream events are joined with newlines."""
+        response = {
+            "stream": [
+                {"result": {"content": [{"type": "text", "text": "line1"}]}},
+                {"result": {"content": [{"type": "text", "text": "line2"}]}},
+            ]
+        }
+        output = extract_output_from_stream(response)
+        assert "line1" in output
+        assert "line2" in output
+
+
+# --- CodeInterpreterToolkit ---
+
+
+class TestCodeInterpreterToolkit:
+    def test_integration_source_set(self):
+        """Verify integration_source='crewai' is passed to CodeInterpreter."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        # Pre-seed sys.modules so the lazy import resolves to our mock
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(region="us-east-1")
+            toolkit._get_or_create_interpreter("default")
+
+        MockCI.assert_called_once_with(
+            region="us-east-1",
+            integration_source="crewai",
+        )
+        mock_ci.start.assert_called_once_with()
+
+    def test_identifier_passed_to_start(self):
+        """Verify custom identifier is passed to start()."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(
+                region="us-west-2", identifier="my-custom-id"
+            )
+            toolkit._get_or_create_interpreter("default")
+
+        mock_ci.start.assert_called_once_with(identifier="my-custom-id")
+
+    def test_no_identifier_no_kwarg(self):
+        """Verify start() called without identifier when not set."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(region="us-west-2")
+            toolkit._get_or_create_interpreter("default")
+
+        mock_ci.start.assert_called_once_with()
+
+    def test_interpreter_reused_for_same_thread(self):
+        """Verify same interpreter returned for repeated calls with same thread_id."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(region="us-west-2")
+            ci1 = toolkit._get_or_create_interpreter("thread-a")
+            ci2 = toolkit._get_or_create_interpreter("thread-a")
+
+        assert ci1 is ci2
+        assert MockCI.call_count == 1
+
+    def test_tool_count(self):
+        """Verify all 15 tools are registered."""
+        toolkit = CodeInterpreterToolkit(region="us-west-2")
+        assert len(toolkit.tools) == 15
+
+    def test_tool_names(self):
+        """Verify expected tool names are present."""
+        toolkit = CodeInterpreterToolkit(region="us-west-2")
+        names = {t.name for t in toolkit.tools}
+        expected = {
+            "execute_code",
+            "execute_command",
+            "list_files",
+            "read_files",
+            "write_files",
+            "delete_files",
+            "start_command_execution",
+            "get_task",
+            "stop_task",
+            "upload_file",
+            "upload_files",
+            "install_packages",
+            "download_file",
+            "download_files",
+            "clear_context",
+        }
+        assert names == expected
+
+    def test_session_timeout_passed_to_start(self):
+        """Verify session_timeout_seconds is passed to start()."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(
+                region="us-west-2", session_timeout_seconds=1800
+            )
+            toolkit._get_or_create_interpreter("default")
+
+        mock_ci.start.assert_called_once_with(session_timeout_seconds=1800)
+
+    def test_session_timeout_with_identifier_passed_to_start(self):
+        """Verify both identifier and session_timeout_seconds are passed to start()."""
+        MockCI = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.session_id = "sess-123"
+        MockCI.return_value = mock_ci
+
+        import sys
+        fake_module = MagicMock()
+        fake_module.CodeInterpreter = MockCI
+        with patch.dict(sys.modules, {"bedrock_agentcore.tools.code_interpreter_client": fake_module}):
+            toolkit = CodeInterpreterToolkit(
+                region="us-west-2",
+                identifier="custom-id",
+                session_timeout_seconds=3600,
+            )
+            toolkit._get_or_create_interpreter("default")
+
+        mock_ci.start.assert_called_once_with(
+            identifier="custom-id", session_timeout_seconds=3600
+        )
+
+    def test_create_code_interpreter_toolkit_passes_identifier(self):
+        """Verify factory function passes identifier through."""
+        toolkit, tools = create_code_interpreter_toolkit(
+            region="us-east-1", identifier="vpc-id"
+        )
+        assert toolkit.identifier == "vpc-id"
+        assert len(tools) == 15
+
+    def test_create_code_interpreter_toolkit_passes_timeout(self):
+        """Verify factory function passes session_timeout_seconds through."""
+        toolkit, tools = create_code_interpreter_toolkit(
+            region="us-east-1", session_timeout_seconds=1800
+        )
+        assert toolkit.session_timeout_seconds == 1800
+        assert len(tools) == 15
+
+
+# --- New Tool Classes ---
+
+
+class TestUploadFileTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.upload_file.return_value = make_stream_response("File uploaded")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = UploadFileTool(mock_toolkit)
+        result = tool._run(path="data.csv", content="a,b\n1,2", description="test data")
+
+        mock_ci.upload_file.assert_called_once_with(
+            path="data.csv", content="a,b\n1,2", description="test data"
+        )
+        assert "File uploaded" in result
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_toolkit._get_or_create_interpreter.side_effect = RuntimeError("boom")
+
+        tool = UploadFileTool(mock_toolkit)
+        result = tool._run(path="x.py", content="code")
+        assert "Error uploading file" in result
+
+
+class TestUploadFilesTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.upload_files.return_value = make_stream_response("2 files uploaded")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = UploadFilesTool(mock_toolkit)
+        files = [
+            {"path": "a.py", "content": "x=1"},
+            {"path": "b.py", "content": "y=2"},
+        ]
+        result = tool._run(files=files)
+
+        mock_ci.upload_files.assert_called_once_with(files=files)
+        assert "2 files uploaded" in result
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_toolkit._get_or_create_interpreter.side_effect = RuntimeError("boom")
+
+        tool = UploadFilesTool(mock_toolkit)
+        result = tool._run(files=[{"path": "a.py", "content": "x=1"}])
+        assert "Error uploading files" in result
+
+
+class TestInstallPackagesTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.install_packages.return_value = make_stream_response(
+            "Successfully installed pandas numpy"
+        )
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = InstallPackagesTool(mock_toolkit)
+        result = tool._run(packages=["pandas", "numpy"], upgrade=True)
+
+        mock_ci.install_packages.assert_called_once_with(
+            packages=["pandas", "numpy"], upgrade=True
+        )
+        assert "Successfully installed" in result
+
+    def test_run_default_upgrade_false(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.install_packages.return_value = make_stream_response("installed")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = InstallPackagesTool(mock_toolkit)
+        tool._run(packages=["requests"])
+
+        mock_ci.install_packages.assert_called_once_with(
+            packages=["requests"], upgrade=False
+        )
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.install_packages.side_effect = ValueError("bad package name")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = InstallPackagesTool(mock_toolkit)
+        result = tool._run(packages=["bad;pkg"])
+        assert "Error installing packages" in result
+
+
+class TestDownloadFileTool:
+    def test_run_text_file(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_file.return_value = "file contents here"
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFileTool(mock_toolkit)
+        result = tool._run(path="output.txt")
+
+        mock_ci.download_file.assert_called_once_with(path="output.txt")
+        assert result == "file contents here"
+
+    def test_run_binary_file(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_file.return_value = b"\x89PNG binary data"
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFileTool(mock_toolkit)
+        result = tool._run(path="image.png")
+        assert "Binary file" in result
+        assert "16 bytes" in result
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_file.side_effect = RuntimeError("not found")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFileTool(mock_toolkit)
+        result = tool._run(path="missing.txt")
+        assert "Error downloading file" in result
+
+
+class TestDownloadFilesTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_files.return_value = {
+            "data.csv": "a,b\n1,2",
+            "img.png": b"\x89PNG",
+        }
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFilesTool(mock_toolkit)
+        result = tool._run(paths=["data.csv", "img.png"])
+
+        assert "data.csv" in result
+        assert "a,b" in result
+        assert "Binary" in result
+
+    def test_run_empty(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_files.return_value = {}
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFilesTool(mock_toolkit)
+        result = tool._run(paths=["missing.txt"])
+        assert result == "No files found"
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.download_files.side_effect = RuntimeError("download failed")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = DownloadFilesTool(mock_toolkit)
+        result = tool._run(paths=["a.txt"])
+        assert "Error downloading files" in result
+
+
+class TestClearContextTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = ClearContextTool(mock_toolkit)
+        result = tool._run()
+
+        mock_ci.clear_context.assert_called_once()
+        assert "cleared successfully" in result
+
+    def test_run_error(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.clear_context.side_effect = RuntimeError("fail")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = ClearContextTool(mock_toolkit)
+        result = tool._run()
+        assert "Error clearing context" in result
+
+
+# --- Existing Tool Classes (regression) ---
+
+
+class TestExecuteCodeTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.invoke.return_value = make_stream_response("42")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = ExecuteCodeTool(mock_toolkit)
+        result = tool._run(code="print(42)")
+
+        mock_ci.invoke.assert_called_once_with(
+            method="executeCode",
+            params={"code": "print(42)", "language": "python", "clearContext": False},
+        )
+        assert "42" in result
+
+
+class TestExecuteCommandTool:
+    def test_run_success(self):
+        mock_toolkit = MagicMock()
+        mock_ci = MagicMock()
+        mock_ci.invoke.return_value = make_stream_response("Python 3.12.0")
+        mock_toolkit._get_or_create_interpreter.return_value = mock_ci
+
+        tool = ExecuteCommandTool(mock_toolkit)
+        result = tool._run(command="python --version")
+
+        mock_ci.invoke.assert_called_once_with(
+            method="executeCommand", params={"command": "python --version"}
+        )
+        assert "Python 3.12.0" in result


### PR DESCRIPTION
## Summary

Enhances the AWS Bedrock AgentCore Browser and Code Interpreter toolkits to expose the full SDK feature surface — session configuration with typed dataclass support, new tool capabilities, and telemetry tracking.

### Telemetry

- Add `integration_source="crewai"` to `BrowserClient` and `CodeInterpreter` constructors for customer acquisition tracking via User-Agent header

### Session Configuration Passthrough (with SDK Typed Dataclass Support)

Expose all `start()` parameters so users can configure sessions at toolkit creation time. Previously only `identifier` was supported — all other SDK options were silently ignored.

All config parameters accept **both** SDK typed dataclasses and plain dicts, matching the SDK's own `BrowserClient.start()` signature. Typed dataclasses give users IDE autocomplete, validation at construction time, and convenience factory methods.

**Browser** — 5 new params on `BrowserToolkit` / `create_browser_toolkit()`:
- `session_timeout_seconds` — session timeout in seconds (1–28800, default 3600)
- `viewport` — `ViewportConfiguration` or dict. Factory methods: `.desktop_hd()`, `.laptop()`, `.mobile()`, etc.
- `proxy_configuration` — `ProxyConfiguration` or dict. Proxy routing with optional auth via Secrets Manager
- `extensions` — `list[BrowserExtension | dict]`. S3-hosted browser extensions
- `profile_configuration` — `ProfileConfiguration` or dict. Persist cookies/local storage across sessions

**Code Interpreter** — 1 new param on `CodeInterpreterToolkit` / `create_code_interpreter_toolkit()`:
- `session_timeout_seconds` — session timeout in seconds (default 900)

All params default to `None` (SDK defaults apply). No validation on our side — the SDK handles it.

### Custom Sandbox Identifier

- Add optional `identifier` parameter to `BrowserToolkit`, `CodeInterpreterToolkit`, and `BrowserSessionManager` for custom browser/interpreter resources (VPC, recording, Web Bot Auth)
- Passed through to `.start(identifier=...)` on the underlying SDK clients

### New Browser Tools (3)

- `GenerateLiveViewUrlTool` — generate a presigned URL for live browser viewing
- `TakeControlTool` — take manual control of the browser (disables automation)
- `ReleaseControlTool` — release manual control (re-enables automation, reconnects Playwright)

### New Code Interpreter Tools (6)

- `UploadFileTool` / `UploadFilesTool` — upload files with optional semantic descriptions
- `DownloadFileTool` / `DownloadFilesTool` — download files from the sandbox
- `InstallPackagesTool` — install pip packages with optional `--upgrade` flag
- `ClearContextTool` — reset the Python execution context

### Browser Session Manager

- Add `reconnect_sync_browser()` / `reconnect_async_browser()` for CDP reconnection after `release_control()`
- Add `get_browser_client()` / `get_async_browser_client()` accessors for the underlying `BrowserClient`
- Thread-safe session creation with per-key events to serialize without blocking unrelated callers

## Usage Examples

```python
# Browser with typed SDK dataclasses (recommended)
from bedrock_agentcore.tools import (
    ViewportConfiguration, ProxyConfiguration, ExternalProxy,
    ProfileConfiguration,
)

toolkit, tools = create_browser_toolkit(
    region="us-west-2",
    viewport=ViewportConfiguration.desktop_hd(),  # 1920x1080
    proxy_configuration=ProxyConfiguration(
        proxies=[ExternalProxy(server="proxy.corp.com", port=8080)],
        bypass_patterns=[".amazonaws.com"],
    ),
    profile_configuration=ProfileConfiguration(profile_identifier="my-profile"),
    session_timeout_seconds=7200,
)

# Browser with plain dicts (also works)
toolkit, tools = create_browser_toolkit(
    region="us-west-2",
    viewport={"width": 1920, "height": 1080},
    proxy_configuration={
        "proxies": [{"externalProxy": {"server": "proxy.corp.com", "port": 8080}}],
        "bypass": {"domainPatterns": [".amazonaws.com"]},
    },
    session_timeout_seconds=7200,
)

# Code interpreter with longer timeout
toolkit, tools = create_code_interpreter_toolkit(
    region="us-west-2",
    session_timeout_seconds=1800,
)
```

## Test Plan

- [x] 68 unit tests (all pass) covering telemetry, identifier passthrough, session config passthrough with both dicts and typed dataclasses (sync + async), all new tools, edge cases
- [x] Live integration tests against real AgentCore sessions verifying:
  - Browser viewport `1920x1080` returned in session API response
  - Browser timeout `600s` applied correctly
  - Code interpreter timeout `1800s` applied correctly
  - Default timeouts (3600s browser, 900s CI) when no config specified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies AgentCore Browser/Code Interpreter session lifecycle and configuration passthrough (including reconnection behavior), which could impact remote session stability and resource cleanup. Changes are covered by new unit tests but touch threaded/async session management and SDK start kwargs.
> 
> **Overview**
> Adds new Amazon Bedrock AgentCore documentation pages (EN/KO) and navigation entries for **AgentCore Browser**, **AgentCore Code Interpreter**, and an **AgentCore Overview**.
> 
> Extends the AgentCore `BrowserToolkit` and `CodeInterpreterToolkit` to pass through additional SDK session configuration (e.g., `session_timeout_seconds`, `viewport`, `proxy_configuration`, `extensions`, `profile_configuration`, plus `identifier`), and tags SDK client creation with `integration_source="crewai"`.
> 
> Introduces new browser tools for human oversight/control (including `generate_live_view_url`, `take_control`, `release_control` with Playwright reconnection) and new code-interpreter tools for file transfer, package install, and context reset. Adds comprehensive unit tests for the new capabilities and config passthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4dd9dda674e73c3e311bca118f323ed2be9a118. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->