### PR TITLE
fix(tools): use LF line endings in generate_tool_specs.py on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
## Problem

On Windows, Python's `open()` in text mode uses CRLF (`\r\n`) line endings by default. Running `generate_tool_specs.py` on Windows regenerates `tool.specs.json` with CRLF, causing every line to appear modified in `git diff` even though content is unchanged.

## Fix

Pass `newline="\n"` to `open()` in `save_to_json()` to force LF line endings regardless of the operating system:

```python
# Before
with open(output_path, "w", encoding="utf-8") as f:

# After
with open(output_path, "w", encoding="utf-8", newline="\n") as f:
```

Fixes #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single file-write option change that only affects newline normalization in generated JSON output.
> 
> **Overview**
> Ensures `ToolSpecExtractor.save_to_json()` opens the output file with `newline="\n"`, so regenerating `tool.specs.json` on Windows uses LF instead of CRLF and avoids whole-file diff churn.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e936f98e571b9353ec302a9a3a53441ddc04afd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->