### PR TITLE
fix(agents): correctly extract tool arguments from AWS Bedrock responses

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {}) or "{}"
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Problem

When using AWS Bedrock models (e.g., `us.amazon.nova-pro-v1:0`), all tool calls receive empty arguments `{}` regardless of what the LLM provides.

The bug is in `crew_agent_executor.py`:
```python
# BEFORE (broken)
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
```

`func_info.get("arguments", "{}")` returns the string `"{}"` (truthy!) when the key is absent. This means the `or` operator never evaluates `tool_call.get("input", {})`, so Bedrock's `input` field is always ignored.

## Fix

Use `.get()` without a default to distinguish a missing key from an empty string, then fall back to the Bedrock `input` field only when the OpenAI `arguments` field is absent or empty:

```python
# AFTER (fixed)
_raw_args = func_info.get("arguments")
func_args = (_raw_args if _raw_args not in (None, "", "{}") else None) or tool_call.get("input", {})
```

Fixes #4748

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core native tool-call parsing in `CrewAgentExecutor`, which can change what arguments are passed into tools across providers. Small, targeted logic change but impacts tool execution correctness.
> 
> **Overview**
> Fixes native tool-call parsing in `CrewAgentExecutor._parse_native_tool_call` so missing OpenAI `function.arguments` no longer defaults to the truthy string `"{}"`.
> 
> When `arguments` is absent/empty, the executor now correctly falls back to Bedrock-style tool call `input`, preventing tools from being invoked with empty `{}` arguments on Bedrock responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c72dab8c9d439d66efbb6fdc464b08bd014a7a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->