### PR TITLE
fix(adapters): ignore extra fields in MCP tool args schema to allow security_context

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/adapters/mcp_adapter.py
+++ b/lib/crewai-tools/src/crewai_tools/adapters/mcp_adapter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from crewai.tools import BaseTool
 from crewai.utilities.pydantic_schema_utils import create_model_from_schema
 from crewai.utilities.string_utils import sanitize_tool_name
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from crewai_tools.adapters.tool_collection import ToolCollection
 
@@ -51,7 +51,14 @@ try:
             """
             tool_name = sanitize_tool_name(mcp_tool.name)
             tool_description = mcp_tool.description or ""
-            args_model = create_model_from_schema(mcp_tool.inputSchema)
+            # Use extra="ignore" so that CrewAI's injected fields (e.g.
+            # security_context) don't trigger Pydantic validation errors.
+            # MCP tools are defined by external servers whose inputSchema
+            # cannot include CrewAI-internal fields.
+            args_model = create_model_from_schema(
+                mcp_tool.inputSchema,
+                __config__=ConfigDict(extra="ignore"),
+            )
 
             class CrewAIMCPTool(BaseTool):
                 name: str = tool_name


### PR DESCRIPTION
## Problem

When using `MCPServerAdapter`, CrewAI injects a `security_context` parameter into every tool call. However, MCP tools' `inputSchema` is defined by external servers and cannot include this internal field. The MCP adapter creates Pydantic models with the default `extra="forbid"` config, causing Pydantic validation to fail:

```
ValidationError: Extra inputs are not permitted
  security_context: extra forbidden
```

## Fix

Pass `ConfigDict(extra="ignore")` when creating the `args_schema` for MCP tools so that CrewAI-injected fields are silently discarded before the tool receives its arguments.

```python
# Before
args_model = create_model_from_schema(mcp_tool.inputSchema)

# After
args_model = create_model_from_schema(
    mcp_tool.inputSchema,
    __config__=ConfigDict(extra="ignore"),
)
```

This is scoped to the MCP adapter only — other tool types are unaffected.

Fixes #4796

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to MCP adapter schema creation and only relaxes validation for unexpected fields, with minimal behavioral impact on normal tool inputs.
> 
> **Overview**
> Fixes MCP tool invocation failures when CrewAI injects internal fields like `security_context` by creating the MCP `args_schema` with `ConfigDict(extra="ignore")`, so unknown fields are dropped instead of raising Pydantic validation errors.
> 
> This change is limited to `mcp_adapter.py` and only affects argument validation for MCP-adapted tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a37dec40f5672ebebe35e1e52c5d4a87b055140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->