### PR TITLE
fix(docs): correct context type annotation in Tasks documentation

### DIFF
--- a/docs/en/concepts/tasks.mdx
+++ b/docs/en/concepts/tasks.mdx
@@ -52,7 +52,7 @@ crew = Crew(
 | **Name** _(optional)_                  | `name`                  | `Optional[str]`             | A name identifier for the task.                                                                                 |
 | **Agent** _(optional)_                 | `agent`                 | `Optional[BaseAgent]`       | The agent responsible for executing the task.                                                                   |
 | **Tools** _(optional)_                 | `tools`                 | `List[BaseTool]`            | The tools/resources the agent is limited to use for this task.                                                  |
-| **Context** _(optional)_               | `context`               | `Optional[List["Task"]]`    | Other tasks whose outputs will be used as context for this task.                                                |
+| **Context** _(optional)_               | `context`               | `Optional[List[Task]]`    | Other tasks whose outputs will be used as context for this task.                                                |
 | **Async Execution** _(optional)_       | `async_execution`       | `Optional[bool]`            | Whether the task should be executed asynchronously. Defaults to False.                                          |
 | **Human Input** _(optional)_           | `human_input`           | `Optional[bool]`            | Whether the task should have a human review the final answer of the agent. Defaults to False.                   |
 | **Markdown** _(optional)_              | `markdown`              | `Optional[bool]`            | Whether the task should instruct the agent to return the final answer formatted in Markdown. Defaults to False. |


### PR DESCRIPTION
## Fix documentation typo in Tasks page

The type annotation for the `context` field currently shows:

Optional[List["Task"]]

This is incorrect because it suggests a string type instead of the actual class reference.

### Correct type
Optional[List[Task]]

### Reason
`context` expects a list of `Task` objects whose outputs will be used as context for the current task. Using quotes implies a string forward reference, which is misleading in documentation.

### Change
Replaced:
Optional[List["Task"]]

With:
Optional[List[Task]]

### Docs page
https://docs.crewai.com/en/concepts/tasks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects a misleading type annotation with no runtime impact.
> 
> **Overview**
> Corrects the `context` field type in `docs/en/concepts/tasks.mdx` from `Optional[List["Task"]]` to `Optional[List[Task]]` to reflect that it accepts `Task` objects (not string forward references).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a99adde10eb456a65a82f569e415280e183b4457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->