### PR TITLE
feat: bump versions to 1.11.0rc1

### DIFF
--- a/lib/crewai-files/src/crewai_files/__init__.py
+++ b/lib/crewai-files/src/crewai_files/__init__.py
@@ -152,4 +152,4 @@ __all__ = [
     "wrap_file_source",
 ]
 
-__version__ = "1.10.2rc2"
+__version__ = "1.11.0rc1"

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pytube~=15.0.0",
     "requests~=2.32.5",
     "docker~=7.1.0",
-    "crewai==1.10.2rc2",
+    "crewai==1.11.0rc1",
     "tiktoken~=0.8.0",
     "beautifulsoup4~=4.13.4",
     "python-docx~=1.2.0",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -309,4 +309,4 @@ __all__ = [
     "ZapierActionTools",
 ]
 
-__version__ = "1.10.2rc2"
+__version__ = "1.11.0rc1"

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -53,7 +53,7 @@ Repository = "https://github.com/crewAIInc/crewAI"
 
 [project.optional-dependencies]
 tools = [
-    "crewai-tools==1.10.2rc2",
+    "crewai-tools==1.11.0rc1",
 ]
 embeddings = [
     "tiktoken~=0.8.0"

--- a/lib/crewai/src/crewai/__init__.py
+++ b/lib/crewai/src/crewai/__init__.py
@@ -42,7 +42,7 @@ def _suppress_pydantic_deprecation_warnings() -> None:
 
 _suppress_pydantic_deprecation_warnings()
 
-__version__ = "1.10.2rc2"
+__version__ = "1.11.0rc1"
 _telemetry_submitted = False
 
 

--- a/lib/crewai/src/crewai/cli/templates/crew/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/crew/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.10.2rc2"
+    "crewai[tools]==1.11.0rc1"
 ]
 
 [project.scripts]

--- a/lib/crewai/src/crewai/cli/templates/flow/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.10.2rc2"
+    "crewai[tools]==1.11.0rc1"
 ]
 
 [project.scripts]

--- a/lib/crewai/src/crewai/cli/templates/tool/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.10.2rc2"
+    "crewai[tools]==1.11.0rc1"
 ]
 
 [tool.crewai]

--- a/lib/devtools/src/crewai_devtools/__init__.py
+++ b/lib/devtools/src/crewai_devtools/__init__.py
@@ -1,3 +1,3 @@
 """CrewAI development tools."""
 
-__version__ = "1.10.2rc2"
+__version__ = "1.11.0rc1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version/dependency bump across packages and CLI templates with no functional logic changes. Main risk is mismatched release tags or dependency pinning issues during packaging/publishing.
> 
> **Overview**
> Bumps release-candidate versions across `crewai`, `crewai-tools`, `crewai-files`, and `crewai-devtools` to `1.11.0rc1`.
> 
> Updates inter-package pins so `crewai-tools` depends on `crewai==1.11.0rc1`, `crewai` optional `tools` depends on `crewai-tools==1.11.0rc1`, and the CLI `crew`/`flow`/`tool` templates generate projects pinned to `crewai[tools]==1.11.0rc1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21c79fa92569b57245cd355d97bed06068bc6fcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->