### PR TITLE
fix: provider-agnostic tool schema for Bedrock/Gemini MCP tools (#4472)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,35 @@ def _patched_make_vcr_request(httpx_request: Any, **kwargs: Any) -> Any:
 httpx_stubs._make_vcr_request = _patched_make_vcr_request
 
 
+# Patch the response-side of VCR to fix httpx.ResponseNotRead errors.
+# VCR's _from_serialized_response mocks httpx.Response.read(), which prevents
+# the response's internal _content attribute from being properly initialized.
+# When OpenAI's client (using with_raw_response) accesses response.content,
+# httpx raises ResponseNotRead because read() was never actually called.
+# This patch ensures _content is explicitly set after response creation.
+_original_from_serialized_response = getattr(
+    httpx_stubs, "_from_serialized_response", None
+)
+
+if _original_from_serialized_response is not None:
+
+    def _patched_from_serialized_response(
+        request: Any, serialized_response: Any, history: Any = None
+    ) -> Any:
+        """Patched version that ensures response._content is properly set."""
+        response = _original_from_serialized_response(request, serialized_response, history)
+        # Explicitly set _content to avoid ResponseNotRead errors
+        # The content was passed to the constructor but the mocked read() prevents
+        # proper initialization of the internal state
+        body_content = serialized_response.get("body", {}).get("string", b"")
+        if isinstance(body_content, str):
+            body_content = body_content.encode("utf-8")
+        response._content = body_content
+        return response
+
+    httpx_stubs._from_serialized_response = _patched_from_serialized_response
+
+
 @pytest.fixture(autouse=True, scope="function")
 def cleanup_event_handlers() -> Generator[None, Any, None]:
     """Clean up event bus handlers after each test to prevent test pollution."""

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -3086,25 +3086,35 @@ class Flow(Generic[T], metaclass=FlowMeta):
             logger.warning(
                 f"Structured output failed, falling back to simple prompting: {e}"
             )
-            response = llm_instance.call(messages=prompt)
-            response_clean = str(response).strip()
+            try:
+                response = llm_instance.call(
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                response_clean = str(response).strip()
 
-            # Exact match (case-insensitive)
-            for outcome in outcomes:
-                if outcome.lower() == response_clean.lower():
-                    return outcome
+                # Exact match (case-insensitive)
+                for outcome in outcomes:
+                    if outcome.lower() == response_clean.lower():
+                        return outcome
 
-            # Partial match
-            for outcome in outcomes:
-                if outcome.lower() in response_clean.lower():
-                    return outcome
+                # Partial match
+                for outcome in outcomes:
+                    if outcome.lower() in response_clean.lower():
+                        return outcome
 
-            # Fallback to first outcome
-            logger.warning(
-                f"Could not match LLM response '{response_clean}' to outcomes {list(outcomes)}. "
-                f"Falling back to first outcome: {outcomes[0]}"
-            )
-            return outcomes[0]
+                # Fallback to first outcome
+                logger.warning(
+                    f"Could not match LLM response '{response_clean}' to outcomes {list(outcomes)}. "
+                    f"Falling back to first outcome: {outcomes[0]}"
+                )
+                return outcomes[0]
+
+            except Exception as fallback_err:
+                logger.warning(
+                    f"Simple prompting also failed: {fallback_err}. "
+                    f"Falling back to first outcome: {outcomes[0]}"
+                )
+                return outcomes[0]
 
     def _log_flow_event(
         self,

--- a/lib/crewai/src/crewai/flow/human_feedback.py
+++ b/lib/crewai/src/crewai/flow/human_feedback.py
@@ -76,6 +76,24 @@ if TYPE_CHECKING:
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+def _serialize_llm_for_context(llm: Any) -> str | None:
+    """Serialize a BaseLLM object to a model string with provider prefix.
+
+    When persisting the LLM for HITL resume, we need to store enough info
+    to reconstruct a working LLM on the resume worker. Just storing the bare
+    model name (e.g. "gemini-3-flash-preview") causes provider inference to
+    fail — it defaults to OpenAI. Including the provider prefix (e.g.
+    "gemini/gemini-3-flash-preview") allows LLM() to correctly route.
+    """
+    model = getattr(llm, "model", None)
+    if not model:
+        return None
+    provider = getattr(llm, "provider", None)
+    if provider and "/" not in model:
+        return f"{provider}/{model}"
+    return model
+
+
 @dataclass
 class HumanFeedbackResult:
     """Result from a @human_feedback decorated method.
@@ -412,7 +430,7 @@ def human_feedback(
                 emit=list(emit) if emit else None,
                 default_outcome=default_outcome,
                 metadata=metadata or {},
-                llm=llm if isinstance(llm, str) else getattr(llm, "model", None),
+                llm=llm if isinstance(llm, str) else _serialize_llm_for_context(llm),
             )
 
             # Determine effective provider:

--- a/lib/crewai/src/crewai/llms/constants.py
+++ b/lib/crewai/src/crewai/llms/constants.py
@@ -240,6 +240,7 @@ ANTHROPIC_MODELS: list[AnthropicModels] = [
 
 GeminiModels: TypeAlias = Literal[
     "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
     "gemini-2.5-pro",
     "gemini-2.5-pro-preview-03-25",
     "gemini-2.5-pro-preview-05-06",
@@ -294,6 +295,7 @@ GeminiModels: TypeAlias = Literal[
 ]
 GEMINI_MODELS: list[GeminiModels] = [
     "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
     "gemini-2.5-pro",
     "gemini-2.5-pro-preview-03-25",
     "gemini-2.5-pro-preview-05-06",

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -1525,6 +1525,7 @@ class OpenAICompletion(BaseLLM):
         """Convert CrewAI tool format to OpenAI function calling format."""
         from crewai.llms.providers.utils.common import safe_tool_conversion
         from crewai.utilities.pydantic_schema_utils import (
+            ensure_all_properties_required,
             force_additional_properties_false,
         )
 
@@ -1546,6 +1547,7 @@ class OpenAICompletion(BaseLLM):
                 params_dict = (
                     parameters if isinstance(parameters, dict) else dict(parameters)
                 )
+                params_dict = ensure_all_properties_required(params_dict)
                 params_dict = force_additional_properties_false(params_dict)
                 openai_tool["function"]["parameters"] = params_dict
 

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -1525,8 +1525,11 @@ class OpenAICompletion(BaseLLM):
         """Convert CrewAI tool format to OpenAI function calling format."""
         from crewai.llms.providers.utils.common import safe_tool_conversion
         from crewai.utilities.pydantic_schema_utils import (
+            convert_oneof_to_anyof,
             ensure_all_properties_required,
+            ensure_type_in_schemas,
             force_additional_properties_false,
+            strip_unsupported_formats,
         )
 
         openai_tools = []
@@ -1547,6 +1550,9 @@ class OpenAICompletion(BaseLLM):
                 params_dict = (
                     parameters if isinstance(parameters, dict) else dict(parameters)
                 )
+                params_dict = strip_unsupported_formats(params_dict)
+                params_dict = ensure_type_in_schemas(params_dict)
+                params_dict = convert_oneof_to_anyof(params_dict)
                 params_dict = ensure_all_properties_required(params_dict)
                 params_dict = force_additional_properties_false(params_dict)
                 openai_tool["function"]["parameters"] = params_dict

--- a/lib/crewai/src/crewai/llms/providers/utils/common.py
+++ b/lib/crewai/src/crewai/llms/providers/utils/common.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import Any
 
-from crewai.utilities.pydantic_schema_utils import generate_model_description
+from crewai.utilities.pydantic_schema_utils import generate_tool_parameters_schema
 from crewai.utilities.string_utils import sanitize_tool_name
 
 
@@ -78,8 +78,7 @@ def extract_tool_info(tool: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
         # Also check for args_schema (Pydantic format)
         if not parameters and "args_schema" in tool:
             if hasattr(tool["args_schema"], "model_json_schema"):
-                schema_output = generate_model_description(tool["args_schema"])
-                parameters = schema_output.get("json_schema", {}).get("schema", {})
+                parameters = generate_tool_parameters_schema(tool["args_schema"])
 
     return name, description, parameters
 

--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -417,24 +417,28 @@ def strip_null_from_types(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
-def _strip_schema_metadata(d: Any) -> Any:
+def _strip_schema_metadata(d: Any, _is_properties: bool = False) -> Any:
     """Recursively remove provider-specific metadata from a JSON schema.
 
-    Strips ``title``, ``default``, and ``additionalProperties`` keys from all
-    nested dicts so that the resulting schema is accepted by any LLM provider
-    (Bedrock, Gemini, Anthropic, OpenAI, etc.).
+    Strips ``title``, ``default``, and ``additionalProperties`` keys from
+    schema nodes. Skips stripping from ``properties`` mapping dicts (where
+    keys are field names, not schema keywords) to avoid accidentally removing
+    field definitions for tools that have fields named ``title`` or ``default``.
 
     Args:
         d: The dictionary/list to clean.
+        _is_properties: Internal flag — True when ``d`` is a ``properties``
+            mapping (field-name → schema) rather than a schema node itself.
 
     Returns:
         The cleaned dictionary/list.
     """
     if isinstance(d, dict):
-        for key in ("title", "default", "additionalProperties"):
-            d.pop(key, None)
-        for v in d.values():
-            _strip_schema_metadata(v)
+        if not _is_properties:
+            for key in ("title", "default", "additionalProperties"):
+                d.pop(key, None)
+        for k, v in d.items():
+            _strip_schema_metadata(v, _is_properties=(k == "properties"))
     elif isinstance(d, list):
         for item in d:
             _strip_schema_metadata(item)

--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -417,6 +417,70 @@ def strip_null_from_types(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+def _strip_schema_metadata(d: Any) -> Any:
+    """Recursively remove provider-specific metadata from a JSON schema.
+
+    Strips ``title``, ``default``, and ``additionalProperties`` keys from all
+    nested dicts so that the resulting schema is accepted by any LLM provider
+    (Bedrock, Gemini, Anthropic, OpenAI, etc.).
+
+    Args:
+        d: The dictionary/list to clean.
+
+    Returns:
+        The cleaned dictionary/list.
+    """
+    if isinstance(d, dict):
+        for key in ("title", "default", "additionalProperties"):
+            d.pop(key, None)
+        for v in d.values():
+            _strip_schema_metadata(v)
+    elif isinstance(d, list):
+        for item in d:
+            _strip_schema_metadata(item)
+    return d
+
+
+def generate_tool_parameters_schema(
+    model: type[BaseModel],
+) -> dict[str, Any]:
+    """Generate a provider-agnostic JSON schema for tool parameters.
+
+    Unlike :func:`generate_model_description`, this function does **not** apply
+    OpenAI-specific transformations such as ``additionalProperties: false``,
+    forcing all properties into ``required``, or adding ``title`` to nested
+    objects.  The result is a clean schema that works with Bedrock, Gemini,
+    Anthropic, and OpenAI alike.
+
+    Steps:
+        1. Obtain Pydantic's JSON schema.
+        2. Resolve ``$ref`` / ``$defs`` inline.
+        3. Strip ``null`` from optional-field type unions.
+        4. Recursively remove ``title``, ``default``, and
+           ``additionalProperties`` keys.
+
+    Args:
+        model: A Pydantic model class (typically the tool's ``args_schema``).
+
+    Returns:
+        A plain JSON-schema ``dict`` suitable for the ``parameters`` key of a
+        tool/function definition.
+    """
+    schema = model.model_json_schema(ref_template="#/$defs/{model}")
+
+    # Inline all $ref definitions
+    schema = resolve_refs(schema)
+    schema.pop("$defs", None)
+
+    # Strip null variants for optional fields (the partial fix from #4579)
+    schema = strip_null_from_types(schema)
+
+    # Remove provider-specific / cosmetic keys
+    schema = _strip_schema_metadata(schema)
+
+    return schema
+
+
 def generate_model_description(
     model: type[BaseModel],
     *,

--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -417,28 +417,40 @@ def strip_null_from_types(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
-def _strip_schema_metadata(d: Any, _is_properties: bool = False) -> Any:
+def _strip_schema_metadata(d: Any, _is_properties_map: bool = False) -> Any:
     """Recursively remove provider-specific metadata from a JSON schema.
 
     Strips ``title``, ``default``, and ``additionalProperties`` keys from
-    schema nodes. Skips stripping from ``properties`` mapping dicts (where
-    keys are field names, not schema keywords) to avoid accidentally removing
-    field definitions for tools that have fields named ``title`` or ``default``.
+    schema nodes. When traversing a ``properties`` mapping (where keys are
+    user-defined field names), the function does **not** pop keys from the
+    mapping itself — it only recurses into each field's schema node and
+    strips metadata there.
 
     Args:
         d: The dictionary/list to clean.
-        _is_properties: Internal flag — True when ``d`` is a ``properties``
-            mapping (field-name → schema) rather than a schema node itself.
+        _is_properties_map: Internal flag — ``True`` when ``d`` is a
+            ``properties`` mapping (field-name -> schema) rather than a
+            schema node itself.
 
     Returns:
         The cleaned dictionary/list.
     """
     if isinstance(d, dict):
-        if not _is_properties:
+        if _is_properties_map:
+            # ``d`` is a properties mapping: each value is a schema node.
+            # Do NOT pop keys from ``d`` (they are field names like
+            # ``title``, ``default``, etc.).  Recurse into each field's
+            # schema node with ``_is_properties_map=False``.
+            for v in d.values():
+                _strip_schema_metadata(v, _is_properties_map=False)
+        else:
+            # ``d`` is a schema node — strip cosmetic/metadata keys.
             for key in ("title", "default", "additionalProperties"):
                 d.pop(key, None)
-        for k, v in d.items():
-            _strip_schema_metadata(v, _is_properties=(k == "properties"))
+            for k, v in d.items():
+                _strip_schema_metadata(
+                    v, _is_properties_map=(k == "properties")
+                )
     elif isinstance(d, list):
         for item in d:
             _strip_schema_metadata(item)

--- a/lib/crewai/tests/test_async_human_feedback.py
+++ b/lib/crewai/tests/test_async_human_feedback.py
@@ -989,8 +989,10 @@ class TestLLMObjectPreservedInContext:
             persistence = SQLiteFlowPersistence(db_path)
 
             # Create a mock BaseLLM object (not a string)
+            # Simulates LLM(model="gemini-2.0-flash", provider="gemini")
             mock_llm_obj = MagicMock()
-            mock_llm_obj.model = "gemini/gemini-2.0-flash"
+            mock_llm_obj.model = "gemini-2.0-flash"
+            mock_llm_obj.provider = "gemini"
 
             class PausingProvider:
                 def __init__(self, persistence: SQLiteFlowPersistence):
@@ -1086,11 +1088,36 @@ class TestLLMObjectPreservedInContext:
 
     def test_none_llm_when_no_model_attr(self) -> None:
         """Test that llm is None when object has no model attribute."""
-        mock_obj = MagicMock(spec=[])  # No attributes
+        from crewai.flow.human_feedback import _serialize_llm_for_context
 
-        # Simulate what the decorator does
-        llm_value = mock_obj if isinstance(mock_obj, str) else getattr(mock_obj, "model", None)
-        assert llm_value is None
+        mock_obj = MagicMock(spec=[])  # No attributes
+        assert _serialize_llm_for_context(mock_obj) is None
+
+    def test_provider_prefix_added_to_bare_model(self) -> None:
+        """Test that provider prefix is added when model has no slash."""
+        from crewai.flow.human_feedback import _serialize_llm_for_context
+
+        mock_obj = MagicMock()
+        mock_obj.model = "gemini-3-flash-preview"
+        mock_obj.provider = "gemini"
+        assert _serialize_llm_for_context(mock_obj) == "gemini/gemini-3-flash-preview"
+
+    def test_provider_prefix_not_doubled_when_already_present(self) -> None:
+        """Test that provider prefix is not added when model already has a slash."""
+        from crewai.flow.human_feedback import _serialize_llm_for_context
+
+        mock_obj = MagicMock()
+        mock_obj.model = "gemini/gemini-2.0-flash"
+        mock_obj.provider = "gemini"
+        assert _serialize_llm_for_context(mock_obj) == "gemini/gemini-2.0-flash"
+
+    def test_no_provider_attr_falls_back_to_bare_model(self) -> None:
+        """Test that bare model is used when no provider attribute exists."""
+        from crewai.flow.human_feedback import _serialize_llm_for_context
+
+        mock_obj = MagicMock(spec=[])
+        mock_obj.model = "gpt-4o-mini"
+        assert _serialize_llm_for_context(mock_obj) == "gpt-4o-mini"
 
 
 class TestAsyncHumanFeedbackEdgeCases:

--- a/lib/crewai/tests/test_human_feedback_decorator.py
+++ b/lib/crewai/tests/test_human_feedback_decorator.py
@@ -400,6 +400,45 @@ class TestCollapseToOutcome:
 
         assert result == "approved"  # First in list
 
+    def test_both_llm_calls_fail_returns_first_outcome(self):
+        """When both structured and simple prompting fail, return outcomes[0]."""
+        flow = Flow()
+
+        with patch("crewai.llm.LLM") as MockLLM:
+            mock_llm = MagicMock()
+            # Both calls raise — simulates wrong provider / auth failure
+            mock_llm.call.side_effect = RuntimeError("Model not found")
+            MockLLM.return_value = mock_llm
+
+            result = flow._collapse_to_outcome(
+                feedback="looks great, approve it",
+                outcomes=["needs_changes", "approved"],
+                llm="gemini-3-flash-preview",
+            )
+
+        assert result == "needs_changes"  # First in list (safe fallback)
+
+    def test_structured_fails_but_simple_succeeds(self):
+        """When structured output fails but simple prompting works, use that."""
+        flow = Flow()
+
+        with patch("crewai.llm.LLM") as MockLLM:
+            mock_llm = MagicMock()
+            # First call (structured) fails, second call (simple) succeeds
+            mock_llm.call.side_effect = [
+                RuntimeError("Function calling not supported"),
+                "approved",
+            ]
+            MockLLM.return_value = mock_llm
+
+            result = flow._collapse_to_outcome(
+                feedback="looks great",
+                outcomes=["needs_changes", "approved"],
+                llm="gpt-4o-mini",
+            )
+
+        assert result == "approved"
+
 
 # -- HITL Learning tests --
 

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -1037,3 +1037,47 @@ class TestGenerateToolParametersSchema:
         assert "properties" in props
         # The schema node for the 'properties' field should have title stripped
         assert "title" not in props["properties"]
+
+    def test_field_named_properties_not_treated_as_properties_map(self) -> None:
+        """Field named 'properties' must not suppress metadata stripping for sibling fields."""
+
+        class Tricky(BaseModel):
+            properties: str = Field(description="Raw schema properties")
+            title: str = Field(description="A field also named title")
+
+        schema = generate_tool_parameters_schema(Tricky)
+        props = schema["properties"]
+        # Both fields must appear — neither should be deleted
+        assert "properties" in props
+        assert "title" in props
+        # Schema nodes for both fields must have their own 'title' stripped
+        assert "title" not in props["properties"]
+        assert "title" not in props["title"]
+
+
+class TestOpenAIStrictModeTransforms:
+    """Verify _convert_tools_for_interference applies the full strict-mode pipeline."""
+
+    def test_strip_unsupported_formats_applied(self) -> None:
+        from crewai.utilities.pydantic_schema_utils import strip_unsupported_formats
+
+        schema = {"type": "object", "properties": {"url": {"type": "string", "format": "uri"}}}
+        result = strip_unsupported_formats(schema)
+        assert "format" not in result["properties"]["url"]
+
+    def test_ensure_type_in_schemas_applied(self) -> None:
+        from crewai.utilities.pydantic_schema_utils import ensure_type_in_schemas
+
+        # Empty schemas {} inside anyOf must become {"type": "object"}
+        schema = {"anyOf": [{}, {"type": "string"}]}
+        result = ensure_type_in_schemas(schema)
+        assert result["anyOf"][0] == {"type": "object"}
+        assert result["anyOf"][1] == {"type": "string"}
+
+    def test_convert_oneof_to_anyof_applied(self) -> None:
+        from crewai.utilities.pydantic_schema_utils import convert_oneof_to_anyof
+
+        schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+        result = convert_oneof_to_anyof(schema)
+        assert "anyOf" in result
+        assert "oneOf" not in result

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from crewai.utilities.pydantic_schema_utils import (
     build_rich_field_description,
@@ -1001,3 +1001,39 @@ class TestGenerateToolParametersSchema:
         assert props["count"]["type"] == "integer"
         assert props["score"]["type"] == "number"
         assert props["active"]["type"] == "boolean"
+
+    def test_field_named_title_preserved(self) -> None:
+        """A user field named 'title' must not be stripped from properties."""
+
+        class BookSearch(BaseModel):
+            title: str = Field(description="Book title to search for")
+            author: str = Field(description="Author name")
+
+        schema = generate_tool_parameters_schema(BookSearch)
+        props = schema["properties"]
+        assert "title" in props, "Field named 'title' was incorrectly stripped"
+        assert props["title"]["type"] == "string"
+        assert "author" in props
+
+    def test_field_named_default_preserved(self) -> None:
+        """A user field named 'default' must not be stripped from properties."""
+
+        class ConfigInput(BaseModel):
+            default: str = Field(description="Default value")
+            name: str
+
+        schema = generate_tool_parameters_schema(ConfigInput)
+        props = schema["properties"]
+        assert "default" in props, "Field named 'default' was incorrectly stripped"
+
+    def test_field_named_properties_still_stripped(self) -> None:
+        """A field named 'properties' should still have its schema metadata stripped."""
+
+        class MetaInput(BaseModel):
+            properties: str = Field(description="Some properties field")
+
+        schema = generate_tool_parameters_schema(MetaInput)
+        props = schema["properties"]
+        assert "properties" in props
+        # The schema node for the 'properties' field should have title stripped
+        assert "title" not in props["properties"]

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -25,6 +25,7 @@ from crewai.utilities.pydantic_schema_utils import (
     ensure_all_properties_required,
     ensure_type_in_schemas,
     force_additional_properties_false,
+    generate_tool_parameters_schema,
     resolve_refs,
     strip_null_from_types,
     strip_unsupported_formats,
@@ -882,3 +883,121 @@ class TestEndToEndMCPSchema:
         )
         assert obj.filters.date_from == datetime.date(2025, 1, 1)
         assert obj.filters.categories == ["news", "tech"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for generate_tool_parameters_schema (provider-agnostic tool schemas)
+# ---------------------------------------------------------------------------
+
+class TestGenerateToolParametersSchema:
+    """Verify that generate_tool_parameters_schema produces clean, provider-agnostic
+    JSON schemas suitable for Bedrock, Gemini, Anthropic, **and** OpenAI."""
+
+    def test_no_additional_properties_key(self) -> None:
+        """Schema must not contain additionalProperties (Bedrock/Gemini reject it)."""
+
+        class SimpleInput(BaseModel):
+            query: str
+
+        schema = generate_tool_parameters_schema(SimpleInput)
+        assert "additionalProperties" not in schema
+
+    def test_optional_fields_not_forced_required(self) -> None:
+        """Optional fields should NOT be forced into the required array.
+
+        generate_model_description forces all fields required (OpenAI strict mode).
+        The tool-parameters variant must preserve the original required array.
+        """
+        from typing import Optional
+
+        class MixedInput(BaseModel):
+            query: str
+            page: Optional[int] = None
+
+        schema = generate_tool_parameters_schema(MixedInput)
+        required = schema.get("required", [])
+        assert "query" in required
+        assert "page" not in required
+
+    def test_nested_objects_have_no_title(self) -> None:
+        """Nested object schemas must not carry a 'title' key (Gemini rejects it)."""
+
+        class Address(BaseModel):
+            city: str
+            zip_code: str
+
+        class Person(BaseModel):
+            name: str
+            address: Address
+
+        schema = generate_tool_parameters_schema(Person)
+
+        # Top-level title removed
+        assert "title" not in schema
+
+        # Nested object title removed
+        addr_schema = schema["properties"]["address"]
+        assert "title" not in addr_schema
+
+    def test_refs_resolved_inline(self) -> None:
+        """$ref and $defs should be fully resolved (no leftover references)."""
+
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        schema = generate_tool_parameters_schema(Outer)
+        assert "$defs" not in schema
+        assert "$ref" not in str(schema)
+
+    def test_null_stripped_from_optional_types(self) -> None:
+        """Optional fields should have null stripped from anyOf/type arrays."""
+        from typing import Optional
+
+        class OptInput(BaseModel):
+            name: Optional[str] = None
+
+        schema = generate_tool_parameters_schema(OptInput)
+        name_prop = schema["properties"]["name"]
+        # Should be simplified to {"type": "string"}, not anyOf with null
+        assert name_prop.get("type") == "string"
+        assert "anyOf" not in name_prop
+
+    def test_default_values_stripped(self) -> None:
+        """Default values should be removed from the schema."""
+        from pydantic import Field
+
+        class WithDefaults(BaseModel):
+            count: int = Field(default=10, description="Item count")
+
+        schema = generate_tool_parameters_schema(WithDefaults)
+        count_prop = schema["properties"]["count"]
+        assert "default" not in count_prop
+
+    def test_preserves_descriptions(self) -> None:
+        """Field descriptions must be preserved."""
+        from pydantic import Field
+
+        class Described(BaseModel):
+            query: str = Field(description="Search query")
+
+        schema = generate_tool_parameters_schema(Described)
+        assert schema["properties"]["query"]["description"] == "Search query"
+
+    def test_preserves_property_types(self) -> None:
+        """Basic property types must be correctly represented."""
+
+        class TypedInput(BaseModel):
+            name: str
+            count: int
+            score: float
+            active: bool
+
+        schema = generate_tool_parameters_schema(TypedInput)
+        props = schema["properties"]
+        assert props["name"]["type"] == "string"
+        assert props["count"]["type"] == "integer"
+        assert props["score"]["type"] == "number"
+        assert props["active"]["type"] == "boolean"

--- a/uv.lock
+++ b/uv.lock
@@ -408,14 +408,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.7"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950, upload-time = "2026-02-06T14:04:14.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/00/3ed12264094ec91f534fae429945efbaa9f8c666f3aa7061cc3b2a26a0cd/authlib-1.6.7-py2.py3-none-any.whl", hash = "sha256:c637340d9a02789d2efa1d003a7437d10d3e565237bcb5fcbc6c134c7b95bab0", size = 244115, upload-time = "2026-02-06T14:04:12.141Z" },
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
 ]
 
 [[package]]
@@ -5940,11 +5940,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]
@@ -7307,7 +7310,7 @@ wheels = [
 
 [[package]]
 name = "snowflake-connector-python"
-version = "4.2.0"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
@@ -7329,28 +7332,28 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/d2/4ae9fc7a0df36ad0ac06bc959757dfbfc58f160f58e1d62e7cebe9901fc7/snowflake_connector_python-4.2.0.tar.gz", hash = "sha256:74b1028caee3af4550a366ef89b33de80940bbf856844dd4d788a6b7a6511aff", size = 915327, upload-time = "2026-01-07T16:44:32.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2f/9b0d1ea2196eeb32e9ac3f9cdf0cfc516ad3788333a75f197c3f55888f70/snowflake_connector_python-4.3.0.tar.gz", hash = "sha256:79f150297b39cfd2481b732554fc4d68b43c83c82eb01e670cc4051cffc089d6", size = 922395, upload-time = "2026-02-12T10:42:31.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/34/2c5c059b12db84113bb01761bd3fdab3e0c0d8d4ccc0c9631be5479960c2/snowflake_connector_python-4.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e1c60e578ddcdf99b46d7c329706aa87ea98c1c877cbe50560e034cc904231e", size = 11908869, upload-time = "2026-01-07T16:44:35.243Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/27/07ab3485f43d92c139fefb30b68a60498b508f2e941d9191f1ec3ac42a20/snowflake_connector_python-4.2.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:cf1805be7e124aa12bdcbb6c7f7f7bd11277aa4fe4d616cfee7633617bba9651", size = 11921560, upload-time = "2026-01-07T16:44:37.995Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/12/ba6bb6cd26bc584637aa63f3e579cb929b9c3637fa830e43b77c2b2e8901/snowflake_connector_python-4.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b877cf5fc086818d86e289fc88453bc354df87a664e57f9b75d8dd7550d2df3", size = 2786595, upload-time = "2026-01-07T16:44:14.314Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/80/bf900ac5ddd5b60a72f0c3f7c276c9b0f29b375997c294f28bd746e9f721/snowflake_connector_python-4.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3654c3923b7ce88aab3be459bad3dba39fe4f989a4871421925a8a48f9a553ca", size = 2814560, upload-time = "2026-01-07T16:44:15.988Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/04/e070116ff779fcd16c5e25ef8b045afb8cc53b12b3494663457718a7d877/snowflake_connector_python-4.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:cdaf91edf94d801fef6cb15c90ba321826b8342826a82375799319d509e6787a", size = 12059955, upload-time = "2026-01-07T16:45:05.556Z" },
-    { url = "https://files.pythonhosted.org/packages/24/5f/2e3ac52d4b433e850c83f91b801b7c4e9935a4d1c4f2ea4fd0c3782c5a3d/snowflake_connector_python-4.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2971212e2bf38b19ed3d71d433102b09cda09ddca02fe4c813cb73f504a31e8", size = 11908767, upload-time = "2026-01-07T16:44:39.982Z" },
-    { url = "https://files.pythonhosted.org/packages/31/f6/74d75623ed75244c4aad1722b83923c806a67f601b41314e8a6b30e160c0/snowflake_connector_python-4.2.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:786d9ad591439996ff5a6014c3730441bcfdc8c6d60f05d98f6576cb2cfa0f05", size = 11921016, upload-time = "2026-01-07T16:44:41.917Z" },
-    { url = "https://files.pythonhosted.org/packages/31/53/ab0d2eed42f1309de2e7656651fdab6ae454032bcc485089ce5e0697b5c2/snowflake_connector_python-4.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74d3d2bcce62bbb7a8fb3adaae37dc2aaeb4e93549509db2f957fb704ce4aa18", size = 2797881, upload-time = "2026-01-07T16:44:17.319Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6f/2aa88f57107fdf0daabd113b479ba50e22d566ae36e860d4dbe68bcb6437/snowflake_connector_python-4.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2cbdffcf5b12199f3060297353e69c5a4c1fc4dfacd0062acbe9a1ace7e50882", size = 2827340, upload-time = "2026-01-07T16:44:19.434Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/5b/d03f1d8dfeab8c81bd1f65cad93385932789971a640db1c6369b5850cc5b/snowflake_connector_python-4.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:939e687ec4667d903b3bca3644b22946606361a2201158e137e448a6cd44605d", size = 12059905, upload-time = "2026-01-07T16:45:07.679Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/90/90df1e0bbc8ba22534af48518e71eb669a3bb6243989a93d59f9db9d8897/snowflake_connector_python-4.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b6e5dde4794fb190add6baee616f0f9a9b5c31502089b680a5be4441926b5173", size = 11907736, upload-time = "2026-01-07T16:44:44.598Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d1/4e9015d37a869022729a146f4c7f312f089938e1f51ac7620f6961f7ce66/snowflake_connector_python-4.2.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:f80f180092d218b578f05da145dd2640edb3c8807264d69169bc4dfb88b8b86c", size = 11919401, upload-time = "2026-01-07T16:44:47.524Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/5a/c65134dedd438f9d8d6eaeb7f573cb95abe4141385a4353cfe88d8c96fb1/snowflake_connector_python-4.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94a59566d3096a662b09423770aede8f99f1d06807d7b884dba8d9f767f0b2cd", size = 2854461, upload-time = "2026-01-07T16:44:21.305Z" },
-    { url = "https://files.pythonhosted.org/packages/94/6d/dd526a07042ca33ce05b8c642ef3da4a72e2cbe09e305170cb866021acd6/snowflake_connector_python-4.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11241089efc6e8d69ea1aa58bb17abe85298e66d278fed4d13381fc362f02564", size = 2887953, upload-time = "2026-01-07T16:44:23.221Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e0/d2db617da5791ec03d17bfd96db6f4c867a3498c4b4d480befc6a1854522/snowflake_connector_python-4.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:823ca257d9639b5468f53a816dc5acaea7c56991f518633c9c5f0fcf0d324721", size = 12058975, upload-time = "2026-01-07T16:45:10.293Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/34/cb523e85f9da46e22ee3c07a4f66a090ab935a1c6e59e4e9638cf8e7bc36/snowflake_connector_python-4.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d103ab3d9175251c1e391c4a155d99faaadd6a1e3c1c36429a711862f7ab021", size = 11908616, upload-time = "2026-01-07T16:44:49.512Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/eb/7a5c2a4dc275048e0b0b67b6b542b4cfdf60da158af8a315e5dd1021f443/snowflake_connector_python-4.2.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:2db02486bf72b2d4da6338bad59c58e18d0be4026b33d62b894db8cb04de403e", size = 11920460, upload-time = "2026-01-07T16:44:51.845Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a2/7f85a01fc13982391166c5458f4fd1078546e6f19f9e0bb184dbf6ec5f53/snowflake_connector_python-4.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b93b0195746c7734ab66889430a418ac7fd66441c11addb683bc15e364bb77c8", size = 2820920, upload-time = "2026-01-07T16:44:24.728Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/80/322dafc03f77f28f1ede160e4989ae758dd27dc94529e424348865bba501/snowflake_connector_python-4.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4773949e33c2503f369c20ac8fd59697e493670fed653fea7349d465ea5a0171", size = 2854097, upload-time = "2026-01-07T16:44:26.817Z" },
-    { url = "https://files.pythonhosted.org/packages/06/05/64d3de8c98f783a3065e60107519b701d1ab7ef15efefa279d338f3fba64/snowflake_connector_python-4.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:3665eae47a6ccaf00ca567936cb16d5cbdd5b9f8ab3ee3a3f072bf3c4b76986c", size = 12058956, upload-time = "2026-01-07T16:45:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7a/44267971eeef7385e4a26aa66f94b5bdc3ef736bcc9b00942b900827faae/snowflake_connector_python-4.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3044e6a237b35f750394f199f5e3800dfeb3227c4c8562584877e814d2dc89a", size = 11916166, upload-time = "2026-02-12T10:42:34.457Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d8/e969f1fcab564f8bcabd26a06b64c345c0acee16c3dc9205140b9b7f5c0b/snowflake_connector_python-4.3.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:e5d360d65d42dd97cf82e688a1a7f235b9bc048b4949c9c5c7052ff2783c444e", size = 11929029, upload-time = "2026-02-12T10:42:37.071Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5b/2b5fc947a2b1ef003be9b1a33f27fd505a99a6f312912ab935355cf37b89/snowflake_connector_python-4.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce55b93120f8b429010bf39cc02e739610b6da2ccdd34fcfc0df04849d0fd9d4", size = 2799195, upload-time = "2026-02-12T10:42:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/c9e1a43ef6528dace99139a47ddcf6dab968e811ec222ac6dc51a7e12d74/snowflake_connector_python-4.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7763c0d5f8e6326ec31f8972cc806fb6d3e07b06ca59f67dfcdf02a34219bcbc", size = 2828441, upload-time = "2026-02-12T10:42:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/75/0a1f326831f00d506dcb5cae6a916da895a394350e22485d8cc00223aff1/snowflake_connector_python-4.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:120463ca391d9deda3bdb185104ba847e12f73c86ef411cfcf827ce49b64d1af", size = 12067537, upload-time = "2026-02-12T10:43:01.705Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ea/d4206836b28ff74ad836414b811942c5bf2c70d3aec2f8985e4ea1890d50/snowflake_connector_python-4.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:762ffa9673465ccc630aba438d648e0b1a2452ba49669a54a60d1625f36898f3", size = 11916055, upload-time = "2026-02-12T10:42:39.327Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/55/b29070a5b2ec2f7bbb0051a724e5e6c8ba91a2da0086bd691b419d28c1f6/snowflake_connector_python-4.3.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:3e2ce47485862fa14ffbf2732f0fd02aa69a7c68a50d5f6286f34ed17527cf87", size = 11928750, upload-time = "2026-02-12T10:42:42.11Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/48/b1e2d99b1dbb6698cb88385e800b43e30c575bcf5450810803526857b204/snowflake_connector_python-4.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6fa80373b82125552e691f47b603766ed783f3d90a5782564854aa224aee9d1", size = 2811711, upload-time = "2026-02-12T10:42:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/51/a1b293fba2d63794283f487173a0c0d3b209464b915427a88d0cfa2408c2/snowflake_connector_python-4.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:676b56eedcc268b7e25a447e736eb8bf8bcacfbc71196c94d6f45746672ee6d5", size = 2841077, upload-time = "2026-02-12T10:42:18.461Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bf/48a0fdb8378e8bcf5448d6c07c495d2b76faa6b910ebcbcf57ffe7e56a0e/snowflake_connector_python-4.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:55163c5d9b93e10d7217aabd56f776b16c0fe13774f8d5db9188824731da9586", size = 12067474, upload-time = "2026-02-12T10:43:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b0/a23284f8c2ae977251071737287d7648fee4ef08de386f37eb6e971e8609/snowflake_connector_python-4.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c18b5021ffa6de8313f2c7f0ae6050c36bcee7cb33bb23d40a7fdf3e0a751f2", size = 11915171, upload-time = "2026-02-12T10:42:44.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/2f91baf604acc4eb7795d7a25b4d414b81a82561dfac2d39c5e103da2947/snowflake_connector_python-4.3.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:9faa9280e41258fb479ec5395b6a17d3dbb316146832e436aed582b300de655e", size = 11926986, upload-time = "2026-02-12T10:42:47.455Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0b/09342214ec888192f9e7305d0a2d438531613f2a32ff5c2155e1e1964371/snowflake_connector_python-4.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca9d22c61f4e3d171b0adad3e9211747917c3a978dfb99564307c1ceadb0f0cd", size = 2867063, upload-time = "2026-02-12T10:42:20.261Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/74/a1a2bd427394214bd7752e72fde257495a18d87d3457343ece9fee00e386/snowflake_connector_python-4.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac18b37e03a29014a9c91aac10c7dbdfa11134c620c6f93dd16f4b99b6a38c2a", size = 2899440, upload-time = "2026-02-12T10:42:22.424Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5a/eda0e80c8cbbef24cfc4aa68587674d8ac0f15fded14e5abc296b8568005/snowflake_connector_python-4.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:726435b2769135b6282601efb2cd8fd53f7deb1ff2fb7da93d28141fa3c8b17e", size = 12066477, upload-time = "2026-02-12T10:43:06.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/7a/eda732425c713e07d7327f0c98473615814365e1a75c8d67c31c43ed2fa9/snowflake_connector_python-4.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e42dd9af46fa3ad0e61c1aa6a227357cace481916797ecb92dbb14adb61931e1", size = 11916032, upload-time = "2026-02-12T10:42:49.957Z" },
+    { url = "https://files.pythonhosted.org/packages/92/40/9ba14e500d1d92f12f0dac8d5b975606f0f15bee69c4ceadba64a8853b16/snowflake_connector_python-4.3.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:e96aaf23f2b021e0d2aac8ac1b541975cd1f6896d9115eefe0938114e694a562", size = 11927984, upload-time = "2026-02-12T10:42:52.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/be/25125ba4b4a1bb211ad8eadff233549cd9a5152c77d92586cd5693ee608f/snowflake_connector_python-4.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e0f66acee330388815fb842f91a46c9cacdefdf02c816354e6adeca8c2c3f86", size = 2832570, upload-time = "2026-02-12T10:42:25.348Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/19144f2e590d55bce17e089017b5dca71fad46a2a0ddb7b1a69a4c91c5c9/snowflake_connector_python-4.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5a8d91c3e0127360bc3de605df9d02ea4d87e4524a50bf2e7c5c4200f9abf78", size = 2866972, upload-time = "2026-02-12T10:42:26.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/28/8f4854bcf267f69387ea785758b3cc5fac1a13452359c234f2fc81eb8ffd/snowflake_connector_python-4.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:c1356a2c615e120f913e5235fe87ff8aadbb479ad5a5ac5c0a84881d5fbe981d", size = 12066562, upload-time = "2026-02-12T10:43:08.846Z" },
 ]
 
 [[package]]
@@ -7743,6 +7746,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary

Fixes #4472 — MCP tools break with Bedrock and Gemini because `extract_tool_info()` uses `generate_model_description()`, which applies OpenAI-specific JSON schema transformations that these providers reject:

- `additionalProperties: false` — rejected by Bedrock
- All properties forced into `required` — breaks optional field semantics on Gemini/Bedrock
- `title` on nested objects — rejected by Gemini

### What this PR does

- Adds `generate_tool_parameters_schema()` in `pydantic_schema_utils.py` — a clean, provider-agnostic alternative to `generate_model_description()` that:
  - Resolves `$ref` / `$defs` inline
  - Strips null from optional field types (preserving the #4579 partial fix)
  - Recursively removes `title`, `default`, and `additionalProperties`
  - Preserves the original `required` array (does NOT force all fields required)
- Updates `extract_tool_info()` in `common.py` to use the new function for the `args_schema` path, which flows through `safe_tool_conversion()` to all providers (Bedrock, Gemini, Anthropic, OpenAI, Azure)
- Adds 8 targeted tests covering: no `additionalProperties`, optional fields not forced required, no `title` on nested objects, refs resolved, null stripped, defaults stripped, descriptions preserved, types preserved

### Context

- PR #4579 (merged) partially fixed this by stripping null types for optional fields
- PR #4473 had the right approach (provider-agnostic schema generation) but was closed after the partial fix
- PR #4601 was also closed without merge
- The root cause remained: `generate_model_description()` is designed for OpenAI structured outputs (strict mode) and should not be used for the shared tool-parameter extraction path

### Why this approach

The `generate_model_description()` function is correct for OpenAI structured outputs — it needs `additionalProperties: false`, all-required, and strict mode. The problem is that `extract_tool_info()` (shared across providers) was reusing it for tool parameter schemas. This PR separates the two concerns with a dedicated function.

## Test plan

- [x] All 8 new `TestGenerateToolParametersSchema` tests pass
- [x] All 81 existing `test_pydantic_schema_utils.py` tests pass (no regressions)
- [x] All 59 existing `test_agent_utils.py` tests pass (no regressions)
- [ ] Manual verification with Bedrock/Gemini MCP tool calls (needs contributor with access)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool `args_schema` is converted into JSON Schema for all providers, which can affect tool-calling payload validation and optional/required semantics. Mitigated by focused unit tests, but still touches a cross-provider integration surface.
> 
> **Overview**
> Fixes MCP tool failures on Bedrock/Gemini by **separating provider-agnostic tool parameter schema generation from OpenAI strict-mode schemas**.
> 
> `extract_tool_info()` now uses a new `generate_tool_parameters_schema()` for Pydantic `args_schema`, producing a cleaned schema (refs inlined, `null` stripped, and removing `title`/`default`/`additionalProperties`) without forcing all fields `required`. OpenAI tool conversion keeps (and strengthens) its strict-mode pipeline by explicitly applying `strip_unsupported_formats`, `ensure_type_in_schemas`, `convert_oneof_to_anyof`, `ensure_all_properties_required`, and `force_additional_properties_false`.
> 
> Adds comprehensive tests for the new provider-agnostic schema output and a few strict-mode transform assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a819adc0ac646073e3aae13c0ef29c3d979135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->