### PR TITLE
fix(agent): respect custom trained_agents_file during inference

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1012,7 +1012,11 @@ class Agent(BaseAgent):
 
     def _use_trained_data(self, task_prompt: str) -> str:
         """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        # Use the crew's configured trained_agents_file if available, otherwise use default
+        trained_file = TRAINED_AGENTS_DATA_FILE
+        if self.crew:
+            trained_file = self.crew.trained_agents_file
+        if data := CrewTrainingHandler(trained_file).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -96,7 +96,7 @@ from crewai.tools.agent_tools.read_file_tool import ReadFileTool
 from crewai.tools.base_tool import BaseTool
 from crewai.types.streaming import CrewStreamingOutput
 from crewai.types.usage_metrics import UsageMetrics
-from crewai.utilities.constants import NOT_SPECIFIED, TRAINING_DATA_FILE
+from crewai.utilities.constants import NOT_SPECIFIED, TRAINED_AGENTS_DATA_FILE, TRAINING_DATA_FILE
 from crewai.utilities.crew.models import CrewContext
 from crewai.utilities.evaluators.crew_evaluator_handler import CrewEvaluator
 from crewai.utilities.evaluators.task_evaluator import TaskEvaluator
@@ -302,6 +302,10 @@ class Crew(FlowTrackable, BaseModel):
     tracing: bool | None = Field(
         default=None,
         description="Whether to enable tracing for the crew. True=always enable, False=always disable, None=check environment/user settings.",
+    )
+    trained_agents_file: str = Field(
+        default=TRAINED_AGENTS_DATA_FILE,
+        description="Path to the trained agents data file to load during inference.",
     )
 
     @field_validator("id", mode="before")

--- a/lib/crewai/tests/test_trained_agents_file.py
+++ b/lib/crewai/tests/test_trained_agents_file.py
@@ -1,0 +1,82 @@
+"""Test for custom trained_agents_file support."""
+import pytest
+from unittest.mock import Mock, patch
+
+from crewai.agent.core import Agent
+from crewai.crew import Crew
+from crewai.task import Task
+
+
+@patch("crewai.agent.core.CrewTrainingHandler")
+def test_agent_use_trained_data_with_custom_file(crew_training_handler):
+    """Test that agent uses crew's trained_agents_file when available."""
+    task_prompt = "What is 1 + 1?"
+    
+    # Create a crew with custom trained_agents_file
+    crew = Crew(
+        trained_agents_file="my_custom_trained.pkl",
+        agents=[],
+        tasks=[]
+    )
+    
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+    )
+    agent.crew = crew
+    
+    crew_training_handler.return_value.load.return_value = {
+        agent.role: {
+            "suggestions": [
+                "The result of the math operation must be right.",
+            ]
+        }
+    }
+
+    result = agent._use_trained_data(task_prompt=task_prompt)
+
+    # Should use the custom filename from crew
+    crew_training_handler.assert_called_with("my_custom_trained.pkl")
+    assert "The result of the math operation must be right." in result
+
+
+@patch("crewai.agent.core.CrewTrainingHandler")
+def test_agent_use_trained_data_fallback_to_default(crew_training_handler):
+    """Test that agent falls back to default when crew has no custom file."""
+    task_prompt = "What is 1 + 1?"
+    
+    # Create a crew with default trained_agents_file
+    crew = Crew(agents=[], tasks=[])
+    
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+    )
+    agent.crew = crew
+    
+    crew_training_handler.return_value.load.return_value = {}
+
+    agent._use_trained_data(task_prompt=task_prompt)
+
+    # Should use the default filename
+    crew_training_handler.assert_called_with("trained_agents_data.pkl")
+
+
+def test_crew_trained_agents_file_default():
+    """Test that Crew has correct default for trained_agents_file."""
+    from crewai.utilities.constants import TRAINED_AGENTS_DATA_FILE
+    
+    crew = Crew(agents=[], tasks=[])
+    assert crew.trained_agents_file == TRAINED_AGENTS_DATA_FILE
+
+
+def test_crew_trained_agents_file_custom():
+    """Test that Crew accepts custom trained_agents_file."""
+    crew = Crew(
+        trained_agents_file="custom_file.pkl",
+        agents=[],
+        tasks=[]
+    )
+    assert crew.trained_agents_file == "custom_file.pkl"


### PR DESCRIPTION
## Problem

When training a Crew with a custom filename (e.g., `crewai train -n 5 -f my_custom_trained.pkl`), the trained data is correctly saved to the specified file. However, during inference (normal execution), agents always load from the hardcoded `trained_agents_data.pkl`, ignoring the custom filename.

## Solution

This PR adds a `trained_agents_file` parameter to the `Crew` class that allows users to specify which trained agents data file to load during inference.

### Changes

1. **Crew class**: Added `trained_agents_file` field (defaults to `trained_agents_data.pkl` for backward compatibility)
2. **Agent._use_trained_data**: Modified to use the crew's configured `trained_agents_file` when available, falling back to the default when no crew is associated

### Usage

```python
# Use custom trained data file during inference
crew = Crew(
    agents=[...],
    tasks=[...],
    trained_agents_file="my_custom_trained.pkl"  # Load from custom file
)
crew.kickoff()
```

### Backward Compatibility

- Default behavior unchanged: if no `trained_agents_file` is specified, uses `trained_agents_data.pkl`
- Agents without a crew still use the default file

Fixes #4905

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible change to which trained-data file is loaded during prompt construction, plus targeted unit tests.
> 
> **Overview**
> Fixes trained-agent inference to **respect a crew-level trained data filename**. `Crew` now exposes `trained_agents_file` (defaulting to `TRAINED_AGENTS_DATA_FILE`), and `Agent._use_trained_data` loads suggestions from that configured path when the agent is attached to a crew, falling back to the default otherwise.
> 
> Adds unit coverage to verify custom-file usage, default fallback behavior, and `Crew` field defaults/overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b60ef5f1744d4da83aa8144a74d0bca4ca8f07e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->