### PR TITLE
docs(agent): mark crew attribute as optional in Agent schema

### DIFF
--- a/docs/en/concepts/agents.mdx
+++ b/docs/en/concepts/agents.mdx
@@ -43,6 +43,7 @@ The Visual Agent Builder enables:
 | **Role**                                | `role`                   | `str`                                 | Defines the agent's function and expertise within the crew.                                              |
 | **Goal**                                | `goal`                   | `str`                                 | The individual objective that guides the agent's decision-making.                                        |
 | **Backstory**                           | `backstory`              | `str`                                 | Provides context and personality to the agent, enriching interactions.                                   |
+| **Crew** _(optional)_                   | `crew`                   | `Optional[Crew]`                      | The crew to which this agent belongs. Set automatically when agent is added to a crew.                   |
 | **LLM** _(optional)_                    | `llm`                    | `Union[str, LLM, Any]`                | Language model that powers the agent. Defaults to the model specified in `OPENAI_MODEL_NAME` or "gpt-4". |
 | **Tools** _(optional)_                  | `tools`                  | `List[BaseTool]`                      | Capabilities or functions available to the agent. Defaults to an empty list.                             |
 | **Function Calling LLM** _(optional)_   | `function_calling_llm`   | `Optional[Any]`                       | Language model for tool calling, overrides crew's LLM if specified.                                      |

--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -81,7 +81,7 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
         max_iter (int): Maximum iterations for an agent to execute a task.
         agent_executor: An instance of the CrewAgentExecutor class.
         llm (Any): Language model that will run the agent.
-        crew (Any): Crew to which the agent belongs.
+        crew (Any | None): Crew to which the agent belongs.
         i18n (I18N): Internationalization settings.
         cache_handler ([CacheHandler]): An instance of the CacheHandler class.
         tools_handler ([ToolsHandler]): An instance of the ToolsHandler class.


### PR DESCRIPTION
The `crew` attribute in `BaseAgent` has `default=None` in the Field definition, making it optional. However, the docstring listed it as `crew (Any)` without indicating optionality, and it was missing from the documentation table entirely.

Changes:
- Update `BaseAgent` docstring to show `crew (Any | None)`
- Add `crew` attribute to agents.mdx documentation table with `_(optional)_` marker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies `BaseAgent.crew` can be `None`; no runtime logic is modified.
> 
> **Overview**
> Clarifies that an agent’s `crew` reference is optional.
> 
> Updates the `BaseAgent` docstring type to `Any | None` and adds `crew` to the Agents docs attribute table as `Optional[Crew]` with an *optional* marker, noting it’s set automatically when added to a crew.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 072d65c71d464ff76620f39c61ca7d80fe09dcca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->