### PR TITLE
fix: respect custom training filename during agent inference

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1012,7 +1012,13 @@ class Agent(BaseAgent):
 
     def _use_trained_data(self, task_prompt: str) -> str:
         """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        # Use custom filename from crew if available, otherwise fall back to default
+        filename = (
+            self.crew._train_filename
+            if self.crew and getattr(self.crew, "_train_filename", None)
+            else TRAINED_AGENTS_DATA_FILE
+        )
+        if data := CrewTrainingHandler(filename).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -172,6 +172,7 @@ class Crew(FlowTrackable, BaseModel):
     _cache_handler: InstanceOf[CacheHandler] = PrivateAttr(default_factory=CacheHandler)
     _memory: Any = PrivateAttr(default=None)  # Unified Memory | MemoryScope
     _train: bool | None = PrivateAttr(default=False)
+    _train_filename: str | None = PrivateAttr(default=None)
     _train_iteration: int | None = PrivateAttr()
     _inputs: dict[str, Any] | None = PrivateAttr(default=None)
     _logging_color: PrinterColor = PrivateAttr(
@@ -603,6 +604,7 @@ class Crew(FlowTrackable, BaseModel):
     def _setup_for_training(self, filename: str) -> None:
         """Sets up the crew for training."""
         self._train = True
+        self._train_filename = filename
 
         for task in self.tasks:
             task.human_input = True

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1064,6 +1064,49 @@ def test_agent_use_trained_data(crew_training_handler):
     )
 
 
+@patch("crewai.agent.core.CrewTrainingHandler")
+def test_agent_use_trained_data_with_custom_filename(crew_training_handler):
+    """Test that custom training filename from crew is used during inference."""
+    from crewai.crew import Crew
+    from crewai.task import Task
+
+    task_prompt = "What is 1 + 1?"
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+        verbose=True,
+    )
+    task = Task(
+        agent=agent,
+        description="Say the word: Hi",
+        expected_output="The word: Hi",
+    )
+    crew = Crew(
+        agents=[agent],
+        tasks=[task],
+    )
+    # Manually link agent to crew (normally done during kickoff)
+    agent.crew = crew
+    # Simulate training setup with custom filename
+    crew._train_filename = "custom_training.pkl"
+
+    crew_training_handler.return_value.load.return_value = {
+        agent.role: {
+            "suggestions": [
+                "Use custom filename.",
+            ]
+        }
+    }
+
+    result = agent._use_trained_data(task_prompt=task_prompt)
+
+    assert "Use custom filename." in result
+    crew_training_handler.assert_has_calls(
+        [mock.call("custom_training.pkl"), mock.call().load()]
+    )
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
## Problem
When training a crew with a custom filename via `crew.train(filename="custom.pkl")`, agents were always loading from the hardcoded 'trained_agents_data.pkl' instead of the custom filename during inference.

## Solution
- Add `_train_filename` attribute to Crew class to store the training filename
- Store the custom filename during `_setup_for_training()`
- Modify `Agent._use_trained_data()` to use the crew's stored filename when available, falling back to the default constant otherwise

## Changes
- `lib/crewai/src/crewai/crew.py`: Added `_train_filename` attribute and set it during training setup
- `lib/crewai/src/crewai/agent/core.py`: Updated `_use_trained_data()` to check for custom filename from crew
- `lib/crewai/tests/agents/test_agent.py`: Added test for custom filename functionality

## Testing
- Added new test `test_agent_use_trained_data_with_custom_filename` that verifies the fix
- All existing training tests pass

Fixes #4905

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in prompt augmentation: inference now reads trained suggestions from a crew-provided file path when set, which could affect output prompts but is well-scoped and covered by a unit test.
> 
> **Overview**
> Fixes trained-data loading during agent inference to **respect a crew-specific training output file**. `Crew` now stores the training filename in a new private `_train_filename` set during `_setup_for_training()`, and `Agent._use_trained_data()` uses that value when present (falling back to `TRAINED_AGENTS_DATA_FILE`).
> 
> Adds a unit test ensuring `CrewTrainingHandler` is called with the custom filename when the agent is associated with a crew.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 789e75e4c4c2cff9fc98bc6e9add0d752bd5ffc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->