### PR TITLE
fix: include thinking_budget in Gemini default ThinkingConfig for Vertex AI compatibility

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -160,7 +160,7 @@ class GeminiCompletion(BaseLLM):
             and float(version_match.group(1)) >= 2.5
         ):
             self.thinking_config = types.ThinkingConfig(
-                include_thoughts=True, thinking_budget=8192
+                include_thoughts=True, thinking_budget=-1
             )
 
     @property

--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -160,7 +160,7 @@ class GeminiCompletion(BaseLLM):
             and float(version_match.group(1)) >= 2.5
         ):
             self.thinking_config = types.ThinkingConfig(
-                include_thoughts=True, thinking_budget=-1
+                include_thoughts=True, thinking_budget=8192
             )
 
     @property

--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -62,6 +62,7 @@ class GeminiCompletion(BaseLLM):
         use_vertexai: bool | None = None,
         response_format: type[BaseModel] | None = None,
         thinking_config: types.ThinkingConfig | None = None,
+        thinking_budget: int | None = None,
         **kwargs: Any,
     ):
         """Initialize Google Gemini chat completion client.
@@ -98,6 +99,10 @@ class GeminiCompletion(BaseLLM):
                            Controls thought output via include_thoughts, thinking_budget,
                            and thinking_level. When None, thinking models automatically
                            get include_thoughts=True so thought content is surfaced.
+                           Takes precedence over thinking_budget if both are provided.
+            thinking_budget: Token budget for thinking (e.g., 8192). Shorthand for creating
+                           a ThinkingConfig with include_thoughts=True and the given budget.
+                           Ignored if thinking_config is provided.
             **kwargs: Additional parameters
         """
         if interceptor is not None:
@@ -145,12 +150,18 @@ class GeminiCompletion(BaseLLM):
         )
 
         self.thinking_config = thinking_config
+        if self.thinking_config is None and thinking_budget is not None:
+            self.thinking_config = types.ThinkingConfig(
+                include_thoughts=True, thinking_budget=thinking_budget
+            )
         if (
             self.thinking_config is None
             and version_match
             and float(version_match.group(1)) >= 2.5
         ):
-            self.thinking_config = types.ThinkingConfig(include_thoughts=True)
+            self.thinking_config = types.ThinkingConfig(
+                include_thoughts=True, thinking_budget=8192
+            )
 
     @property
     def stop(self) -> list[str]:


### PR DESCRIPTION
## Summary
- Fixes `400 INVALID_ARGUMENT` error on Vertex AI when using gemini-2.5+ models: `Thinking_config.include_thoughts is only enabled when thinking is enabled`
- Default auto-config now sets `thinking_budget=8192` alongside `include_thoughts=True`
- Adds `thinking_budget` parameter for easy user configuration

## Test plan
- [ ] Verify gemini-2.5+ models work on Vertex AI without error
- [ ] Verify explicit `thinking_config` still takes precedence
- [ ] Verify `thinking_budget` param creates correct ThinkingConfig

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts default `thinking_config` behavior for Gemini 2.5+ models and adds a new init parameter, which can change token usage/costs and model behavior (especially on Vertex AI) but is limited in scope to the Gemini provider.
> 
> **Overview**
> Fixes Gemini *thinking model* configuration to be Vertex AI compatible by ensuring `thinking_config` includes a `thinking_budget` when auto-enabled for gemini-2.5+ (defaulting to `8192` instead of only setting `include_thoughts=True`).
> 
> Adds a new `thinking_budget` constructor parameter as a shorthand to create a `ThinkingConfig` (only when `thinking_config` isn’t explicitly provided) and updates the docstring to clarify precedence/behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ae3e059f9e77087496ba45b4a54caa76b0b6622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->