### PR TITLE
fix: respect custom trained agents file during inference

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1011,8 +1011,20 @@ class Agent(BaseAgent):
         return task_prompt
 
     def _use_trained_data(self, task_prompt: str) -> str:
-        """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        """Use trained data for the agent task prompt to improve output.
+
+        Loads trained agent suggestions from the crew's configured
+        ``trained_agents_file`` when available, falling back to the default
+        ``TRAINED_AGENTS_DATA_FILE`` constant.  This allows users who trained
+        with a custom filename (``crew.train(filename="custom.pkl")``) to have
+        their suggestions picked up automatically during inference by setting
+        ``Crew(trained_agents_file="custom.pkl")``.
+        """
+        trained_file = TRAINED_AGENTS_DATA_FILE
+        if self.crew and getattr(self.crew, "trained_agents_file", None):
+            trained_file = self.crew.trained_agents_file
+
+        if data := CrewTrainingHandler(trained_file).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -295,6 +295,15 @@ class Crew(FlowTrackable, BaseModel):
         default_factory=SecurityConfig,
         description="Security configuration for the crew, including fingerprinting.",
     )
+    trained_agents_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a custom trained agents data file (.pkl) to use during "
+            "inference. When set, agents will load training suggestions from "
+            "this file instead of the default 'trained_agents_data.pkl'. "
+            "This should match the filename used during `crew.train()`."
+        ),
+    )
     token_usage: UsageMetrics | None = Field(
         default=None,
         description="Metrics for the LLM usage during all tasks execution.",

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1064,6 +1064,48 @@ def test_agent_use_trained_data(crew_training_handler):
     )
 
 
+def test_agent_use_trained_data_custom_file(crew_training_handler):
+    """When Crew.trained_agents_file is set, _use_trained_data should load from
+    that file instead of the default TRAINED_AGENTS_DATA_FILE."""
+    from crewai import Crew
+
+    task_prompt = "What is 1 + 1?"
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+        verbose=True,
+    )
+    task = Task(
+        description="test task",
+        expected_output="test output",
+        agent=agent,
+    )
+    crew = Crew(
+        agents=[agent],
+        tasks=[task],
+        trained_agents_file="my_custom_trained.pkl",
+    )
+
+    crew_training_handler.return_value.load.return_value = {
+        agent.role: {
+            "suggestions": [
+                "Custom suggestion from custom file.",
+            ]
+        }
+    }
+
+    result = agent._use_trained_data(task_prompt=task_prompt)
+
+    assert (
+        result == "What is 1 + 1?\n\nYou MUST follow these instructions: \n"
+        " - Custom suggestion from custom file."
+    )
+    crew_training_handler.assert_has_calls(
+        [mock.call("my_custom_trained.pkl"), mock.call().load()]
+    )
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
## Problem

When training a crew with a custom filename (`crew.train(n_iterations=5, filename='my_custom_trained.pkl')`), the trained suggestions are correctly saved to the custom file. However, during inference, `Agent._use_trained_data()` always loads from the hardcoded `TRAINED_AGENTS_DATA_FILE` (`trained_agents_data.pkl`), completely ignoring the custom file.

This means users who train with a custom filename will never see their trained suggestions applied during normal execution.

Closes #4905

## Solution

1. Added a `trained_agents_file` optional parameter to the `Crew` class
2. Updated `Agent._use_trained_data()` to check `self.crew.trained_agents_file` first, falling back to the default `TRAINED_AGENTS_DATA_FILE`
3. Added a test to verify the custom file path is used when configured

## Usage

```python
# Train with custom file
crew.train(n_iterations=5, filename='my_custom_trained.pkl')

# Use the same file during inference
crew = Crew(
    agents=[...],
    tasks=[...],
    trained_agents_file='my_custom_trained.pkl',
)
crew.kickoff()
```

## Changes

- `lib/crewai/src/crewai/crew.py`: Added `trained_agents_file` field
- `lib/crewai/src/crewai/agent/core.py`: Updated `_use_trained_data()` to use crew's custom file
- `lib/crewai/tests/agents/test_agent.py`: Added test for custom file path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible change to which `.pkl` file is read for trained suggestions during inference, plus a test covering the new configuration path.
> 
> **Overview**
> Fixes inference to **respect a crew-provided trained agents data file**.
> 
> `Crew` gains an optional `trained_agents_file` field, and `Agent._use_trained_data()` now loads suggestions from this path when set, falling back to the default `TRAINED_AGENTS_DATA_FILE`. Adds a unit test ensuring the custom filename is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1fb5b7505ee8ac750d3008d471004a6e91804b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->