### PR TITLE
docs: update changelog and version for v1.11.0rc2

### DIFF
--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,31 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Mar 17, 2026">
+  ## v1.11.0rc2
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.11.0rc2)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Enhance LLM response handling and serialization.
+  - Upgrade vulnerable transitive dependencies (authlib, PyJWT, snowflake-connector-python).
+  - Replace `os.system` with `subprocess.run` in unsafe mode pip install.
+
+  ### Documentation
+  - Update Exa Search Tool page with improved naming, description, and configuration options.
+  - Add Custom MCP Servers in How-To Guide.
+  - Update OTEL collectors documentation.
+  - Update MCP documentation.
+  - Update changelog and version for v1.11.0rc1.
+
+  ## Contributors
+
+  @10ishq, @greysonlalonde, @joaomdmoura, @lucasgomide, @mattatcha, @theCyberTech, @vinibrsl
+
+</Update>
+
 <Update label="Mar 15, 2026">
   ## v1.11.0rc1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,31 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 3월 17일">
+  ## v1.11.0rc2
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.11.0rc2)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - LLM 응답 처리 및 직렬화 개선.
+  - 취약한 전이 종속성(authlib, PyJWT, snowflake-connector-python) 업그레이드.
+  - 안전하지 않은 모드에서 pip 설치 시 `os.system`을 `subprocess.run`으로 교체.
+
+  ### 문서
+  - 개선된 이름, 설명 및 구성 옵션으로 Exa 검색 도구 페이지 업데이트.
+  - 사용 방법 가이드에 사용자 지정 MCP 서버 추가.
+  - OTEL 수집기 문서 업데이트.
+  - MCP 문서 업데이트.
+  - v1.11.0rc1에 대한 변경 로그 및 버전 업데이트.
+
+  ## 기여자
+
+  @10ishq, @greysonlalonde, @joaomdmoura, @lucasgomide, @mattatcha, @theCyberTech, @vinibrsl
+
+</Update>
+
 <Update label="2026년 3월 15일">
   ## v1.11.0rc1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,31 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="17 mar 2026">
+  ## v1.11.0rc2
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.11.0rc2)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Aprimorar o manuseio e a serialização das respostas do LLM.
+  - Atualizar dependências transitivas vulneráveis (authlib, PyJWT, snowflake-connector-python).
+  - Substituir `os.system` por `subprocess.run` na instalação do pip em modo inseguro.
+
+  ### Documentação
+  - Atualizar a página da Ferramenta de Pesquisa Exa com nomes, descrições e opções de configuração aprimoradas.
+  - Adicionar Servidores MCP Personalizados no Guia de Como Fazer.
+  - Atualizar a documentação dos coletores OTEL.
+  - Atualizar a documentação do MCP.
+  - Atualizar o changelog e a versão para v1.11.0rc1.
+
+  ## Contributors
+
+  @10ishq, @greysonlalonde, @joaomdmoura, @lucasgomide, @mattatcha, @theCyberTech, @vinibrsl
+
+</Update>
+
 <Update label="15 mar 2026">
   ## v1.11.0rc1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new changelog entry across locales; no runtime behavior is affected.
> 
> **Overview**
> Adds a new **`v1.11.0rc2`** release entry to the changelog in `docs/en`, `docs/ko`, and `docs/pt-BR`, including the GitHub release link, categorized bullet lists of bug fixes/documentation updates, and an updated contributor list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 349c0030b999cce82d56af04d89a5b2270881117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->