### PR TITLE
fix: _use_trained_data ignores custom training filename

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1012,7 +1012,12 @@ class Agent(BaseAgent):
 
     def _use_trained_data(self, task_prompt: str) -> str:
         """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        filename = (
+            self.crew._train_filename
+            if self.crew and self.crew._train_filename
+            else TRAINED_AGENTS_DATA_FILE
+        )
+        if data := CrewTrainingHandler(filename).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -173,6 +173,7 @@ class Crew(FlowTrackable, BaseModel):
     _memory: Any = PrivateAttr(default=None)  # Unified Memory | MemoryScope
     _train: bool | None = PrivateAttr(default=False)
     _train_iteration: int | None = PrivateAttr()
+    _train_filename: str | None = PrivateAttr(default=None)
     _inputs: dict[str, Any] | None = PrivateAttr(default=None)
     _logging_color: PrinterColor = PrivateAttr(
         default="bold_purple",
@@ -603,6 +604,7 @@ class Crew(FlowTrackable, BaseModel):
     def _setup_for_training(self, filename: str) -> None:
         """Sets up the crew for training."""
         self._train = True
+        self._train_filename = filename
 
         for task in self.tasks:
             task.human_input = True


### PR DESCRIPTION
## Summary

- `crew.train(n_iterations, filename)` correctly saves trained agent data to the user-specified `filename`
- However, `Agent._use_trained_data()` always loaded from the hardcoded `TRAINED_AGENTS_DATA_FILE` constant (`"trained_agents_data.pkl"`), completely ignoring any custom filename
- This meant training data saved to a non-default file was silently never applied at inference time

**Changes:**
- Added `_train_filename: str | None = PrivateAttr(default=None)` to `Crew`
- `_setup_for_training()` now stores the filename: `self._train_filename = filename`
- `Agent._use_trained_data()` now uses `self.crew._train_filename` when available, falling back to `TRAINED_AGENTS_DATA_FILE` for backward compatibility

## Reproduction

```python
crew.train(n_iterations=3, filename="my_custom_training.pkl")
# Training data saved to "my_custom_training.pkl" ✓

crew.kickoff()
# BUG: _use_trained_data loads from "trained_agents_data.pkl" (always empty) ✗
# FIX: _use_trained_data loads from "my_custom_training.pkl" ✓
```

## Test plan

- [ ] `agent._use_trained_data()` uses `crew._train_filename` when set
- [ ] Falls back to `TRAINED_AGENTS_DATA_FILE` when `crew` is `None` or `_train_filename` is `None`
- [ ] Existing test `test_agent_use_trained_data` continues to pass (no crew set, uses default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only changes which training data file is loaded when injecting trained suggestions into an agent prompt; behavior is unchanged when no custom filename is used.
> 
> **Overview**
> Fixes trained-data injection so inference uses the *same file* that `Crew.train(..., filename=...)` wrote.
> 
> `Crew` now stores the training output filename in a private `_train_filename`, and `Agent._use_trained_data()` loads trained suggestions from that filename when available, falling back to `TRAINED_AGENTS_DATA_FILE` for backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c350c696a51094de56cc2547f1e89be9f09ab7f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->