### PR TITLE
fix(memory): escape record_ids in lancedb delete filter expression

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -405,7 +405,8 @@ class LanceDBStorage:
         with store_lock(self._lock_name):
             if record_ids and not (categories or metadata_filter):
                 before = int(self._table.count_rows())
-                ids_expr = ", ".join(f"'{rid}'" for rid in record_ids)
+                safe_ids = [str(rid).replace("'", "''") for rid in record_ids]
+                ids_expr = ", ".join(f"'{rid}'" for rid in safe_ids)
                 self._do_write("delete", f"id IN ({ids_expr})")
                 return before - int(self._table.count_rows())
             if categories or metadata_filter:


### PR DESCRIPTION
# Summary
- The delete() method in LanceDBStorage interpolated record_ids directly into a filter expression without escaping single quotes, while touch_records(), get_record(), and update() in the same file all correctly apply .replace("'", "''"). This was a copy-paste omission.
- A crafted record_id containing a single quote could break out of the string literal in the filter expression.
# Changes
- Added safe_ids = [str(rid).replace("'", "''") for rid in record_ids] before building the IN (...) expression, matching the pattern used by adjacent methods.
# Test plan
- Existing unit tests for LanceDBStorage.delete() should continue to pass
- Verify with a record_id containing ' that the filter is correctly escaped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how `record_ids` are interpolated into LanceDB delete filter expressions to prevent malformed queries or injection via unescaped quotes. Low functional risk, but impacts deletion behavior for IDs containing special characters.
> 
> **Overview**
> Fixes `LanceDBStorage.delete()` to **escape single quotes in `record_ids`** before constructing the `id IN (...)` filter expression.
> 
> This aligns deletion-by-ID behavior with other methods (e.g. `touch_records`, `get_record`, `update`) and prevents crafted IDs from breaking the LanceDB filter syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e8fb7a09f39b311ea0ac58f0aa026859cf3779d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->