### PR TITLE
fix(memory): return deep copies of module-level fallback defaults

### DIFF
--- a/lib/crewai/src/crewai/memory/analyze.py
+++ b/lib/crewai/src/crewai/memory/analyze.py
@@ -312,7 +312,7 @@ def analyze_for_save(
             e,
             exc_info=False,
         )
-        return _SAVE_DEFAULTS
+        return _SAVE_DEFAULTS.model_copy(deep=True)
 
 
 _CONSOLIDATION_DEFAULT = ConsolidationPlan(actions=[], insert_new=True)
@@ -372,4 +372,4 @@ def analyze_for_consolidation(
             e,
             exc_info=False,
         )
-        return _CONSOLIDATION_DEFAULT
+        return _CONSOLIDATION_DEFAULT.model_copy(deep=True)


### PR DESCRIPTION
# Summary
- analyze_for_save() and analyze_for_consolidation() return module-level singleton Pydantic objects (_SAVE_DEFAULTS, _CONSOLIDATION_DEFAULT) when LLM analysis fails. These objects contain mutable list fields.
- Any caller that mutates the returned object (e.g., result.categories.append("x")) permanently corrupts the defaults for all subsequent error paths within the process lifetime.
# Changes
Changed return _SAVE_DEFAULTS → return _SAVE_DEFAULTS.model_copy(deep=True) (same for _CONSOLIDATION_DEFAULT).
# Test plan
Verify that consecutive calls to analyze_for_save() with LLM failures return independent objects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the exception/fallback return paths to return deep-copied Pydantic defaults, preventing cross-call state leakage without affecting successful LLM analysis.
> 
> **Overview**
> When LLM-based analysis fails, `analyze_for_save()` and `analyze_for_consolidation()` now return `model_copy(deep=True)` of their module-level default Pydantic objects instead of the shared singletons.
> 
> This prevents callers from accidentally mutating the shared fallback defaults (e.g., list fields) and impacting subsequent requests within the same process.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50d6cea00b8b1f54fc795a8882c3cdc75562d817. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->