### PR TITLE
fix(crew): add missing drain_writes call in akickoff finally block

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -937,6 +937,8 @@ class Crew(FlowTrackable, BaseModel):
             )
             raise
         finally:
+            if self._memory is not None and hasattr(self._memory, "drain_writes"):
+                self._memory.drain_writes()
             clear_files(self.id)
             detach(token)
 


### PR DESCRIPTION
# Summary
- The synchronous kickoff() correctly calls self._memory.drain_writes() in its finally block to ensure all background memory saves complete before returning.
- The async akickoff() was missing this call, so background memory writes could be silently lost when using the async entry point.
# Changes
Added the same drain_writes() call to akickoff()'s finally block.
# Test plan
Run a crew with memory enabled via akickoff() and verify memory records are persisted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a guarded `drain_writes()` call in an async `finally` block to prevent losing queued memory writes, with minimal behavioral impact beyond waiting for persistence.
> 
> **Overview**
> Native async `Crew.akickoff()` now mirrors the sync `kickoff()` cleanup behavior by calling `self._memory.drain_writes()` (when supported) in its `finally` block before `clear_files()`/context detach.
> 
> This prevents background memory saves from being dropped when using the native async entrypoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be486926184101e91f810ead2e77dc0a7d2c72f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->