### PR TITLE
fix(crew): deduplicate manager agent token usage accounting

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1755,21 +1755,13 @@ class Crew(FlowTrackable, BaseModel):
                     token_sum = agent._token_process.get_summary()
                     total_usage_metrics.add_usage_metrics(token_sum)
 
-        if self.manager_agent and hasattr(self.manager_agent, "_token_process"):
-            token_sum = self.manager_agent._token_process.get_summary()
-            total_usage_metrics.add_usage_metrics(token_sum)
-
-        if (
-            self.manager_agent
-            and hasattr(self.manager_agent, "llm")
-            and hasattr(self.manager_agent.llm, "get_token_usage_summary")
-        ):
+        if self.manager_agent:
             if isinstance(self.manager_agent.llm, BaseLLM):
                 llm_usage = self.manager_agent.llm.get_token_usage_summary()
-            else:
-                llm_usage = self.manager_agent.llm._token_process.get_summary()
-
-            total_usage_metrics.add_usage_metrics(llm_usage)
+                total_usage_metrics.add_usage_metrics(llm_usage)
+            elif hasattr(self.manager_agent, "_token_process"):
+                token_sum = self.manager_agent._token_process.get_summary()
+                total_usage_metrics.add_usage_metrics(token_sum)
 
         self.usage_metrics = total_usage_metrics
         return total_usage_metrics


### PR DESCRIPTION
# Summary
- calculate_usage_metrics() counted the manager agent's token usage twice: once via _token_process.get_summary() and again via llm.get_token_usage_summary(), because the two checks were independent if blocks instead of mutually exclusive branches.
- For regular agents, the code correctly uses if/else to choose one path. The manager agent path was missing the else.
# Changes
Restructured to use the same if isinstance(llm, BaseLLM) / else pattern as regular agents.
# Test plan
Run a hierarchical crew and verify usage_metrics values are not inflated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to usage metrics aggregation logic that only affects reported token counts for hierarchical crews.
> 
> **Overview**
> Fixes `Crew.calculate_usage_metrics()` so the manager agent’s token usage is **only** added once by making the `BaseLLM.get_token_usage_summary()` path and the `_token_process.get_summary()` fallback mutually exclusive (matching the regular agent logic). This prevents inflated `usage_metrics`/token totals when both mechanisms are present on the manager agent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2334c2bb7c582939953e4a4bfc02732bd7a495b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->