### PR TITLE
fix(llm): set success_callback independently of failure_callback

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2243,12 +2243,15 @@ class LLM(BaseLLM):
                 ]
 
             failure_callbacks_str = os.environ.get("LITELLM_FAILURE_CALLBACKS", "")
+            failure_callbacks: list[str | Callable[..., Any] | CustomLogger] = []
             if failure_callbacks_str:
-                failure_callbacks: list[str | Callable[..., Any] | CustomLogger] = [
+                failure_callbacks = [
                     cb.strip() for cb in failure_callbacks_str.split(",") if cb.strip()
                 ]
 
+            if success_callbacks:
                 litellm.success_callback = success_callbacks
+            if failure_callbacks:
                 litellm.failure_callback = failure_callbacks
 
     def __copy__(self) -> LLM:


### PR DESCRIPTION
# Summary
LLM.set_env_callbacks() nested the litellm.success_callback assignment inside the if failure_callbacks_str: block due to an indentation error. This meant LITELLM_SUCCESS_CALLBACKS was silently ignored when LITELLM_FAILURE_CALLBACKS was not set.
# Changes
Moved both callback assignments to independent top-level guards so each list is applied whenever its environment variable is present, regardless of the other.
# Test plan
Set only LITELLM_SUCCESS_CALLBACKS=langfuse (without LITELLM_FAILURE_CALLBACKS) and verify litellm.success_callback is correctly set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow fix limited to wiring LiteLLM success/failure callbacks from env vars.
> 
> **Overview**
> Fixes an indentation/control-flow bug in `LLM.set_env_callbacks()` (`llm.py`) so `litellm.success_callback` and `litellm.failure_callback` are set *independently* based on their respective environment variables.
> 
> This ensures `LITELLM_SUCCESS_CALLBACKS` no longer gets ignored when `LITELLM_FAILURE_CALLBACKS` is absent, and avoids overwriting callbacks with empty lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d11edf9ca09bced5bad6fd47d48954f440a8c64c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->