### PR TITLE
feat: add Novita AI as a native LLM provider

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -43,6 +43,7 @@ from crewai.llms.constants import (
     AZURE_MODELS,
     BEDROCK_MODELS,
     GEMINI_MODELS,
+    NOVITA_MODELS,
     OPENAI_MODELS,
 )
 from crewai.utilities import InternalInstructor
@@ -311,6 +312,10 @@ LLM_CONTEXT_WINDOW_SIZES: Final[dict[str, int]] = {
     "mistral/mistral-large-latest": 32768,
     "mistral/mistral-large-2407": 32768,
     "mistral/mistral-large-2402": 32768,
+    # novita
+    "moonshotai/kimi-k2.5": 131072,
+    "zai-org/glm-5": 131072,
+    "minimax/minimax-m2.5": 131072,
 }
 
 DEFAULT_CONTEXT_WINDOW_SIZE: Final[int] = 8192
@@ -325,6 +330,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "gemini",
     "bedrock",
     "aws",
+    "novita",
 ]
 
 
@@ -384,6 +390,7 @@ class LLM(BaseLLM):
                 "gemini": "gemini",
                 "bedrock": "bedrock",
                 "aws": "bedrock",
+                "novita": "novita",
             }
 
             canonical_provider = provider_mapping.get(prefix.lower())
@@ -394,6 +401,12 @@ class LLM(BaseLLM):
                 provider = canonical_provider
                 use_native = True
                 model_string = model_part
+            elif model in NOVITA_MODELS:
+                # Handle vendor/model IDs (e.g. "moonshotai/kimi-k2.5")
+                # that are Novita models but whose prefix is a vendor, not a provider
+                provider = "novita"
+                use_native = True
+                model_string = model
             else:
                 provider = prefix
                 use_native = False
@@ -483,6 +496,9 @@ class LLM(BaseLLM):
                 for prefix in ["gpt-", "gpt-35-", "o1", "o3", "o4", "azure-"]
             )
 
+        if provider == "novita":
+            return model in NOVITA_MODELS
+
         return False
 
     @classmethod
@@ -518,6 +534,9 @@ class LLM(BaseLLM):
             # azure does not provide a list of available models, determine a better way to handle this
             return True
 
+        if provider == "novita" and model in NOVITA_MODELS:
+            return True
+
         # Fallback to pattern matching for models not in constants
         return cls._matches_provider_pattern(model, provider)
 
@@ -546,6 +565,9 @@ class LLM(BaseLLM):
 
         if model in BEDROCK_MODELS:
             return "bedrock"
+
+        if model in NOVITA_MODELS:
+            return "novita"
 
         if model in AZURE_MODELS:
             return "azure"
@@ -581,6 +603,11 @@ class LLM(BaseLLM):
             from crewai.llms.providers.bedrock.completion import BedrockCompletion
 
             return BedrockCompletion
+
+        if provider == "novita":
+            from crewai.llms.providers.novita.completion import NovitaCompletion
+
+            return NovitaCompletion
 
         return None
 

--- a/lib/crewai/src/crewai/llms/constants.py
+++ b/lib/crewai/src/crewai/llms/constants.py
@@ -1,6 +1,18 @@
 from typing import Literal, TypeAlias
 
 
+NovitaModels: TypeAlias = Literal[
+    "moonshotai/kimi-k2.5",
+    "zai-org/glm-5",
+    "minimax/minimax-m2.5",
+]
+NOVITA_MODELS: list[NovitaModels] = [
+    "moonshotai/kimi-k2.5",
+    "zai-org/glm-5",
+    "minimax/minimax-m2.5",
+]
+
+
 OpenAIModels: TypeAlias = Literal[
     "gpt-3.5-turbo",
     "gpt-3.5-turbo-0125",

--- a/lib/crewai/src/crewai/llms/providers/novita/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/novita/completion.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from crewai.llms.providers.openai.completion import OpenAICompletion
+
+if TYPE_CHECKING:
+    import httpx
+
+    from crewai.llms.hooks.base import BaseInterceptor
+
+NOVITA_BASE_URL = "https://api.novita.ai/openai"
+NOVITA_DEFAULT_MODEL = "moonshotai/kimi-k2.5"
+
+
+class NovitaCompletion(OpenAICompletion):
+    """Novita AI completion implementation.
+
+    Uses the OpenAI-compatible endpoint at https://api.novita.ai/openai.
+    Inherits all functionality from OpenAICompletion.
+    """
+
+    def __init__(
+        self,
+        model: str = NOVITA_DEFAULT_MODEL,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        max_retries: int = 2,
+        temperature: float | None = None,
+        provider: str | None = None,
+        interceptor: BaseInterceptor[httpx.Request, httpx.Response] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize Novita AI completion client.
+
+        Args:
+            model: Model ID, defaults to moonshotai/kimi-k2.5.
+            api_key: Novita API key. Falls back to NOVITA_API_KEY env var.
+            base_url: Override base URL. Defaults to https://api.novita.ai/openai.
+            **kwargs: Passed through to OpenAICompletion.
+        """
+        resolved_api_key = api_key or os.getenv("NOVITA_API_KEY")
+        if not resolved_api_key:
+            raise ValueError(
+                "Novita AI API key is required. "
+                "Set the NOVITA_API_KEY environment variable or pass api_key."
+            )
+
+        super().__init__(
+            model=model,
+            api_key=resolved_api_key,
+            base_url=base_url or NOVITA_BASE_URL,
+            timeout=timeout,
+            max_retries=max_retries,
+            temperature=temperature,
+            provider=provider or "novita",
+            interceptor=interceptor,
+            # Force completions API — Responses API is OpenAI-specific
+            api="completions",
+            **kwargs,
+        )
+
+    def _get_client_params(self) -> dict[str, Any]:
+        """Get client parameters with Novita AI defaults."""
+        if self.api_key is None:
+            self.api_key = os.getenv("NOVITA_API_KEY")
+            if self.api_key is None:
+                raise ValueError(
+                    "Novita AI API key is required. "
+                    "Set the NOVITA_API_KEY environment variable or pass api_key."
+                )
+
+        base_params = {
+            "api_key": self.api_key,
+            "base_url": self.base_url or NOVITA_BASE_URL,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
+        }
+
+        client_params = {k: v for k, v in base_params.items() if v is not None}
+
+        if self.client_params:
+            client_params.update(self.client_params)
+
+        return client_params


### PR DESCRIPTION
## Summary

- Adds [Novita AI](https://novita.ai/) as a native LLM provider via its OpenAI-compatible endpoint (`https://api.novita.ai/openai`)
- New `NovitaCompletion` class that extends `OpenAICompletion` — minimal code, inherits all chat completions, streaming, tool-calling, and structured output support
- Registers `novita` in the provider routing (`SUPPORTED_NATIVE_PROVIDERS`, `provider_mapping`, `_get_native_provider`, etc.)
- Supported models: `moonshotai/kimi-k2.5` (default), `zai-org/glm-5`, `minimax/minimax-m2.5`

## Usage

```python
from crewai import LLM

# With provider prefix
llm = LLM(model="novita/moonshotai/kimi-k2.5")

# Direct vendor/model ID (auto-detected)
llm = LLM(model="moonshotai/kimi-k2.5")

# Explicit provider kwarg
llm = LLM(model="zai-org/glm-5", provider="novita")
```

API key is read from `NOVITA_API_KEY` environment variable or passed as `api_key` constructor parameter.

## Design decisions

- **Extends OpenAICompletion** instead of duplicating code — Novita's API is fully OpenAI-compatible
- **Forces `api="completions"`** — the Responses API is OpenAI-specific and not supported by Novita
- **Vendor-prefixed model IDs** (e.g. `moonshotai/kimi-k2.5`) are auto-detected via `NOVITA_MODELS` lookup before the generic `/`-split logic kicks in, so users don't need the `novita/` prefix

## Test plan

- [ ] Verify `LLM(model="novita/moonshotai/kimi-k2.5")` routes to `NovitaCompletion`
- [ ] Verify `LLM(model="moonshotai/kimi-k2.5")` auto-detects Novita provider
- [ ] Verify `NOVITA_API_KEY` env var is picked up correctly
- [ ] Verify chat completion and tool calling work end-to-end with a Novita API key
- [ ] Verify existing providers are unaffected (no changes to existing provider files)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new native provider and modifies LLM provider inference/routing, which could change how some `model` strings are resolved and instantiated at runtime. Low algorithmic complexity, but affects core LLM initialization paths and requires correct API key/base URL configuration.
> 
> **Overview**
> Adds **Novita AI** as a native LLM provider backed by Novita’s OpenAI-compatible endpoint.
> 
> Updates `LLM` provider routing to recognize `novita` (including vendor-prefixed model IDs like `moonshotai/kimi-k2.5`), adds `NOVITA_MODELS` constants, and registers context window sizes for the supported Novita models.
> 
> Introduces `NovitaCompletion`, a thin wrapper over `OpenAICompletion` that defaults the base URL to `https://api.novita.ai/openai`, requires `NOVITA_API_KEY`, and forces use of the OpenAI *Completions* API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bef65c35c2643025c30c2e17c4fa2fa055c1a71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->