### PR TITLE
fix: prioritize tool_calls over text when available_functions is None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,7 +1234,14 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # This must be checked before the text fallback below, because some LLMs
+        # return both text *and* tool_calls; the tool_calls should take priority.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls (or no available functions), return the text response directly as long as there is a text response
         if (not tool_calls or not available_functions) and text_response:
             self._handle_emit_call_events(
                 response=text_response,
@@ -1244,11 +1251,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1022,3 +1022,49 @@ async def test_usage_info_streaming_with_acall():
     assert llm._token_usage["total_tokens"] > 0
 
     assert len(result) > 0
+
+
+def test_tool_calls_prioritized_over_text_when_no_available_functions():
+    """When an LLM returns both text content AND tool_calls, and
+    available_functions is None (executor handles execution), the tool_calls
+    should be returned -- not the text.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4788
+    """
+    llm = LLM(model="gpt-4o-mini", is_litellm=True)
+
+    # Build a fake litellm ModelResponse with both text AND tool_calls
+    fake_tool_call = MagicMock()
+    fake_tool_call.function.name = "code_search"
+    fake_tool_call.function.arguments = '{"query": "test"}'
+    fake_tool_call.id = "call_abc123"
+    fake_tool_call.type = "function"
+
+    fake_message = MagicMock()
+    fake_message.content = "I will search for the given query."
+    fake_message.tool_calls = [fake_tool_call]
+
+    fake_choice = MagicMock()
+    fake_choice.message = fake_message
+
+    fake_response = MagicMock()
+    fake_response.choices = [fake_choice]
+    fake_response.usage = MagicMock(
+        total_tokens=100, prompt_tokens=80, completion_tokens=20
+    )
+
+    params = {"messages": [{"role": "user", "content": "search for test"}]}
+
+    with patch.object(llm, "_call_litellm", return_value=fake_response):
+        result = llm._handle_non_streaming_response(
+            params=params,
+            callbacks=None,
+            available_functions=None,
+        )
+
+    # The method should return tool_calls (list), NOT the text string
+    assert isinstance(result, list), (
+        f"Expected tool_calls list but got text: {result!r}"
+    )
+    assert len(result) == 1
+    assert result[0].function.name == "code_search"


### PR DESCRIPTION
## Summary

Fixes #4788

- When an LLM returns both `content` (text) **and** `tool_calls` in the same response, and `available_functions` is `None` (the executor handles tool execution externally), the text response was being returned instead of the tool calls
- The tool calls were silently discarded, and the text was treated as a final answer by the agent executor loop
- **Fix:** swap the order of checks 5) and 6) in `_handle_non_streaming_response` so that `tool_calls` are returned to the caller before falling back to the text path

This is a one-line logic change (reorder two `if` blocks) in `lib/crewai/src/crewai/llm.py`.

## Affected models

Any model that returns both text and tool_calls in the same response, including:
- `anthropic/claude-haiku-4.5` (via OpenRouter / Bedrock)
- `anthropic/claude-sonnet-4.6` (via OpenRouter / Bedrock)

## Test plan

- [x] Added unit test `test_tool_calls_prioritized_over_text_when_no_available_functions` that mocks a response with both text and tool_calls and asserts tool_calls are returned
- [ ] Manual testing with Claude models via OpenRouter that reproduce the original issue


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk logic reorder in non-streaming LLM response handling; behavior change only affects the edge case where providers return both `content` and `tool_calls` without `available_functions`, potentially altering executor flow but now matches intended tool-execution semantics.
> 
> **Overview**
> Fixes non-streaming LiteLLM response handling so that when a model returns both **text** and `tool_calls` and `available_functions` is `None`, `_handle_non_streaming_response` returns the `tool_calls` (for external execution) instead of falling back to the text response.
> 
> Adds a regression unit test (`test_tool_calls_prioritized_over_text_when_no_available_functions`) that mocks a response containing both fields and asserts `tool_calls` are prioritized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 497521d7d73d1167eec3be57ef99300af001840f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->