### PR TITLE
fix: prioritize tool calls over text when available_functions is None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,15 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # This must be checked before the text fallback below, because some LLMs
+        # (e.g. Claude) return both text AND tool calls in the same response.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1251,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:
@@ -1364,7 +1366,15 @@ class LLM(BaseLLM):
 
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        if (not tool_calls or not available_functions) and text_response:
+        # If there are tool calls but no available functions, return the tool calls
+        # This allows the caller (e.g., executor) to handle tool execution.
+        # This must be checked before the text fallback below, because some LLMs
+        # (e.g. Claude) return both text AND tool calls in the same response.
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # If no tool calls, return the text response directly
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1373,11 +1383,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1022,3 +1022,137 @@ async def test_usage_info_streaming_with_acall():
     assert llm._token_usage["total_tokens"] > 0
 
     assert len(result) > 0
+
+
+def test_tool_calls_prioritized_over_text_when_no_available_functions():
+    """When an LLM returns both text AND tool calls (e.g. Claude), tool calls
+    should be returned instead of the text when available_functions is None.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4788
+    """
+    from litellm.types.utils import (
+        ChatCompletionMessageToolCall,
+        Function,
+        Message,
+    )
+
+    tool_call = ChatCompletionMessageToolCall(
+        index=0,
+        function=Function(
+            arguments='{"query": "test"}',
+            name="search_tool",
+        ),
+        id="call_123",
+        type="function",
+    )
+
+    mock_message = Message(
+        content="I will search for that.",
+        role="assistant",
+        tool_calls=[tool_call],
+    )
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = MagicMock(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+    )
+
+    llm = LLM(model="openai/anthropic/claude-sonnet-4-20250514", is_litellm=True)
+
+    with patch("litellm.completion", return_value=mock_response):
+        result = llm.call(
+            messages=[{"role": "user", "content": "Search for test"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search_tool",
+                        "description": "Search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            available_functions=None,
+        )
+
+    # Should return the tool calls list, NOT the text response
+    assert isinstance(result, list), (
+        f"Expected list of tool calls, got {type(result)}: {result}"
+    )
+    assert len(result) == 1
+    assert result[0].function.name == "search_tool"
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_prioritized_over_text_when_no_available_functions_async():
+    """Async version: tool calls should be prioritized over text when
+    available_functions is None.
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4788
+    """
+    from litellm.types.utils import (
+        ChatCompletionMessageToolCall,
+        Function,
+        Message,
+    )
+
+    tool_call = ChatCompletionMessageToolCall(
+        index=0,
+        function=Function(
+            arguments='{"query": "test"}',
+            name="search_tool",
+        ),
+        id="call_456",
+        type="function",
+    )
+
+    mock_message = Message(
+        content="I will search for that.",
+        role="assistant",
+        tool_calls=[tool_call],
+    )
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = MagicMock(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+    )
+
+    llm = LLM(model="openai/anthropic/claude-sonnet-4-20250514", is_litellm=True)
+
+    async def mock_acompletion(**kwargs):
+        return mock_response
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await llm.acall(
+            messages=[{"role": "user", "content": "Search for test"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search_tool",
+                        "description": "Search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            available_functions=None,
+        )
+
+    # Should return the tool calls list, NOT the text response
+    assert isinstance(result, list), (
+        f"Expected list of tool calls, got {type(result)}: {result}"
+    )
+    assert len(result) == 1
+    assert result[0].function.name == "search_tool"


### PR DESCRIPTION
## Summary
- When an LLM (e.g. Claude) returns both text content AND tool calls in a single response, the text was incorrectly returned instead of the tool calls — silently discarding the tool calls
- Root cause: in `_handle_non_streaming_response` (and its async counterpart), the condition `(not tool_calls or not available_functions) and text_response` at step 5 matched before step 6 could return tool calls for external execution
- Fix: reorder steps 5 and 6 so that tool calls with `available_functions=None` are returned first, then fall back to text-only responses

## Test plan
- [x] Added `test_tool_calls_prioritized_over_text_when_no_available_functions` — sync path
- [x] Added `test_tool_calls_prioritized_over_text_when_no_available_functions_async` — async path
- Both tests mock an LLM response containing both `content` text AND `tool_calls`, pass `available_functions=None`, and verify tool calls are returned (not text)

Fixes #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes non-streaming LLM response selection logic to return `tool_calls` instead of text when `available_functions` is missing, which can affect downstream callers that previously received a string fallback.
> 
> **Overview**
> **Fixes a non-streaming tool-calling regression.** When an LLM returns both `content` text and `tool_calls` in the same response and `available_functions` is `None`, the LLM now returns the `tool_calls` list (for external execution) instead of incorrectly falling back to text.
> 
> Adds sync and async regression tests that mock a Claude-style response containing both text and tool calls and assert tool calls are prioritized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac4d00d0d965ad453fe081df8d2d6776cd6d2051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->