### PR TITLE
feat: remove --public/--private flags from tool publish

### DIFF
--- a/docs/en/enterprise/guides/tool-repository.mdx
+++ b/docs/en/enterprise/guides/tool-repository.mdx
@@ -9,10 +9,7 @@ mode: "wide"
 
 The Tool Repository is a package manager for CrewAI tools. It allows users to publish, install, and manage tools that integrate with CrewAI crews and flows.
 
-Tools can be:
-
-- **Private**: accessible only within your organization (default)
-- **Public**: accessible to all CrewAI users if published with the `--public` flag
+All tools are private by default and accessible only within your organization.
 
 The repository is not a version control system. Use Git to track code changes and enable collaboration.
 
@@ -104,12 +101,6 @@ To publish the tool:
 
 ```bash
 crewai tool publish
-```
-
-By default, tools are published as private. To make a tool public:
-
-```bash
-crewai tool publish --public
 ```
 
 For more details on how to build tools, see [Creating your own tools](/en/concepts/tools#creating-your-own-tools).

--- a/docs/ko/enterprise/guides/tool-repository.mdx
+++ b/docs/ko/enterprise/guides/tool-repository.mdx
@@ -9,10 +9,7 @@ mode: "wide"
 
 Tool Repository는 CrewAI 도구를 위한 패키지 관리자입니다. 사용자는 CrewAI crew와 flow에 통합되는 도구를 게시, 설치 및 관리할 수 있습니다.
 
-도구는 다음과 같이 분류됩니다:
-
-- **비공개**: 조직 내에서만 접근할 수 있습니다(기본값)
-- **공개**: `--public` 플래그로 게시하면 모든 CrewAI 사용자가 접근할 수 있습니다
+모든 도구는 기본적으로 비공개이며 조직 내에서만 접근할 수 있습니다.
 
 이 저장소는 버전 관리 시스템이 아닙니다. 코드 변경 사항을 추적하고 협업을 활성화하려면 Git을 사용하십시오.
 
@@ -58,12 +55,6 @@ git commit -m "Initial version"
 
 ```bash
 crewai tool publish
-```
-
-기본적으로 도구는 비공개로 게시됩니다. 도구를 공개로 설정하려면:
-
-```bash
-crewai tool publish --public
 ```
 
 도구 빌드에 대한 자세한 내용은 [나만의 도구 만들기](/ko/concepts/tools#creating-your-own-tools)를 참고하세요.

--- a/docs/pt-BR/enterprise/guides/tool-repository.mdx
+++ b/docs/pt-BR/enterprise/guides/tool-repository.mdx
@@ -9,10 +9,7 @@ mode: "wide"
 
 O Repositório de Ferramentas é um gerenciador de pacotes para ferramentas da CrewAI. Ele permite que usuários publiquem, instalem e gerenciem ferramentas que se integram com crews e flows da CrewAI.
 
-As ferramentas podem ser:
-
-- **Privadas**: acessíveis apenas dentro da sua organização (padrão)
-- **Públicas**: acessíveis a todos os usuários CrewAI se publicadas com a flag `--public`
+Todas as ferramentas são privadas por padrão e acessíveis apenas dentro da sua organização.
 
 O repositório não é um sistema de controle de versões. Use Git para rastrear mudanças no código e permitir colaboração.
 
@@ -58,12 +55,6 @@ Para publicar a ferramenta:
 
 ```bash
 crewai tool publish
-```
-
-Por padrão, as ferramentas são publicadas como privadas. Para tornar uma ferramenta pública:
-
-```bash
-crewai tool publish --public
 ```
 
 Para mais detalhes sobre como construir ferramentas, acesse [Criando suas próprias ferramentas](/pt-BR/concepts/tools#creating-your-own-tools).

--- a/lib/crewai/src/crewai/cli/cli.py
+++ b/lib/crewai/src/crewai/cli/cli.py
@@ -452,12 +452,10 @@ def tool_install(handle: str):
     default=False,
     help="Bypasses Git remote validations",
 )
-@click.option("--public", "is_public", flag_value=True, default=False)
-@click.option("--private", "is_public", flag_value=False)
-def tool_publish(is_public: bool, force: bool):
+def tool_publish(force: bool):
     tool_cmd = ToolCommand()
     tool_cmd.login()
-    tool_cmd.publish(is_public, force)
+    tool_cmd.publish(force)
 
 
 @crewai.group()

--- a/lib/crewai/src/crewai/cli/plus_api.py
+++ b/lib/crewai/src/crewai/cli/plus_api.py
@@ -68,7 +68,6 @@ class PlusAPI:
     def publish_tool(
         self,
         handle: str,
-        is_public: bool,
         version: str,
         description: str | None,
         encoded_file: str,
@@ -76,7 +75,6 @@ class PlusAPI:
     ) -> httpx.Response:
         params = {
             "handle": handle,
-            "public": is_public,
             "version": version,
             "file": encoded_file,
             "description": description,

--- a/lib/crewai/src/crewai/cli/tools/main.py
+++ b/lib/crewai/src/crewai/cli/tools/main.py
@@ -73,7 +73,7 @@ class ToolCommand(BaseCommand, PlusAPIMixin):
         finally:
             os.chdir(old_directory)
 
-    def publish(self, is_public: bool, force: bool = False) -> None:
+    def publish(self, force: bool = False) -> None:
         if not git.Repository().is_synced() and not force:
             console.print(
                 "[bold red]Failed to publish tool.[/bold red]\n"
@@ -129,7 +129,6 @@ class ToolCommand(BaseCommand, PlusAPIMixin):
         console.print("[bold blue]Publishing tool to repository...[/bold blue]")
         publish_response = self.plus_api_client.publish_tool(
             handle=project_name,
-            is_public=is_public,
             version=project_version,
             description=project_description,
             encoded_file=f"data:application/x-gzip;base64,{encoded_tarball}",

--- a/lib/crewai/tests/cli/test_plus_api.py
+++ b/lib/crewai/tests/cli/test_plus_api.py
@@ -120,18 +120,16 @@ class TestPlusAPI(unittest.TestCase):
         mock_response = MagicMock()
         mock_make_request.return_value = mock_response
         handle = "test_tool_handle"
-        public = True
         version = "1.0.0"
         description = "Test tool description"
         encoded_file = "encoded_test_file"
 
         response = self.api.publish_tool(
-            handle, public, version, description, encoded_file
+            handle, version, description, encoded_file
         )
 
         params = {
             "handle": handle,
-            "public": public,
             "version": version,
             "file": encoded_file,
             "description": description,
@@ -157,18 +155,16 @@ class TestPlusAPI(unittest.TestCase):
         mock_client_class.return_value.__enter__.return_value = mock_client_instance
 
         handle = "test_tool_handle"
-        public = True
         version = "1.0.0"
         description = "Test tool description"
         encoded_file = "encoded_test_file"
 
         response = self.api.publish_tool(
-            handle, public, version, description, encoded_file
+            handle, version, description, encoded_file
         )
 
         expected_params = {
             "handle": handle,
-            "public": public,
             "version": version,
             "file": encoded_file,
             "description": description,
@@ -185,18 +181,16 @@ class TestPlusAPI(unittest.TestCase):
         mock_response = MagicMock()
         mock_make_request.return_value = mock_response
         handle = "test_tool_handle"
-        public = False
         version = "2.0.0"
         description = None
         encoded_file = "encoded_test_file"
 
         response = self.api.publish_tool(
-            handle, public, version, description, encoded_file
+            handle, version, description, encoded_file
         )
 
         params = {
             "handle": handle,
-            "public": public,
             "version": version,
             "file": encoded_file,
             "description": description,

--- a/lib/crewai/tests/cli/tools/test_main.py
+++ b/lib/crewai/tests/cli/tools/test_main.py
@@ -163,7 +163,7 @@ def test_install_api_error(mock_get, capsys, tool_command):
 @patch("crewai.cli.tools.main.git.Repository.is_synced", return_value=False)
 def test_publish_when_not_in_sync(mock_is_synced, capsys, tool_command):
     with raises(SystemExit):
-        tool_command.publish(is_public=True)
+        tool_command.publish()
 
     output = capsys.readouterr().out
     assert "Local changes need to be resolved before publishing" in output
@@ -204,7 +204,7 @@ def test_publish_when_not_in_sync_and_force(
     mock_publish_response.json.return_value = {"handle": "sample-tool"}
     mock_publish.return_value = mock_publish_response
 
-    tool_command.publish(is_public=True, force=True)
+    tool_command.publish(force=True)
 
     mock_get_project_name.assert_called_with(require=True)
     mock_get_project_version.assert_called_with(require=True)
@@ -217,7 +217,6 @@ def test_publish_when_not_in_sync_and_force(
     mock_open.assert_called_with(unittest.mock.ANY, "rb")
     mock_publish.assert_called_with(
         handle="sample-tool",
-        is_public=True,
         version="1.0.0",
         description="A sample tool",
         encoded_file=unittest.mock.ANY,
@@ -259,7 +258,7 @@ def test_publish_success(
     mock_publish_response.json.return_value = {"handle": "sample-tool"}
     mock_publish.return_value = mock_publish_response
 
-    tool_command.publish(is_public=True)
+    tool_command.publish()
 
     mock_get_project_name.assert_called_with(require=True)
     mock_get_project_version.assert_called_with(require=True)
@@ -272,7 +271,6 @@ def test_publish_success(
     mock_open.assert_called_with(unittest.mock.ANY, "rb")
     mock_publish.assert_called_with(
         handle="sample-tool",
-        is_public=True,
         version="1.0.0",
         description="A sample tool",
         encoded_file=unittest.mock.ANY,
@@ -313,7 +311,7 @@ def test_publish_failure(
     mock_publish.return_value = mock_publish_response
 
     with raises(SystemExit):
-        tool_command.publish(is_public=True)
+        tool_command.publish()
     output = capsys.readouterr().out
     assert "Failed to complete operation" in output
     assert "Name is already taken" in output
@@ -355,7 +353,7 @@ def test_publish_api_error(
     mock_publish.return_value = mock_response
 
     with raises(SystemExit):
-        tool_command.publish(is_public=True)
+        tool_command.publish()
     output = capsys.readouterr().out
     assert "Request to Enterprise API failed" in output
 


### PR DESCRIPTION
## Summary

- Removes `--public` and `--private` CLI flags from `crewai tool publish` — all tools are now private to the organization by default
- Removes `is_public` parameter from `ToolCommand.publish()`, `PlusAPI.publish_tool()`, and the API request payload
- Updates tool repository docs in EN, PT-BR, and KO to reflect the new behaviour
- Updates all affected tests

## Test plan

- [x] All existing tests pass (`test_main.py`, `test_plus_api.py`)
- [x] Ruff linting passes
- [ ] Manually verify `crewai tool publish` no longer accepts `--public` or `--private`


towards ENG-1453
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `crewai tool publish` CLI interface and removes the `public` field from the publish API payload, which could break users/scripts or require server-side compatibility.
> 
> **Overview**
> `crewai tool publish` no longer accepts `--public`/`--private` and now always publishes tools as *organization-private*.
> 
> This removes the `is_public` argument throughout the publish flow (CLI command, `ToolCommand.publish`, `PlusAPI.publish_tool`) and drops the `public` field from the request payload. Docs (EN/PT-BR/KO) and affected unit tests are updated to reflect the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a60aa3dacaf5c6ed27964daf46513ab9409d6e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->