### PR TITLE
fix: respect custom trained_file path in Agent._use_trained_data (fixes #4905)

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -131,6 +131,10 @@ class Agent(BaseAgent):
             embedder: Embedder configuration for the agent.
             apps: List of applications that the agent can access through CrewAI Platform.
             mcps: List of MCP server references for tool integration.
+            trained_file: Optional path to a custom trained-agents data file.
+                When provided, overrides the default ``trained_agents_data.pkl``
+                during inference so you can use any file produced by
+                ``crewai train -f <custom>.pkl`` without renaming it.
     """
 
     model_config = ConfigDict()
@@ -254,6 +258,14 @@ class Agent(BaseAgent):
     executor_class: type[CrewAgentExecutor] | type[AgentExecutor] = Field(
         default=CrewAgentExecutor,
         description="Class to use for the agent executor. Defaults to CrewAgentExecutor, can optionally use AgentExecutor.",
+    )
+    trained_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a custom trained-agents data file (e.g. 'my_custom_trained.pkl'). "
+            "When set, this overrides the default 'trained_agents_data.pkl' used during inference. "
+            "Useful for multi-experiment workflows, CI, or production runs where explicit filenames are required."
+        ),
     )
 
     @model_validator(mode="before")
@@ -1011,8 +1023,15 @@ class Agent(BaseAgent):
         return task_prompt
 
     def _use_trained_data(self, task_prompt: str) -> str:
-        """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        """Use trained data for the agent task prompt to improve output.
+
+        If ``trained_file`` is set on the agent, that file is used instead of the
+        default ``trained_agents_data.pkl``.  This allows multi-experiment workflows
+        to specify the exact file produced by ``crewai train -f <custom>.pkl`` without
+        renaming it manually.
+        """
+        trained_data_file = self.trained_file or TRAINED_AGENTS_DATA_FILE
+        if data := CrewTrainingHandler(trained_data_file).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1064,6 +1064,37 @@ def test_agent_use_trained_data(crew_training_handler):
     )
 
 
+@patch("crewai.agent.core.CrewTrainingHandler")
+def test_agent_use_trained_data_custom_file(crew_training_handler):
+    """trained_file overrides the default trained_agents_data.pkl path."""
+    task_prompt = "What is 1 + 1?"
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+        verbose=True,
+        trained_file="my_custom_trained.pkl",
+    )
+    crew_training_handler.return_value.load.return_value = {
+        agent.role: {
+            "suggestions": [
+                "The result of the math operation must be right.",
+            ]
+        }
+    }
+
+    result = agent._use_trained_data(task_prompt=task_prompt)
+
+    assert (
+        result == "What is 1 + 1?\n\nYou MUST follow these instructions: \n"
+        " - The result of the math operation must be right."
+    )
+    # Must have been called with the custom filename, NOT the default
+    crew_training_handler.assert_has_calls(
+        [mock.call("my_custom_trained.pkl"), mock.call().load()]
+    )
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
## Summary

Fixes #4905

When training a crew with a custom filename (`crewai train -f my_custom.pkl`), the trained data was never applied during inference because `_use_trained_data` always loaded from the hardcoded `TRAINED_AGENTS_DATA_FILE` constant (`trained_agents_data.pkl`).

## Root cause

```python
# agent/core.py — before this fix
def _use_trained_data(self, task_prompt: str) -> str:
    if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():  # ❌ always hardcoded
        ...
```

## Solution

Introduce a new optional field `trained_file` on the `Agent` model. When set, it is used as the source file for trained agent suggestions; otherwise it falls back to `TRAINED_AGENTS_DATA_FILE` (unchanged default behaviour).

```python
# agent/core.py — after this fix
def _use_trained_data(self, task_prompt: str) -> str:
    trained_data_file = self.trained_file or TRAINED_AGENTS_DATA_FILE  # ✅
    if data := CrewTrainingHandler(trained_data_file).load():
        ...
```

## Usage

```python
agent = Agent(
    role='researcher',
    goal='...',
    backstory='...',
    trained_file='my_custom_trained.pkl',  # matches -f arg used during training
)
```

## Changes

| File | Change |
|------|--------|
| `src/crewai/agent/core.py` | Add `trained_file: str \| None = None` field; update `_use_trained_data` to use it; update docstrings |
| `tests/agents/test_agent.py` | Add `test_agent_use_trained_data_custom_file` unit test |

## Testing

The existing `test_agent_use_trained_data` test still passes (default path unchanged).  
The new `test_agent_use_trained_data_custom_file` test verifies that `CrewTrainingHandler` is called with the custom filename instead of the default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible change that only affects how `_use_trained_data` selects the training data file, covered by a new unit test.
> 
> **Overview**
> Fixes trained-data inference to respect a new optional `Agent.trained_file` path, falling back to `TRAINED_AGENTS_DATA_FILE` when unset.
> 
> Updates `_use_trained_data` to load suggestions from the selected file and adds a unit test asserting `CrewTrainingHandler` is invoked with the custom filename.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb74adbca09f199ee3b6df6b915900b670848f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->