### PR TITLE
fix(agent): respect custom training data file path instead of hardcoded default

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -255,6 +255,14 @@ class Agent(BaseAgent):
         default=CrewAgentExecutor,
         description="Class to use for the agent executor. Defaults to CrewAgentExecutor, can optionally use AgentExecutor.",
     )
+    trained_agents_data_file: str = Field(
+        default=TRAINED_AGENTS_DATA_FILE,
+        description=(
+            "Path to the trained agents data file used when loading training results. "
+            "Defaults to 'trained_agents_data.pkl'. Set this to the custom filename "
+            "passed with `-f` during `crewai train` so agents load the correct data."
+        ),
+    )
 
     @model_validator(mode="before")
     def validate_from_repository(cls, v: Any) -> dict[str, Any] | None | Any:  # noqa: N805
@@ -1012,7 +1020,7 @@ class Agent(BaseAgent):
 
     def _use_trained_data(self, task_prompt: str) -> str:
         """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        if data := CrewTrainingHandler(self.trained_agents_data_file).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1064,6 +1064,37 @@ def test_agent_use_trained_data(crew_training_handler):
     )
 
 
+def test_agent_use_trained_data_custom_file(crew_training_handler):
+    """Agent should load trained data from custom file path when specified."""
+    task_prompt = "What is 1 + 1?"
+    custom_file = "my_custom_training.pkl"
+    agent = Agent(
+        role="researcher",
+        goal="test goal",
+        backstory="test backstory",
+        verbose=True,
+        trained_agents_data_file=custom_file,
+    )
+    crew_training_handler.return_value.load.return_value = {
+        agent.role: {
+            "suggestions": [
+                "The result of the math operation must be right.",
+            ]
+        }
+    }
+
+    result = agent._use_trained_data(task_prompt=task_prompt)
+
+    assert (
+        result == "What is 1 + 1?\n\nYou MUST follow these instructions: \n"
+        " - The result of the math operation must be right."
+    )
+    # Ensure custom file is used instead of hardcoded default
+    crew_training_handler.assert_has_calls(
+        [mock.call(custom_file), mock.call().load()]
+    )
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
Fixes #4905

## Problem

Agents always load from the hardcoded constant `TRAINED_AGENTS_DATA_FILE` (`trained_agents_data.pkl`), completely ignoring any custom file path passed with `-f` during `crewai train`.

Steps to reproduce:
```bash
crewai train -n 3 -f my_custom_training.pkl
# Training saves to my_custom_training.pkl ✓
# But at runtime, agents load from trained_agents_data.pkl ✗
```

## Root Cause

`Agent._use_trained_data()` in `agent/core.py` hardcodes the file path:
```python
# Before (broken)
if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
```

## Fix

1. Add `trained_agents_data_file` field to `Agent` with default value of `TRAINED_AGENTS_DATA_FILE` (fully backward compatible)
2. Use `self.trained_agents_data_file` in `_use_trained_data()` instead of the module-level constant
3. Add test verifying custom file path is used correctly

```python
# After (fixed)
if data := CrewTrainingHandler(self.trained_agents_data_file).load():
```

Users can now specify the custom file when creating agents:
```python
agent = Agent(
    role="researcher",
    goal="...",
    backstory="...",
    trained_agents_data_file="my_custom_training.pkl",  # matches -f flag
)
```

## Changes

- `src/crewai/agent/core.py`: add `trained_agents_data_file` field, fix `_use_trained_data()`
- `tests/agents/test_agent.py`: add `test_agent_use_trained_data_custom_file` test