### PR TITLE
fix: extract Bedrock tool call arguments from input field

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary
Fixes #4748.

**Root cause:** In `crew_agent_executor.py`, `func_info.get("arguments", "{}") or tool_call.get("input", {})` always evaluates to `"{}"` (a truthy string) when the `arguments` key is absent, so the `or` branch that checks `tool_call["input"]` never runs. AWS Bedrock places tool call arguments in the `input` field, not `arguments`.

**Fix:** Changed to `func_info.get("arguments") or tool_call.get("input") or {}` — matching the already-correct pattern in `agent_utils.py` line 1224.

## Changes
- `lib/crewai/src/crewai/agents/crew_agent_executor.py`: Removed default `"{}"` from `get("arguments")` so falsy `None` falls through to the `input` field check.

## Testing
- Verified fix matches the existing correct pattern in `agent_utils.py`
- Change is minimal (1 line) and backward-compatible
- OpenAI-style tool calls (with `arguments` key) continue to work

Made with [Cursor](https://cursor.com)