### PR TITLE
fix: serialize crew.memory to bool in telemetry span attributes

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -279,7 +279,11 @@ class Telemetry:
             self._add_attribute(span, "python_version", platform.python_version())
             add_crew_attributes(span, crew, self._add_attribute)
             self._add_attribute(span, "crew_process", crew.process)
-            self._add_attribute(span, "crew_memory", crew.memory)
+            self._add_attribute(
+                span,
+                "crew_memory",
+                crew.memory if isinstance(crew.memory, bool) else bool(crew.memory),
+            )
             self._add_attribute(span, "crew_number_of_tasks", len(crew.tasks))
             self._add_attribute(span, "crew_number_of_agents", len(crew.agents))
 

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -1,6 +1,6 @@
 import os
 import threading
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from crewai import Agent, Crew, Task
@@ -159,3 +159,89 @@ def test_no_signal_handler_traceback_in_non_main_thread():
     mock_holder["logger"].debug.assert_any_call(
         "Skipping signal handler registration: not running in main thread"
     )
+
+
+@pytest.mark.telemetry
+class TestCrewMemoryTelemetrySerialization:
+    """Regression tests for https://github.com/crewAIInc/crewAI/issues/4703"""
+
+    def _create_telemetry(self):
+        with patch.dict(
+            os.environ,
+            {"CREWAI_DISABLE_TELEMETRY": "false", "OTEL_SDK_DISABLED": "false"},
+        ):
+            with patch("crewai.telemetry.telemetry.TracerProvider"):
+                return Telemetry()
+
+    def _make_mock_crew(self, memory_value):
+        crew = Mock()
+        crew.memory = memory_value
+        crew.share_crew = False
+        crew.agents = []
+        crew.tasks = []
+        crew.process = "sequential"
+        crew.fingerprint = None
+        return crew
+
+    def test_custom_memory_object_does_not_crash(self):
+        """crew_creation should not raise when crew.memory is a non-bool object."""
+        telemetry = self._create_telemetry()
+        crew = self._make_mock_crew(memory_value=Mock())
+
+        # Should not raise; before the fix this would cause:
+        # "Invalid type Mock for attribute 'crew_memory' value."
+        telemetry.crew_creation(crew, inputs=None)
+
+    def test_custom_memory_object_serialized_as_bool(self):
+        """crew.memory should be converted to a bool for the telemetry span."""
+        telemetry = self._create_telemetry()
+        memory_object = Mock()  # truthy non-bool
+        crew = self._make_mock_crew(memory_value=memory_object)
+
+        captured = {}
+        original_add = telemetry._add_attribute
+
+        def spy_add(span, key, value):
+            captured[key] = value
+            original_add(span, key, value)
+
+        telemetry._add_attribute = spy_add
+        telemetry.crew_creation(crew, inputs=None)
+
+        assert "crew_memory" in captured
+        assert captured["crew_memory"] is True
+        assert type(captured["crew_memory"]) is bool
+
+    def test_bool_memory_passes_through_unchanged(self):
+        """crew.memory=True should remain True (not get re-wrapped)."""
+        telemetry = self._create_telemetry()
+        crew = self._make_mock_crew(memory_value=True)
+
+        captured = {}
+        original_add = telemetry._add_attribute
+
+        def spy_add(span, key, value):
+            captured[key] = value
+            original_add(span, key, value)
+
+        telemetry._add_attribute = spy_add
+        telemetry.crew_creation(crew, inputs=None)
+
+        assert captured["crew_memory"] is True
+
+    def test_false_memory_passes_through_unchanged(self):
+        """crew.memory=False should remain False."""
+        telemetry = self._create_telemetry()
+        crew = self._make_mock_crew(memory_value=False)
+
+        captured = {}
+        original_add = telemetry._add_attribute
+
+        def spy_add(span, key, value):
+            captured[key] = value
+            original_add(span, key, value)
+
+        telemetry._add_attribute = spy_add
+        telemetry.crew_creation(crew, inputs=None)
+
+        assert captured["crew_memory"] is False


### PR DESCRIPTION
## What
Convert `crew.memory` to a `bool` before passing it to `span.set_attribute()` in telemetry, so that custom `Memory` instances don't crash OpenTelemetry.

## Why
Fixes #4703

When a user passes a custom `Memory` object (e.g. with a custom `LanceDBStorage` backend) instead of `memory=True`, the telemetry module passes the `Memory` instance directly to `span.set_attribute("crew_memory", crew.memory)`. OpenTelemetry only accepts primitive types (`bool`, `str`, `int`, `float`, `bytes`), so it raises:

```
Invalid type Memory for attribute 'crew_memory' value.
Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This prevents the crew from initializing at all.

## How
One-line change in `crew_creation()` (`lib/crewai/src/crewai/telemetry/telemetry.py`, line 282):

```python
# Before
self._add_attribute(span, "crew_memory", crew.memory)

# After
self._add_attribute(
    span,
    "crew_memory",
    crew.memory if isinstance(crew.memory, bool) else bool(crew.memory),
)
```

- If `crew.memory` is already a `bool` (`True`/`False`), it passes through unchanged.
- If it's a `Memory` object (truthy), it becomes `True`.
- If it's `None` or falsy, it becomes `False`.

This preserves backward compatibility and keeps the telemetry attribute semantically correct ("is memory enabled?").

## Testing

Added 4 unit tests in `lib/crewai/tests/telemetry/test_telemetry.py`:

| Test | Verifies |
|------|----------|
| `test_custom_memory_object_does_not_crash` | `crew_creation()` doesn't raise with a non-bool memory |
| `test_custom_memory_object_serialized_as_bool` | Memory object → `True` in span attribute |
| `test_bool_memory_passes_through_unchanged` | `memory=True` stays `True` |
| `test_false_memory_passes_through_unchanged` | `memory=False` stays `False` |

All 14 tests pass (10 existing + 4 new):

```
======================== 14 passed, 3 warnings in 6.61s ========================
```

Ruff lint and format checks pass on the source file.