### PR TITLE
fix: Bedrock tool call args extraction fails due to truthy default

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or {}
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

- Fixes the Bedrock tool argument extraction bug where `.get("arguments", "{}")` returns the truthy default string `"{}"` when the key is absent, preventing the `or` branch from ever reaching Bedrock's `input` field
- Changed to `.get("arguments") or .get("input") or {}` to match the already-correct pattern used in `agent_utils.py` line 1224

## Root Cause

In `crew_agent_executor.py` line 850:
```python
# Before (broken): default "{}" is truthy, so Bedrock's input is never read
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})

# After (fixed): None is falsy, so the or-chain works correctly
func_args = func_info.get("arguments") or tool_call.get("input") or {}
```

This is a one-line fix. The same correct pattern already exists in `utilities/agent_utils.py` line 1224.

## Affected Models

All AWS Bedrock models (Nova Pro, Nova Lite, Nova Micro, Claude via Bedrock) that use the `input` field instead of `function.arguments`.

Fixes #4748