### PR TITLE
fix(cli): update model list with latest claude and gemini models

### DIFF
--- a/lib/crewai/src/crewai/cli/constants.py
+++ b/lib/crewai/src/crewai/cli/constants.py
@@ -142,10 +142,11 @@ MODELS: dict[str, list[str]] = {
         "o1-preview",
     ],
     "anthropic": [
-        "claude-3-5-sonnet-20240620",
-        "claude-3-sonnet-20240229",
-        "claude-3-opus-20240229",
-        "claude-3-haiku-20240307",
+        "claude-sonnet-4-20250514",
+        "claude-opus-4-20250514",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-5-haiku-20241022",
     ],
     "gemini": [
         "gemini/gemini-3-pro-preview",


### PR DESCRIPTION
Fixes #4317

  Updated the Anthropic model list with Claude 4 Sonnet, Opus, and Haiku 4.5. Removed obsolete Claude 3 entries, kept recent 3.5 variants.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested?
  - [x] I believe this change is already covered by existing unit tests

  ## Suggested Checklist
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] I ran uv run make format; uv run make lint to appease the lint gods
