### PR TITLE
fix(bedrock): use explicit key check for tool call argument extraction

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            if "arguments" in func_info:
+                func_args = func_info["arguments"]
+            elif "input" in tool_call:
+                func_args = tool_call["input"]
+            else:
+                func_args = {}
             return call_id, func_name, func_args
         return None
 
@@ -900,6 +905,8 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         )
         if parse_error is not None:
             return parse_error
+        if args_dict is None:
+            args_dict = {}
 
         if original_tool is None:
             for tool in self.original_tools or []:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1221,7 +1221,12 @@ def extract_tool_call_info(
         )
         func_info = tool_call.get("function", {})
         func_name = func_info.get("name", "") or tool_call.get("name", "")
-        func_args = func_info.get("arguments") or tool_call.get("input") or {}
+        if func_info and "arguments" in func_info:
+            func_args = func_info["arguments"]
+        elif "input" in tool_call:
+            func_args = tool_call["input"]
+        else:
+            func_args = {}
         return call_id, sanitize_tool_name(func_name), func_args
     return None
 

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1276,3 +1276,47 @@ class TestNativeToolCallingJsonParseError:
 
         assert "Error" in result["result"]
         assert "validation failed" in result["result"].lower() or "missing" in result["result"].lower()
+
+
+def test_parse_bedrock_tool_call_arguments() -> None:
+    """Regression test for #4748."""
+    from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+    executor = object.__new__(CrewAgentExecutor)
+
+    bedrock_tool_call: dict[str, object] = {
+        "toolUseId": "tooluse_abc123",
+        "name": "calculator",
+        "input": {"expression": "5 + 3"},
+    }
+
+    result = executor._parse_native_tool_call(bedrock_tool_call)
+
+    assert result is not None
+    call_id, func_name, func_args = result
+    assert call_id == "tooluse_abc123"
+    assert func_name == "calculator"
+    assert func_args == {"expression": "5 + 3"}
+
+
+def test_parse_openai_tool_call_arguments() -> None:
+    """Verify OpenAI format still works after fix."""
+    from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+    executor = object.__new__(CrewAgentExecutor)
+
+    openai_tool_call: dict[str, object] = {
+        "id": "call_abc123",
+        "function": {
+            "name": "search",
+            "arguments": '{"query": "python"}',
+        },
+    }
+
+    result = executor._parse_native_tool_call(openai_tool_call)
+
+    assert result is not None
+    call_id, func_name, func_args = result
+    assert call_id == "call_abc123"
+    assert func_name == "search"
+    assert func_args == '{"query": "python"}'


### PR DESCRIPTION
Fixes #4748

  The dict-based tool call parser used a truthy fallback that prevented Bedrock's input field from being reached:

  ```python
  # Before: default '{}' is truthy, so input branch never executes
  func_args = func_info.get('arguments', '{}') or tool_call.get('input', {})

  # After: explicit key presence check
  if 'arguments' in func_info:
      func_args = func_info['arguments']
  elif 'input' in tool_call:
      func_args = tool_call['input']
  else:
      func_args = {}
  ```

  Fixed in both crew_agent_executor.py and agent_utils.py.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested?
  - [x] I added new unit tests to cover this change

  ## Suggested Checklist
  - [x] I have performed a self-review of my own code
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I ran uv run make format; uv run make lint to appease the lint gods
