### PR TITLE
fix(anthropic): insert user message between consecutive assistant messages

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -223,7 +223,9 @@ class AnthropicCompletion(BaseLLM):
         self.response_format = response_format
         # Tool search config
         if tool_search is True:
-            self.tool_search = AnthropicToolSearchConfig()
+            self.tool_search: AnthropicToolSearchConfig | None = (
+                AnthropicToolSearchConfig()
+            )
         elif isinstance(tool_search, AnthropicToolSearchConfig):
             self.tool_search = tool_search
         else:
@@ -786,6 +788,20 @@ class AnthropicCompletion(BaseLLM):
         elif formatted_messages[0]["role"] != "user":
             # If first message is not from user, insert a user message at the beginning
             formatted_messages.insert(0, {"role": "user", "content": "Hello"})
+
+        # Ensure no consecutive assistant messages (Anthropic requirement)
+        i = 0
+        while i < len(formatted_messages) - 1:
+            if (
+                formatted_messages[i].get("role") == "assistant"
+                and formatted_messages[i + 1].get("role") == "assistant"
+            ):
+                formatted_messages.insert(
+                    i + 1, {"role": "user", "content": "Continue."}
+                )
+                i += 2
+            else:
+                i += 1
 
         return formatted_messages, system_message
 

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -1463,3 +1463,37 @@ def test_tool_search_saves_input_tokens():
         f"Expected tool_search ({usage_search.prompt_tokens}) to use fewer input tokens "
         f"than no search ({usage_no_search.prompt_tokens})"
     )
+
+
+def test_format_messages_no_consecutive_assistants():
+    """Regression test for #4798."""
+    llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "I will search for that."},
+        {"role": "assistant", "content": "Here are the results."},
+        {"role": "assistant", "content": "The final answer is 42."},
+    ]
+
+    result, _ = llm._format_messages_for_anthropic(messages)
+
+    roles = [m["role"] for m in result]
+    for i in range(len(roles) - 1):
+        assert not (roles[i] == "assistant" and roles[i + 1] == "assistant")
+
+
+def test_format_messages_alternating_preserved():
+    """Verify alternating messages are not modified."""
+    llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "user", "content": "Search for X"},
+        {"role": "assistant", "content": "Found X"},
+    ]
+
+    result, _ = llm._format_messages_for_anthropic(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant", "user", "assistant"]


### PR DESCRIPTION
Fixes #4798 - Claude rejects consecutive assistant messages in conversation history. During the ReAct loop, CrewAI can create assistant-assistant sequences. The Anthropic formatter now inserts a synthetic user message between them, similar to the existing Bedrock approach.