### PR TITLE
feat: add OCI Generative AI provider — basic text completion

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -104,6 +104,9 @@ azure-ai-inference = [
 anthropic = [
     "anthropic~=0.73.0",
 ]
+oci = [
+    "oci>=2.168.0",
+]
 a2a = [
      "a2a-sdk~=0.3.10",
      "httpx-auth~=0.23.1",

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -342,6 +342,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "cerebras",
     "dashscope",
     "snowflake",
+    "oci",
 ]
 
 
@@ -447,6 +448,7 @@ class LLM(BaseLLM):
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
                 "snowflake": "snowflake",
+                "oci": "oci",
             }
 
             canonical_provider = provider_mapping.get(prefix.lower())
@@ -579,6 +581,9 @@ class LLM(BaseLLM):
         if provider == "snowflake":
             return True
 
+        if provider == "oci":
+            return model_lower.startswith("ocid1.generativeaiendpoint") or "." in model_lower
+
         return False
 
     @classmethod
@@ -614,6 +619,7 @@ class LLM(BaseLLM):
             # azure does not provide a list of available models, determine a better way to handle this
             return True
 
+        # Fallback to pattern matching for models not in constants (includes OCI)
         return cls._matches_provider_pattern(model, provider)
 
     @staticmethod
@@ -711,6 +717,11 @@ class LLM(BaseLLM):
             )
 
             return OpenAICompatibleCompletion
+
+        if provider == "oci":
+            from crewai.llms.providers.oci.completion import OCICompletion
+
+            return OCICompletion
 
         return None
 

--- a/lib/crewai/src/crewai/llms/providers/oci/__init__.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/__init__.py
@@ -1,0 +1,5 @@
+from crewai.llms.providers.oci.completion import OCICompletion
+
+__all__ = [
+    "OCICompletion",
+]

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from pydantic import BaseModel
+
+from crewai.events.types.llm_events import LLMCallType
+from crewai.llms.base_llm import BaseLLM, llm_call_context
+from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
+from crewai.utilities.types import LLMMessage
+
+
+if TYPE_CHECKING:
+    from crewai.agent.core import Agent
+    from crewai.task import Task
+    from crewai.tools.base_tool import BaseTool
+
+
+CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
+DEFAULT_OCI_REGION = "us-chicago-1"
+DEFAULT_OCI_TIMEOUT = (10, 240)
+
+
+def _get_oci_module() -> Any:
+    """Backward-compatible module-local alias used by tests and patches."""
+    return get_oci_module()
+
+
+class OCICompletion(BaseLLM):
+    """OCI Generative AI native provider for CrewAI.
+
+    Supports basic text completions for generic (Meta, Google, OpenAI, xAI)
+    and Cohere model families hosted on the OCI Generative AI service.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        compartment_id: str | None = None,
+        service_endpoint: str | None = None,
+        auth_type: Literal[
+            "API_KEY",
+            "SECURITY_TOKEN",
+            "INSTANCE_PRINCIPAL",
+            "RESOURCE_PRINCIPAL",
+        ]
+        | str = "API_KEY",
+        auth_profile: str | None = None,
+        auth_file_location: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        top_k: int | None = None,
+        oci_provider: str | None = None,
+        timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
+        client: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("provider", None)
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            provider="oci",
+            **kwargs,
+        )
+
+        self.compartment_id = compartment_id or os.getenv("OCI_COMPARTMENT_ID")
+        if not self.compartment_id:
+            raise ValueError(
+                "OCI compartment_id is required. Set compartment_id or OCI_COMPARTMENT_ID."
+            )
+
+        self.service_endpoint = service_endpoint or os.getenv("OCI_SERVICE_ENDPOINT")
+        if self.service_endpoint is None:
+            region = os.getenv("OCI_REGION", DEFAULT_OCI_REGION)
+            self.service_endpoint = (
+                f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+            )
+
+        self.auth_type = str(auth_type).upper()
+        self.auth_profile = cast(
+            str, auth_profile or os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+        )
+        self.auth_file_location = cast(
+            str,
+            auth_file_location
+            or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
+        )
+        self.max_tokens = max_tokens
+        self.top_p = top_p
+        self.top_k = top_k
+        self.oci_provider = oci_provider or self._infer_provider(model)
+        self._oci = _get_oci_module()
+
+        if client is not None:
+            self.client = client
+        else:
+            client_kwargs = create_oci_client_kwargs(
+                auth_type=self.auth_type,
+                service_endpoint=self.service_endpoint,
+                auth_file_location=self.auth_file_location,
+                auth_profile=self.auth_profile,
+                timeout=timeout,
+                oci_module=self._oci,
+            )
+            self.client = self._oci.generative_ai_inference.GenerativeAiInferenceClient(
+                **client_kwargs
+            )
+        self._client_lock = threading.Lock()
+        self.last_response_metadata = None
+
+    # ------------------------------------------------------------------
+    # Provider inference
+    # ------------------------------------------------------------------
+
+    def _infer_provider(self, model: str) -> str:
+        if model.startswith(CUSTOM_ENDPOINT_PREFIX):
+            return "generic"
+        if model.lower().startswith("cohere."):
+            return "cohere"
+        return "generic"
+
+    def _is_openai_gpt5_family(self) -> bool:
+        return self.model.lower().startswith("openai.gpt-5")
+
+    def _build_serving_mode(self) -> Any:
+        models = self._oci.generative_ai_inference.models
+        if self.model.startswith(CUSTOM_ENDPOINT_PREFIX):
+            return models.DedicatedServingMode(endpoint_id=self.model)
+        return models.OnDemandServingMode(model_id=self.model)
+
+    # ------------------------------------------------------------------
+    # Message helpers
+    # ------------------------------------------------------------------
+
+    def _normalize_messages(
+        self, messages: str | list[LLMMessage]
+    ) -> list[LLMMessage]:
+        return self._format_messages(messages)
+
+    def _coerce_text(self, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, Mapping):
+                    if item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                    elif "text" in item:
+                        parts.append(str(item["text"]))
+            return "\n".join(part for part in parts if part)
+        return str(content)
+
+    def _build_generic_content(self, content: Any) -> list[Any]:
+        """Translate CrewAI message content into OCI generic content objects."""
+        models = self._oci.generative_ai_inference.models
+        if isinstance(content, str):
+            return [models.TextContent(text=content or ".")]
+
+        if not isinstance(content, list):
+            return [models.TextContent(text=self._coerce_text(content) or ".")]
+
+        processed: list[Any] = []
+        for item in content:
+            if isinstance(item, str):
+                processed.append(models.TextContent(text=item or "."))
+            elif isinstance(item, Mapping) and item.get("type") == "text":
+                processed.append(
+                    models.TextContent(text=str(item.get("text", "")) or ".")
+                )
+            else:
+                processed.append(
+                    models.TextContent(text=self._coerce_text(item) or ".")
+                )
+        return processed or [models.TextContent(text=".")]
+
+    def _build_generic_messages(self, messages: list[LLMMessage]) -> list[Any]:
+        """Map CrewAI conversation messages into OCI generic chat messages."""
+        models = self._oci.generative_ai_inference.models
+        role_map = {
+            "user": models.UserMessage,
+            "assistant": models.AssistantMessage,
+            "system": models.SystemMessage,
+        }
+        oci_messages: list[Any] = []
+
+        for message in messages:
+            role = str(message.get("role", "user")).lower()
+            message_cls = role_map.get(role)
+            if message_cls is None:
+                logging.debug("Skipping unsupported OCI message role: %s", role)
+                continue
+            oci_messages.append(
+                message_cls(
+                    content=self._build_generic_content(message.get("content", "")),
+                )
+            )
+
+        return oci_messages
+
+    def _build_cohere_chat_history(
+        self, messages: list[LLMMessage]
+    ) -> tuple[list[Any], str]:
+        """Translate CrewAI messages into Cohere's split history + message shape."""
+        models = self._oci.generative_ai_inference.models
+        chat_history: list[Any] = []
+
+        for message in messages[:-1]:
+            role = str(message.get("role", "user")).lower()
+            content = message.get("content", "")
+
+            if role in ("user", "system"):
+                message_cls = (
+                    models.CohereUserMessage
+                    if role == "user"
+                    else models.CohereSystemMessage
+                )
+                chat_history.append(message_cls(message=self._coerce_text(content)))
+            elif role == "assistant":
+                chat_history.append(
+                    models.CohereChatBotMessage(
+                        message=self._coerce_text(content) or " ",
+                    )
+                )
+
+        last_message = messages[-1] if messages else {"role": "user", "content": ""}
+        message_text = self._coerce_text(last_message.get("content", ""))
+        return chat_history, message_text
+
+    # ------------------------------------------------------------------
+    # Request building
+    # ------------------------------------------------------------------
+
+    def _build_chat_request(
+        self,
+        messages: list[LLMMessage],
+    ) -> Any:
+        """Build the provider-specific OCI chat request for the current model."""
+        models = self._oci.generative_ai_inference.models
+
+        if self.oci_provider == "cohere":
+            chat_history, message_text = self._build_cohere_chat_history(messages)
+            request_kwargs: dict[str, Any] = {
+                "message": message_text,
+                "chat_history": chat_history,
+                "api_format": models.BaseChatRequest.API_FORMAT_COHERE,
+            }
+        else:
+            request_kwargs = {
+                "messages": self._build_generic_messages(messages),
+                "api_format": models.BaseChatRequest.API_FORMAT_GENERIC,
+            }
+
+        if self.temperature is not None and not self._is_openai_gpt5_family():
+            request_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            if self.oci_provider == "generic" and self.model.lower().startswith("openai."):
+                request_kwargs["max_completion_tokens"] = self.max_tokens
+            else:
+                request_kwargs["max_tokens"] = self.max_tokens
+        if self.top_p is not None:
+            request_kwargs["top_p"] = self.top_p
+        if self.top_k is not None:
+            request_kwargs["top_k"] = self.top_k
+
+        if self.stop and not self._is_openai_gpt5_family():
+            stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"
+            request_kwargs[stop_key] = list(self.stop)
+
+        if self.oci_provider == "cohere":
+            return models.CohereChatRequest(**request_kwargs)
+        return models.GenericChatRequest(**request_kwargs)
+
+    # ------------------------------------------------------------------
+    # Response extraction
+    # ------------------------------------------------------------------
+
+    def _extract_text(self, response: Any) -> str:
+        chat_response = response.data.chat_response
+        if self.oci_provider == "cohere":
+            if getattr(chat_response, "text", None):
+                return chat_response.text or ""
+            message = getattr(chat_response, "message", None)
+            if message is not None:
+                content = getattr(message, "content", None) or []
+                return "".join(
+                    part.text for part in content if getattr(part, "text", None)
+                )
+            return ""
+
+        choices = getattr(chat_response, "choices", None) or []
+        if not choices:
+            return ""
+        message = getattr(choices[0], "message", None)
+        if message is None:
+            return ""
+        content = getattr(message, "content", None) or []
+        return "".join(part.text for part in content if getattr(part, "text", None))
+
+    def _extract_usage(self, response: Any) -> dict[str, int]:
+        chat_response = response.data.chat_response
+        usage = getattr(chat_response, "usage", None)
+        if usage is None:
+            return {}
+        return {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    def _extract_response_metadata(self, response: Any) -> dict[str, Any]:
+        chat_response = response.data.chat_response
+        metadata: dict[str, Any] = {}
+
+        finish_reason = getattr(chat_response, "finish_reason", None)
+        if finish_reason is None:
+            choices = getattr(chat_response, "choices", None) or []
+            if choices:
+                finish_reason = getattr(choices[0], "finish_reason", None)
+
+        if finish_reason is not None:
+            metadata["finish_reason"] = finish_reason
+
+        usage = self._extract_usage(response)
+        if usage:
+            metadata["usage"] = usage
+
+        return metadata
+
+    # ------------------------------------------------------------------
+    # Call paths
+    # ------------------------------------------------------------------
+
+    def _finalize_text_response(
+        self,
+        *,
+        content: str,
+        messages: list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> str:
+        content = self._apply_stop_words(content)
+        content = self._invoke_after_llm_call_hooks(messages, content, from_agent)
+        self._emit_call_completed_event(
+            response=content,
+            call_type=LLMCallType.LLM_CALL,
+            from_task=from_task,
+            from_agent=from_agent,
+            messages=messages,
+        )
+        return content
+
+    def _call_impl(
+        self,
+        *,
+        messages: list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> str:
+        chat_request = self._build_chat_request(messages)
+        chat_details = self._oci.generative_ai_inference.models.ChatDetails(
+            compartment_id=self.compartment_id,
+            serving_mode=self._build_serving_mode(),
+            chat_request=chat_request,
+        )
+        response = self._chat(chat_details)
+        self.last_response_metadata = self._extract_response_metadata(response) or None
+        usage = (self.last_response_metadata or {}).get("usage", {})
+        if usage:
+            self._track_token_usage_internal(usage)
+
+        content = self._extract_text(response)
+        return self._finalize_text_response(
+            content=content,
+            messages=messages,
+            from_task=from_task,
+            from_agent=from_agent,
+        )
+
+    def call(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        response_model: type[BaseModel] | None = None,
+    ) -> str | BaseModel | list[dict[str, Any]]:
+        with llm_call_context():
+            try:
+                normalized_messages = self._normalize_messages(messages)
+                self._emit_call_started_event(
+                    messages=normalized_messages,
+                    tools=tools,
+                    callbacks=callbacks,
+                    available_functions=available_functions,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+
+                if not self._invoke_before_llm_call_hooks(
+                    normalized_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
+                return self._call_impl(
+                    messages=normalized_messages,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+            except Exception as error:
+                error_message = f"OCI Generative AI call failed: {error!s}"
+                self._emit_call_failed_event(
+                    error=error_message,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+                raise
+
+    async def acall(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        response_model: type[BaseModel] | None = None,
+    ) -> str | Any:
+        return await asyncio.to_thread(
+            self.call,
+            messages,
+            tools=tools,
+            callbacks=callbacks,
+            available_functions=available_functions,
+            from_task=from_task,
+            from_agent=from_agent,
+            response_model=response_model,
+        )
+
+    # ------------------------------------------------------------------
+    # Client serialization
+    # ------------------------------------------------------------------
+
+    def _chat(self, chat_details: Any) -> Any:
+        with self._client_lock:
+            return self.client.chat(chat_details)
+

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -216,7 +216,7 @@ class OCICompletion(BaseLLM):
             role = str(message.get("role", "user")).lower()
             message_cls = role_map.get(role)
             if message_cls is None:
-                logging.debug("Skipping unsupported OCI message role: %s", role)
+                logging.warning("Skipping unsupported OCI message role: %s", role)
                 continue
             oci_messages.append(
                 message_cls(
@@ -249,6 +249,10 @@ class OCICompletion(BaseLLM):
                     models.CohereChatBotMessage(
                         message=self._coerce_text(content) or " ",
                     )
+                )
+            else:
+                logging.warning(
+                    "Skipping unsupported OCI Cohere message role: %s", role
                 )
 
         last_message = messages[-1] if messages else {"role": "user", "content": ""}
@@ -375,6 +379,8 @@ class OCICompletion(BaseLLM):
         messages: list[LLMMessage],
         from_task: Task | None,
         from_agent: Agent | None,
+        usage: dict[str, Any] | None = None,
+        finish_reason: str | None = None,
     ) -> str:
         """Apply stop-word trimming and ``after_llm_call`` hooks, then emit the ``call_completed`` event."""
         content = self._apply_stop_words(content)
@@ -385,6 +391,8 @@ class OCICompletion(BaseLLM):
             from_task=from_task,
             from_agent=from_agent,
             messages=messages,
+            usage=usage,
+            finish_reason=finish_reason,
         )
         return content
 
@@ -414,6 +422,8 @@ class OCICompletion(BaseLLM):
             messages=messages,
             from_task=from_task,
             from_agent=from_agent,
+            usage=usage or None,
+            finish_reason=(self.last_response_metadata or {}).get("finish_reason"),
         )
 
     def call(

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -14,7 +14,6 @@ from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
 from crewai.utilities.types import LLMMessage
 
-
 if TYPE_CHECKING:
     from crewai.agent.core import Agent
     from crewai.task import Task
@@ -44,13 +43,15 @@ class OCICompletion(BaseLLM):
         *,
         compartment_id: str | None = None,
         service_endpoint: str | None = None,
-        auth_type: Literal[
-            "API_KEY",
-            "SECURITY_TOKEN",
-            "INSTANCE_PRINCIPAL",
-            "RESOURCE_PRINCIPAL",
-        ]
-        | str = "API_KEY",
+        auth_type: (
+            Literal[
+                "API_KEY",
+                "SECURITY_TOKEN",
+                "INSTANCE_PRINCIPAL",
+                "RESOURCE_PRINCIPAL",
+            ]
+            | str
+        ) = "API_KEY",
         auth_profile: str | None = None,
         auth_file_location: str | None = None,
         temperature: float | None = None,
@@ -89,8 +90,7 @@ class OCICompletion(BaseLLM):
         )
         self.auth_file_location = cast(
             str,
-            auth_file_location
-            or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
+            auth_file_location or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
         )
         self.max_tokens = max_tokens
         self.top_p = top_p
@@ -139,9 +139,7 @@ class OCICompletion(BaseLLM):
     # Message helpers
     # ------------------------------------------------------------------
 
-    def _normalize_messages(
-        self, messages: str | list[LLMMessage]
-    ) -> list[LLMMessage]:
+    def _normalize_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         return self._format_messages(messages)
 
     def _coerce_text(self, content: Any) -> str:
@@ -265,7 +263,11 @@ class OCICompletion(BaseLLM):
         if self.temperature is not None and not self._is_openai_gpt5_family():
             request_kwargs["temperature"] = self.temperature
         if self.max_tokens is not None:
-            if self.oci_provider == "generic" and self.model.lower().startswith("openai."):
+            # OpenAI GPT-5 family on OCI rejects `max_tokens` and requires
+            # `max_completion_tokens` instead (verified live: HTTP 400
+            # `Invalid 'maxTokens': ... Use 'maxCompletionTokens' instead.`).
+            # GPT-4o / GPT-4.1 / Llama / Cohere keep using `max_tokens`.
+            if self._is_openai_gpt5_family():
                 request_kwargs["max_completion_tokens"] = self.max_tokens
             else:
                 request_kwargs["max_tokens"] = self.max_tokens
@@ -457,4 +459,3 @@ class OCICompletion(BaseLLM):
     def _chat(self, chat_details: Any) -> Any:
         with self._client_lock:
             return self.client.chat(chat_details)
-

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -58,6 +58,7 @@ class OCICompletion(BaseLLM):
         max_tokens: int | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        reasoning_effort: str | None = None,
         oci_provider: str | None = None,
         timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
         client: Any | None = None,
@@ -95,6 +96,10 @@ class OCICompletion(BaseLLM):
         self.max_tokens = max_tokens
         self.top_p = top_p
         self.top_k = top_k
+        # Reasoning-token budget: NONE / MINIMAL / LOW / MEDIUM / HIGH.
+        # Honoured by GPT-5 family, Gemini 2.5, Grok reasoning variants,
+        # Cohere Command-A-Reasoning. Ignored by non-reasoning models.
+        self.reasoning_effort = reasoning_effort
         self.oci_provider = oci_provider or self._infer_provider(model)
         self._oci = _get_oci_module()
 
@@ -275,6 +280,8 @@ class OCICompletion(BaseLLM):
             request_kwargs["top_p"] = self.top_p
         if self.top_k is not None:
             request_kwargs["top_k"] = self.top_k
+        if self.reasoning_effort is not None:
+            request_kwargs["reasoning_effort"] = self.reasoning_effort
 
         if self.stop and not self._is_openai_gpt5_family():
             stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -14,6 +14,7 @@ from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
 from crewai.utilities.types import LLMMessage
 
+
 if TYPE_CHECKING:
     from crewai.agent.core import Agent
     from crewai.task import Task
@@ -64,6 +65,14 @@ class OCICompletion(BaseLLM):
         client: Any | None = None,
         **kwargs: Any,
     ) -> None:
+        """Configure the OCI Generative AI client and chat parameters.
+
+        Resolves compartment, service endpoint, and auth from explicit args
+        or `OCI_*` environment variables, then builds a
+        ``GenerativeAiInferenceClient`` (unless ``client`` is provided for
+        testing). Infers the OCI provider family (cohere vs generic) from
+        the model id when ``oci_provider`` is not given.
+        """
         kwargs.pop("provider", None)
         super().__init__(
             model=model,
@@ -125,6 +134,7 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _infer_provider(self, model: str) -> str:
+        """Infer the OCI request family (``cohere`` or ``generic``) from the model id."""
         if model.startswith(CUSTOM_ENDPOINT_PREFIX):
             return "generic"
         if model.lower().startswith("cohere."):
@@ -132,9 +142,11 @@ class OCICompletion(BaseLLM):
         return "generic"
 
     def _is_openai_gpt5_family(self) -> bool:
+        """Return True if the current model is in the OpenAI GPT-5 family."""
         return self.model.lower().startswith("openai.gpt-5")
 
     def _build_serving_mode(self) -> Any:
+        """Pick OCI serving mode: ``DedicatedServingMode`` for custom-endpoint OCIDs, ``OnDemandServingMode`` otherwise."""
         models = self._oci.generative_ai_inference.models
         if self.model.startswith(CUSTOM_ENDPOINT_PREFIX):
             return models.DedicatedServingMode(endpoint_id=self.model)
@@ -145,9 +157,11 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _normalize_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
+        """Coerce a string or message list into the canonical CrewAI message list shape."""
         return self._format_messages(messages)
 
     def _coerce_text(self, content: Any) -> str:
+        """Flatten mixed message content (str / list of parts / dicts with ``text``) into a plain string."""
         if content is None:
             return ""
         if isinstance(content, str):
@@ -296,6 +310,7 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _extract_text(self, response: Any) -> str:
+        """Pull the assistant text out of an OCI chat response, handling both Cohere and generic shapes."""
         chat_response = response.data.chat_response
         if self.oci_provider == "cohere":
             if getattr(chat_response, "text", None):
@@ -318,6 +333,7 @@ class OCICompletion(BaseLLM):
         return "".join(part.text for part in content if getattr(part, "text", None))
 
     def _extract_usage(self, response: Any) -> dict[str, int]:
+        """Return ``{prompt_tokens, completion_tokens, total_tokens}`` from the OCI response, or an empty dict if unavailable."""
         chat_response = response.data.chat_response
         usage = getattr(chat_response, "usage", None)
         if usage is None:
@@ -329,6 +345,7 @@ class OCICompletion(BaseLLM):
         }
 
     def _extract_response_metadata(self, response: Any) -> dict[str, Any]:
+        """Collect ``finish_reason`` and ``usage`` into a metadata dict for ``last_response_metadata``."""
         chat_response = response.data.chat_response
         metadata: dict[str, Any] = {}
 
@@ -359,6 +376,7 @@ class OCICompletion(BaseLLM):
         from_task: Task | None,
         from_agent: Agent | None,
     ) -> str:
+        """Apply stop-word trimming and ``after_llm_call`` hooks, then emit the ``call_completed`` event."""
         content = self._apply_stop_words(content)
         content = self._invoke_after_llm_call_hooks(messages, content, from_agent)
         self._emit_call_completed_event(
@@ -377,6 +395,7 @@ class OCICompletion(BaseLLM):
         from_task: Task | None,
         from_agent: Agent | None,
     ) -> str:
+        """Build the OCI chat request, invoke the service, record metadata, and return the finalized text."""
         chat_request = self._build_chat_request(messages)
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
@@ -407,6 +426,14 @@ class OCICompletion(BaseLLM):
         from_agent: Agent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | BaseModel | list[dict[str, Any]]:
+        """Run a synchronous chat completion against OCI Generative AI.
+
+        Emits ``call_started`` / ``call_completed`` / ``call_failed`` events
+        and runs the ``before_llm_call`` / ``after_llm_call`` hooks. Raises
+        ``ValueError`` if a ``before_llm_call`` hook blocks the call; any
+        other exception is wrapped with an ``OCI Generative AI call failed``
+        message and re-raised.
+        """
         with llm_call_context():
             try:
                 normalized_messages = self._normalize_messages(messages)
@@ -448,6 +475,7 @@ class OCICompletion(BaseLLM):
         from_agent: Agent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | Any:
+        """Async wrapper around :meth:`call` that runs the blocking OCI client in a worker thread."""
         return await asyncio.to_thread(
             self.call,
             messages,
@@ -464,5 +492,6 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _chat(self, chat_details: Any) -> Any:
+        """Thread-safe wrapper around the underlying OCI ``client.chat`` call (the SDK client is not re-entrant)."""
         with self._client_lock:
             return self.client.chat(chat_details)

--- a/lib/crewai/src/crewai/utilities/oci.py
+++ b/lib/crewai/src/crewai/utilities/oci.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_oci_module() -> Any:
+    """Import the OCI SDK lazily for optional CrewAI OCI integrations."""
+    try:
+        import oci  # type: ignore[import-untyped]
+    except ImportError:
+        raise ImportError(
+            'OCI support is not available, to install: uv add "crewai[oci]"'
+        ) from None
+    return oci
+
+
+def create_oci_client_kwargs(
+    *,
+    auth_type: str,
+    service_endpoint: str | None,
+    auth_file_location: str,
+    auth_profile: str,
+    timeout: tuple[int, int],
+    oci_module: Any | None = None,
+) -> dict[str, Any]:
+    """Build OCI SDK client kwargs for the supported auth modes."""
+    oci = oci_module or get_oci_module()
+    client_kwargs: dict[str, Any] = {
+        "config": {},
+        "service_endpoint": service_endpoint,
+        "retry_strategy": oci.retry.DEFAULT_RETRY_STRATEGY,
+        "timeout": timeout,
+    }
+
+    auth_type_upper = auth_type.upper()
+    if auth_type_upper == "API_KEY":
+        client_kwargs["config"] = oci.config.from_file(
+            file_location=auth_file_location,
+            profile_name=auth_profile,
+        )
+    elif auth_type_upper == "SECURITY_TOKEN":
+        config = oci.config.from_file(
+            file_location=auth_file_location,
+            profile_name=auth_profile,
+        )
+        key_file = config["key_file"]
+        security_token_file = config["security_token_file"]
+        private_key = oci.signer.load_private_key_from_file(key_file, None)
+        with open(security_token_file, encoding="utf-8") as file:
+            security_token = file.read()
+        client_kwargs["config"] = config
+        client_kwargs["signer"] = oci.auth.signers.SecurityTokenSigner(
+            security_token, private_key
+        )
+    elif auth_type_upper == "INSTANCE_PRINCIPAL":
+        client_kwargs["signer"] = (
+            oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+        )
+    elif auth_type_upper == "RESOURCE_PRINCIPAL":
+        client_kwargs["signer"] = oci.auth.signers.get_resource_principals_signer()
+    else:
+        valid_types = [
+            "API_KEY",
+            "SECURITY_TOKEN",
+            "INSTANCE_PRINCIPAL",
+            "RESOURCE_PRINCIPAL",
+        ]
+        raise ValueError(
+            f"Invalid OCI auth_type '{auth_type}'. Valid values: {valid_types}"
+        )
+
+    return client_kwargs

--- a/lib/crewai/tests/llms/oci/conftest.py
+++ b/lib/crewai/tests/llms/oci/conftest.py
@@ -1,0 +1,189 @@
+"""Fixtures for OCI provider unit and integration tests."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake OCI SDK module (replaces `import oci` in unit tests)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_oci_module() -> MagicMock:
+    """Build a lightweight mock of the OCI SDK surface used by OCICompletion."""
+    oci = MagicMock()
+
+    # Models namespace
+    models = oci.generative_ai_inference.models
+
+    # Serving modes
+    models.OnDemandServingMode = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.DedicatedServingMode = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Content types
+    models.TextContent = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Message types
+    for cls_name in (
+        "UserMessage",
+        "AssistantMessage",
+        "SystemMessage",
+        "CohereUserMessage",
+        "CohereSystemMessage",
+        "CohereChatBotMessage",
+    ):
+        setattr(models, cls_name, MagicMock(side_effect=lambda **kw: MagicMock(**kw)))
+
+    # Request types
+    models.GenericChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.CohereChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.BaseChatRequest = MagicMock()
+    models.BaseChatRequest.API_FORMAT_GENERIC = "GENERIC"
+    models.BaseChatRequest.API_FORMAT_COHERE = "COHERE"
+
+    # ChatDetails
+    models.ChatDetails = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Auth helpers
+    oci.config.from_file = MagicMock(return_value={"key_file": "/tmp/k", "security_token_file": "/tmp/t"})
+    oci.signer.load_private_key_from_file = MagicMock(return_value="pk")
+    oci.auth.signers.SecurityTokenSigner = MagicMock()
+    oci.auth.signers.InstancePrincipalsSecurityTokenSigner = MagicMock()
+    oci.auth.signers.get_resource_principals_signer = MagicMock()
+    oci.retry.DEFAULT_RETRY_STRATEGY = "default_retry"
+
+    # Client constructor
+    oci.generative_ai_inference.GenerativeAiInferenceClient = MagicMock()
+
+    return oci
+
+
+def _make_fake_chat_response(text: str = "Hello from OCI") -> MagicMock:
+    """Build a minimal OCI chat response for generic models."""
+    text_part = MagicMock()
+    text_part.text = text
+
+    message = MagicMock()
+    message.content = [text_part]
+    message.tool_calls = None
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    usage.total_tokens = 15
+    chat_response.usage = usage
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def _make_fake_cohere_chat_response(text: str = "Hello from Cohere") -> MagicMock:
+    """Build a minimal OCI chat response for Cohere models."""
+    chat_response = MagicMock()
+    chat_response.text = text
+    chat_response.finish_reason = "COMPLETE"
+    chat_response.tool_calls = None
+
+    usage = MagicMock()
+    usage.prompt_tokens = 8
+    usage.completion_tokens = 4
+    usage.total_tokens = 12
+    chat_response.usage = usage
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+@pytest.fixture()
+def oci_fake_module() -> MagicMock:
+    return _make_fake_oci_module()
+
+
+@pytest.fixture()
+def patch_oci_module(monkeypatch: pytest.MonkeyPatch, oci_fake_module: MagicMock) -> MagicMock:
+    """Patch the OCI module import so no real SDK is needed."""
+    monkeypatch.setattr(
+        "crewai.llms.providers.oci.completion._get_oci_module",
+        lambda: oci_fake_module,
+    )
+    return oci_fake_module
+
+
+@pytest.fixture()
+def oci_response_factories() -> dict[str, Any]:
+    return {
+        "chat": _make_fake_chat_response,
+        "cohere_chat": _make_fake_cohere_chat_response,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit test defaults
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def oci_unit_values() -> dict[str, str]:
+    return {
+        "compartment_id": "ocid1.compartment.oc1..test",
+        "model": "meta.llama-3.3-70b-instruct",
+        "cohere_model": "cohere.command-r-plus-08-2024",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration test fixtures (live OCI calls)
+# ---------------------------------------------------------------------------
+
+def _env_models(env_var: str, fallback_var: str, default: str) -> list[str]:
+    """Read model list from env, supporting comma-separated values."""
+    raw = os.getenv(env_var) or os.getenv(fallback_var) or default
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _skip_unless_live_config() -> dict[str, str]:
+    """Return live config dict or skip the test."""
+    compartment = os.getenv("OCI_COMPARTMENT_ID")
+    if not compartment:
+        pytest.skip("OCI_COMPARTMENT_ID not set — skipping live test")
+    region = os.getenv("OCI_REGION")
+    endpoint = os.getenv("OCI_SERVICE_ENDPOINT")
+    if not region and not endpoint:
+        pytest.skip("Set OCI_REGION or OCI_SERVICE_ENDPOINT for live tests")
+    config: dict[str, str] = {"compartment_id": compartment}
+    if endpoint:
+        config["service_endpoint"] = endpoint
+    if os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
+    if os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+    if os.getenv("OCI_AUTH_FILE_LOCATION"):
+        config["auth_file_location"] = os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config")
+    return config
+
+
+@pytest.fixture(
+    params=_env_models("OCI_TEST_MODELS", "OCI_TEST_MODEL", "meta.llama-3.3-70b-instruct"),
+    ids=lambda m: m,
+)
+def oci_chat_model(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def oci_live_config() -> dict[str, str]:
+    return _skip_unless_live_config()

--- a/lib/crewai/tests/llms/oci/conftest.py
+++ b/lib/crewai/tests/llms/oci/conftest.py
@@ -167,12 +167,12 @@ def _skip_unless_live_config() -> dict[str, str]:
     config: dict[str, str] = {"compartment_id": compartment}
     if endpoint:
         config["service_endpoint"] = endpoint
-    if os.getenv("OCI_AUTH_TYPE"):
-        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
-    if os.getenv("OCI_AUTH_PROFILE"):
-        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
-    if os.getenv("OCI_AUTH_FILE_LOCATION"):
-        config["auth_file_location"] = os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config")
+    if auth_type := os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = auth_type
+    if auth_profile := os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = auth_profile
+    if auth_file_location := os.getenv("OCI_AUTH_FILE_LOCATION"):
+        config["auth_file_location"] = auth_file_location
     return config
 
 

--- a/lib/crewai/tests/llms/oci/test_oci.py
+++ b/lib/crewai/tests/llms/oci/test_oci.py
@@ -1,0 +1,269 @@
+"""Unit tests for the OCI Generative AI provider (mocked SDK)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Provider routing
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_is_used_when_oci_provider(patch_oci_module):
+    """LLM(model='oci/...') should resolve to OCICompletion."""
+    from crewai.llm import LLM
+
+    fake_client = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+    llm = LLM(
+        model="oci/meta.llama-3.3-70b-instruct",
+        compartment_id="ocid1.compartment.oc1..test",
+    )
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    # LLM.__new__ returns the native provider instance directly
+    assert isinstance(llm, OCICompletion)
+
+
+@pytest.mark.parametrize(
+    "model_id, expected_provider",
+    [
+        ("meta.llama-3.3-70b-instruct", "generic"),
+        ("google.gemini-2.5-flash", "generic"),
+        ("openai.gpt-4o", "generic"),
+        ("xai.grok-3", "generic"),
+        ("cohere.command-r-plus-08-2024", "cohere"),
+    ],
+)
+def test_oci_completion_infers_provider_family(
+    patch_oci_module, oci_unit_values, model_id, expected_provider
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=model_id,
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm.oci_provider == expected_provider
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_values):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        temperature=0.7,
+        max_tokens=512,
+        top_p=0.9,
+        top_k=40,
+    )
+    assert llm.temperature == 0.7
+    assert llm.max_tokens == 512
+    assert llm.top_p == 0.9
+    assert llm.top_k == 40
+    assert llm.compartment_id == oci_unit_values["compartment_id"]
+
+
+def test_oci_completion_uses_region_to_build_endpoint(patch_oci_module, oci_unit_values, monkeypatch):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    monkeypatch.delenv("OCI_SERVICE_ENDPOINT", raising=False)
+    monkeypatch.setenv("OCI_REGION", "us-ashburn-1")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert "us-ashburn-1" in llm.service_endpoint
+
+
+# ---------------------------------------------------------------------------
+# Basic call
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_call_uses_chat_api(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]("test response")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(messages=[{"role": "user", "content": "Say hello"}])
+
+    assert "test response" in result
+    fake_client.chat.assert_called_once()
+
+
+def test_oci_completion_cohere_call(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["cohere_chat"]("cohere reply")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(messages=[{"role": "user", "content": "Hi"}])
+
+    assert "cohere reply" in result
+    fake_client.chat.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Message normalization
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_treats_none_content_as_empty_text(
+    patch_oci_module, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm._coerce_text(None) == ""
+
+
+def test_oci_completion_call_normalizes_messages_once(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    """Ensure normalize is not called twice when _call_impl receives a list."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    call_count = 0
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    original_normalize = llm._normalize_messages
+
+    def counting_normalize(msgs):
+        nonlocal call_count
+        call_count += 1
+        return original_normalize(msgs)
+
+    llm._normalize_messages = counting_normalize
+
+    llm.call(messages=[{"role": "user", "content": "hi"}])
+    # call() normalizes once, _call_impl should not normalize again
+    assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# OpenAI model quirks
+# ---------------------------------------------------------------------------
+
+
+def test_oci_openai_models_use_max_completion_tokens(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-4o",
+        compartment_id=oci_unit_values["compartment_id"],
+        max_tokens=1024,
+    )
+    request = llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args
+    assert call_kwargs is not None
+    kwargs = call_kwargs[1] if call_kwargs[1] else {}
+    assert kwargs.get("max_completion_tokens") == 1024
+    assert "max_tokens" not in kwargs
+
+
+def test_oci_openai_gpt5_omits_unsupported_temperature_and_stop(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-5",
+        compartment_id=oci_unit_values["compartment_id"],
+        temperature=0.5,
+    )
+    llm.stop = ["END"]
+    llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args[1]
+    assert "temperature" not in call_kwargs
+    assert "stop" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oci_completion_acall_delegates_to_call(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]("async result")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = await llm.acall(messages=[{"role": "user", "content": "async test"}])
+
+    assert "async result" in result

--- a/lib/crewai/tests/llms/oci/test_oci.py
+++ b/lib/crewai/tests/llms/oci/test_oci.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Provider routing
 # ---------------------------------------------------------------------------
@@ -45,7 +44,9 @@ def test_oci_completion_infers_provider_family(
 ):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=model_id,
         compartment_id=oci_unit_values["compartment_id"],
@@ -61,7 +62,9 @@ def test_oci_completion_infers_provider_family(
 def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_values):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=oci_unit_values["model"],
         compartment_id=oci_unit_values["compartment_id"],
@@ -77,12 +80,16 @@ def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_val
     assert llm.compartment_id == oci_unit_values["compartment_id"]
 
 
-def test_oci_completion_uses_region_to_build_endpoint(patch_oci_module, oci_unit_values, monkeypatch):
+def test_oci_completion_uses_region_to_build_endpoint(
+    patch_oci_module, oci_unit_values, monkeypatch
+):
     from crewai.llms.providers.oci.completion import OCICompletion
 
     monkeypatch.delenv("OCI_SERVICE_ENDPOINT", raising=False)
     monkeypatch.setenv("OCI_REGION", "us-ashburn-1")
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
 
     llm = OCICompletion(
         model=oci_unit_values["model"],
@@ -123,7 +130,9 @@ def test_oci_completion_cohere_call(
     from crewai.llms.providers.oci.completion import OCICompletion
 
     fake_client = MagicMock()
-    fake_client.chat.return_value = oci_response_factories["cohere_chat"]("cohere reply")
+    fake_client.chat.return_value = oci_response_factories["cohere_chat"](
+        "cohere reply"
+    )
     patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
         fake_client
     )
@@ -148,7 +157,9 @@ def test_oci_completion_treats_none_content_as_empty_text(
 ):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=oci_unit_values["model"],
         compartment_id=oci_unit_values["compartment_id"],
@@ -192,9 +203,44 @@ def test_oci_completion_call_normalizes_messages_once(
 # ---------------------------------------------------------------------------
 
 
-def test_oci_openai_models_use_max_completion_tokens(
+def test_oci_gpt5_family_uses_max_completion_tokens(
     patch_oci_module, oci_response_factories, oci_unit_values
 ):
+    """GPT-5 family on OCI rejects `max_tokens` and requires `max_completion_tokens`.
+
+    Verified live against OCI us-chicago-1: passing `max_tokens` to
+    openai.gpt-5* returns HTTP 400 with the message
+    ``Invalid 'maxTokens': ... Use 'maxCompletionTokens' instead.``.
+    Other openai.* models (gpt-4o, gpt-4.1) and non-openai models
+    continue to use ``max_tokens``.
+    """
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-5.5",
+        compartment_id=oci_unit_values["compartment_id"],
+        max_tokens=1024,
+    )
+    llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args
+    assert call_kwargs is not None
+    kwargs = call_kwargs[1] if call_kwargs[1] else {}
+    assert kwargs.get("max_completion_tokens") == 1024
+    assert "max_tokens" not in kwargs
+
+
+def test_oci_openai_gpt4o_keeps_max_tokens(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    """GPT-4o (and other non-GPT-5 OpenAI models) on OCI accept `max_tokens`."""
     from crewai.llms.providers.oci.completion import OCICompletion
 
     fake_client = MagicMock()
@@ -208,14 +254,14 @@ def test_oci_openai_models_use_max_completion_tokens(
         compartment_id=oci_unit_values["compartment_id"],
         max_tokens=1024,
     )
-    request = llm._build_chat_request([{"role": "user", "content": "test"}])
+    llm._build_chat_request([{"role": "user", "content": "test"}])
 
     models = patch_oci_module.generative_ai_inference.models
     call_kwargs = models.GenericChatRequest.call_args
     assert call_kwargs is not None
     kwargs = call_kwargs[1] if call_kwargs[1] else {}
-    assert kwargs.get("max_completion_tokens") == 1024
-    assert "max_tokens" not in kwargs
+    assert kwargs.get("max_tokens") == 1024
+    assert "max_completion_tokens" not in kwargs
 
 
 def test_oci_openai_gpt5_omits_unsupported_temperature_and_stop(

--- a/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
@@ -1,0 +1,33 @@
+"""Live integration tests for OCI Generative AI basic text completion.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_MODELS="meta.llama-3.3-70b-instruct,cohere.command-r-plus-08-2024,google.gemini-2.5-flash" \
+    uv run pytest tests/llms/oci/test_oci_integration_basic.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+def test_oci_live_basic_call(oci_chat_model: str, oci_live_config: dict):
+    """Synchronous text completion with a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    result = llm.call(messages=[{"role": "user", "content": "Say 'hello world' in one sentence."}])
+
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_oci_live_async_call(oci_chat_model: str, oci_live_config: dict):
+    """Async text completion with a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    result = await llm.acall(messages=[{"role": "user", "content": "What is 2+2? Answer in one word."}])
+
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
@@ -4,7 +4,7 @@ Run with:
     OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
     OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
     OCI_TEST_MODELS="meta.llama-3.3-70b-instruct,cohere.command-r-plus-08-2024,google.gemini-2.5-flash" \
-    uv run pytest tests/llms/oci/test_oci_integration_basic.py -v
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_basic.py -v
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T15:35:51.457693Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1027,6 +1027,15 @@ wheels = [
 ]
 
 [[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,6 +1325,74 @@ wheels = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/4c/4e40cc26347ac8254d3f25b9f94710b8e8df24ee4dddc1ba41907a88a94d/crc32c-2.7.1.tar.gz", hash = "sha256:f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c", size = 45712, upload-time = "2024-09-24T06:20:17.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f8/2c5cc5b8d16c76a66548283d74d1f4979c8970c2a274e63f76fbfaa0cf4e/crc32c-2.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1fd1f9c6b50d7357736676278a1b8c8986737b8a1c76d7eab4baa71d0b6af67f", size = 49668, upload-time = "2024-09-24T06:18:02.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/52/cdebceaed37a5657ee4864881da0f29f4036867dfb79bb058d38d4d737f3/crc32c-2.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:805c2be1bc0e251c48439a62b0422385899c15289483692bc70e78473c1039f1", size = 37151, upload-time = "2024-09-24T06:18:04.173Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/33/6476918b4cac85a18e32dc754e9d653b0dcd96518d661cbbf91bf8aec8cc/crc32c-2.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f4333e62b7844dfde112dbb8489fd2970358eddc3310db21e943a9f6994df749", size = 35370, upload-time = "2024-09-24T06:18:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/8972a70d7c39f37240f554c348fd9e15a4d8d0a548b1bc3139cd4e1cfb66/crc32c-2.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f0fadc741e79dc705e2d9ee967473e8a061d26b04310ed739f1ee292f33674f", size = 54110, upload-time = "2024-09-24T06:18:06.758Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/0b045f84c7acc36312a91211190bf84e73a0bbd30f21cbaf3670c4dba9b2/crc32c-2.7.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91ced31055d26d59385d708bbd36689e1a1d604d4b0ceb26767eb5a83156f85d", size = 51792, upload-time = "2024-09-24T06:18:07.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e2/acaabbc172b7c45ec62f273cd2e214f626e2b4324eca9152dea6095a26f4/crc32c-2.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36ffa999b72e3c17f6a066ae9e970b40f8c65f38716e436c39a33b809bc6ed9f", size = 52884, upload-time = "2024-09-24T06:18:09.449Z" },
+    { url = "https://files.pythonhosted.org/packages/60/40/963ba3d2ec0d8e4a2ceaf90e8f9cb10911a926fe75d4329e013a51343122/crc32c-2.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e80114dd7f462297e54d5da1b9ff472e5249c5a2b406aa51c371bb0edcbf76bd", size = 53888, upload-time = "2024-09-24T06:18:11.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b8/8a093b9dc1792b2cec9805e1428e97be0338a45ac9fae2fd5911613eacb1/crc32c-2.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:676f5b46da268b5190f9fb91b3f037a00d114b411313664438525db876adc71f", size = 52098, upload-time = "2024-09-24T06:18:12.522Z" },
+    { url = "https://files.pythonhosted.org/packages/26/76/a254ddb4ae83b545f6e08af384d62268a99d00f5c58a468754f8416468ce/crc32c-2.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8d0e660c9ed269e90692993a4457a932fc22c9cc96caf79dd1f1a84da85bb312", size = 52716, upload-time = "2024-09-24T06:18:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/6062806e5b6cb8d9af3c62945a5a07fa22c3b4dc59084d2fa2e533f9aaa1/crc32c-2.7.1-cp310-cp310-win32.whl", hash = "sha256:17a2c3f8c6d85b04b5511af827b5dbbda4e672d188c0b9f20a8156e93a1aa7b6", size = 38363, upload-time = "2024-09-24T06:18:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a9/dc935e26c8d7bd4722bc1312ed88f443e6e36816b46835b4464baa3f7c6d/crc32c-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3208764c29688f91a35392073229975dd7687b6cb9f76b919dae442cabcd5126", size = 39795, upload-time = "2024-09-24T06:18:17.182Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/2f37f46368bbfd50edfc11b96f0aa135699034b1b020966c70ebaff3463b/crc32c-2.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19e03a50545a3ef400bd41667d5525f71030488629c57d819e2dd45064f16192", size = 49672, upload-time = "2024-09-24T06:18:18.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b8/e52f7c4b045b871c2984d70f37c31d4861b533a8082912dfd107a96cf7c1/crc32c-2.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c03286b1e5ce9bed7090084f206aacd87c5146b4b10de56fe9e86cbbbf851cf", size = 37155, upload-time = "2024-09-24T06:18:19.373Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ee/0cfa82a68736697f3c7e435ba658c2ef8c997f42b89f6ab4545efe1b2649/crc32c-2.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ebbf144a1a56a532b353e81fa0f3edca4f4baa1bf92b1dde2c663a32bb6a15", size = 35372, upload-time = "2024-09-24T06:18:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/92/c878aaba81c431fcd93a059e9f6c90db397c585742793f0bf6e0c531cc67/crc32c-2.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96b794fd11945298fdd5eb1290a812efb497c14bc42592c5c992ca077458eeba", size = 54879, upload-time = "2024-09-24T06:18:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f5/ab828ab3907095e06b18918408748950a9f726ee2b37be1b0839fb925ee1/crc32c-2.7.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df7194dd3c0efb5a21f5d70595b7a8b4fd9921fbbd597d6d8e7a11eca3e2d27", size = 52588, upload-time = "2024-09-24T06:18:24.463Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2b/9e29e9ac4c4213d60491db09487125db358cd9263490fbadbd55e48fbe03/crc32c-2.7.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d698eec444b18e296a104d0b9bb6c596c38bdcb79d24eba49604636e9d747305", size = 53674, upload-time = "2024-09-24T06:18:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ed/df3c4c14bf1b29f5c9b52d51fb6793e39efcffd80b2941d994e8f7f5f688/crc32c-2.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e07cf10ef852d219d179333fd706d1c415626f1f05e60bd75acf0143a4d8b225", size = 54691, upload-time = "2024-09-24T06:18:26.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/47/4917af3c9c1df2fff28bbfa6492673c9adeae5599dcc207bbe209847489c/crc32c-2.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d2a051f296e6e92e13efee3b41db388931cdb4a2800656cd1ed1d9fe4f13a086", size = 52896, upload-time = "2024-09-24T06:18:28.174Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6f/26fc3dda5835cda8f6cd9d856afe62bdeae428de4c34fea200b0888e8835/crc32c-2.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1738259802978cdf428f74156175da6a5fdfb7256f647fdc0c9de1bc6cd7173", size = 53554, upload-time = "2024-09-24T06:18:29.104Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3e/6f39127f7027c75d130c0ba348d86a6150dff23761fbc6a5f71659f4521e/crc32c-2.7.1-cp311-cp311-win32.whl", hash = "sha256:f7786d219a1a1bf27d0aa1869821d11a6f8e90415cfffc1e37791690d4a848a1", size = 38370, upload-time = "2024-09-24T06:18:30.013Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fb/1587c2705a3a47a3d0067eecf9a6fec510761c96dec45c7b038fb5c8ff46/crc32c-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:887f6844bb3ad35f0778cd10793ad217f7123a5422e40041231b8c4c7329649d", size = 39795, upload-time = "2024-09-24T06:18:31.324Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/02/998dc21333413ce63fe4c1ca70eafe61ca26afc7eb353f20cecdb77d614e/crc32c-2.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f7d1c4e761fe42bf856130daf8b2658df33fe0ced3c43dadafdfeaa42b57b950", size = 49568, upload-time = "2024-09-24T06:18:32.425Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/3e/e3656bfa76e50ef87b7136fef2dbf3c46e225629432fc9184fdd7fd187ff/crc32c-2.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:73361c79a6e4605204457f19fda18b042a94508a52e53d10a4239da5fb0f6a34", size = 37019, upload-time = "2024-09-24T06:18:34.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7d/5ff9904046ad15a08772515db19df43107bf5e3901a89c36a577b5f40ba0/crc32c-2.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd778fc8ac0ed2ffbfb122a9aa6a0e409a8019b894a1799cda12c01534493e0", size = 35373, upload-time = "2024-09-24T06:18:35.02Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/41/4aedc961893f26858ab89fc772d0eaba91f9870f19eaa933999dcacb94ec/crc32c-2.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ef661b34e9f25991fface7f9ad85e81bbc1b3fe3b916fd58c893eabe2fa0b8", size = 54675, upload-time = "2024-09-24T06:18:35.954Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/63/8cabf09b7e39b9fec8f7010646c8b33057fc8d67e6093b3cc15563d23533/crc32c-2.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:571aa4429444b5d7f588e4377663592145d2d25eb1635abb530f1281794fc7c9", size = 52386, upload-time = "2024-09-24T06:18:36.896Z" },
+    { url = "https://files.pythonhosted.org/packages/79/13/13576941bf7cf95026abae43d8427c812c0054408212bf8ed490eda846b0/crc32c-2.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c02a3bd67dea95cdb25844aaf44ca2e1b0c1fd70b287ad08c874a95ef4bb38db", size = 53495, upload-time = "2024-09-24T06:18:38.099Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b6/55ffb26d0517d2d6c6f430ce2ad36ae7647c995c5bfd7abce7f32bb2bad1/crc32c-2.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99d17637c4867672cb8adeea007294e3c3df9d43964369516cfe2c1f47ce500a", size = 54456, upload-time = "2024-09-24T06:18:39.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1a/5562e54cb629ecc5543d3604dba86ddfc7c7b7bf31d64005b38a00d31d31/crc32c-2.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f4a400ac3c69a32e180d8753fd7ec7bccb80ade7ab0812855dce8a208e72495f", size = 52647, upload-time = "2024-09-24T06:18:40.021Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ec/ce4138eaf356cd9aae60bbe931755e5e0151b3eca5f491fce6c01b97fd59/crc32c-2.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:588587772e55624dd9c7a906ec9e8773ae0b6ac5e270fc0bc84ee2758eba90d5", size = 53332, upload-time = "2024-09-24T06:18:40.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/144b42cd838a901175a916078781cb2c3c9f977151c9ba085aebd6d15b22/crc32c-2.7.1-cp312-cp312-win32.whl", hash = "sha256:9f14b60e5a14206e8173dd617fa0c4df35e098a305594082f930dae5488da428", size = 38371, upload-time = "2024-09-24T06:18:42.711Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c4/7929dcd5d9b57db0cce4fe6f6c191049380fc6d8c9b9f5581967f4ec018e/crc32c-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:7c810a246660a24dc818047dc5f89c7ce7b2814e1e08a8e99993f4103f7219e8", size = 39805, upload-time = "2024-09-24T06:18:43.6Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/1a6d60d5b3b5edc8382777b64100343cb4aa6a7e172fae4a6cfcb8ebbbd9/crc32c-2.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:24949bffb06fc411cc18188d33357923cb935273642164d0bb37a5f375654169", size = 49567, upload-time = "2024-09-24T06:18:44.485Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/0dd652d4e950e6348bbf16b964b3325e4ad8220470774128fc0b0dd069cb/crc32c-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d5d326e7e118d4fa60187770d86b66af2fdfc63ce9eeb265f0d3e7d49bebe0b", size = 37018, upload-time = "2024-09-24T06:18:45.434Z" },
+    { url = "https://files.pythonhosted.org/packages/47/02/2bd65fdef10139b6a802d83a7f966b7750fe5ffb1042f7cbe5dbb6403869/crc32c-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba110df60c64c8e2d77a9425b982a520ccdb7abe42f06604f4d98a45bb1fff62", size = 35374, upload-time = "2024-09-24T06:18:46.304Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/3e797d1ed92d357a6a4c5b41cea15a538b27a8fdf18c7863747eb50b73ad/crc32c-2.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c277f9d16a3283e064d54854af0976b72abaa89824955579b2b3f37444f89aae", size = 54641, upload-time = "2024-09-24T06:18:47.207Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/4ddeef755caaa75680c559562b6c71f5910fee4c4f3a2eb5ea8b57f0e48c/crc32c-2.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:881af0478a01331244e27197356929edbdeaef6a9f81b5c6bacfea18d2139289", size = 52338, upload-time = "2024-09-24T06:18:49.31Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cf/32f019be5de9f6e180926a50ee5f08648e686c7d9a59f2c5d0806a77b1c7/crc32c-2.7.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724d5ff4d29ff093a983ae656be3307093706d850ea2a233bf29fcacc335d945", size = 53447, upload-time = "2024-09-24T06:18:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8b/92f3f62f3bafe8f7ab4af7bfb7246dc683fd11ec0d6dfb73f91e09079f69/crc32c-2.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2416c4d88696ac322632555c0f81ab35e15f154bc96055da6cf110d642dbc10", size = 54484, upload-time = "2024-09-24T06:18:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b2/113a50f8781f76af5ac65ffdb907e72bddbe974de8e02247f0d58bc48040/crc32c-2.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:60254251b88ec9b9795215f0f9ec015a6b5eef8b2c5fba1267c672d83c78fc02", size = 52703, upload-time = "2024-09-24T06:18:52.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6c/309229e9acda8cf36a8ff4061d70b54d905f79b7037e16883ce6590a24ab/crc32c-2.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:edefc0e46f3c37372183f70338e5bdee42f6789b62fcd36ec53aa933e9dfbeaf", size = 53367, upload-time = "2024-09-24T06:18:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/6c6324d920396e1bd9f3efbe8753da071be0ca52bd22d6c82d446b8d6975/crc32c-2.7.1-cp313-cp313-win32.whl", hash = "sha256:813af8111218970fe2adb833c5e5239f091b9c9e76f03b4dd91aaba86e99b499", size = 38377, upload-time = "2024-09-24T06:18:54.487Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/f01ccfab538db07ef3f6b4ede46357ff147a81dd4f3c59ca6a34c791a549/crc32c-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:7d9ede7be8e4ec1c9e90aaf6884decbeef10e3473e6ddac032706d710cab5888", size = 39803, upload-time = "2024-09-24T06:18:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/61dcae7568b33acfde70c9d651c7d891c0c578c39cc049107c1cf61f1367/crc32c-2.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db9ac92294284b22521356715784b91cc9094eee42a5282ab281b872510d1831", size = 49386, upload-time = "2024-09-24T06:18:56.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/80f17c089799ab2b4c247443bdd101d6ceda30c46d7f193e16b5ca29c5a0/crc32c-2.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8fcd7f2f29a30dc92af64a9ee3d38bde0c82bd20ad939999427aac94bbd87373", size = 36937, upload-time = "2024-09-24T06:18:57.77Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/5fcfc71a3de493d920fd2590843762a2749981ea56b802b380e5df82309d/crc32c-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5c056ef043393085523e149276a7ce0cb534b872e04f3e20d74d9a94a75c0ad7", size = 35292, upload-time = "2024-09-24T06:18:58.676Z" },
+    { url = "https://files.pythonhosted.org/packages/03/de/fef962e898a953558fe1c55141644553e84ef4190693a31244c59a0856c7/crc32c-2.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0", size = 54223, upload-time = "2024-09-24T06:18:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/21/14/fceca1a6f45c0a1814fe8602a65657b75c27425162445925ba87438cad6b/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb9424ec1a8ca54763155a703e763bcede82e6569fe94762614bb2de1412d4e1", size = 51588, upload-time = "2024-09-24T06:19:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3b/13d40a7dfbf9ef05c84a0da45544ee72080dca4ce090679e5105689984bd/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88732070f6175530db04e0bb36880ac45c33d49f8ac43fa0e50cfb1830049d23", size = 52678, upload-time = "2024-09-24T06:19:02.661Z" },
+    { url = "https://files.pythonhosted.org/packages/36/09/65ffc4fb9fa60ff6714eeb50a92284a4525e5943f0b040b572c0c76368c1/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57a20dfc27995f568f64775eea2bbb58ae269f1a1144561df5e4a4955f79db32", size = 53847, upload-time = "2024-09-24T06:19:03.705Z" },
+    { url = "https://files.pythonhosted.org/packages/24/71/938e926085b7288da052db7c84416f3ce25e71baf7ab5b63824c7bcb6f22/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f7186d098bfd2cff25eac6880b7c7ad80431b90610036131c1c7dd0eab42a332", size = 51860, upload-time = "2024-09-24T06:19:04.726Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d8/4526d5380189d6f2fa27256c204100f30214fe402f47cf6e9fb9a91ab890/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55a77e29a265418fa34bef15bd0f2c60afae5348988aaf35ed163b4bbf93cf37", size = 52508, upload-time = "2024-09-24T06:19:05.731Z" },
+    { url = "https://files.pythonhosted.org/packages/19/30/15f7e35176488b77e5b88751947d321d603fccac273099ace27c7b2d50a6/crc32c-2.7.1-cp313-cp313t-win32.whl", hash = "sha256:ae38a4b6aa361595d81cab441405fbee905c72273e80a1c010fb878ae77ac769", size = 38319, upload-time = "2024-09-24T06:19:07.233Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c4/0b3eee04dac195f4730d102d7a9fbea894ae7a32ce075f84336df96a385d/crc32c-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eee2a43b663feb6c79a6c1c6e5eae339c2b72cfac31ee54ec0209fa736cf7ee5", size = 39781, upload-time = "2024-09-24T06:19:08.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/e0/14d392075db47c53a3890aa110e3640b22fb9736949c47b13d5b5e4599f7/crc32c-2.7.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2e83fedebcdeb80c19e76b7a0e5103528bb062521c40702bf34516a429e81df3", size = 36448, upload-time = "2024-09-24T06:19:50.456Z" },
+    { url = "https://files.pythonhosted.org/packages/03/27/f1dab3066c90e9424d22bc942eecdc2e77267f7e805ddb5a2419bbcbace6/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30004a7383538ef93bda9b22f7b3805bc0aa5625ab2675690e1b676b19417d4b", size = 38184, upload-time = "2024-09-24T06:19:51.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f3/479acfa99803c261cdd6b44f37b55bd77bdbce6163ec1f51b2014b095495/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a01b0983aa87f517c12418f9898ecf2083bf86f4ea04122e053357c3edb0d73f", size = 38256, upload-time = "2024-09-24T06:19:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/4edb9c45457c54d51ca539f850761f31b7ab764177902b6f3247ff8c1b75/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb2b963c42128b38872e9ed63f04a73ce1ff89a1dfad7ea38add6fe6296497b8", size = 37868, upload-time = "2024-09-24T06:19:54.159Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b0/5680db08eff8f2116a4f9bd949f8bbe9cf260e1c3451228f54c60b110d79/crc32c-2.7.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cdd5e576fee5d255c1e68a4dae4420f21e57e6f05900b38d5ae47c713fc3330d", size = 39826, upload-time = "2024-09-24T06:19:55.4Z" },
+]
+
+[[package]]
 name = "crewai"
 source = { editable = "lib/crewai" }
 dependencies = [
@@ -1393,6 +1470,9 @@ litellm = [
 mem0 = [
     { name = "mem0ai" },
 ]
+oci = [
+    { name = "oci" },
+]
 openpyxl = [
     { name = "openpyxl" },
 ]
@@ -1451,6 +1531,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<2" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
+    { name = "oci", marker = "extra == 'oci'", specifier = ">=2.168.0" },
     { name = "openai", specifier = ">=2.30.0,<3" },
     { name = "openpyxl", specifier = "~=3.1.5" },
     { name = "openpyxl", marker = "extra == 'openpyxl'", specifier = "~=3.1.5" },
@@ -1474,7 +1555,7 @@ requires-dist = [
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "oci", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"
@@ -5437,6 +5518,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/93/76a5fc3833aaa833b4152950d9cdfd328493a48316c24e32ddefe9b8870f/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ba6863230648a9b0e11502d2745d881cf74262720238bc0093c3eabd22a3b24c", size = 3683450, upload-time = "2025-09-16T15:34:49.589Z" },
     { url = "https://files.pythonhosted.org/packages/15/3c/4c389362c187630c42f61ef9214e67fc336e44b8aafc47cf49ba9ab8007d/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:887615da9eeefeb2df849d87c380e04877487aa29dbeb367efc3f17f667470d3", size = 3766628, upload-time = "2025-09-16T15:34:51.937Z" },
     { url = "https://files.pythonhosted.org/packages/03/12/08547e63edf2239ec6660af434602208ab6f394955ef660a6edda13a0bee/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:4eec1fb32ffa4fb9fe9ad584611ff031927a5c22732b56075ee7204f0e35ebdf", size = 3944069, upload-time = "2025-09-16T15:34:54.108Z" },
+]
+
+[[package]]
+name = "oci"
+version = "2.181.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "circuitbreaker" },
+    { name = "crc32c" },
+    { name = "cryptography" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/b3/4f80ae248dc9872bcc2b0e677548f86c2a3fa4df0082bbe00e17058bc988/oci-2.181.1.tar.gz", hash = "sha256:05587d120014238c6d5459328517eb02862f20f10e085a14f2ed48e5ca082672", size = 17489251, upload-time = "2026-07-07T06:10:28.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/bd/7141e3f3b2ae7041a883d97bf3d0d9d9d4745c61b659743ebe3afe5e7624/oci-2.181.1-py3-none-any.whl", hash = "sha256:a7e4424e1c1f917afedfdf1a7b1bc0b99b75683a774e2270afba8ed09fcce95a", size = 35749804, upload-time = "2026-07-07T06:10:20.315Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add native OCI Generative AI text completion provider (`OCICompletion`) supporting generic (Meta, Google, OpenAI, xAI) and Cohere model families
- Shared OCI auth utilities (`utilities/oci.py`) for API key, security token, instance principal, and resource principal auth
- OCI registered as optional dependency (`crewai[oci]`)
- 15 unit tests (mocked SDK) + 2 parametrized integration tests (tested live against `meta.llama-3.3-70b-instruct`, `cohere.command-r-plus-08-2024`, `google.gemini-2.5-flash`, `openai.gpt-5.2-chat-latest`)

This is **PR 1 of a series** — follow-up PRs will add streaming, tool calling, structured output, multimodal, and embeddings support.

Supersedes #4885 (closed per reviewer feedback to split by scope).
Tracking issue: #4944

## What's included

| File | Lines | What |
|------|-------|------|
| `utilities/oci.py` | 72 | Shared `get_oci_module()` + `create_oci_client_kwargs()` |
| `llms/providers/oci/completion.py` | 505 | `OCICompletion(BaseLLM)` — init, message building, basic call/acall |
| `llm.py` | +13 | Provider registration (routing, pattern matching, import) |
| `pyproject.toml` | +3 | `oci` optional dependency |
| Tests | 491 | conftest + 15 unit + 2 integration (parametrized across models) |

## What's NOT included (deferred to follow-up PRs)

- Streaming (`iter_stream`, `astream`)
- Tool calling / function calling
- Structured output (`response_model`)
- Multimodal (vision, documents, audio, video)
- OCI embeddings provider
- OCI tools (will be a standalone PyPI package per [community tools guidelines](https://docs.crewai.com/en/guides/tools/publish-custom-tools))

## Test plan

- [x] 15 unit tests pass (mocked OCI SDK, no credentials needed)
- [x] Integration tests pass against 4 model families via OCI GenAI API:
  - `meta.llama-3.3-70b-instruct`
  - `cohere.command-r-plus-08-2024`
  - `google.gemini-2.5-flash`
  - `openai.gpt-5.2-chat-latest`
- [x] Both sync (`call`) and async (`acall`) paths verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new native LLM provider and OCI authentication paths; risk is mainly around request/response translation and credential/config handling for a new external SDK.
> 
> **Overview**
> Adds **native Oracle Cloud Infrastructure (OCI) Generative AI** support for basic chat/text completion via a new `OCICompletion` provider, including model-family request shaping (generic vs Cohere) and sync/async call paths with token-usage tracking.
> 
> Registers `oci` as a supported native provider in `LLM` routing (prefix handling + model pattern matching) and adds a shared `utilities/oci.py` helper for lazy SDK import plus multiple OCI auth modes. Includes an optional dependency `crewai[oci]` and a new test suite with mocked-SDK unit tests plus opt-in live integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e6ffdb755a0f455c4ee8c52520fb8a179a50af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->