### PR TITLE
feat: add OCI Generative AI embeddings provider

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -104,6 +104,9 @@ azure-ai-inference = [
 anthropic = [
     "anthropic~=0.73.0",
 ]
+oci = [
+    "oci>=2.168.0",
+]
 a2a = [
      "a2a-sdk~=0.3.10",
      "httpx-auth~=0.23.1",

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -342,6 +342,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "cerebras",
     "dashscope",
     "snowflake",
+    "oci",
 ]
 
 
@@ -447,6 +448,7 @@ class LLM(BaseLLM):
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
                 "snowflake": "snowflake",
+                "oci": "oci",
             }
 
             canonical_provider = provider_mapping.get(prefix.lower())
@@ -579,6 +581,9 @@ class LLM(BaseLLM):
         if provider == "snowflake":
             return True
 
+        if provider == "oci":
+            return model_lower.startswith("ocid1.generativeaiendpoint") or "." in model_lower
+
         return False
 
     @classmethod
@@ -614,6 +619,7 @@ class LLM(BaseLLM):
             # azure does not provide a list of available models, determine a better way to handle this
             return True
 
+        # Fallback to pattern matching for models not in constants (includes OCI)
         return cls._matches_provider_pattern(model, provider)
 
     @staticmethod
@@ -711,6 +717,11 @@ class LLM(BaseLLM):
             )
 
             return OpenAICompatibleCompletion
+
+        if provider == "oci":
+            from crewai.llms.providers.oci.completion import OCICompletion
+
+            return OCICompletion
 
         return None
 

--- a/lib/crewai/src/crewai/llms/providers/oci/__init__.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/__init__.py
@@ -1,5 +1,19 @@
 from crewai.llms.providers.oci.completion import OCICompletion
+from crewai.llms.providers.oci.vision import (
+    IMAGE_EMBEDDING_MODELS,
+    VISION_MODELS,
+    encode_image,
+    is_vision_model,
+    load_image,
+    to_data_uri,
+)
 
 __all__ = [
+    "IMAGE_EMBEDDING_MODELS",
+    "VISION_MODELS",
     "OCICompletion",
+    "encode_image",
+    "is_vision_model",
+    "load_image",
+    "to_data_uri",
 ]

--- a/lib/crewai/src/crewai/llms/providers/oci/__init__.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/__init__.py
@@ -1,0 +1,5 @@
+from crewai.llms.providers.oci.completion import OCICompletion
+
+__all__ = [
+    "OCICompletion",
+]

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from pydantic import BaseModel
+
+from crewai.events.types.llm_events import LLMCallType
+from crewai.llms.base_llm import BaseLLM, llm_call_context
+from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
+from crewai.utilities.types import LLMMessage
+
+
+if TYPE_CHECKING:
+    from crewai.agent.core import Agent
+    from crewai.task import Task
+    from crewai.tools.base_tool import BaseTool
+
+
+CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
+DEFAULT_OCI_REGION = "us-chicago-1"
+DEFAULT_OCI_TIMEOUT = (10, 240)
+
+
+def _get_oci_module() -> Any:
+    """Backward-compatible module-local alias used by tests and patches."""
+    return get_oci_module()
+
+
+class OCICompletion(BaseLLM):
+    """OCI Generative AI native provider for CrewAI.
+
+    Supports basic text completions for generic (Meta, Google, OpenAI, xAI)
+    and Cohere model families hosted on the OCI Generative AI service.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        compartment_id: str | None = None,
+        service_endpoint: str | None = None,
+        auth_type: Literal[
+            "API_KEY",
+            "SECURITY_TOKEN",
+            "INSTANCE_PRINCIPAL",
+            "RESOURCE_PRINCIPAL",
+        ]
+        | str = "API_KEY",
+        auth_profile: str | None = None,
+        auth_file_location: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        top_k: int | None = None,
+        oci_provider: str | None = None,
+        timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
+        client: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("provider", None)
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            provider="oci",
+            **kwargs,
+        )
+
+        self.compartment_id = compartment_id or os.getenv("OCI_COMPARTMENT_ID")
+        if not self.compartment_id:
+            raise ValueError(
+                "OCI compartment_id is required. Set compartment_id or OCI_COMPARTMENT_ID."
+            )
+
+        self.service_endpoint = service_endpoint or os.getenv("OCI_SERVICE_ENDPOINT")
+        if self.service_endpoint is None:
+            region = os.getenv("OCI_REGION", DEFAULT_OCI_REGION)
+            self.service_endpoint = (
+                f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+            )
+
+        self.auth_type = str(auth_type).upper()
+        self.auth_profile = cast(
+            str, auth_profile or os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+        )
+        self.auth_file_location = cast(
+            str,
+            auth_file_location
+            or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
+        )
+        self.max_tokens = max_tokens
+        self.top_p = top_p
+        self.top_k = top_k
+        self.oci_provider = oci_provider or self._infer_provider(model)
+        self._oci = _get_oci_module()
+
+        if client is not None:
+            self.client = client
+        else:
+            client_kwargs = create_oci_client_kwargs(
+                auth_type=self.auth_type,
+                service_endpoint=self.service_endpoint,
+                auth_file_location=self.auth_file_location,
+                auth_profile=self.auth_profile,
+                timeout=timeout,
+                oci_module=self._oci,
+            )
+            self.client = self._oci.generative_ai_inference.GenerativeAiInferenceClient(
+                **client_kwargs
+            )
+        self._client_lock = threading.Lock()
+        self.last_response_metadata = None
+
+    # ------------------------------------------------------------------
+    # Provider inference
+    # ------------------------------------------------------------------
+
+    def _infer_provider(self, model: str) -> str:
+        if model.startswith(CUSTOM_ENDPOINT_PREFIX):
+            return "generic"
+        if model.lower().startswith("cohere."):
+            return "cohere"
+        return "generic"
+
+    def _is_openai_gpt5_family(self) -> bool:
+        return self.model.lower().startswith("openai.gpt-5")
+
+    def _build_serving_mode(self) -> Any:
+        models = self._oci.generative_ai_inference.models
+        if self.model.startswith(CUSTOM_ENDPOINT_PREFIX):
+            return models.DedicatedServingMode(endpoint_id=self.model)
+        return models.OnDemandServingMode(model_id=self.model)
+
+    # ------------------------------------------------------------------
+    # Message helpers
+    # ------------------------------------------------------------------
+
+    def _normalize_messages(
+        self, messages: str | list[LLMMessage]
+    ) -> list[LLMMessage]:
+        return self._format_messages(messages)
+
+    def _coerce_text(self, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, Mapping):
+                    if item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                    elif "text" in item:
+                        parts.append(str(item["text"]))
+            return "\n".join(part for part in parts if part)
+        return str(content)
+
+    def _build_generic_content(self, content: Any) -> list[Any]:
+        """Translate CrewAI message content into OCI generic content objects."""
+        models = self._oci.generative_ai_inference.models
+        if isinstance(content, str):
+            return [models.TextContent(text=content or ".")]
+
+        if not isinstance(content, list):
+            return [models.TextContent(text=self._coerce_text(content) or ".")]
+
+        processed: list[Any] = []
+        for item in content:
+            if isinstance(item, str):
+                processed.append(models.TextContent(text=item or "."))
+            elif isinstance(item, Mapping) and item.get("type") == "text":
+                processed.append(
+                    models.TextContent(text=str(item.get("text", "")) or ".")
+                )
+            else:
+                processed.append(
+                    models.TextContent(text=self._coerce_text(item) or ".")
+                )
+        return processed or [models.TextContent(text=".")]
+
+    def _build_generic_messages(self, messages: list[LLMMessage]) -> list[Any]:
+        """Map CrewAI conversation messages into OCI generic chat messages."""
+        models = self._oci.generative_ai_inference.models
+        role_map = {
+            "user": models.UserMessage,
+            "assistant": models.AssistantMessage,
+            "system": models.SystemMessage,
+        }
+        oci_messages: list[Any] = []
+
+        for message in messages:
+            role = str(message.get("role", "user")).lower()
+            message_cls = role_map.get(role)
+            if message_cls is None:
+                logging.debug("Skipping unsupported OCI message role: %s", role)
+                continue
+            oci_messages.append(
+                message_cls(
+                    content=self._build_generic_content(message.get("content", "")),
+                )
+            )
+
+        return oci_messages
+
+    def _build_cohere_chat_history(
+        self, messages: list[LLMMessage]
+    ) -> tuple[list[Any], str]:
+        """Translate CrewAI messages into Cohere's split history + message shape."""
+        models = self._oci.generative_ai_inference.models
+        chat_history: list[Any] = []
+
+        for message in messages[:-1]:
+            role = str(message.get("role", "user")).lower()
+            content = message.get("content", "")
+
+            if role in ("user", "system"):
+                message_cls = (
+                    models.CohereUserMessage
+                    if role == "user"
+                    else models.CohereSystemMessage
+                )
+                chat_history.append(message_cls(message=self._coerce_text(content)))
+            elif role == "assistant":
+                chat_history.append(
+                    models.CohereChatBotMessage(
+                        message=self._coerce_text(content) or " ",
+                    )
+                )
+
+        last_message = messages[-1] if messages else {"role": "user", "content": ""}
+        message_text = self._coerce_text(last_message.get("content", ""))
+        return chat_history, message_text
+
+    # ------------------------------------------------------------------
+    # Request building
+    # ------------------------------------------------------------------
+
+    def _build_chat_request(
+        self,
+        messages: list[LLMMessage],
+    ) -> Any:
+        """Build the provider-specific OCI chat request for the current model."""
+        models = self._oci.generative_ai_inference.models
+
+        if self.oci_provider == "cohere":
+            chat_history, message_text = self._build_cohere_chat_history(messages)
+            request_kwargs: dict[str, Any] = {
+                "message": message_text,
+                "chat_history": chat_history,
+                "api_format": models.BaseChatRequest.API_FORMAT_COHERE,
+            }
+        else:
+            request_kwargs = {
+                "messages": self._build_generic_messages(messages),
+                "api_format": models.BaseChatRequest.API_FORMAT_GENERIC,
+            }
+
+        if self.temperature is not None and not self._is_openai_gpt5_family():
+            request_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            if self.oci_provider == "generic" and self.model.lower().startswith("openai."):
+                request_kwargs["max_completion_tokens"] = self.max_tokens
+            else:
+                request_kwargs["max_tokens"] = self.max_tokens
+        if self.top_p is not None:
+            request_kwargs["top_p"] = self.top_p
+        if self.top_k is not None:
+            request_kwargs["top_k"] = self.top_k
+
+        if self.stop and not self._is_openai_gpt5_family():
+            stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"
+            request_kwargs[stop_key] = list(self.stop)
+
+        if self.oci_provider == "cohere":
+            return models.CohereChatRequest(**request_kwargs)
+        return models.GenericChatRequest(**request_kwargs)
+
+    # ------------------------------------------------------------------
+    # Response extraction
+    # ------------------------------------------------------------------
+
+    def _extract_text(self, response: Any) -> str:
+        chat_response = response.data.chat_response
+        if self.oci_provider == "cohere":
+            if getattr(chat_response, "text", None):
+                return chat_response.text or ""
+            message = getattr(chat_response, "message", None)
+            if message is not None:
+                content = getattr(message, "content", None) or []
+                return "".join(
+                    part.text for part in content if getattr(part, "text", None)
+                )
+            return ""
+
+        choices = getattr(chat_response, "choices", None) or []
+        if not choices:
+            return ""
+        message = getattr(choices[0], "message", None)
+        if message is None:
+            return ""
+        content = getattr(message, "content", None) or []
+        return "".join(part.text for part in content if getattr(part, "text", None))
+
+    def _extract_usage(self, response: Any) -> dict[str, int]:
+        chat_response = response.data.chat_response
+        usage = getattr(chat_response, "usage", None)
+        if usage is None:
+            return {}
+        return {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    def _extract_response_metadata(self, response: Any) -> dict[str, Any]:
+        chat_response = response.data.chat_response
+        metadata: dict[str, Any] = {}
+
+        finish_reason = getattr(chat_response, "finish_reason", None)
+        if finish_reason is None:
+            choices = getattr(chat_response, "choices", None) or []
+            if choices:
+                finish_reason = getattr(choices[0], "finish_reason", None)
+
+        if finish_reason is not None:
+            metadata["finish_reason"] = finish_reason
+
+        usage = self._extract_usage(response)
+        if usage:
+            metadata["usage"] = usage
+
+        return metadata
+
+    # ------------------------------------------------------------------
+    # Call paths
+    # ------------------------------------------------------------------
+
+    def _finalize_text_response(
+        self,
+        *,
+        content: str,
+        messages: list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> str:
+        content = self._apply_stop_words(content)
+        content = self._invoke_after_llm_call_hooks(messages, content, from_agent)
+        self._emit_call_completed_event(
+            response=content,
+            call_type=LLMCallType.LLM_CALL,
+            from_task=from_task,
+            from_agent=from_agent,
+            messages=messages,
+        )
+        return content
+
+    def _call_impl(
+        self,
+        *,
+        messages: list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> str:
+        chat_request = self._build_chat_request(messages)
+        chat_details = self._oci.generative_ai_inference.models.ChatDetails(
+            compartment_id=self.compartment_id,
+            serving_mode=self._build_serving_mode(),
+            chat_request=chat_request,
+        )
+        response = self._chat(chat_details)
+        self.last_response_metadata = self._extract_response_metadata(response) or None
+        usage = (self.last_response_metadata or {}).get("usage", {})
+        if usage:
+            self._track_token_usage_internal(usage)
+
+        content = self._extract_text(response)
+        return self._finalize_text_response(
+            content=content,
+            messages=messages,
+            from_task=from_task,
+            from_agent=from_agent,
+        )
+
+    def call(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        response_model: type[BaseModel] | None = None,
+    ) -> str | BaseModel | list[dict[str, Any]]:
+        with llm_call_context():
+            try:
+                normalized_messages = self._normalize_messages(messages)
+                self._emit_call_started_event(
+                    messages=normalized_messages,
+                    tools=tools,
+                    callbacks=callbacks,
+                    available_functions=available_functions,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+
+                if not self._invoke_before_llm_call_hooks(
+                    normalized_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
+                return self._call_impl(
+                    messages=normalized_messages,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+            except Exception as error:
+                error_message = f"OCI Generative AI call failed: {error!s}"
+                self._emit_call_failed_event(
+                    error=error_message,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                )
+                raise
+
+    async def acall(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        response_model: type[BaseModel] | None = None,
+    ) -> str | Any:
+        return await asyncio.to_thread(
+            self.call,
+            messages,
+            tools=tools,
+            callbacks=callbacks,
+            available_functions=available_functions,
+            from_task=from_task,
+            from_agent=from_agent,
+            response_model=response_model,
+        )
+
+    # ------------------------------------------------------------------
+    # Client serialization
+    # ------------------------------------------------------------------
+
+    def _chat(self, chat_details: Any) -> Any:
+        with self._client_lock:
+            return self.client.chat(chat_details)
+

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -200,8 +200,19 @@ class OCICompletion(BaseLLM):
             return "\n".join(part for part in parts if part)
         return str(content)
 
+    def _message_has_multimodal_content(self, content: Any) -> bool:
+        if not isinstance(content, list):
+            return False
+        for item in content:
+            if isinstance(item, Mapping) and item.get("type") not in (None, "text"):
+                return True
+        return False
+
     def _build_generic_content(self, content: Any) -> list[Any]:
-        """Translate CrewAI message content into OCI generic content objects."""
+        """Translate CrewAI message content into OCI generic content objects.
+
+        Handles text, image_url, document_url, video_url, and audio_url types.
+        """
         models = self._oci.generative_ai_inference.models
         if isinstance(content, str):
             return [models.TextContent(text=content or ".")]
@@ -213,14 +224,52 @@ class OCICompletion(BaseLLM):
         for item in content:
             if isinstance(item, str):
                 processed.append(models.TextContent(text=item or "."))
-            elif isinstance(item, Mapping) and item.get("type") == "text":
+                continue
+            if not isinstance(item, Mapping):
+                raise ValueError(
+                    f"OCI message content items must be strings or dictionaries, got: {type(item)}"
+                )
+
+            content_type = item.get("type")
+            if content_type == "text":
                 processed.append(
                     models.TextContent(text=str(item.get("text", "")) or ".")
                 )
-            else:
+            elif content_type == "image_url":
+                image_url = item.get("image_url", {})
+                url = image_url.get("url") if isinstance(image_url, Mapping) else None
+                if not url:
+                    raise ValueError("OCI image_url content requires image_url.url")
                 processed.append(
-                    models.TextContent(text=self._coerce_text(item) or ".")
+                    models.ImageContent(image_url=models.ImageUrl(url=url))
                 )
+            elif content_type in ("document_url", "document", "file"):
+                doc_data = item.get("document_url") or item.get("document") or item.get("file")
+                url = doc_data.get("url") if isinstance(doc_data, Mapping) else item.get("url")
+                if not url:
+                    raise ValueError("OCI document content requires a url")
+                processed.append(
+                    models.DocumentContent(document_url=models.DocumentUrl(url=url))
+                )
+            elif content_type in ("video_url", "video"):
+                video_data = item.get("video_url") or item.get("video")
+                url = video_data.get("url") if isinstance(video_data, Mapping) else item.get("url")
+                if not url:
+                    raise ValueError("OCI video content requires a url")
+                processed.append(
+                    models.VideoContent(video_url=models.VideoUrl(url=url))
+                )
+            elif content_type in ("audio_url", "audio"):
+                audio_data = item.get("audio_url") or item.get("audio")
+                url = audio_data.get("url") if isinstance(audio_data, Mapping) else item.get("url")
+                if not url:
+                    raise ValueError("OCI audio content requires a url")
+                processed.append(
+                    models.AudioContent(audio_url=models.AudioUrl(url=url))
+                )
+            else:
+                raise ValueError(f"Unsupported OCI content type: {content_type}")
+
         return processed or [models.TextContent(text=".")]
 
     def _build_generic_messages(self, messages: list[LLMMessage]) -> list[Any]:
@@ -298,6 +347,10 @@ class OCICompletion(BaseLLM):
         for message in history_messages:
             role = str(message.get("role", "user")).lower()
             content = message.get("content", "")
+            if self._message_has_multimodal_content(content):
+                raise ValueError(
+                    "OCI Cohere models currently support text-only messages in CrewAI."
+                )
 
             if role in ("user", "system"):
                 message_cls = (
@@ -524,6 +577,10 @@ class OCICompletion(BaseLLM):
         models = self._oci.generative_ai_inference.models
 
         if self.oci_provider == "cohere":
+            if any(self._message_has_multimodal_content(msg.get("content")) for msg in messages):
+                raise ValueError(
+                    "OCI Cohere models currently support text-only messages in CrewAI."
+                )
             chat_history, tool_results, message_text = self._build_cohere_chat_history(
                 messages
             )
@@ -1320,6 +1377,9 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def supports_function_calling(self) -> bool:
+        return True
+
+    def supports_multimodal(self) -> bool:
         return True
 
     def get_context_window_size(self) -> int:

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+import json
 import logging
 import os
 import threading
 from typing import TYPE_CHECKING, Any, Literal, cast
+import uuid
 
 from pydantic import BaseModel
 
@@ -60,6 +62,7 @@ class OCICompletion(BaseLLM):
         top_p: float | None = None,
         top_k: int | None = None,
         reasoning_effort: str | None = None,
+        stream: bool = False,
         oci_provider: str | None = None,
         timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
         client: Any | None = None,
@@ -109,6 +112,7 @@ class OCICompletion(BaseLLM):
         # Honoured by GPT-5 family, Gemini 2.5, Grok reasoning variants,
         # Cohere Command-A-Reasoning. Ignored by non-reasoning models.
         self.reasoning_effort = reasoning_effort
+        self.stream = stream
         self.oci_provider = oci_provider or self._infer_provider(model)
         self._oci = _get_oci_module()
 
@@ -262,6 +266,8 @@ class OCICompletion(BaseLLM):
     def _build_chat_request(
         self,
         messages: list[LLMMessage],
+        *,
+        is_stream: bool = False,
     ) -> Any:
         """Build the provider-specific OCI chat request for the current model."""
         models = self._oci.generative_ai_inference.models
@@ -300,6 +306,12 @@ class OCICompletion(BaseLLM):
         if self.stop and not self._is_openai_gpt5_family():
             stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"
             request_kwargs[stop_key] = list(self.stop)
+
+        if is_stream:
+            request_kwargs["is_stream"] = True
+            request_kwargs["stream_options"] = models.StreamOptions(
+                is_include_usage=True
+            )
 
         if self.oci_provider == "cohere":
             return models.CohereChatRequest(**request_kwargs)
@@ -365,6 +377,75 @@ class OCICompletion(BaseLLM):
         return metadata
 
     # ------------------------------------------------------------------
+    # Streaming extraction
+    # ------------------------------------------------------------------
+
+    def _parse_stream_event(self, event: Any) -> dict[str, Any]:
+        """Convert OCI SSE event payloads into plain dicts."""
+        event_data = getattr(event, "data", None)
+        if not event_data:
+            return {}
+        if isinstance(event_data, str):
+            try:
+                parsed = json.loads(event_data)
+                if isinstance(parsed, Mapping):
+                    return dict(parsed)
+                return {}
+            except json.JSONDecodeError:
+                logging.debug("Skipping invalid OCI SSE payload: %s", event_data)
+                return {}
+        if isinstance(event_data, Mapping):
+            return dict(event_data)
+        return {}
+
+    def _extract_text_from_stream_event(self, event_data: dict[str, Any]) -> str:
+        if self.oci_provider == "cohere":
+            if "text" in event_data:
+                return str(event_data.get("text", ""))
+            message = event_data.get("message", {})
+            if isinstance(message, Mapping):
+                content = message.get("content", [])
+                if isinstance(content, list):
+                    return "".join(
+                        str(part.get("text", ""))
+                        for part in content
+                        if isinstance(part, Mapping)
+                    )
+            return ""
+
+        message = event_data.get("message", {})
+        if not isinstance(message, Mapping):
+            return ""
+        content = message.get("content", [])
+        if not isinstance(content, list):
+            return ""
+        return "".join(
+            str(part.get("text", ""))
+            for part in content
+            if isinstance(part, Mapping) and part.get("text")
+        )
+
+    def _extract_usage_from_stream_event(self, event_data: dict[str, Any]) -> dict[str, int]:
+        usage = event_data.get("usage")
+        if not isinstance(usage, Mapping):
+            return {}
+        return {
+            "prompt_tokens": int(usage.get("promptTokens", 0) or 0),
+            "completion_tokens": int(usage.get("completionTokens", 0) or 0),
+            "total_tokens": int(usage.get("totalTokens", 0) or 0),
+        }
+
+    def _extract_metadata_from_stream_event(self, event_data: dict[str, Any]) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        finish_reason = event_data.get("finishReason")
+        if finish_reason is not None:
+            metadata["finish_reason"] = finish_reason
+        usage = self._extract_usage_from_stream_event(event_data)
+        if usage:
+            metadata["usage"] = usage
+        return metadata
+
+    # ------------------------------------------------------------------
     # Call paths
     # ------------------------------------------------------------------
 
@@ -416,6 +497,142 @@ class OCICompletion(BaseLLM):
             from_agent=from_agent,
         )
 
+    def _stream_call_impl(
+        self,
+        *,
+        messages: str | list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> str:
+        """Handle OCI streaming while reconstructing final text state."""
+        normalized_messages = (
+            messages if isinstance(messages, list) else self._normalize_messages(messages)
+        )
+        chat_request = self._build_chat_request(normalized_messages, is_stream=True)
+        chat_details = self._oci.generative_ai_inference.models.ChatDetails(
+            compartment_id=self.compartment_id,
+            serving_mode=self._build_serving_mode(),
+            chat_request=chat_request,
+        )
+        full_response = ""
+        usage_data: dict[str, int] = {}
+        response_metadata: dict[str, Any] = {}
+        response_id = uuid.uuid4().hex
+
+        for event in self._stream_chat_events(chat_details):
+            event_data = self._parse_stream_event(event)
+            if not event_data:
+                continue
+
+            text_chunk = self._extract_text_from_stream_event(event_data)
+            if text_chunk:
+                full_response += text_chunk
+                self._emit_stream_chunk_event(
+                    chunk=text_chunk,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    call_type=LLMCallType.LLM_CALL,
+                    response_id=response_id,
+                )
+
+            usage_chunk = self._extract_usage_from_stream_event(event_data)
+            if usage_chunk:
+                usage_data = usage_chunk
+            response_metadata.update(self._extract_metadata_from_stream_event(event_data))
+
+        if usage_data:
+            self._track_token_usage_internal(usage_data)
+            response_metadata["usage"] = usage_data
+        self.last_response_metadata = response_metadata or None
+
+        return self._finalize_text_response(
+            content=full_response,
+            messages=normalized_messages,
+            from_task=from_task,
+            from_agent=from_agent,
+        )
+
+    def iter_stream(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+    ) -> Any:
+        """Yield raw text chunks from OCI without triggering tool recursion."""
+        normalized_messages = self._normalize_messages(messages)
+        chat_request = self._build_chat_request(normalized_messages, is_stream=True)
+        chat_details = self._oci.generative_ai_inference.models.ChatDetails(
+            compartment_id=self.compartment_id,
+            serving_mode=self._build_serving_mode(),
+            chat_request=chat_request,
+        )
+        response = self._chat(chat_details)
+        usage_data: dict[str, int] = {}
+        response_metadata: dict[str, Any] = {}
+
+        for event in response.data.events():
+            event_data = self._parse_stream_event(event)
+            if not event_data:
+                continue
+            text_chunk = self._extract_text_from_stream_event(event_data)
+            if text_chunk:
+                yield text_chunk
+            usage_chunk = self._extract_usage_from_stream_event(event_data)
+            if usage_chunk:
+                usage_data = usage_chunk
+            response_metadata.update(self._extract_metadata_from_stream_event(event_data))
+
+        if usage_data:
+            self._track_token_usage_internal(usage_data)
+            response_metadata["usage"] = usage_data
+        self.last_response_metadata = response_metadata or None
+
+    async def astream(
+        self,
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+    ) -> Any:
+        """Expose the sync OCI SSE stream through an async generator facade."""
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
+        error_holder: list[BaseException] = []
+
+        def _producer() -> None:
+            try:
+                for chunk in self.iter_stream(
+                    messages=messages,
+                    tools=tools,
+                    callbacks=callbacks,
+                    available_functions=available_functions,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                ):
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+            except BaseException as error:
+                error_holder.append(error)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        thread = threading.Thread(target=_producer, daemon=True)
+        thread.start()
+
+        while True:
+            chunk = await queue.get()
+            if chunk is None:
+                break
+            yield chunk
+
+        thread.join()
+        if error_holder:
+            raise error_holder[0]
+
     def call(
         self,
         messages: str | list[LLMMessage],
@@ -450,6 +667,13 @@ class OCICompletion(BaseLLM):
                     normalized_messages, from_agent
                 ):
                     raise ValueError("LLM call blocked by before_llm_call hook")
+
+                if self.stream:
+                    return self._stream_call_impl(
+                        messages=normalized_messages,
+                        from_task=from_task,
+                        from_agent=from_agent,
+                    )
 
                 return self._call_impl(
                     messages=normalized_messages,
@@ -495,3 +719,25 @@ class OCICompletion(BaseLLM):
         """Thread-safe wrapper around the underlying OCI ``client.chat`` call (the SDK client is not re-entrant)."""
         with self._client_lock:
             return self.client.chat(chat_details)
+
+    def _stream_chat_events(self, chat_details: Any) -> Any:
+        """Yield streaming events while holding the shared OCI client lock."""
+        with self._client_lock:
+            response = self.client.chat(chat_details)
+            yield from response.data.events()
+
+    # ------------------------------------------------------------------
+    # Capability declarations
+    # ------------------------------------------------------------------
+
+    def get_context_window_size(self) -> int:
+        model_lower = self.model.lower()
+        if model_lower.startswith("google.gemini"):
+            return 1048576
+        if model_lower.startswith("openai."):
+            return 200000
+        if model_lower.startswith("cohere."):
+            return 128000
+        if model_lower.startswith("meta."):
+            return 131072
+        return 131072

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+import inspect
 import json
 import logging
 import os
@@ -26,6 +27,17 @@ if TYPE_CHECKING:
 CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
 DEFAULT_OCI_REGION = "us-chicago-1"
 DEFAULT_OCI_TIMEOUT = (10, 240)
+_OCI_TOOL_RESULT_GUIDANCE = (
+    "You have received tool results above. Respond to the user with a helpful, "
+    "natural language answer that incorporates the tool results. Do not output "
+    "raw JSON or tool call syntax. If you need additional information, you may "
+    "call another tool."
+)
+_OCI_RESERVED_REQUEST_KWARGS = {
+    "tool_choice",
+    "parallel_tool_calls",
+    "tool_result_guidance",
+}
 
 
 def _get_oci_module() -> Any:
@@ -65,6 +77,7 @@ class OCICompletion(BaseLLM):
         stream: bool = False,
         oci_provider: str | None = None,
         timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
+        max_sequential_tool_calls: int = 8,
         client: Any | None = None,
         **kwargs: Any,
     ) -> None:
@@ -114,6 +127,7 @@ class OCICompletion(BaseLLM):
         self.reasoning_effort = reasoning_effort
         self.stream = stream
         self.oci_provider = oci_provider or self._infer_provider(model)
+        self.max_sequential_tool_calls = max_sequential_tool_calls
         self._oci = _get_oci_module()
 
         if client is not None:
@@ -218,13 +232,45 @@ class OCICompletion(BaseLLM):
 
         for message in messages:
             role = str(message.get("role", "user")).lower()
+            if role == "tool":
+                tool_kwargs: dict[str, Any] = {
+                    "content": self._build_generic_content(message.get("content", "")),
+                }
+                if message.get("tool_call_id"):
+                    tool_kwargs["tool_call_id"] = message["tool_call_id"]
+                oci_messages.append(models.ToolMessage(**tool_kwargs))
+                continue
+
             message_cls = role_map.get(role)
             if message_cls is None:
                 logging.debug("Skipping unsupported OCI message role: %s", role)
                 continue
+
+            message_kwargs: dict[str, Any] = {
+                "content": self._build_generic_content(message.get("content", "")),
+            }
+            if role == "assistant" and message.get("tool_calls"):
+                message_kwargs["tool_calls"] = [
+                    models.FunctionCall(
+                        id=tool_call.get("id"),
+                        name=tool_call.get("function", {}).get("name"),
+                        arguments=tool_call.get("function", {}).get("arguments", "{}"),
+                    )
+                    for tool_call in message.get("tool_calls", [])
+                    if tool_call.get("function", {}).get("name")
+                ]
+                if not message_kwargs["content"]:
+                    message_kwargs["content"] = [models.TextContent(text=".")]
+
+            oci_messages.append(message_cls(**message_kwargs))
+
+        if (
+            self._tool_result_guidance_enabled()
+            and any(str(message.get("role", "")).lower() == "tool" for message in messages)
+        ):
             oci_messages.append(
-                message_cls(
-                    content=self._build_generic_content(message.get("content", "")),
+                models.SystemMessage(
+                    content=[models.TextContent(text=_OCI_TOOL_RESULT_GUIDANCE)]
                 )
             )
 
@@ -232,12 +278,21 @@ class OCICompletion(BaseLLM):
 
     def _build_cohere_chat_history(
         self, messages: list[LLMMessage]
-    ) -> tuple[list[Any], str]:
-        """Translate CrewAI messages into Cohere's split history + message shape."""
+    ) -> tuple[list[Any], list[Any] | None, str]:
+        """Translate CrewAI messages into Cohere's split history/tool-results shape."""
         models = self._oci.generative_ai_inference.models
         chat_history: list[Any] = []
+        trailing_tool_count = 0
+        for message in reversed(messages):
+            if str(message.get("role", "")).lower() != "tool":
+                break
+            trailing_tool_count += 1
 
-        for message in messages[:-1]:
+        history_messages = (
+            messages[:-trailing_tool_count] if trailing_tool_count else messages[:-1]
+        )
+
+        for message in history_messages:
             role = str(message.get("role", "user")).lower()
             content = message.get("content", "")
 
@@ -249,15 +304,188 @@ class OCICompletion(BaseLLM):
                 )
                 chat_history.append(message_cls(message=self._coerce_text(content)))
             elif role == "assistant":
+                tool_calls = None
+                if message.get("tool_calls"):
+                    tool_calls = []
+                    for tool_call in message.get("tool_calls", []):
+                        function_info = tool_call.get("function", {})
+                        function_name = function_info.get("name")
+                        if not function_name:
+                            continue
+                        raw_arguments = function_info.get("arguments", "{}")
+                        if isinstance(raw_arguments, str):
+                            try:
+                                parameters = json.loads(raw_arguments)
+                            except json.JSONDecodeError:
+                                parameters = {}
+                        elif isinstance(raw_arguments, Mapping):
+                            parameters = dict(raw_arguments)
+                        else:
+                            parameters = {}
+                        tool_calls.append(
+                            models.CohereToolCall(name=function_name, parameters=parameters)
+                        )
                 chat_history.append(
                     models.CohereChatBotMessage(
                         message=self._coerce_text(content) or " ",
+                        tool_calls=tool_calls,
+                    )
+                )
+            elif role == "tool":
+                tool_name = message.get("name") or "tool"
+                chat_history.append(
+                    models.CohereToolMessage(
+                        tool_results=[
+                            models.CohereToolResult(
+                                call=models.CohereToolCall(name=tool_name, parameters={}),
+                                outputs=[{"output": self._coerce_text(content)}],
+                            )
+                        ]
                     )
                 )
 
         last_message = messages[-1] if messages else {"role": "user", "content": ""}
+        tool_results: list[Any] = []
+        if str(last_message.get("role", "user")).lower() == "tool":
+            previous_tool_calls: dict[str, dict[str, Any]] = {}
+            for message in messages:
+                if str(message.get("role", "")).lower() != "assistant":
+                    continue
+                for tool_call in message.get("tool_calls", []):
+                    tool_call_id = tool_call.get("id")
+                    if not tool_call_id:
+                        continue
+                    function_info = tool_call.get("function", {})
+                    raw_arguments = function_info.get("arguments", "{}")
+                    if isinstance(raw_arguments, str):
+                        try:
+                            parameters = json.loads(raw_arguments)
+                        except json.JSONDecodeError:
+                            parameters = {}
+                    elif isinstance(raw_arguments, Mapping):
+                        parameters = dict(raw_arguments)
+                    else:
+                        parameters = {}
+                    previous_tool_calls[tool_call_id] = {
+                        "name": function_info.get("name", "tool"),
+                        "parameters": parameters,
+                    }
+
+            for message in messages[-trailing_tool_count:]:
+                if str(message.get("role", "")).lower() != "tool":
+                    continue
+                tool_call_id = message.get("tool_call_id")
+                if not isinstance(tool_call_id, str):
+                    continue
+                previous_call = previous_tool_calls.get(tool_call_id, {})
+                tool_results.append(
+                    models.CohereToolResult(
+                        call=models.CohereToolCall(
+                            name=previous_call.get("name", message.get("name", "tool")),
+                            parameters=previous_call.get("parameters", {}),
+                        ),
+                        outputs=[{"output": self._coerce_text(message.get("content", ""))}],
+                    )
+                )
+
         message_text = self._coerce_text(last_message.get("content", ""))
-        return chat_history, message_text
+        if tool_results:
+            message_text = ""
+
+        return chat_history, tool_results or None, message_text
+
+    # ------------------------------------------------------------------
+    # Tool formatting
+    # ------------------------------------------------------------------
+
+    def _format_tools(self, tools: list[dict[str, Any]] | None) -> list[Any]:
+        if not tools:
+            return []
+        models = self._oci.generative_ai_inference.models
+        formatted: list[Any] = []
+        for tool in tools:
+            if not isinstance(tool, Mapping):
+                continue
+            function_spec = tool.get("function", {})
+            if not isinstance(function_spec, Mapping):
+                continue
+            name = function_spec.get("name")
+            if not name:
+                continue
+            parameters = function_spec.get("parameters", {})
+            if not isinstance(parameters, Mapping):
+                parameters = {}
+
+            if self.oci_provider == "cohere":
+                param_defs = {}
+                required = set(parameters.get("required", []))
+                for pname, pschema in parameters.get("properties", {}).items():
+                    if not isinstance(pschema, Mapping):
+                        continue
+                    param_defs[pname] = models.CohereParameterDefinition(
+                        description=pschema.get("description", ""),
+                        type=pschema.get("type", "object"),
+                        is_required=pname in required,
+                    )
+                formatted.append(models.CohereTool(
+                    name=name,
+                    description=function_spec.get("description", name),
+                    parameter_definitions=param_defs,
+                ))
+            else:
+                formatted.append(models.FunctionDefinition(
+                    name=name,
+                    description=function_spec.get("description", name),
+                    parameters={
+                        "type": parameters.get("type", "object"),
+                        "properties": parameters.get("properties", {}),
+                        "required": parameters.get("required", []),
+                    },
+                ))
+        return formatted
+
+    def _tool_result_guidance_enabled(self) -> bool:
+        return bool(self.additional_params.get("tool_result_guidance"))
+
+    def _parallel_tool_calls_enabled(self) -> bool:
+        return bool(self.additional_params.get("parallel_tool_calls"))
+
+    def _build_tool_choice(self) -> Any | None:
+        tool_choice = self.additional_params.get("tool_choice")
+        if tool_choice is None:
+            return None
+        models = self._oci.generative_ai_inference.models
+        if isinstance(tool_choice, str):
+            if tool_choice == "auto":
+                return models.ToolChoiceAuto()
+            if tool_choice == "none":
+                return models.ToolChoiceNone()
+            if tool_choice in ("any", "required"):
+                return models.ToolChoiceRequired()
+            return models.ToolChoiceFunction(name=tool_choice)
+        if isinstance(tool_choice, bool):
+            return models.ToolChoiceRequired() if tool_choice else models.ToolChoiceNone()
+        if isinstance(tool_choice, Mapping):
+            fn = tool_choice.get("function")
+            if isinstance(fn, Mapping) and fn.get("name"):
+                return models.ToolChoiceFunction(name=str(fn["name"]))
+            return models.ToolChoiceAuto()
+        raise ValueError("Unrecognized OCI tool_choice. Expected str, bool, or function mapping.")
+
+    def _allowed_passthrough_request_keys(self, request_cls: type[Any]) -> set[str]:
+        """Return request attributes that can safely be forwarded to the OCI SDK."""
+        attribute_map = getattr(request_cls, "attribute_map", None)
+        if isinstance(attribute_map, Mapping):
+            return {str(key) for key in attribute_map}
+        swagger_types = getattr(request_cls, "swagger_types", None)
+        if isinstance(swagger_types, Mapping):
+            return {str(key) for key in swagger_types}
+        signature = inspect.signature(request_cls)
+        return {
+            name
+            for name, param in signature.parameters.items()
+            if name != "self" and param.kind is not inspect.Parameter.VAR_KEYWORD
+        }
 
     # ------------------------------------------------------------------
     # Request building
@@ -266,6 +494,7 @@ class OCICompletion(BaseLLM):
     def _build_chat_request(
         self,
         messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
         *,
         is_stream: bool = False,
     ) -> Any:
@@ -273,12 +502,16 @@ class OCICompletion(BaseLLM):
         models = self._oci.generative_ai_inference.models
 
         if self.oci_provider == "cohere":
-            chat_history, message_text = self._build_cohere_chat_history(messages)
+            chat_history, tool_results, message_text = self._build_cohere_chat_history(
+                messages
+            )
             request_kwargs: dict[str, Any] = {
                 "message": message_text,
                 "chat_history": chat_history,
                 "api_format": models.BaseChatRequest.API_FORMAT_COHERE,
             }
+            if tool_results:
+                request_kwargs["tool_results"] = tool_results
         else:
             request_kwargs = {
                 "messages": self._build_generic_messages(messages),
@@ -307,6 +540,20 @@ class OCICompletion(BaseLLM):
             stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"
             request_kwargs[stop_key] = list(self.stop)
 
+        formatted_tools = self._format_tools(tools)
+        if formatted_tools:
+            request_kwargs["tools"] = formatted_tools
+            if self.oci_provider == "cohere":
+                if self._parallel_tool_calls_enabled():
+                    raise ValueError("OCI Cohere models do not support parallel_tool_calls.")
+                request_kwargs.setdefault("is_force_single_step", False)
+            else:
+                tool_choice = self._build_tool_choice()
+                if tool_choice is not None:
+                    request_kwargs["tool_choice"] = tool_choice
+                if self._parallel_tool_calls_enabled():
+                    request_kwargs["is_parallel_tool_calls"] = True
+
         if is_stream:
             request_kwargs["is_stream"] = True
             request_kwargs["stream_options"] = models.StreamOptions(
@@ -314,7 +561,20 @@ class OCICompletion(BaseLLM):
             )
 
         if self.oci_provider == "cohere":
+            allowed = self._allowed_passthrough_request_keys(models.CohereChatRequest)
+            passthrough = {
+                k: v for k, v in self.additional_params.items()
+                if k not in _OCI_RESERVED_REQUEST_KWARGS and k in allowed
+            }
+            request_kwargs.update(passthrough)
             return models.CohereChatRequest(**request_kwargs)
+
+        allowed = self._allowed_passthrough_request_keys(models.GenericChatRequest)
+        passthrough = {
+            k: v for k, v in self.additional_params.items()
+            if k not in _OCI_RESERVED_REQUEST_KWARGS and k in allowed
+        }
+        request_kwargs.update(passthrough)
         return models.GenericChatRequest(**request_kwargs)
 
     # ------------------------------------------------------------------
@@ -343,6 +603,42 @@ class OCICompletion(BaseLLM):
             return ""
         content = getattr(message, "content", None) or []
         return "".join(part.text for part in content if getattr(part, "text", None))
+
+    def _extract_tool_calls(self, response: Any) -> list[dict[str, Any]]:
+        """Normalize provider-specific tool calls back into CrewAI's shape."""
+        chat_response = response.data.chat_response
+        raw: list[Any] = []
+        if self.oci_provider == "cohere":
+            raw = getattr(chat_response, "tool_calls", None) or []
+        else:
+            choices = getattr(chat_response, "choices", None) or []
+            if choices:
+                msg = getattr(choices[0], "message", None)
+                raw = getattr(msg, "tool_calls", None) or []
+
+        if self.oci_provider == "cohere":
+            return [
+                {
+                    "id": uuid.uuid4().hex,
+                    "type": "function",
+                    "function": {
+                        "name": getattr(tc, "name", ""),
+                        "arguments": json.dumps(getattr(tc, "parameters", {}) or {}),
+                    },
+                }
+                for tc in raw
+            ]
+        return [
+            {
+                "id": getattr(tc, "id", None),
+                "type": "function",
+                "function": {
+                    "name": getattr(tc, "name", ""),
+                    "arguments": getattr(tc, "arguments", "{}"),
+                },
+            }
+            for tc in raw
+        ]
 
     def _extract_usage(self, response: Any) -> dict[str, int]:
         """Return ``{prompt_tokens, completion_tokens, total_tokens}`` from the OCI response, or an empty dict if unavailable."""
@@ -425,6 +721,31 @@ class OCICompletion(BaseLLM):
             if isinstance(part, Mapping) and part.get("text")
         )
 
+    def _extract_tool_calls_from_stream_event(
+        self, event_data: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        message = event_data.get("message", {})
+        if self.oci_provider == "cohere":
+            raw = event_data.get("toolCalls", [])
+        else:
+            raw = message.get("toolCalls", []) if isinstance(message, Mapping) else []
+        if not isinstance(raw, list):
+            return []
+        if self.oci_provider == "cohere":
+            return [
+                {"id": None, "type": "function", "function": {
+                    "name": str(tc.get("name", "")),
+                    "arguments": json.dumps(tc.get("parameters", {})),
+                }}
+                for tc in raw if isinstance(tc, Mapping)
+            ]
+        return [
+            {"id": tc.get("id"), "type": "function", "function": {
+                "name": tc.get("name"), "arguments": tc.get("arguments"),
+            }}
+            for tc in raw if isinstance(tc, Mapping)
+        ]
+
     def _extract_usage_from_stream_event(self, event_data: dict[str, Any]) -> dict[str, int]:
         usage = event_data.get("usage")
         if not isinstance(usage, Mapping):
@@ -444,6 +765,94 @@ class OCICompletion(BaseLLM):
         if usage:
             metadata["usage"] = usage
         return metadata
+
+    # ------------------------------------------------------------------
+    # Tool execution
+    # ------------------------------------------------------------------
+
+    def _handle_tool_calls(
+        self,
+        *,
+        normalized_messages: list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None,
+        callbacks: list[Any] | None,
+        available_functions: dict[str, Any] | None,
+        from_task: Task | None,
+        from_agent: Agent | None,
+        tool_depth: int,
+        tool_calls: list[dict[str, Any]],
+    ) -> str | BaseModel | list[dict[str, Any]]:
+        """Execute one round of tool calls and recurse until the model finishes."""
+        if tool_calls and not available_functions:
+            self._emit_call_completed_event(
+                response=tool_calls,
+                call_type=LLMCallType.TOOL_CALL,
+                from_task=from_task,
+                from_agent=from_agent,
+                messages=normalized_messages,
+            )
+            return tool_calls
+
+        if tool_depth >= self.max_sequential_tool_calls:
+            raise RuntimeError(
+                "OCI native provider exceeded max_sequential_tool_calls."
+            )
+
+        next_messages = list(normalized_messages)
+        next_messages.append(
+            {"role": "assistant", "content": None, "tool_calls": tool_calls}
+        )
+
+        for tool_call in tool_calls:
+            fn = tool_call.get("function", {})
+            fn_name = fn.get("name", "")
+            raw_args = fn.get("arguments", "{}")
+            if isinstance(raw_args, str):
+                try:
+                    fn_args = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    fn_args = {}
+            elif isinstance(raw_args, Mapping):
+                fn_args = dict(raw_args)
+            else:
+                fn_args = {}
+
+            result = self._handle_tool_execution(
+                function_name=fn_name,
+                function_args=fn_args,
+                available_functions=available_functions or {},
+                from_task=from_task,
+                from_agent=from_agent,
+            )
+            if result is None:
+                result = f"Tool '{fn_name}' failed or returned no result."
+
+            next_messages.append({
+                "role": "tool",
+                "tool_call_id": str(tool_call.get("id") or uuid.uuid4().hex),
+                "name": fn_name,
+                "content": str(result),
+            })
+
+        if self.stream:
+            return self._stream_call_impl(
+                messages=next_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                tool_depth=tool_depth + 1,
+            )
+        return self._call_impl(
+            messages=next_messages,
+            tools=tools,
+            callbacks=callbacks,
+            available_functions=available_functions,
+            from_task=from_task,
+            from_agent=from_agent,
+            tool_depth=tool_depth + 1,
+        )
 
     # ------------------------------------------------------------------
     # Call paths
@@ -472,12 +881,19 @@ class OCICompletion(BaseLLM):
     def _call_impl(
         self,
         *,
-        messages: list[LLMMessage],
-        from_task: Task | None,
-        from_agent: Agent | None,
-    ) -> str:
-        """Build the OCI chat request, invoke the service, record metadata, and return the finalized text."""
-        chat_request = self._build_chat_request(messages)
+        messages: str | list[LLMMessage],
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        tool_depth: int = 0,
+    ) -> str | BaseModel | list[dict[str, Any]]:
+        """Build the OCI chat request, invoke the service, record metadata, and return the finalized text (running the tool loop when the model requests tool calls)."""
+        normalized_messages = (
+            messages if isinstance(messages, list) else self._normalize_messages(messages)
+        )
+        chat_request = self._build_chat_request(normalized_messages, tools=tools)
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
             serving_mode=self._build_serving_mode(),
@@ -490,6 +906,19 @@ class OCICompletion(BaseLLM):
             self._track_token_usage_internal(usage)
 
         content = self._extract_text(response)
+        tool_calls = self._extract_tool_calls(response)
+        if tool_calls:
+            return self._handle_tool_calls(
+                normalized_messages=normalized_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                tool_depth=tool_depth,
+                tool_calls=tool_calls,
+            )
+
         return self._finalize_text_response(
             content=content,
             messages=messages,
@@ -501,20 +930,27 @@ class OCICompletion(BaseLLM):
         self,
         *,
         messages: str | list[LLMMessage],
-        from_task: Task | None,
-        from_agent: Agent | None,
-    ) -> str:
-        """Handle OCI streaming while reconstructing final text state."""
+        tools: list[dict[str, BaseTool]] | None = None,
+        callbacks: list[Any] | None = None,
+        available_functions: dict[str, Any] | None = None,
+        from_task: Task | None = None,
+        from_agent: Agent | None = None,
+        tool_depth: int = 0,
+    ) -> str | BaseModel | list[dict[str, Any]]:
+        """Handle OCI streaming while reconstructing final text/tool state."""
         normalized_messages = (
             messages if isinstance(messages, list) else self._normalize_messages(messages)
         )
-        chat_request = self._build_chat_request(normalized_messages, is_stream=True)
+        chat_request = self._build_chat_request(
+            normalized_messages, tools=tools, is_stream=True
+        )
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
             serving_mode=self._build_serving_mode(),
             chat_request=chat_request,
         )
         full_response = ""
+        tool_calls_by_index: dict[int, dict[str, Any]] = {}
         usage_data: dict[str, int] = {}
         response_metadata: dict[str, Any] = {}
         response_id = uuid.uuid4().hex
@@ -535,6 +971,32 @@ class OCICompletion(BaseLLM):
                     response_id=response_id,
                 )
 
+            stream_tool_calls = self._extract_tool_calls_from_stream_event(event_data)
+            for index, tc in enumerate(stream_tool_calls):
+                state = tool_calls_by_index.setdefault(
+                    index,
+                    {"id": None, "type": "function", "function": {"name": None, "arguments": ""}},
+                )
+                if tc.get("id"):
+                    state["id"] = tc["id"]
+                fn = tc.get("function", {})
+                if fn.get("name"):
+                    state["function"]["name"] = fn["name"]
+                chunk_args = fn.get("arguments")
+                if chunk_args:
+                    state["function"]["arguments"] += str(chunk_args)
+                self._emit_stream_chunk_event(
+                    chunk=str(chunk_args or ""),
+                    tool_call={"id": state["id"], "type": "function", "function": {
+                        "name": state["function"]["name"],
+                        "arguments": str(chunk_args or ""),
+                    }},
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    call_type=LLMCallType.TOOL_CALL,
+                    response_id=response_id,
+                )
+
             usage_chunk = self._extract_usage_from_stream_event(event_data)
             if usage_chunk:
                 usage_data = usage_chunk
@@ -544,6 +1006,31 @@ class OCICompletion(BaseLLM):
             self._track_token_usage_internal(usage_data)
             response_metadata["usage"] = usage_data
         self.last_response_metadata = response_metadata or None
+
+        tool_calls = [
+            {
+                "id": tc.get("id") or uuid.uuid4().hex,
+                "type": "function",
+                "function": {
+                    "name": tc["function"].get("name", "") or "",
+                    "arguments": tc["function"].get("arguments", "") or "",
+                },
+            }
+            for _, tc in sorted(tool_calls_by_index.items())
+            if tc["function"].get("name")
+        ]
+
+        if tool_calls:
+            return self._handle_tool_calls(
+                normalized_messages=normalized_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                tool_depth=tool_depth,
+                tool_calls=tool_calls,
+            )
 
         return self._finalize_text_response(
             content=full_response,
@@ -671,14 +1158,22 @@ class OCICompletion(BaseLLM):
                 if self.stream:
                     return self._stream_call_impl(
                         messages=normalized_messages,
+                        tools=tools,
+                        callbacks=callbacks,
+                        available_functions=available_functions,
                         from_task=from_task,
                         from_agent=from_agent,
+                        tool_depth=0,
                     )
 
                 return self._call_impl(
                     messages=normalized_messages,
+                    tools=tools,
+                    callbacks=callbacks,
+                    available_functions=available_functions,
                     from_task=from_task,
                     from_agent=from_agent,
+                    tool_depth=0,
                 )
             except Exception as error:
                 error_message = f"OCI Generative AI call failed: {error!s}"
@@ -729,6 +1224,9 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
     # Capability declarations
     # ------------------------------------------------------------------
+
+    def supports_function_calling(self) -> bool:
+        return True
 
     def get_context_window_size(self) -> int:
         model_lower = self.model.lower()

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal, cast
 import uuid
@@ -15,6 +16,7 @@ from pydantic import BaseModel
 from crewai.events.types.llm_events import LLMCallType
 from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
+from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.types import LLMMessage
 
 
@@ -27,6 +29,7 @@ if TYPE_CHECKING:
 CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
 DEFAULT_OCI_REGION = "us-chicago-1"
 DEFAULT_OCI_TIMEOUT = (10, 240)
+_OCI_SCHEMA_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9_-]")
 _OCI_TOOL_RESULT_GUIDANCE = (
     "You have received tool results above. Respond to the user with a helpful, "
     "natural language answer that incorporates the tool results. Do not output "
@@ -491,10 +494,29 @@ class OCICompletion(BaseLLM):
     # Request building
     # ------------------------------------------------------------------
 
+    def _build_response_format(
+        self, response_model: type[BaseModel] | None
+    ) -> Any | None:
+        if response_model is None:
+            return None
+        models = self._oci.generative_ai_inference.models
+        schema_description = generate_model_description(response_model)["json_schema"]
+        schema_name = _OCI_SCHEMA_NAME_PATTERN.sub("_", schema_description["name"])
+        json_schema = models.ResponseJsonSchema(
+            name=schema_name,
+            description=(response_model.__doc__ or "").strip() or schema_name,
+            schema=schema_description["schema"],
+            is_strict=schema_description["strict"],
+        )
+        if self.oci_provider == "cohere":
+            return models.CohereResponseJsonFormat(schema=json_schema.schema)
+        return models.JsonSchemaResponseFormat(json_schema=json_schema)
+
     def _build_chat_request(
         self,
         messages: list[LLMMessage],
         tools: list[dict[str, Any]] | None = None,
+        response_model: type[BaseModel] | None = None,
         *,
         is_stream: bool = False,
     ) -> Any:
@@ -553,6 +575,10 @@ class OCICompletion(BaseLLM):
                     request_kwargs["tool_choice"] = tool_choice
                 if self._parallel_tool_calls_enabled():
                     request_kwargs["is_parallel_tool_calls"] = True
+
+        response_format = self._build_response_format(response_model)
+        if response_format is not None:
+            request_kwargs["response_format"] = response_format
 
         if is_stream:
             request_kwargs["is_stream"] = True
@@ -767,6 +793,44 @@ class OCICompletion(BaseLLM):
         return metadata
 
     # ------------------------------------------------------------------
+    # Structured output
+    # ------------------------------------------------------------------
+
+    def _parse_structured_response(
+        self,
+        *,
+        content: str,
+        response_model: type[BaseModel],
+        messages: list[LLMMessage],
+        from_task: Task | None,
+        from_agent: Agent | None,
+    ) -> BaseModel:
+        try:
+            structured_response = self._validate_structured_output(
+                content, response_model
+            )
+        except Exception as error:
+            raise ValueError(
+                f"Failed to validate OCI structured response with model "
+                f"{response_model.__name__}: {error}"
+            ) from error
+
+        if not isinstance(structured_response, BaseModel):
+            raise ValueError(
+                f"OCI structured response parsing returned unexpected type: "
+                f"{type(structured_response)}"
+            )
+
+        self._emit_call_completed_event(
+            response=structured_response.model_dump_json(),
+            call_type=LLMCallType.LLM_CALL,
+            from_task=from_task,
+            from_agent=from_agent,
+            messages=messages,
+        )
+        return structured_response
+
+    # ------------------------------------------------------------------
     # Tool execution
     # ------------------------------------------------------------------
 
@@ -780,6 +844,7 @@ class OCICompletion(BaseLLM):
         from_task: Task | None,
         from_agent: Agent | None,
         tool_depth: int,
+        response_model: type[BaseModel] | None = None,
         tool_calls: list[dict[str, Any]],
     ) -> str | BaseModel | list[dict[str, Any]]:
         """Execute one round of tool calls and recurse until the model finishes."""
@@ -843,6 +908,7 @@ class OCICompletion(BaseLLM):
                 from_task=from_task,
                 from_agent=from_agent,
                 tool_depth=tool_depth + 1,
+                response_model=response_model,
             )
         return self._call_impl(
             messages=next_messages,
@@ -852,6 +918,7 @@ class OCICompletion(BaseLLM):
             from_task=from_task,
             from_agent=from_agent,
             tool_depth=tool_depth + 1,
+            response_model=response_model,
         )
 
     # ------------------------------------------------------------------
@@ -888,12 +955,15 @@ class OCICompletion(BaseLLM):
         from_task: Task | None = None,
         from_agent: Agent | None = None,
         tool_depth: int = 0,
+        response_model: type[BaseModel] | None = None,
     ) -> str | BaseModel | list[dict[str, Any]]:
         """Build the OCI chat request, invoke the service, record metadata, and return the finalized text (running the tool loop when the model requests tool calls)."""
         normalized_messages = (
             messages if isinstance(messages, list) else self._normalize_messages(messages)
         )
-        chat_request = self._build_chat_request(normalized_messages, tools=tools)
+        chat_request = self._build_chat_request(
+            normalized_messages, tools=tools, response_model=response_model
+        )
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
             serving_mode=self._build_serving_mode(),
@@ -916,7 +986,17 @@ class OCICompletion(BaseLLM):
                 from_task=from_task,
                 from_agent=from_agent,
                 tool_depth=tool_depth,
+                response_model=response_model,
                 tool_calls=tool_calls,
+            )
+
+        if response_model is not None:
+            return self._parse_structured_response(
+                content=content,
+                response_model=response_model,
+                messages=normalized_messages,
+                from_task=from_task,
+                from_agent=from_agent,
             )
 
         return self._finalize_text_response(
@@ -936,13 +1016,15 @@ class OCICompletion(BaseLLM):
         from_task: Task | None = None,
         from_agent: Agent | None = None,
         tool_depth: int = 0,
+        response_model: type[BaseModel] | None = None,
     ) -> str | BaseModel | list[dict[str, Any]]:
         """Handle OCI streaming while reconstructing final text/tool state."""
         normalized_messages = (
             messages if isinstance(messages, list) else self._normalize_messages(messages)
         )
         chat_request = self._build_chat_request(
-            normalized_messages, tools=tools, is_stream=True
+            normalized_messages, tools=tools, response_model=response_model,
+            is_stream=True,
         )
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
@@ -1029,7 +1111,17 @@ class OCICompletion(BaseLLM):
                 from_task=from_task,
                 from_agent=from_agent,
                 tool_depth=tool_depth,
+                response_model=response_model,
                 tool_calls=tool_calls,
+            )
+
+        if response_model is not None:
+            return self._parse_structured_response(
+                content=full_response,
+                response_model=response_model,
+                messages=normalized_messages,
+                from_task=from_task,
+                from_agent=from_agent,
             )
 
         return self._finalize_text_response(
@@ -1164,6 +1256,7 @@ class OCICompletion(BaseLLM):
                         from_task=from_task,
                         from_agent=from_agent,
                         tool_depth=0,
+                        response_model=response_model,
                     )
 
                 return self._call_impl(
@@ -1174,6 +1267,7 @@ class OCICompletion(BaseLLM):
                     from_task=from_task,
                     from_agent=from_agent,
                     tool_depth=0,
+                    response_model=response_model,
                 )
             except Exception as error:
                 error_message = f"OCI Generative AI call failed: {error!s}"

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
 CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
 DEFAULT_OCI_REGION = "us-chicago-1"
 DEFAULT_OCI_TIMEOUT = (10, 240)
+# Cohere models that reject the v1 COHERE api format and require COHEREV2
+# (verified live: command-a-vision returns 400 on CohereChatRequest).
+_COHERE_V2_MODEL_MARKERS = ("command-a-vision", "command-a-reasoning")
 _OCI_SCHEMA_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9_-]")
 _OCI_TOOL_RESULT_GUIDANCE = (
     "You have received tool results above. Respond to the user with a helpful, "
@@ -155,10 +158,13 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _infer_provider(self, model: str) -> str:
-        """Infer the OCI request family (``cohere`` or ``generic``) from the model id."""
+        """Infer the OCI request family (``cohere``, ``cohere_v2``, or ``generic``) from the model id."""
         if model.startswith(CUSTOM_ENDPOINT_PREFIX):
             return "generic"
-        if model.lower().startswith("cohere."):
+        model_lower = model.lower()
+        if model_lower.startswith("cohere."):
+            if any(marker in model_lower for marker in _COHERE_V2_MODEL_MARKERS):
+                return "cohere_v2"
             return "cohere"
         return "generic"
 
@@ -328,6 +334,93 @@ class OCICompletion(BaseLLM):
 
         return oci_messages
 
+    def _build_cohere_v2_content(self, content: Any) -> list[Any]:
+        """Translate CrewAI message content into Cohere v2 content objects (text + images)."""
+        models = self._oci.generative_ai_inference.models
+        if isinstance(content, str):
+            return [models.CohereTextContentV2(text=content or ".")]
+        if not isinstance(content, list):
+            return [models.CohereTextContentV2(text=self._coerce_text(content) or ".")]
+
+        processed: list[Any] = []
+        for item in content:
+            if isinstance(item, str):
+                processed.append(models.CohereTextContentV2(text=item or "."))
+                continue
+            if not isinstance(item, Mapping):
+                raise ValueError(
+                    f"OCI message content items must be strings or dictionaries, got: {type(item)}"
+                )
+            content_type = item.get("type")
+            if content_type == "text":
+                processed.append(
+                    models.CohereTextContentV2(text=str(item.get("text", "")) or ".")
+                )
+            elif content_type == "image_url":
+                image_url = item.get("image_url", {})
+                url = image_url.get("url") if isinstance(image_url, Mapping) else None
+                if not url:
+                    raise ValueError("OCI image_url content requires image_url.url")
+                processed.append(
+                    models.CohereImageContentV2(
+                        image_url=models.CohereImageUrlV2(url=url)
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"OCI Cohere v2 models support text and image_url content, got: {content_type}"
+                )
+        return processed or [models.CohereTextContentV2(text=".")]
+
+    def _build_cohere_v2_messages(self, messages: list[LLMMessage]) -> list[Any]:
+        """Map CrewAI conversation messages into Cohere v2 chat messages."""
+        models = self._oci.generative_ai_inference.models
+        role_map = {
+            "user": models.CohereUserMessageV2,
+            "assistant": models.CohereAssistantMessageV2,
+            "system": models.CohereSystemMessageV2,
+        }
+        oci_messages: list[Any] = []
+
+        for message in messages:
+            role = str(message.get("role", "user")).lower()
+            if role == "tool":
+                tool_kwargs: dict[str, Any] = {
+                    "content": self._build_cohere_v2_content(message.get("content", "")),
+                }
+                if message.get("tool_call_id"):
+                    tool_kwargs["tool_call_id"] = message["tool_call_id"]
+                oci_messages.append(models.CohereToolMessageV2(**tool_kwargs))
+                continue
+
+            message_cls = role_map.get(role)
+            if message_cls is None:
+                logging.debug("Skipping unsupported OCI message role: %s", role)
+                continue
+
+            message_kwargs: dict[str, Any] = {
+                "content": self._build_cohere_v2_content(message.get("content", "")),
+            }
+            if role == "assistant" and message.get("tool_calls"):
+                message_kwargs["tool_calls"] = [
+                    models.CohereToolCallV2(
+                        id=tool_call.get("id"),
+                        type="FUNCTION",
+                        function={
+                            "name": tool_call.get("function", {}).get("name"),
+                            "arguments": tool_call.get("function", {}).get(
+                                "arguments", "{}"
+                            ),
+                        },
+                    )
+                    for tool_call in message.get("tool_calls", [])
+                    if tool_call.get("function", {}).get("name")
+                ]
+
+            oci_messages.append(message_cls(**message_kwargs))
+
+        return oci_messages
+
     def _build_cohere_chat_history(
         self, messages: list[LLMMessage]
     ) -> tuple[list[Any], list[Any] | None, str]:
@@ -488,6 +581,19 @@ class OCICompletion(BaseLLM):
                     description=function_spec.get("description", name),
                     parameter_definitions=param_defs,
                 ))
+            elif self.oci_provider == "cohere_v2":
+                formatted.append(models.CohereToolV2(
+                    type="FUNCTION",
+                    function=models.Function(
+                        name=name,
+                        description=function_spec.get("description", name),
+                        parameters={
+                            "type": parameters.get("type", "object"),
+                            "properties": parameters.get("properties", {}),
+                            "required": parameters.get("required", []),
+                        },
+                    ),
+                ))
             else:
                 formatted.append(models.FunctionDefinition(
                     name=name,
@@ -561,7 +667,7 @@ class OCICompletion(BaseLLM):
             schema=schema_description["schema"],
             is_strict=schema_description["strict"],
         )
-        if self.oci_provider == "cohere":
+        if self.oci_provider in ("cohere", "cohere_v2"):
             return models.CohereResponseJsonFormat(schema=json_schema.schema)
         return models.JsonSchemaResponseFormat(json_schema=json_schema)
 
@@ -591,6 +697,11 @@ class OCICompletion(BaseLLM):
             }
             if tool_results:
                 request_kwargs["tool_results"] = tool_results
+        elif self.oci_provider == "cohere_v2":
+            request_kwargs = {
+                "messages": self._build_cohere_v2_messages(messages),
+                "api_format": models.BaseChatRequest.API_FORMAT_COHEREV2,
+            }
         else:
             request_kwargs = {
                 "messages": self._build_generic_messages(messages),
@@ -612,20 +723,25 @@ class OCICompletion(BaseLLM):
             request_kwargs["top_p"] = self.top_p
         if self.top_k is not None:
             request_kwargs["top_k"] = self.top_k
-        if self.reasoning_effort is not None:
+        if self.reasoning_effort is not None and self.oci_provider == "generic":
             request_kwargs["reasoning_effort"] = self.reasoning_effort
 
         if self.stop and not self._is_openai_gpt5_family():
-            stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"
+            stop_key = (
+                "stop_sequences"
+                if self.oci_provider in ("cohere", "cohere_v2")
+                else "stop"
+            )
             request_kwargs[stop_key] = list(self.stop)
 
         formatted_tools = self._format_tools(tools)
         if formatted_tools:
             request_kwargs["tools"] = formatted_tools
-            if self.oci_provider == "cohere":
+            if self.oci_provider in ("cohere", "cohere_v2"):
                 if self._parallel_tool_calls_enabled():
                     raise ValueError("OCI Cohere models do not support parallel_tool_calls.")
-                request_kwargs.setdefault("is_force_single_step", False)
+                if self.oci_provider == "cohere":
+                    request_kwargs.setdefault("is_force_single_step", False)
             else:
                 tool_choice = self._build_tool_choice()
                 if tool_choice is not None:
@@ -652,6 +768,15 @@ class OCICompletion(BaseLLM):
             request_kwargs.update(passthrough)
             return models.CohereChatRequest(**request_kwargs)
 
+        if self.oci_provider == "cohere_v2":
+            allowed = self._allowed_passthrough_request_keys(models.CohereChatRequestV2)
+            passthrough = {
+                k: v for k, v in self.additional_params.items()
+                if k not in _OCI_RESERVED_REQUEST_KWARGS and k in allowed
+            }
+            request_kwargs.update(passthrough)
+            return models.CohereChatRequestV2(**request_kwargs)
+
         allowed = self._allowed_passthrough_request_keys(models.GenericChatRequest)
         passthrough = {
             k: v for k, v in self.additional_params.items()
@@ -667,7 +792,7 @@ class OCICompletion(BaseLLM):
     def _extract_text(self, response: Any) -> str:
         """Pull the assistant text out of an OCI chat response, handling both Cohere and generic shapes."""
         chat_response = response.data.chat_response
-        if self.oci_provider == "cohere":
+        if self.oci_provider in ("cohere", "cohere_v2"):
             if getattr(chat_response, "text", None):
                 return chat_response.text or ""
             message = getattr(chat_response, "message", None)
@@ -693,6 +818,22 @@ class OCICompletion(BaseLLM):
         raw: list[Any] = []
         if self.oci_provider == "cohere":
             raw = getattr(chat_response, "tool_calls", None) or []
+        elif self.oci_provider == "cohere_v2":
+            message = getattr(chat_response, "message", None)
+            raw = getattr(message, "tool_calls", None) or []
+            return [
+                {
+                    "id": getattr(tc, "id", None) or uuid.uuid4().hex,
+                    "type": "function",
+                    "function": {
+                        "name": self._cohere_v2_function_field(tc, "name"),
+                        "arguments": self._cohere_v2_function_field(
+                            tc, "arguments", "{}"
+                        ),
+                    },
+                }
+                for tc in raw
+            ]
         else:
             choices = getattr(chat_response, "choices", None) or []
             if choices:
@@ -722,6 +863,17 @@ class OCICompletion(BaseLLM):
             }
             for tc in raw
         ]
+
+    @staticmethod
+    def _cohere_v2_function_field(tool_call: Any, field: str, default: str = "") -> str:
+        """Read ``name``/``arguments`` from a Cohere v2 tool call whose ``function`` may be an SDK object or a plain dict."""
+        function = getattr(tool_call, "function", None)
+        if isinstance(function, Mapping):
+            return str(function.get(field, default) or default)
+        value = getattr(function, field, None)
+        if value is None:
+            value = getattr(tool_call, field, None)
+        return str(value or default)
 
     def _extract_usage(self, response: Any) -> dict[str, int]:
         """Return ``{prompt_tokens, completion_tokens, total_tokens}`` from the OCI response, or an empty dict if unavailable."""
@@ -819,6 +971,17 @@ class OCICompletion(BaseLLM):
                 {"id": None, "type": "function", "function": {
                     "name": str(tc.get("name", "")),
                     "arguments": json.dumps(tc.get("parameters", {})),
+                }}
+                for tc in raw if isinstance(tc, Mapping)
+            ]
+        if self.oci_provider == "cohere_v2":
+            # Cohere v2 nests name/arguments under a `function` object.
+            return [
+                {"id": tc.get("id"), "type": "function", "function": {
+                    "name": (tc.get("function") or {}).get("name", tc.get("name")),
+                    "arguments": (tc.get("function") or {}).get(
+                        "arguments", tc.get("arguments", "{}")
+                    ),
                 }}
                 for tc in raw if isinstance(tc, Mapping)
             ]

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -301,7 +301,7 @@ class OCICompletion(BaseLLM):
 
             message_cls = role_map.get(role)
             if message_cls is None:
-                logging.debug("Skipping unsupported OCI message role: %s", role)
+                logging.warning("Skipping unsupported OCI message role: %s", role)
                 continue
 
             message_kwargs: dict[str, Any] = {
@@ -491,6 +491,10 @@ class OCICompletion(BaseLLM):
                             )
                         ]
                     )
+                )
+            else:
+                logging.warning(
+                    "Skipping unsupported OCI Cohere message role: %s", role
                 )
 
         last_message = messages[-1] if messages else {"role": "user", "content": ""}
@@ -1152,6 +1156,8 @@ class OCICompletion(BaseLLM):
         messages: list[LLMMessage],
         from_task: Task | None,
         from_agent: Agent | None,
+        usage: dict[str, Any] | None = None,
+        finish_reason: str | None = None,
     ) -> str:
         """Apply stop-word trimming and ``after_llm_call`` hooks, then emit the ``call_completed`` event."""
         content = self._apply_stop_words(content)
@@ -1162,6 +1168,8 @@ class OCICompletion(BaseLLM):
             from_task=from_task,
             from_agent=from_agent,
             messages=messages,
+            usage=usage,
+            finish_reason=finish_reason,
         )
         return content
 
@@ -1224,6 +1232,8 @@ class OCICompletion(BaseLLM):
             messages=messages,
             from_task=from_task,
             from_agent=from_agent,
+            usage=usage or None,
+            finish_reason=(self.last_response_metadata or {}).get("finish_reason"),
         )
 
     def _stream_call_impl(

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -14,7 +14,6 @@ from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
 from crewai.utilities.types import LLMMessage
 
-
 if TYPE_CHECKING:
     from crewai.agent.core import Agent
     from crewai.task import Task
@@ -44,13 +43,15 @@ class OCICompletion(BaseLLM):
         *,
         compartment_id: str | None = None,
         service_endpoint: str | None = None,
-        auth_type: Literal[
-            "API_KEY",
-            "SECURITY_TOKEN",
-            "INSTANCE_PRINCIPAL",
-            "RESOURCE_PRINCIPAL",
-        ]
-        | str = "API_KEY",
+        auth_type: (
+            Literal[
+                "API_KEY",
+                "SECURITY_TOKEN",
+                "INSTANCE_PRINCIPAL",
+                "RESOURCE_PRINCIPAL",
+            ]
+            | str
+        ) = "API_KEY",
         auth_profile: str | None = None,
         auth_file_location: str | None = None,
         temperature: float | None = None,
@@ -89,8 +90,7 @@ class OCICompletion(BaseLLM):
         )
         self.auth_file_location = cast(
             str,
-            auth_file_location
-            or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
+            auth_file_location or os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config"),
         )
         self.max_tokens = max_tokens
         self.top_p = top_p
@@ -139,9 +139,7 @@ class OCICompletion(BaseLLM):
     # Message helpers
     # ------------------------------------------------------------------
 
-    def _normalize_messages(
-        self, messages: str | list[LLMMessage]
-    ) -> list[LLMMessage]:
+    def _normalize_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         return self._format_messages(messages)
 
     def _coerce_text(self, content: Any) -> str:
@@ -265,7 +263,11 @@ class OCICompletion(BaseLLM):
         if self.temperature is not None and not self._is_openai_gpt5_family():
             request_kwargs["temperature"] = self.temperature
         if self.max_tokens is not None:
-            if self.oci_provider == "generic" and self.model.lower().startswith("openai."):
+            # OpenAI GPT-5 family on OCI rejects `max_tokens` and requires
+            # `max_completion_tokens` instead (verified live: HTTP 400
+            # `Invalid 'maxTokens': ... Use 'maxCompletionTokens' instead.`).
+            # GPT-4o / GPT-4.1 / Llama / Cohere keep using `max_tokens`.
+            if self._is_openai_gpt5_family():
                 request_kwargs["max_completion_tokens"] = self.max_tokens
             else:
                 request_kwargs["max_tokens"] = self.max_tokens
@@ -457,4 +459,3 @@ class OCICompletion(BaseLLM):
     def _chat(self, chat_details: Any) -> Any:
         with self._client_lock:
             return self.client.chat(chat_details)
-

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -58,6 +58,7 @@ class OCICompletion(BaseLLM):
         max_tokens: int | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        reasoning_effort: str | None = None,
         oci_provider: str | None = None,
         timeout: tuple[int, int] = DEFAULT_OCI_TIMEOUT,
         client: Any | None = None,
@@ -95,6 +96,10 @@ class OCICompletion(BaseLLM):
         self.max_tokens = max_tokens
         self.top_p = top_p
         self.top_k = top_k
+        # Reasoning-token budget: NONE / MINIMAL / LOW / MEDIUM / HIGH.
+        # Honoured by GPT-5 family, Gemini 2.5, Grok reasoning variants,
+        # Cohere Command-A-Reasoning. Ignored by non-reasoning models.
+        self.reasoning_effort = reasoning_effort
         self.oci_provider = oci_provider or self._infer_provider(model)
         self._oci = _get_oci_module()
 
@@ -275,6 +280,8 @@ class OCICompletion(BaseLLM):
             request_kwargs["top_p"] = self.top_p
         if self.top_k is not None:
             request_kwargs["top_k"] = self.top_k
+        if self.reasoning_effort is not None:
+            request_kwargs["reasoning_effort"] = self.reasoning_effort
 
         if self.stop and not self._is_openai_gpt5_family():
             stop_key = "stop_sequences" if self.oci_provider == "cohere" else "stop"

--- a/lib/crewai/src/crewai/llms/providers/oci/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/completion.py
@@ -14,6 +14,7 @@ from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
 from crewai.utilities.types import LLMMessage
 
+
 if TYPE_CHECKING:
     from crewai.agent.core import Agent
     from crewai.task import Task
@@ -64,6 +65,14 @@ class OCICompletion(BaseLLM):
         client: Any | None = None,
         **kwargs: Any,
     ) -> None:
+        """Configure the OCI Generative AI client and chat parameters.
+
+        Resolves compartment, service endpoint, and auth from explicit args
+        or `OCI_*` environment variables, then builds a
+        ``GenerativeAiInferenceClient`` (unless ``client`` is provided for
+        testing). Infers the OCI provider family (cohere vs generic) from
+        the model id when ``oci_provider`` is not given.
+        """
         kwargs.pop("provider", None)
         super().__init__(
             model=model,
@@ -125,6 +134,7 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _infer_provider(self, model: str) -> str:
+        """Infer the OCI request family (``cohere`` or ``generic``) from the model id."""
         if model.startswith(CUSTOM_ENDPOINT_PREFIX):
             return "generic"
         if model.lower().startswith("cohere."):
@@ -132,9 +142,11 @@ class OCICompletion(BaseLLM):
         return "generic"
 
     def _is_openai_gpt5_family(self) -> bool:
+        """Return True if the current model is in the OpenAI GPT-5 family."""
         return self.model.lower().startswith("openai.gpt-5")
 
     def _build_serving_mode(self) -> Any:
+        """Pick OCI serving mode: ``DedicatedServingMode`` for custom-endpoint OCIDs, ``OnDemandServingMode`` otherwise."""
         models = self._oci.generative_ai_inference.models
         if self.model.startswith(CUSTOM_ENDPOINT_PREFIX):
             return models.DedicatedServingMode(endpoint_id=self.model)
@@ -145,9 +157,11 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _normalize_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
+        """Coerce a string or message list into the canonical CrewAI message list shape."""
         return self._format_messages(messages)
 
     def _coerce_text(self, content: Any) -> str:
+        """Flatten mixed message content (str / list of parts / dicts with ``text``) into a plain string."""
         if content is None:
             return ""
         if isinstance(content, str):
@@ -296,6 +310,7 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _extract_text(self, response: Any) -> str:
+        """Pull the assistant text out of an OCI chat response, handling both Cohere and generic shapes."""
         chat_response = response.data.chat_response
         if self.oci_provider == "cohere":
             if getattr(chat_response, "text", None):
@@ -318,6 +333,7 @@ class OCICompletion(BaseLLM):
         return "".join(part.text for part in content if getattr(part, "text", None))
 
     def _extract_usage(self, response: Any) -> dict[str, int]:
+        """Return ``{prompt_tokens, completion_tokens, total_tokens}`` from the OCI response, or an empty dict if unavailable."""
         chat_response = response.data.chat_response
         usage = getattr(chat_response, "usage", None)
         if usage is None:
@@ -329,6 +345,7 @@ class OCICompletion(BaseLLM):
         }
 
     def _extract_response_metadata(self, response: Any) -> dict[str, Any]:
+        """Collect ``finish_reason`` and ``usage`` into a metadata dict for ``last_response_metadata``."""
         chat_response = response.data.chat_response
         metadata: dict[str, Any] = {}
 
@@ -359,6 +376,7 @@ class OCICompletion(BaseLLM):
         from_task: Task | None,
         from_agent: Agent | None,
     ) -> str:
+        """Apply stop-word trimming and ``after_llm_call`` hooks, then emit the ``call_completed`` event."""
         content = self._apply_stop_words(content)
         content = self._invoke_after_llm_call_hooks(messages, content, from_agent)
         self._emit_call_completed_event(
@@ -377,6 +395,7 @@ class OCICompletion(BaseLLM):
         from_task: Task | None,
         from_agent: Agent | None,
     ) -> str:
+        """Build the OCI chat request, invoke the service, record metadata, and return the finalized text."""
         chat_request = self._build_chat_request(messages)
         chat_details = self._oci.generative_ai_inference.models.ChatDetails(
             compartment_id=self.compartment_id,
@@ -407,6 +426,14 @@ class OCICompletion(BaseLLM):
         from_agent: Agent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | BaseModel | list[dict[str, Any]]:
+        """Run a synchronous chat completion against OCI Generative AI.
+
+        Emits ``call_started`` / ``call_completed`` / ``call_failed`` events
+        and runs the ``before_llm_call`` / ``after_llm_call`` hooks. Raises
+        ``ValueError`` if a ``before_llm_call`` hook blocks the call; any
+        other exception is wrapped with an ``OCI Generative AI call failed``
+        message and re-raised.
+        """
         with llm_call_context():
             try:
                 normalized_messages = self._normalize_messages(messages)
@@ -448,6 +475,7 @@ class OCICompletion(BaseLLM):
         from_agent: Agent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | Any:
+        """Async wrapper around :meth:`call` that runs the blocking OCI client in a worker thread."""
         return await asyncio.to_thread(
             self.call,
             messages,
@@ -464,5 +492,6 @@ class OCICompletion(BaseLLM):
     # ------------------------------------------------------------------
 
     def _chat(self, chat_details: Any) -> Any:
+        """Thread-safe wrapper around the underlying OCI ``client.chat`` call (the SDK client is not re-entrant)."""
         with self._client_lock:
             return self.client.chat(chat_details)

--- a/lib/crewai/src/crewai/llms/providers/oci/vision.py
+++ b/lib/crewai/src/crewai/llms/providers/oci/vision.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+
+
+VISION_MODELS: list[str] = [
+    "meta.llama-3.2-90b-vision-instruct",
+    "meta.llama-3.2-11b-vision-instruct",
+    "meta.llama-4-scout-17b-16e-instruct",
+    "meta.llama-4-maverick-17b-128e-instruct-fp8",
+    "google.gemini-2.5-flash",
+    "google.gemini-2.5-pro",
+    "google.gemini-2.5-flash-lite",
+    "xai.grok-4",
+    "xai.grok-4-1-fast-reasoning",
+    "xai.grok-4-1-fast-non-reasoning",
+    "xai.grok-4-fast-reasoning",
+    "xai.grok-4-fast-non-reasoning",
+    "cohere.command-a-vision",
+]
+
+IMAGE_EMBEDDING_MODELS: list[str] = [
+    "cohere.embed-v4.0",
+    "cohere.embed-multilingual-image-v3.0",
+]
+
+
+def to_data_uri(image: str | bytes | Path, mime_type: str = "image/png") -> str:
+    """Convert bytes, file paths, or data URIs into a data URI."""
+    if isinstance(image, bytes):
+        encoded = base64.standard_b64encode(image).decode("utf-8")
+        return f"data:{mime_type};base64,{encoded}"
+
+    image_str = str(image)
+    if image_str.startswith("data:"):
+        return image_str
+
+    path = Path(image_str)
+    detected_mime = mimetypes.guess_type(str(path))[0] or mime_type
+    encoded = base64.standard_b64encode(path.read_bytes()).decode("utf-8")
+    return f"data:{detected_mime};base64,{encoded}"
+
+
+def load_image(file_path: str | Path) -> dict[str, dict[str, str] | str]:
+    return {"type": "image_url", "image_url": {"url": to_data_uri(file_path)}}
+
+
+def encode_image(
+    image_bytes: bytes, mime_type: str = "image/png"
+) -> dict[str, dict[str, str] | str]:
+    return {"type": "image_url", "image_url": {"url": to_data_uri(image_bytes, mime_type)}}
+
+
+def is_vision_model(model_id: str) -> bool:
+    return model_id in VISION_MODELS

--- a/lib/crewai/src/crewai/rag/embeddings/factory.py
+++ b/lib/crewai/src/crewai/rag/embeddings/factory.py
@@ -70,6 +70,10 @@ if TYPE_CHECKING:
     from crewai.rag.embeddings.providers.instructor.types import InstructorProviderSpec
     from crewai.rag.embeddings.providers.jina.types import JinaProviderSpec
     from crewai.rag.embeddings.providers.microsoft.types import AzureProviderSpec
+    from crewai.rag.embeddings.providers.oci.embedding_callable import (
+        OCIEmbeddingFunction,
+    )
+    from crewai.rag.embeddings.providers.oci.types import OCIProviderSpec
     from crewai.rag.embeddings.providers.ollama.types import OllamaProviderSpec
     from crewai.rag.embeddings.providers.onnx.types import ONNXProviderSpec
     from crewai.rag.embeddings.providers.openai.types import OpenAIProviderSpec
@@ -99,6 +103,7 @@ PROVIDER_PATHS = {
     "instructor": "crewai.rag.embeddings.providers.instructor.instructor_provider.InstructorProvider",
     "jina": "crewai.rag.embeddings.providers.jina.jina_provider.JinaProvider",
     "ollama": "crewai.rag.embeddings.providers.ollama.ollama_provider.OllamaProvider",
+    "oci": "crewai.rag.embeddings.providers.oci.oci_provider.OCIProvider",
     "onnx": "crewai.rag.embeddings.providers.onnx.onnx_provider.ONNXProvider",
     "openai": "crewai.rag.embeddings.providers.openai.openai_provider.OpenAIProvider",
     "openclip": "crewai.rag.embeddings.providers.openclip.openclip_provider.OpenCLIPProvider",
@@ -214,6 +219,10 @@ def build_embedder_from_dict(
 
 @overload
 def build_embedder_from_dict(spec: ONNXProviderSpec) -> ONNXMiniLM_L6_V2: ...
+
+
+@overload
+def build_embedder_from_dict(spec: OCIProviderSpec) -> OCIEmbeddingFunction: ...
 
 
 @overload

--- a/lib/crewai/src/crewai/rag/embeddings/providers/oci/__init__.py
+++ b/lib/crewai/src/crewai/rag/embeddings/providers/oci/__init__.py
@@ -1,0 +1,17 @@
+"""OCI embedding provider exports."""
+
+from crewai.rag.embeddings.providers.oci.embedding_callable import (
+    OCIEmbeddingFunction,
+)
+from crewai.rag.embeddings.providers.oci.oci_provider import OCIProvider
+from crewai.rag.embeddings.providers.oci.types import (
+    OCIProviderConfig,
+    OCIProviderSpec,
+)
+
+__all__ = [
+    "OCIEmbeddingFunction",
+    "OCIProvider",
+    "OCIProviderConfig",
+    "OCIProviderSpec",
+]

--- a/lib/crewai/src/crewai/rag/embeddings/providers/oci/embedding_callable.py
+++ b/lib/crewai/src/crewai/rag/embeddings/providers/oci/embedding_callable.py
@@ -1,0 +1,181 @@
+"""OCI embedding function implementation."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator, Sequence
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, cast
+
+from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+from typing_extensions import Unpack
+
+from crewai.rag.embeddings.providers.oci.types import OCIProviderConfig
+from crewai.utilities.oci import create_oci_client_kwargs, get_oci_module
+
+
+CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
+DEFAULT_OCI_REGION = "us-chicago-1"
+
+
+def _get_oci_module() -> Any:
+    """Backward-compatible module-local alias used by tests and patches."""
+    return get_oci_module()
+
+
+class OCIEmbeddingFunction(EmbeddingFunction[Documents]):
+    """Embedding function for OCI Generative AI embedding models."""
+
+    def __init__(self, **kwargs: Unpack[OCIProviderConfig]) -> None:
+        self._config = kwargs
+        self._client: Any = kwargs.get("client")
+        if self._client is None:
+            service_endpoint = kwargs.get("service_endpoint")
+            region = kwargs.get("region") or os.getenv("OCI_REGION", DEFAULT_OCI_REGION)
+            if service_endpoint is None:
+                service_endpoint = (
+                    f"https://inference.generativeai.{region}.oci.oraclecloud.com"
+                )
+
+            client_kwargs = create_oci_client_kwargs(
+                auth_type=kwargs.get("auth_type", "API_KEY"),
+                service_endpoint=service_endpoint,
+                auth_file_location=kwargs.get("auth_file_location", "~/.oci/config"),
+                auth_profile=kwargs.get("auth_profile", "DEFAULT"),
+                timeout=kwargs.get("timeout", (10, 120)),
+                oci_module=_get_oci_module(),
+            )
+            self._client = (
+                _get_oci_module().generative_ai_inference.GenerativeAiInferenceClient(
+                    **client_kwargs
+                )
+            )
+
+    def _require_client(self) -> Any:
+        if self._client is None:
+            raise ValueError("OCI embedding client is not initialized.")
+        return self._client
+
+    @staticmethod
+    def name() -> str:
+        return "oci"
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> OCIEmbeddingFunction:
+        timeout = config.get("timeout")
+        if isinstance(timeout, list):
+            config = dict(config)
+            config["timeout"] = tuple(timeout)
+        return OCIEmbeddingFunction(**config)
+
+    def get_config(self) -> dict[str, Any]:
+        config = dict(self._config)
+        config.pop("client", None)
+        timeout = config.get("timeout")
+        if isinstance(timeout, tuple):
+            config["timeout"] = list(timeout)
+        return config
+
+    def _get_serving_mode(self) -> Any:
+        oci = _get_oci_module()
+        model_name = self._config.get("model_name")
+        if not model_name:
+            raise ValueError("OCI embeddings require model_name")
+        if model_name.startswith(CUSTOM_ENDPOINT_PREFIX):
+            return oci.generative_ai_inference.models.DedicatedServingMode(
+                endpoint_id=model_name
+            )
+        return oci.generative_ai_inference.models.OnDemandServingMode(
+            model_id=model_name
+        )
+
+    def _build_request(
+        self, inputs: list[str], *, input_type: str | None = None
+    ) -> Any:
+        oci = _get_oci_module()
+        compartment_id = self._config.get("compartment_id") or os.getenv(
+            "OCI_COMPARTMENT_ID"
+        )
+        if not compartment_id:
+            raise ValueError(
+                "OCI embeddings require compartment_id. Set it explicitly or use OCI_COMPARTMENT_ID."
+            )
+
+        request_kwargs: dict[str, Any] = {
+            "serving_mode": self._get_serving_mode(),
+            "compartment_id": compartment_id,
+            "truncate": self._config.get("truncate", "END"),
+            "inputs": inputs,
+        }
+
+        resolved_input_type = input_type or self._config.get("input_type")
+        if resolved_input_type:
+            request_kwargs["input_type"] = resolved_input_type
+
+        output_dimensions = self._config.get("output_dimensions")
+        if output_dimensions is not None:
+            embed_text_details = oci.generative_ai_inference.models.EmbedTextDetails
+            if hasattr(embed_text_details, "output_dimensions"):
+                request_kwargs["output_dimensions"] = output_dimensions
+            else:
+                raise ValueError(
+                    "output_dimensions requires a newer OCI SDK. Upgrade the oci package."
+                )
+
+        return oci.generative_ai_inference.models.EmbedTextDetails(**request_kwargs)
+
+    def _batch_inputs(self, input: list[str]) -> Iterator[list[str]]:
+        batch_size = self._config.get("batch_size", 96)
+        for index in range(0, len(input), batch_size):
+            yield input[index : index + batch_size]
+
+    @staticmethod
+    def _to_data_uri(image: str | bytes | Path, mime_type: str = "image/png") -> str:
+        if isinstance(image, Path):
+            resolved_mime = mimetypes.guess_type(image.name)[0] or mime_type
+            data = image.read_bytes()
+            return (
+                f"data:{resolved_mime};base64,"
+                f"{base64.b64encode(data).decode('ascii')}"
+            )
+        if isinstance(image, bytes):
+            return f"data:{mime_type};base64,{base64.b64encode(image).decode('ascii')}"
+        if image.startswith("data:"):
+            return image
+        path = Path(image)
+        if path.exists():
+            return OCIEmbeddingFunction._to_data_uri(path, mime_type=mime_type)
+        raise ValueError(
+            "OCI image embeddings require a file path, raw bytes, or a data URI."
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        if isinstance(input, str):
+            input = [input]
+        embeddings: Embeddings = []
+        for chunk in self._batch_inputs(input):
+            response = self._require_client().embed_text(self._build_request(chunk))
+            embeddings.extend(cast(Embeddings, response.data.embeddings))
+        return embeddings
+
+    def embed_image(
+        self, image: str | bytes | Path, *, mime_type: str = "image/png"
+    ) -> list[float]:
+        return [
+            float(value)
+            for value in self.embed_image_batch([image], mime_type=mime_type)[0]
+        ]
+
+    def embed_image_batch(
+        self, images: Sequence[str | bytes | Path], *, mime_type: str = "image/png"
+    ) -> Embeddings:
+        embeddings: Embeddings = []
+        for image in images:
+            data_uri = self._to_data_uri(image, mime_type=mime_type)
+            response = self._require_client().embed_text(
+                self._build_request([data_uri], input_type="IMAGE")
+            )
+            embeddings.extend(cast(Embeddings, response.data.embeddings))
+        return embeddings

--- a/lib/crewai/src/crewai/rag/embeddings/providers/oci/oci_provider.py
+++ b/lib/crewai/src/crewai/rag/embeddings/providers/oci/oci_provider.py
@@ -1,0 +1,75 @@
+"""OCI embeddings provider."""
+
+from typing import Any
+
+from pydantic import AliasChoices, Field
+
+from crewai.rag.core.base_embeddings_provider import BaseEmbeddingsProvider
+from crewai.rag.embeddings.providers.oci.embedding_callable import OCIEmbeddingFunction
+
+
+class OCIProvider(BaseEmbeddingsProvider[OCIEmbeddingFunction]):
+    """OCI Generative AI embeddings provider."""
+
+    embedding_callable: type[OCIEmbeddingFunction] = Field(
+        default=OCIEmbeddingFunction,
+        description="OCI embedding function class",
+    )
+    model_name: str = Field(
+        default="cohere.embed-english-v3.0",
+        description="Model name to use for embeddings",
+        validation_alias=AliasChoices(
+            "EMBEDDINGS_OCI_MODEL_NAME", "OCI_EMBED_MODEL", "model", "model_name",
+        ),
+    )
+    compartment_id: str = Field(
+        description="OCI compartment ID",
+        validation_alias=AliasChoices(
+            "EMBEDDINGS_OCI_COMPARTMENT_ID", "OCI_COMPARTMENT_ID", "compartment_id",
+        ),
+    )
+    service_endpoint: str | None = Field(
+        default=None,
+        description="OCI Generative AI inference endpoint",
+        validation_alias=AliasChoices(
+            "EMBEDDINGS_OCI_SERVICE_ENDPOINT", "OCI_SERVICE_ENDPOINT", "service_endpoint",
+        ),
+    )
+    region: str | None = Field(
+        default=None,
+        description="OCI region for endpoint derivation",
+        validation_alias=AliasChoices(
+            "EMBEDDINGS_OCI_REGION", "OCI_REGION", "region",
+        ),
+    )
+    auth_type: str = Field(
+        default="API_KEY",
+        description="OCI SDK auth type",
+        validation_alias=AliasChoices("EMBEDDINGS_OCI_AUTH_TYPE", "OCI_AUTH_TYPE"),
+    )
+    auth_profile: str = Field(
+        default="DEFAULT",
+        description="OCI config profile name",
+        validation_alias=AliasChoices("EMBEDDINGS_OCI_AUTH_PROFILE", "OCI_AUTH_PROFILE"),
+    )
+    auth_file_location: str = Field(
+        default="~/.oci/config",
+        description="OCI config file location",
+        validation_alias=AliasChoices(
+            "EMBEDDINGS_OCI_AUTH_FILE_LOCATION", "OCI_AUTH_FILE_LOCATION",
+        ),
+    )
+    truncate: str = Field(default="END", description="OCI embedding truncate policy")
+    input_type: str | None = Field(
+        default=None,
+        description="Optional OCI embedding input type such as SEARCH_DOCUMENT or SEARCH_QUERY",
+    )
+    output_dimensions: int | None = Field(
+        default=None,
+        description="Optional output dimensions for compatible OCI embedding models",
+    )
+    batch_size: int = Field(default=96, description="OCI embedding batch size")
+    timeout: tuple[int, int] = Field(
+        default=(10, 120), description="OCI SDK connect/read timeout"
+    )
+    client: Any | None = Field(default=None, description="Injected OCI client")

--- a/lib/crewai/src/crewai/rag/embeddings/providers/oci/types.py
+++ b/lib/crewai/src/crewai/rag/embeddings/providers/oci/types.py
@@ -1,0 +1,30 @@
+"""Type definitions for OCI embedding providers."""
+
+from typing import Annotated, Any, Literal
+
+from typing_extensions import Required, TypedDict
+
+
+class OCIProviderConfig(TypedDict, total=False):
+    """Configuration for OCI embedding provider."""
+
+    model_name: Annotated[str, "cohere.embed-english-v3.0"]
+    compartment_id: str
+    service_endpoint: str
+    region: str
+    auth_type: str
+    auth_profile: str
+    auth_file_location: str
+    truncate: str
+    input_type: str
+    output_dimensions: int
+    batch_size: int
+    timeout: tuple[int, int]
+    client: Any
+
+
+class OCIProviderSpec(TypedDict, total=False):
+    """OCI provider specification."""
+
+    provider: Required[Literal["oci"]]
+    config: OCIProviderConfig

--- a/lib/crewai/src/crewai/rag/embeddings/types.py
+++ b/lib/crewai/src/crewai/rag/embeddings/types.py
@@ -17,6 +17,7 @@ from crewai.rag.embeddings.providers.ibm.types import (
 from crewai.rag.embeddings.providers.instructor.types import InstructorProviderSpec
 from crewai.rag.embeddings.providers.jina.types import JinaProviderSpec
 from crewai.rag.embeddings.providers.microsoft.types import AzureProviderSpec
+from crewai.rag.embeddings.providers.oci.types import OCIProviderSpec
 from crewai.rag.embeddings.providers.ollama.types import OllamaProviderSpec
 from crewai.rag.embeddings.providers.onnx.types import ONNXProviderSpec
 from crewai.rag.embeddings.providers.openai.types import OpenAIProviderSpec
@@ -39,6 +40,7 @@ ProviderSpec: TypeAlias = (
     | InstructorProviderSpec
     | JinaProviderSpec
     | OllamaProviderSpec
+    | OCIProviderSpec
     | ONNXProviderSpec
     | OpenAIProviderSpec
     | OpenCLIPProviderSpec
@@ -61,6 +63,7 @@ AllowedEmbeddingProviders = Literal[
     "instructor",
     "jina",
     "ollama",
+    "oci",
     "onnx",
     "openai",
     "openclip",

--- a/lib/crewai/src/crewai/utilities/oci.py
+++ b/lib/crewai/src/crewai/utilities/oci.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_oci_module() -> Any:
+    """Import the OCI SDK lazily for optional CrewAI OCI integrations."""
+    try:
+        import oci  # type: ignore[import-untyped]
+    except ImportError:
+        raise ImportError(
+            'OCI support is not available, to install: uv add "crewai[oci]"'
+        ) from None
+    return oci
+
+
+def create_oci_client_kwargs(
+    *,
+    auth_type: str,
+    service_endpoint: str | None,
+    auth_file_location: str,
+    auth_profile: str,
+    timeout: tuple[int, int],
+    oci_module: Any | None = None,
+) -> dict[str, Any]:
+    """Build OCI SDK client kwargs for the supported auth modes."""
+    oci = oci_module or get_oci_module()
+    client_kwargs: dict[str, Any] = {
+        "config": {},
+        "service_endpoint": service_endpoint,
+        "retry_strategy": oci.retry.DEFAULT_RETRY_STRATEGY,
+        "timeout": timeout,
+    }
+
+    auth_type_upper = auth_type.upper()
+    if auth_type_upper == "API_KEY":
+        client_kwargs["config"] = oci.config.from_file(
+            file_location=auth_file_location,
+            profile_name=auth_profile,
+        )
+    elif auth_type_upper == "SECURITY_TOKEN":
+        config = oci.config.from_file(
+            file_location=auth_file_location,
+            profile_name=auth_profile,
+        )
+        key_file = config["key_file"]
+        security_token_file = config["security_token_file"]
+        private_key = oci.signer.load_private_key_from_file(key_file, None)
+        with open(security_token_file, encoding="utf-8") as file:
+            security_token = file.read()
+        client_kwargs["config"] = config
+        client_kwargs["signer"] = oci.auth.signers.SecurityTokenSigner(
+            security_token, private_key
+        )
+    elif auth_type_upper == "INSTANCE_PRINCIPAL":
+        client_kwargs["signer"] = (
+            oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+        )
+    elif auth_type_upper == "RESOURCE_PRINCIPAL":
+        client_kwargs["signer"] = oci.auth.signers.get_resource_principals_signer()
+    else:
+        valid_types = [
+            "API_KEY",
+            "SECURITY_TOKEN",
+            "INSTANCE_PRINCIPAL",
+            "RESOURCE_PRINCIPAL",
+        ]
+        raise ValueError(
+            f"Invalid OCI auth_type '{auth_type}'. Valid values: {valid_types}"
+        )
+
+    return client_kwargs

--- a/lib/crewai/tests/llms/oci/conftest.py
+++ b/lib/crewai/tests/llms/oci/conftest.py
@@ -1,0 +1,189 @@
+"""Fixtures for OCI provider unit and integration tests."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake OCI SDK module (replaces `import oci` in unit tests)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_oci_module() -> MagicMock:
+    """Build a lightweight mock of the OCI SDK surface used by OCICompletion."""
+    oci = MagicMock()
+
+    # Models namespace
+    models = oci.generative_ai_inference.models
+
+    # Serving modes
+    models.OnDemandServingMode = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.DedicatedServingMode = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Content types
+    models.TextContent = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Message types
+    for cls_name in (
+        "UserMessage",
+        "AssistantMessage",
+        "SystemMessage",
+        "CohereUserMessage",
+        "CohereSystemMessage",
+        "CohereChatBotMessage",
+    ):
+        setattr(models, cls_name, MagicMock(side_effect=lambda **kw: MagicMock(**kw)))
+
+    # Request types
+    models.GenericChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.CohereChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.BaseChatRequest = MagicMock()
+    models.BaseChatRequest.API_FORMAT_GENERIC = "GENERIC"
+    models.BaseChatRequest.API_FORMAT_COHERE = "COHERE"
+
+    # ChatDetails
+    models.ChatDetails = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+
+    # Auth helpers
+    oci.config.from_file = MagicMock(return_value={"key_file": "/tmp/k", "security_token_file": "/tmp/t"})
+    oci.signer.load_private_key_from_file = MagicMock(return_value="pk")
+    oci.auth.signers.SecurityTokenSigner = MagicMock()
+    oci.auth.signers.InstancePrincipalsSecurityTokenSigner = MagicMock()
+    oci.auth.signers.get_resource_principals_signer = MagicMock()
+    oci.retry.DEFAULT_RETRY_STRATEGY = "default_retry"
+
+    # Client constructor
+    oci.generative_ai_inference.GenerativeAiInferenceClient = MagicMock()
+
+    return oci
+
+
+def _make_fake_chat_response(text: str = "Hello from OCI") -> MagicMock:
+    """Build a minimal OCI chat response for generic models."""
+    text_part = MagicMock()
+    text_part.text = text
+
+    message = MagicMock()
+    message.content = [text_part]
+    message.tool_calls = None
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    usage.total_tokens = 15
+    chat_response.usage = usage
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def _make_fake_cohere_chat_response(text: str = "Hello from Cohere") -> MagicMock:
+    """Build a minimal OCI chat response for Cohere models."""
+    chat_response = MagicMock()
+    chat_response.text = text
+    chat_response.finish_reason = "COMPLETE"
+    chat_response.tool_calls = None
+
+    usage = MagicMock()
+    usage.prompt_tokens = 8
+    usage.completion_tokens = 4
+    usage.total_tokens = 12
+    chat_response.usage = usage
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+@pytest.fixture()
+def oci_fake_module() -> MagicMock:
+    return _make_fake_oci_module()
+
+
+@pytest.fixture()
+def patch_oci_module(monkeypatch: pytest.MonkeyPatch, oci_fake_module: MagicMock) -> MagicMock:
+    """Patch the OCI module import so no real SDK is needed."""
+    monkeypatch.setattr(
+        "crewai.llms.providers.oci.completion._get_oci_module",
+        lambda: oci_fake_module,
+    )
+    return oci_fake_module
+
+
+@pytest.fixture()
+def oci_response_factories() -> dict[str, Any]:
+    return {
+        "chat": _make_fake_chat_response,
+        "cohere_chat": _make_fake_cohere_chat_response,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit test defaults
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def oci_unit_values() -> dict[str, str]:
+    return {
+        "compartment_id": "ocid1.compartment.oc1..test",
+        "model": "meta.llama-3.3-70b-instruct",
+        "cohere_model": "cohere.command-r-plus-08-2024",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration test fixtures (live OCI calls)
+# ---------------------------------------------------------------------------
+
+def _env_models(env_var: str, fallback_var: str, default: str) -> list[str]:
+    """Read model list from env, supporting comma-separated values."""
+    raw = os.getenv(env_var) or os.getenv(fallback_var) or default
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _skip_unless_live_config() -> dict[str, str]:
+    """Return live config dict or skip the test."""
+    compartment = os.getenv("OCI_COMPARTMENT_ID")
+    if not compartment:
+        pytest.skip("OCI_COMPARTMENT_ID not set — skipping live test")
+    region = os.getenv("OCI_REGION")
+    endpoint = os.getenv("OCI_SERVICE_ENDPOINT")
+    if not region and not endpoint:
+        pytest.skip("Set OCI_REGION or OCI_SERVICE_ENDPOINT for live tests")
+    config: dict[str, str] = {"compartment_id": compartment}
+    if endpoint:
+        config["service_endpoint"] = endpoint
+    if os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
+    if os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+    if os.getenv("OCI_AUTH_FILE_LOCATION"):
+        config["auth_file_location"] = os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config")
+    return config
+
+
+@pytest.fixture(
+    params=_env_models("OCI_TEST_MODELS", "OCI_TEST_MODEL", "meta.llama-3.3-70b-instruct"),
+    ids=lambda m: m,
+)
+def oci_chat_model(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def oci_live_config() -> dict[str, str]:
+    return _skip_unless_live_config()

--- a/lib/crewai/tests/llms/oci/conftest.py
+++ b/lib/crewai/tests/llms/oci/conftest.py
@@ -167,12 +167,12 @@ def _skip_unless_live_config() -> dict[str, str]:
     config: dict[str, str] = {"compartment_id": compartment}
     if endpoint:
         config["service_endpoint"] = endpoint
-    if os.getenv("OCI_AUTH_TYPE"):
-        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
-    if os.getenv("OCI_AUTH_PROFILE"):
-        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
-    if os.getenv("OCI_AUTH_FILE_LOCATION"):
-        config["auth_file_location"] = os.getenv("OCI_AUTH_FILE_LOCATION", "~/.oci/config")
+    if auth_type := os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = auth_type
+    if auth_profile := os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = auth_profile
+    if auth_file_location := os.getenv("OCI_AUTH_FILE_LOCATION"):
+        config["auth_file_location"] = auth_file_location
     return config
 
 

--- a/lib/crewai/tests/llms/oci/conftest.py
+++ b/lib/crewai/tests/llms/oci/conftest.py
@@ -36,15 +36,27 @@ def _make_fake_oci_module() -> MagicMock:
         "CohereUserMessage",
         "CohereSystemMessage",
         "CohereChatBotMessage",
+        "CohereUserMessageV2",
+        "CohereSystemMessageV2",
+        "CohereAssistantMessageV2",
+        "CohereToolMessageV2",
+        "CohereTextContentV2",
+        "CohereImageContentV2",
+        "CohereImageUrlV2",
+        "CohereToolCallV2",
+        "CohereToolV2",
+        "Function",
     ):
         setattr(models, cls_name, MagicMock(side_effect=lambda **kw: MagicMock(**kw)))
 
     # Request types
     models.GenericChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
     models.CohereChatRequest = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    models.CohereChatRequestV2 = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
     models.BaseChatRequest = MagicMock()
     models.BaseChatRequest.API_FORMAT_GENERIC = "GENERIC"
     models.BaseChatRequest.API_FORMAT_COHERE = "COHERE"
+    models.BaseChatRequest.API_FORMAT_COHEREV2 = "COHEREV2"
 
     # ChatDetails
     models.ChatDetails = MagicMock(side_effect=lambda **kw: MagicMock(**kw))

--- a/lib/crewai/tests/llms/oci/test_oci.py
+++ b/lib/crewai/tests/llms/oci/test_oci.py
@@ -1,0 +1,269 @@
+"""Unit tests for the OCI Generative AI provider (mocked SDK)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Provider routing
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_is_used_when_oci_provider(patch_oci_module):
+    """LLM(model='oci/...') should resolve to OCICompletion."""
+    from crewai.llm import LLM
+
+    fake_client = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+    llm = LLM(
+        model="oci/meta.llama-3.3-70b-instruct",
+        compartment_id="ocid1.compartment.oc1..test",
+    )
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    # LLM.__new__ returns the native provider instance directly
+    assert isinstance(llm, OCICompletion)
+
+
+@pytest.mark.parametrize(
+    "model_id, expected_provider",
+    [
+        ("meta.llama-3.3-70b-instruct", "generic"),
+        ("google.gemini-2.5-flash", "generic"),
+        ("openai.gpt-4o", "generic"),
+        ("xai.grok-3", "generic"),
+        ("cohere.command-r-plus-08-2024", "cohere"),
+    ],
+)
+def test_oci_completion_infers_provider_family(
+    patch_oci_module, oci_unit_values, model_id, expected_provider
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=model_id,
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm.oci_provider == expected_provider
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_values):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        temperature=0.7,
+        max_tokens=512,
+        top_p=0.9,
+        top_k=40,
+    )
+    assert llm.temperature == 0.7
+    assert llm.max_tokens == 512
+    assert llm.top_p == 0.9
+    assert llm.top_k == 40
+    assert llm.compartment_id == oci_unit_values["compartment_id"]
+
+
+def test_oci_completion_uses_region_to_build_endpoint(patch_oci_module, oci_unit_values, monkeypatch):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    monkeypatch.delenv("OCI_SERVICE_ENDPOINT", raising=False)
+    monkeypatch.setenv("OCI_REGION", "us-ashburn-1")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert "us-ashburn-1" in llm.service_endpoint
+
+
+# ---------------------------------------------------------------------------
+# Basic call
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_call_uses_chat_api(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]("test response")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(messages=[{"role": "user", "content": "Say hello"}])
+
+    assert "test response" in result
+    fake_client.chat.assert_called_once()
+
+
+def test_oci_completion_cohere_call(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["cohere_chat"]("cohere reply")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(messages=[{"role": "user", "content": "Hi"}])
+
+    assert "cohere reply" in result
+    fake_client.chat.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Message normalization
+# ---------------------------------------------------------------------------
+
+
+def test_oci_completion_treats_none_content_as_empty_text(
+    patch_oci_module, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm._coerce_text(None) == ""
+
+
+def test_oci_completion_call_normalizes_messages_once(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    """Ensure normalize is not called twice when _call_impl receives a list."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    call_count = 0
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    original_normalize = llm._normalize_messages
+
+    def counting_normalize(msgs):
+        nonlocal call_count
+        call_count += 1
+        return original_normalize(msgs)
+
+    llm._normalize_messages = counting_normalize
+
+    llm.call(messages=[{"role": "user", "content": "hi"}])
+    # call() normalizes once, _call_impl should not normalize again
+    assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# OpenAI model quirks
+# ---------------------------------------------------------------------------
+
+
+def test_oci_openai_models_use_max_completion_tokens(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-4o",
+        compartment_id=oci_unit_values["compartment_id"],
+        max_tokens=1024,
+    )
+    request = llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args
+    assert call_kwargs is not None
+    kwargs = call_kwargs[1] if call_kwargs[1] else {}
+    assert kwargs.get("max_completion_tokens") == 1024
+    assert "max_tokens" not in kwargs
+
+
+def test_oci_openai_gpt5_omits_unsupported_temperature_and_stop(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-5",
+        compartment_id=oci_unit_values["compartment_id"],
+        temperature=0.5,
+    )
+    llm.stop = ["END"]
+    llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args[1]
+    assert "temperature" not in call_kwargs
+    assert "stop" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oci_completion_acall_delegates_to_call(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]("async result")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = await llm.acall(messages=[{"role": "user", "content": "async test"}])
+
+    assert "async result" in result

--- a/lib/crewai/tests/llms/oci/test_oci.py
+++ b/lib/crewai/tests/llms/oci/test_oci.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Provider routing
 # ---------------------------------------------------------------------------
@@ -45,7 +44,9 @@ def test_oci_completion_infers_provider_family(
 ):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=model_id,
         compartment_id=oci_unit_values["compartment_id"],
@@ -61,7 +62,9 @@ def test_oci_completion_infers_provider_family(
 def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_values):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=oci_unit_values["model"],
         compartment_id=oci_unit_values["compartment_id"],
@@ -77,12 +80,16 @@ def test_oci_completion_initialization_parameters(patch_oci_module, oci_unit_val
     assert llm.compartment_id == oci_unit_values["compartment_id"]
 
 
-def test_oci_completion_uses_region_to_build_endpoint(patch_oci_module, oci_unit_values, monkeypatch):
+def test_oci_completion_uses_region_to_build_endpoint(
+    patch_oci_module, oci_unit_values, monkeypatch
+):
     from crewai.llms.providers.oci.completion import OCICompletion
 
     monkeypatch.delenv("OCI_SERVICE_ENDPOINT", raising=False)
     monkeypatch.setenv("OCI_REGION", "us-ashburn-1")
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
 
     llm = OCICompletion(
         model=oci_unit_values["model"],
@@ -123,7 +130,9 @@ def test_oci_completion_cohere_call(
     from crewai.llms.providers.oci.completion import OCICompletion
 
     fake_client = MagicMock()
-    fake_client.chat.return_value = oci_response_factories["cohere_chat"]("cohere reply")
+    fake_client.chat.return_value = oci_response_factories["cohere_chat"](
+        "cohere reply"
+    )
     patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
         fake_client
     )
@@ -148,7 +157,9 @@ def test_oci_completion_treats_none_content_as_empty_text(
 ):
     from crewai.llms.providers.oci.completion import OCICompletion
 
-    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
     llm = OCICompletion(
         model=oci_unit_values["model"],
         compartment_id=oci_unit_values["compartment_id"],
@@ -192,9 +203,44 @@ def test_oci_completion_call_normalizes_messages_once(
 # ---------------------------------------------------------------------------
 
 
-def test_oci_openai_models_use_max_completion_tokens(
+def test_oci_gpt5_family_uses_max_completion_tokens(
     patch_oci_module, oci_response_factories, oci_unit_values
 ):
+    """GPT-5 family on OCI rejects `max_tokens` and requires `max_completion_tokens`.
+
+    Verified live against OCI us-chicago-1: passing `max_tokens` to
+    openai.gpt-5* returns HTTP 400 with the message
+    ``Invalid 'maxTokens': ... Use 'maxCompletionTokens' instead.``.
+    Other openai.* models (gpt-4o, gpt-4.1) and non-openai models
+    continue to use ``max_tokens``.
+    """
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = oci_response_factories["chat"]()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    llm = OCICompletion(
+        model="openai.gpt-5.5",
+        compartment_id=oci_unit_values["compartment_id"],
+        max_tokens=1024,
+    )
+    llm._build_chat_request([{"role": "user", "content": "test"}])
+
+    models = patch_oci_module.generative_ai_inference.models
+    call_kwargs = models.GenericChatRequest.call_args
+    assert call_kwargs is not None
+    kwargs = call_kwargs[1] if call_kwargs[1] else {}
+    assert kwargs.get("max_completion_tokens") == 1024
+    assert "max_tokens" not in kwargs
+
+
+def test_oci_openai_gpt4o_keeps_max_tokens(
+    patch_oci_module, oci_response_factories, oci_unit_values
+):
+    """GPT-4o (and other non-GPT-5 OpenAI models) on OCI accept `max_tokens`."""
     from crewai.llms.providers.oci.completion import OCICompletion
 
     fake_client = MagicMock()
@@ -208,14 +254,14 @@ def test_oci_openai_models_use_max_completion_tokens(
         compartment_id=oci_unit_values["compartment_id"],
         max_tokens=1024,
     )
-    request = llm._build_chat_request([{"role": "user", "content": "test"}])
+    llm._build_chat_request([{"role": "user", "content": "test"}])
 
     models = patch_oci_module.generative_ai_inference.models
     call_kwargs = models.GenericChatRequest.call_args
     assert call_kwargs is not None
     kwargs = call_kwargs[1] if call_kwargs[1] else {}
-    assert kwargs.get("max_completion_tokens") == 1024
-    assert "max_tokens" not in kwargs
+    assert kwargs.get("max_tokens") == 1024
+    assert "max_completion_tokens" not in kwargs
 
 
 def test_oci_openai_gpt5_omits_unsupported_temperature_and_stop(

--- a/lib/crewai/tests/llms/oci/test_oci_cohere_v2.py
+++ b/lib/crewai/tests/llms/oci/test_oci_cohere_v2.py
@@ -1,0 +1,163 @@
+"""Unit tests for OCI Cohere v2 (COHEREV2) api-format support (mocked SDK)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_v2_llm(patch_oci_module, oci_unit_values, **kwargs):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    return OCICompletion(
+        model="cohere.command-a-vision",
+        compartment_id=oci_unit_values["compartment_id"],
+        **kwargs,
+    )
+
+
+def test_oci_infers_cohere_v2_for_command_a_vision(patch_oci_module, oci_unit_values):
+    """command-a-vision must route to the COHEREV2 api format, not v1."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    assert llm.oci_provider == "cohere_v2"
+
+
+def test_oci_infers_cohere_v1_for_command_a(patch_oci_module, oci_unit_values):
+    """Plain command-a keeps using the v1 COHERE api format."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model="cohere.command-a-03-2025",
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm.oci_provider == "cohere"
+
+
+def test_oci_cohere_v2_chat_request_uses_v2_format(patch_oci_module, oci_unit_values):
+    """The request must be a CohereChatRequestV2 with api_format COHEREV2 and v2 messages."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values, max_tokens=64)
+    llm._build_chat_request([{"role": "user", "content": "hello"}])
+
+    request_cls = patch_oci_module.generative_ai_inference.models.CohereChatRequestV2
+    request_cls.assert_called_once()
+    kwargs = request_cls.call_args.kwargs
+    assert kwargs["api_format"] == "COHEREV2"
+    assert kwargs["max_tokens"] == 64
+    patch_oci_module.generative_ai_inference.models.CohereUserMessageV2.assert_called_once()
+
+
+def test_oci_cohere_v2_builds_image_content(patch_oci_module, oci_unit_values):
+    """image_url content should produce CohereImageContentV2 with CohereImageUrlV2."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    content = [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+    ]
+    result = llm._build_cohere_v2_content(content)
+
+    assert len(result) == 2
+    patch_oci_module.generative_ai_inference.models.CohereImageContentV2.assert_called_once()
+    patch_oci_module.generative_ai_inference.models.CohereImageUrlV2.assert_called_once()
+
+
+def test_oci_cohere_v2_rejects_unknown_content_type(patch_oci_module, oci_unit_values):
+    """Unsupported content types should raise instead of being silently dropped."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    with pytest.raises(ValueError, match="text and image_url"):
+        llm._build_cohere_v2_content([{"type": "video_url", "video_url": {"url": "x"}}])
+
+
+def test_oci_cohere_v2_formats_tools(patch_oci_module, oci_unit_values):
+    """Tools should be CohereToolV2(type=FUNCTION, function=Function(...))."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }]
+    formatted = llm._format_tools(tools)
+
+    assert len(formatted) == 1
+    tool_cls = patch_oci_module.generative_ai_inference.models.CohereToolV2
+    tool_cls.assert_called_once()
+    assert tool_cls.call_args.kwargs["type"] == "FUNCTION"
+    fn_cls = patch_oci_module.generative_ai_inference.models.Function
+    assert fn_cls.call_args.kwargs["name"] == "get_weather"
+
+
+def test_oci_cohere_v2_extracts_message_text(patch_oci_module, oci_unit_values):
+    """Response text lives on chat_response.message.content[].text."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+
+    part = MagicMock()
+    part.text = "v2 says hi"
+    message = MagicMock()
+    message.content = [part]
+    chat_response = MagicMock()
+    chat_response.text = None
+    chat_response.message = message
+    response = MagicMock()
+    response.data.chat_response = chat_response
+
+    assert llm._extract_text(response) == "v2 says hi"
+
+
+def test_oci_cohere_v2_extracts_tool_calls(patch_oci_module, oci_unit_values):
+    """Tool calls come from message.tool_calls with a nested function object."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+
+    function = MagicMock()
+    function.name = "get_weather"
+    function.arguments = '{"city": "Toronto"}'
+    tool_call = MagicMock()
+    tool_call.id = "call_1"
+    tool_call.function = function
+    message = MagicMock()
+    message.tool_calls = [tool_call]
+    chat_response = MagicMock()
+    chat_response.message = message
+    response = MagicMock()
+    response.data.chat_response = chat_response
+
+    calls = llm._extract_tool_calls(response)
+    assert calls == [{
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city": "Toronto"}'},
+    }]
+
+
+def test_oci_cohere_v2_stream_event_text(patch_oci_module, oci_unit_values):
+    """V2 SSE payloads carry text under message.content[].text (verified live)."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    event = {
+        "apiFormat": "COHEREV2",
+        "message": {"role": "ASSISTANT", "content": [{"type": "TEXT", "text": "chunk"}]},
+    }
+    assert llm._extract_text_from_stream_event(event) == "chunk"
+
+
+def test_oci_cohere_v2_stream_event_tool_calls(patch_oci_module, oci_unit_values):
+    """V2 stream tool calls nest name/arguments under function."""
+    llm = _make_v2_llm(patch_oci_module, oci_unit_values)
+    event = {
+        "message": {
+            "toolCalls": [{
+                "id": "c1",
+                "type": "FUNCTION",
+                "function": {"name": "f", "arguments": "{}"},
+            }]
+        }
+    }
+    calls = llm._extract_tool_calls_from_stream_event(event)
+    assert calls == [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]

--- a/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
@@ -1,0 +1,33 @@
+"""Live integration tests for OCI Generative AI basic text completion.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_MODELS="meta.llama-3.3-70b-instruct,cohere.command-r-plus-08-2024,google.gemini-2.5-flash" \
+    uv run pytest tests/llms/oci/test_oci_integration_basic.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+def test_oci_live_basic_call(oci_chat_model: str, oci_live_config: dict):
+    """Synchronous text completion with a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    result = llm.call(messages=[{"role": "user", "content": "Say 'hello world' in one sentence."}])
+
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_oci_live_async_call(oci_chat_model: str, oci_live_config: dict):
+    """Async text completion with a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    result = await llm.acall(messages=[{"role": "user", "content": "What is 2+2? Answer in one word."}])
+
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_basic.py
@@ -4,7 +4,7 @@ Run with:
     OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
     OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
     OCI_TEST_MODELS="meta.llama-3.3-70b-instruct,cohere.command-r-plus-08-2024,google.gemini-2.5-flash" \
-    uv run pytest tests/llms/oci/test_oci_integration_basic.py -v
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_basic.py -v
 """
 
 from __future__ import annotations

--- a/lib/crewai/tests/llms/oci/test_oci_integration_multimodal.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_multimodal.py
@@ -1,0 +1,106 @@
+"""Live integration tests for OCI Generative AI multimodal content.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_MULTIMODAL_MODELS="google.gemini-2.5-flash" \
+    uv run pytest tests/llms/oci/test_oci_integration_multimodal.py -v
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import struct
+import zlib
+
+import pytest
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+def _env_models(env_var: str, fallback: str, default: str) -> list[str]:
+    raw = os.getenv(env_var) or os.getenv(fallback) or default
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _skip_unless_live():
+    compartment = os.getenv("OCI_COMPARTMENT_ID")
+    if not compartment:
+        pytest.skip("OCI_COMPARTMENT_ID not set")
+    region = os.getenv("OCI_REGION")
+    endpoint = os.getenv("OCI_SERVICE_ENDPOINT")
+    if not region and not endpoint:
+        pytest.skip("Set OCI_REGION or OCI_SERVICE_ENDPOINT")
+    config: dict[str, str] = {"compartment_id": compartment}
+    if endpoint:
+        config["service_endpoint"] = endpoint
+    if os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
+    if os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+    return config
+
+
+def _make_red_png() -> bytes:
+    """Generate a minimal valid 2x2 red PNG image in memory."""
+    width, height = 2, 2
+    # Each row: filter byte (0) + RGB pixels
+    raw_data = b""
+    for _ in range(height):
+        raw_data += b"\x00"  # filter: none
+        for _ in range(width):
+            raw_data += b"\xff\x00\x00"  # red pixel
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", ihdr)
+    png += _chunk(b"IDAT", zlib.compress(raw_data))
+    png += _chunk(b"IEND", b"")
+    return png
+
+
+def _png_data_uri() -> str:
+    """Return a data URI for a small red PNG."""
+    png_bytes = _make_red_png()
+    encoded = base64.standard_b64encode(png_bytes).decode("utf-8")
+    return f"data:image/png;base64,{encoded}"
+
+
+@pytest.fixture(
+    params=_env_models(
+        "OCI_TEST_MULTIMODAL_MODELS", "OCI_TEST_MULTIMODAL_MODEL", "google.gemini-2.5-flash"
+    ),
+    ids=lambda m: m,
+)
+def oci_multimodal_model(request):
+    return request.param
+
+
+@pytest.fixture()
+def oci_multimodal_config():
+    return _skip_unless_live()
+
+
+def test_oci_live_image_input(oci_multimodal_model: str, oci_multimodal_config: dict):
+    """Vision model should describe an image sent as a data URI."""
+    llm = OCICompletion(model=oci_multimodal_model, **oci_multimodal_config)
+    result = llm.call(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What color is this image? Answer in one word."},
+                    {"type": "image_url", "image_url": {"url": _png_data_uri()}},
+                ],
+            }
+        ]
+    )
+
+    assert isinstance(result, str)
+    assert len(result) > 0
+    assert "red" in result.lower()

--- a/lib/crewai/tests/llms/oci/test_oci_integration_multimodal.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_multimodal.py
@@ -4,7 +4,7 @@ Run with:
     OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
     OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
     OCI_TEST_MULTIMODAL_MODELS="google.gemini-2.5-flash" \
-    uv run pytest tests/llms/oci/test_oci_integration_multimodal.py -v
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_multimodal.py -v
 """
 
 from __future__ import annotations

--- a/lib/crewai/tests/llms/oci/test_oci_integration_streaming.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_streaming.py
@@ -1,0 +1,40 @@
+"""Live integration tests for OCI Generative AI streaming.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_MODELS="meta.llama-3.3-70b-instruct,cohere.command-r-plus-08-2024" \
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_streaming.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+def test_oci_live_streaming_call(oci_chat_model: str, oci_live_config: dict):
+    """Streaming text completion with a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, stream=True, **oci_live_config)
+    result = llm.call(
+        messages=[{"role": "user", "content": "Count from 1 to 5, one per line."}]
+    )
+
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_oci_live_astream(oci_chat_model: str, oci_live_config: dict):
+    """Async streaming should yield text chunks from a live OCI model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    chunks: list[str] = []
+    async for chunk in llm.astream(
+        messages=[{"role": "user", "content": "Say hello in three words."}]
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+    full_text = "".join(chunks)
+    assert len(full_text) > 0

--- a/lib/crewai/tests/llms/oci/test_oci_integration_structured.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_structured.py
@@ -1,0 +1,33 @@
+"""Live integration tests for OCI Generative AI structured output.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_MODELS="meta.llama-3.3-70b-instruct" \
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_structured.py -v
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+class CapitalResponse(BaseModel):
+    """Response containing a country's capital city."""
+    country: str
+    capital: str
+
+
+def test_oci_live_structured_output(oci_chat_model: str, oci_live_config: dict):
+    """Structured output should return a validated Pydantic model."""
+    llm = OCICompletion(model=oci_chat_model, **oci_live_config)
+    result = llm.call(
+        messages=[{"role": "user", "content": "What is the capital of France? Answer with country and capital fields."}],
+        response_model=CapitalResponse,
+    )
+
+    assert isinstance(result, CapitalResponse)
+    assert result.capital.lower() == "paris"
+    assert result.country.lower() == "france"

--- a/lib/crewai/tests/llms/oci/test_oci_integration_tools.py
+++ b/lib/crewai/tests/llms/oci/test_oci_integration_tools.py
@@ -1,0 +1,100 @@
+"""Live integration tests for OCI Generative AI tool calling.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    OCI_TEST_TOOL_MODELS="meta.llama-3.3-70b-instruct" \
+    uv run pytest lib/crewai/tests/llms/oci/test_oci_integration_tools.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from crewai.llms.providers.oci.completion import OCICompletion
+
+
+def _env_models(env_var: str, fallback: str, default: str) -> list[str]:
+    raw = os.getenv(env_var) or os.getenv(fallback) or default
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _skip_unless_live():
+    compartment = os.getenv("OCI_COMPARTMENT_ID")
+    if not compartment:
+        pytest.skip("OCI_COMPARTMENT_ID not set")
+    region = os.getenv("OCI_REGION")
+    endpoint = os.getenv("OCI_SERVICE_ENDPOINT")
+    if not region and not endpoint:
+        pytest.skip("Set OCI_REGION or OCI_SERVICE_ENDPOINT")
+    config: dict[str, str] = {"compartment_id": compartment}
+    if endpoint:
+        config["service_endpoint"] = endpoint
+    if os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
+    if os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+    return config
+
+
+TOOL_SPEC = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add_numbers",
+            "description": "Add two numbers together",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number", "description": "First number"},
+                    "b": {"type": "number", "description": "Second number"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    }
+]
+
+
+@pytest.fixture(
+    params=_env_models("OCI_TEST_TOOL_MODELS", "OCI_TEST_TOOL_MODEL", "meta.llama-3.3-70b-instruct"),
+    ids=lambda m: m,
+)
+def oci_tool_model(request):
+    return request.param
+
+
+@pytest.fixture()
+def oci_tool_config():
+    return _skip_unless_live()
+
+
+def test_oci_live_tool_call_returns_raw(oci_tool_model: str, oci_tool_config: dict):
+    """Without available_functions, tool calls should be returned raw."""
+    llm = OCICompletion(model=oci_tool_model, **oci_tool_config)
+    result = llm.call(
+        messages=[{"role": "user", "content": "What is 3 + 7? Use the add_numbers tool."}],
+        tools=TOOL_SPEC,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert result[0]["function"]["name"] == "add_numbers"
+
+
+def test_oci_live_tool_call_with_execution(oci_tool_model: str, oci_tool_config: dict):
+    """With available_functions, tools should execute and model should respond."""
+    def add_numbers(a: float, b: float) -> str:
+        return str(float(a) + float(b))
+
+    llm = OCICompletion(model=oci_tool_model, **oci_tool_config)
+    result = llm.call(
+        messages=[{"role": "user", "content": "What is 3 + 7? Use the add_numbers tool."}],
+        tools=TOOL_SPEC,
+        available_functions={"add_numbers": add_numbers},
+    )
+
+    assert isinstance(result, str)
+    assert "10" in result

--- a/lib/crewai/tests/llms/oci/test_oci_multimodal.py
+++ b/lib/crewai/tests/llms/oci/test_oci_multimodal.py
@@ -1,0 +1,195 @@
+"""Unit tests for OCI provider multimodal content (mocked SDK)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_oci_builds_image_content(patch_oci_module, oci_unit_values):
+    """image_url content should produce ImageContent with ImageUrl."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    # Mock multimodal content types
+    patch_oci_module.generative_ai_inference.models.ImageContent = MagicMock(
+        side_effect=lambda **kw: MagicMock(type="image", **kw)
+    )
+    patch_oci_module.generative_ai_inference.models.ImageUrl = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    content = [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+    ]
+    result = llm._build_generic_content(content)
+
+    assert len(result) == 2
+    patch_oci_module.generative_ai_inference.models.ImageContent.assert_called_once()
+    patch_oci_module.generative_ai_inference.models.ImageUrl.assert_called_once()
+
+
+def test_oci_builds_document_content(patch_oci_module, oci_unit_values):
+    """document_url content should produce DocumentContent."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.models.DocumentContent = MagicMock(
+        side_effect=lambda **kw: MagicMock(type="document", **kw)
+    )
+    patch_oci_module.generative_ai_inference.models.DocumentUrl = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    content = [{"type": "document_url", "document_url": {"url": "data:application/pdf;base64,xyz"}}]
+    result = llm._build_generic_content(content)
+
+    assert len(result) == 1
+    patch_oci_module.generative_ai_inference.models.DocumentContent.assert_called_once()
+
+
+def test_oci_builds_video_content(patch_oci_module, oci_unit_values):
+    """video_url content should produce VideoContent."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.models.VideoContent = MagicMock(
+        side_effect=lambda **kw: MagicMock(type="video", **kw)
+    )
+    patch_oci_module.generative_ai_inference.models.VideoUrl = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    content = [{"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}]
+    result = llm._build_generic_content(content)
+
+    assert len(result) == 1
+    patch_oci_module.generative_ai_inference.models.VideoContent.assert_called_once()
+
+
+def test_oci_builds_audio_content(patch_oci_module, oci_unit_values):
+    """audio_url content should produce AudioContent."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.models.AudioContent = MagicMock(
+        side_effect=lambda **kw: MagicMock(type="audio", **kw)
+    )
+    patch_oci_module.generative_ai_inference.models.AudioUrl = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    content = [{"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,wav123"}}]
+    result = llm._build_generic_content(content)
+
+    assert len(result) == 1
+    patch_oci_module.generative_ai_inference.models.AudioContent.assert_called_once()
+
+
+def test_oci_rejects_unsupported_content_type(patch_oci_module, oci_unit_values):
+    """Unknown content types should raise ValueError."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+
+    with pytest.raises(ValueError, match="Unsupported OCI content type"):
+        llm._build_generic_content([{"type": "hologram", "data": "xyz"}])
+
+
+def test_oci_cohere_rejects_multimodal(patch_oci_module, oci_unit_values):
+    """Cohere models should reject multimodal content in _build_chat_request."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+
+    messages = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "Describe this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]}
+    ]
+
+    with pytest.raises(ValueError, match="text-only"):
+        llm._build_chat_request(messages)
+
+
+def test_oci_message_has_multimodal_content(patch_oci_module, oci_unit_values):
+    """_message_has_multimodal_content should detect non-text content types."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+
+    assert llm._message_has_multimodal_content("just text") is False
+    assert llm._message_has_multimodal_content([{"type": "text", "text": "hi"}]) is False
+    assert llm._message_has_multimodal_content([{"type": "image_url", "image_url": {"url": "x"}}]) is True
+    assert llm._message_has_multimodal_content([{"type": "text"}, {"type": "audio_url"}]) is True
+
+
+def test_oci_supports_multimodal(patch_oci_module, oci_unit_values):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm.supports_multimodal() is True
+
+
+def test_vision_helpers():
+    """Test vision.py utility functions."""
+    from crewai.llms.providers.oci.vision import (
+        VISION_MODELS,
+        encode_image,
+        is_vision_model,
+        to_data_uri,
+    )
+
+    # to_data_uri with bytes
+    uri = to_data_uri(b"\x89PNG", "image/png")
+    assert uri.startswith("data:image/png;base64,")
+
+    # to_data_uri passthrough
+    existing = "data:image/jpeg;base64,abc"
+    assert to_data_uri(existing) == existing
+
+    # encode_image
+    result = encode_image(b"\x89PNG")
+    assert result["type"] == "image_url"
+    assert result["image_url"]["url"].startswith("data:image/png;base64,")
+
+    # is_vision_model
+    assert is_vision_model("google.gemini-2.5-flash") is True
+    assert is_vision_model("meta.llama-3.3-70b-instruct") is False
+
+    assert len(VISION_MODELS) > 0

--- a/lib/crewai/tests/llms/oci/test_oci_streaming.py
+++ b/lib/crewai/tests/llms/oci/test_oci_streaming.py
@@ -1,0 +1,158 @@
+"""Unit tests for OCI provider streaming (mocked SDK)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_fake_stream_event(text: str = "", finish_reason: str | None = None, usage: dict | None = None) -> MagicMock:
+    """Build a single SSE event with optional text, finish, and usage."""
+    payload: dict = {}
+    if text:
+        payload["message"] = {"content": [{"text": text}]}
+    if finish_reason:
+        payload["finishReason"] = finish_reason
+    if usage:
+        payload["usage"] = usage
+
+    import json
+    event = MagicMock()
+    event.data = json.dumps(payload)
+    return event
+
+
+def _make_fake_stream_response(*events: MagicMock) -> MagicMock:
+    """Wrap events into a response.data.events() iterable."""
+    response = MagicMock()
+    response.data.events.return_value = iter(events)
+    return response
+
+
+def test_oci_completion_streams_generic_responses(
+    patch_oci_module, oci_unit_values
+):
+    """Streaming call should accumulate text chunks and return full response."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    events = [
+        _make_fake_stream_event(text="Hello "),
+        _make_fake_stream_event(text="world"),
+        _make_fake_stream_event(
+            finish_reason="stop",
+            usage={"promptTokens": 5, "completionTokens": 2, "totalTokens": 7},
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_fake_stream_response(*events)
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    # StreamOptions mock
+    patch_oci_module.generative_ai_inference.models.StreamOptions = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        stream=True,
+    )
+    result = llm.call(messages=[{"role": "user", "content": "Say hello"}])
+
+    assert "Hello " in result
+    assert "world" in result
+    assert llm.last_response_metadata is not None
+    assert llm.last_response_metadata.get("finish_reason") == "stop"
+
+
+def test_oci_iter_stream_yields_text_chunks(
+    patch_oci_module, oci_unit_values
+):
+    """iter_stream should yield individual text chunks."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    events = [
+        _make_fake_stream_event(text="chunk1"),
+        _make_fake_stream_event(text="chunk2"),
+        _make_fake_stream_event(
+            usage={"promptTokens": 3, "completionTokens": 2, "totalTokens": 5},
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_fake_stream_response(*events)
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    patch_oci_module.generative_ai_inference.models.StreamOptions = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    chunks = list(llm.iter_stream(messages=[{"role": "user", "content": "test"}]))
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert llm.last_response_metadata is not None
+    assert llm.last_response_metadata["usage"]["total_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_oci_astream_yields_text_chunks(
+    patch_oci_module, oci_unit_values
+):
+    """astream should yield chunks via async generator."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    events = [
+        _make_fake_stream_event(text="async1"),
+        _make_fake_stream_event(text="async2"),
+        _make_fake_stream_event(),
+    ]
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_fake_stream_response(*events)
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    patch_oci_module.generative_ai_inference.models.StreamOptions = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    chunks = []
+    async for chunk in llm.astream(messages=[{"role": "user", "content": "test"}]):
+        chunks.append(chunk)
+
+    assert chunks == ["async1", "async2"]
+
+
+def test_oci_stream_chat_events_holds_client_lock(
+    patch_oci_module, oci_unit_values
+):
+    """_stream_chat_events should hold the client lock for the full iteration."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    events = [_make_fake_stream_event(text="a"), _make_fake_stream_event(text="b")]
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_fake_stream_response(*events)
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+
+    locked_during_call: list[bool] = []
+    original_chat = fake_client.chat
+
+    def chat_recording_lock(details):
+        locked_during_call.append(llm._client_lock.locked())
+        return original_chat(details)
+
+    fake_client.chat = chat_recording_lock
+
+    chat_details = MagicMock()
+    assert not llm._client_lock.locked()
+    list(llm._stream_chat_events(chat_details))
+    assert locked_during_call == [True]
+    assert not llm._client_lock.locked()

--- a/lib/crewai/tests/llms/oci/test_oci_structured.py
+++ b/lib/crewai/tests/llms/oci/test_oci_structured.py
@@ -1,0 +1,204 @@
+"""Unit tests for OCI provider structured output (mocked SDK)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+
+class WeatherResponse(BaseModel):
+    """Weather forecast response."""
+    city: str
+    temperature: float
+    unit: str
+
+
+def _make_json_response(data: dict) -> MagicMock:
+    """Build a fake OCI response returning JSON text."""
+    text_part = MagicMock()
+    text_part.text = json.dumps(data)
+
+    message = MagicMock()
+    message.content = [text_part]
+    message.tool_calls = None
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+    chat_response.usage = MagicMock(prompt_tokens=10, completion_tokens=8, total_tokens=18)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def _make_cohere_json_response(data: dict) -> MagicMock:
+    """Build a fake OCI Cohere response returning JSON text."""
+    chat_response = MagicMock()
+    chat_response.text = json.dumps(data)
+    chat_response.tool_calls = None
+    chat_response.finish_reason = "COMPLETE"
+    chat_response.usage = MagicMock(prompt_tokens=8, completion_tokens=6, total_tokens=14)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def test_oci_completion_structured_output_generic(
+    patch_oci_module, oci_unit_values
+):
+    """response_model should parse JSON response into a Pydantic model."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_json_response(
+        {"city": "NYC", "temperature": 72.0, "unit": "F"}
+    )
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    # Mock schema-related models
+    patch_oci_module.generative_ai_inference.models.ResponseJsonSchema = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+    patch_oci_module.generative_ai_inference.models.JsonSchemaResponseFormat = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "Weather in NYC?"}],
+        response_model=WeatherResponse,
+    )
+
+    assert isinstance(result, WeatherResponse)
+    assert result.city == "NYC"
+    assert result.temperature == 72.0
+    assert result.unit == "F"
+
+
+def test_oci_completion_structured_output_cohere(
+    patch_oci_module, oci_unit_values
+):
+    """Cohere models should use CohereResponseJsonFormat for structured output."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_cohere_json_response(
+        {"city": "London", "temperature": 15.0, "unit": "C"}
+    )
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    patch_oci_module.generative_ai_inference.models.ResponseJsonSchema = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+    patch_oci_module.generative_ai_inference.models.CohereResponseJsonFormat = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "Weather in London?"}],
+        response_model=WeatherResponse,
+    )
+
+    assert isinstance(result, WeatherResponse)
+    assert result.city == "London"
+
+
+def test_oci_completion_structured_output_with_fenced_json(
+    patch_oci_module, oci_unit_values
+):
+    """Should handle JSON wrapped in markdown fences."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fenced = '```json\n{"city": "Tokyo", "temperature": 25.0, "unit": "C"}\n```'
+    text_part = MagicMock()
+    text_part.text = fenced
+
+    message = MagicMock()
+    message.content = [text_part]
+    message.tool_calls = None
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+    chat_response.usage = MagicMock(prompt_tokens=10, completion_tokens=8, total_tokens=18)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = response
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    patch_oci_module.generative_ai_inference.models.ResponseJsonSchema = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+    patch_oci_module.generative_ai_inference.models.JsonSchemaResponseFormat = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "Weather in Tokyo?"}],
+        response_model=WeatherResponse,
+    )
+
+    assert isinstance(result, WeatherResponse)
+    assert result.city == "Tokyo"
+
+
+def test_oci_build_response_format_returns_none_without_model(
+    patch_oci_module, oci_unit_values
+):
+    """_build_response_format should return None when no response_model."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm._build_response_format(None) is None
+
+
+def test_oci_build_response_format_creates_json_schema(
+    patch_oci_module, oci_unit_values
+):
+    """_build_response_format should create a JsonSchemaResponseFormat for generic models."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    patch_oci_module.generative_ai_inference.models.ResponseJsonSchema = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+    patch_oci_module.generative_ai_inference.models.JsonSchemaResponseFormat = MagicMock(
+        side_effect=lambda **kw: MagicMock(**kw)
+    )
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm._build_response_format(WeatherResponse)
+
+    assert result is not None
+    patch_oci_module.generative_ai_inference.models.JsonSchemaResponseFormat.assert_called_once()

--- a/lib/crewai/tests/llms/oci/test_oci_tools.py
+++ b/lib/crewai/tests/llms/oci/test_oci_tools.py
@@ -1,0 +1,291 @@
+"""Unit tests for OCI provider tool calling (mocked SDK)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_tool_call_response(tool_name: str = "get_weather", args: dict | None = None) -> MagicMock:
+    """Build a fake OCI response with a generic tool call."""
+    tc = MagicMock()
+    tc.id = "tc_001"
+    tc.name = tool_name
+    tc.arguments = json.dumps(args or {"city": "NYC"})
+
+    message = MagicMock()
+    message.content = [MagicMock(text="")]
+    message.tool_calls = [tc]
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "tool_calls"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+    chat_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def _make_text_response(text: str = "The weather is sunny.") -> MagicMock:
+    """Build a fake OCI text response (used after tool execution)."""
+    text_part = MagicMock()
+    text_part.text = text
+
+    message = MagicMock()
+    message.content = [text_part]
+    message.tool_calls = None
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    chat_response = MagicMock()
+    chat_response.choices = [choice]
+    chat_response.finish_reason = None
+    chat_response.usage = MagicMock(prompt_tokens=20, completion_tokens=10, total_tokens=30)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+def _make_cohere_tool_call_response(tool_name: str = "get_weather") -> MagicMock:
+    """Build a fake OCI Cohere response with a tool call."""
+    tc = MagicMock()
+    tc.name = tool_name
+    tc.parameters = {"city": "NYC"}
+
+    chat_response = MagicMock()
+    chat_response.text = ""
+    chat_response.tool_calls = [tc]
+    chat_response.finish_reason = "COMPLETE"
+    chat_response.usage = MagicMock(prompt_tokens=8, completion_tokens=4, total_tokens=12)
+
+    response = MagicMock()
+    response.data.chat_response = chat_response
+    return response
+
+
+SAMPLE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "The city name"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def test_oci_completion_returns_tool_calls_for_executor(
+    patch_oci_module, oci_unit_values
+):
+    """When no available_functions, tool calls should be returned raw."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_tool_call_response()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "What is the weather?"}],
+        tools=SAMPLE_TOOLS,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["function"]["name"] == "get_weather"
+
+
+def test_oci_completion_executes_tool_calls_recursively(
+    patch_oci_module, oci_unit_values
+):
+    """With available_functions, tool should be executed and model re-called."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    # First call returns tool call, second call returns text
+    fake_client.chat.side_effect = [
+        _make_tool_call_response(),
+        _make_text_response("It is sunny in NYC."),
+    ]
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+
+    def mock_get_weather(city: str) -> str:
+        return f"Sunny in {city}"
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "Weather in NYC?"}],
+        tools=SAMPLE_TOOLS,
+        available_functions={"get_weather": mock_get_weather},
+    )
+
+    assert isinstance(result, str)
+    assert "sunny" in result.lower() or "NYC" in result
+    assert fake_client.chat.call_count == 2
+
+
+def test_oci_completion_formats_generic_tools(
+    patch_oci_module, oci_unit_values
+):
+    """_format_tools should produce FunctionDefinition for generic models."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    formatted = llm._format_tools(SAMPLE_TOOLS)
+
+    assert len(formatted) == 1
+    models = patch_oci_module.generative_ai_inference.models
+    models.FunctionDefinition.assert_called_once()
+
+
+def test_oci_completion_formats_cohere_tools(
+    patch_oci_module, oci_unit_values
+):
+    """_format_tools should produce CohereTool for Cohere models."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    formatted = llm._format_tools(SAMPLE_TOOLS)
+
+    assert len(formatted) == 1
+    models = patch_oci_module.generative_ai_inference.models
+    models.CohereTool.assert_called_once()
+
+
+def test_oci_completion_cohere_extracts_tool_calls(
+    patch_oci_module, oci_unit_values
+):
+    """Cohere tool calls should be normalized to CrewAI shape with generated IDs."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_cohere_tool_call_response()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    result = llm.call(
+        messages=[{"role": "user", "content": "Weather?"}],
+        tools=SAMPLE_TOOLS,
+    )
+
+    assert isinstance(result, list)
+    assert result[0]["function"]["name"] == "get_weather"
+    assert result[0]["id"]  # Should have a generated UUID
+
+
+def test_oci_completion_rejects_parallel_tools_for_cohere(
+    patch_oci_module, oci_unit_values
+):
+    """Cohere models should raise if parallel_tool_calls is enabled."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["cohere_model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        parallel_tool_calls=True,
+    )
+
+    with pytest.raises(ValueError, match="parallel_tool_calls"):
+        llm._build_chat_request(
+            [{"role": "user", "content": "test"}],
+            tools=SAMPLE_TOOLS,
+        )
+
+
+def test_oci_completion_respects_max_sequential_tool_calls(
+    patch_oci_module, oci_unit_values
+):
+    """Should raise RuntimeError when tool depth exceeds max."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    # Always return tool calls to force recursion
+    fake_client.chat.return_value = _make_tool_call_response()
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+
+    def mock_tool(city: str) -> str:
+        return "result"
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        max_sequential_tool_calls=2,
+    )
+
+    with pytest.raises(RuntimeError, match="max_sequential_tool_calls"):
+        llm.call(
+            messages=[{"role": "user", "content": "test"}],
+            tools=SAMPLE_TOOLS,
+            available_functions={"get_weather": mock_tool},
+        )
+
+
+def test_oci_completion_supports_function_calling(
+    patch_oci_module, oci_unit_values
+):
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = MagicMock()
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+    )
+    assert llm.supports_function_calling() is True
+
+
+def test_oci_completion_filters_unknown_passthrough_params(
+    patch_oci_module, oci_unit_values
+):
+    """Unknown additional_params should not crash the OCI SDK request."""
+    from crewai.llms.providers.oci.completion import OCICompletion
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = _make_text_response("ok")
+    patch_oci_module.generative_ai_inference.GenerativeAiInferenceClient.return_value = fake_client
+    # Make GenericChatRequest only accept known keys
+    patch_oci_module.generative_ai_inference.models.GenericChatRequest.attribute_map = {
+        "messages": "messages",
+        "api_format": "apiFormat",
+    }
+
+    llm = OCICompletion(
+        model=oci_unit_values["model"],
+        compartment_id=oci_unit_values["compartment_id"],
+        additional_params={"bogus_param": "should_be_filtered"},
+    )
+    # Should not raise
+    result = llm.call(messages=[{"role": "user", "content": "test"}])
+    assert isinstance(result, str)

--- a/lib/crewai/tests/rag/embeddings/test_factory_oci.py
+++ b/lib/crewai/tests/rag/embeddings/test_factory_oci.py
@@ -1,0 +1,207 @@
+"""Tests for OCI embedding provider wiring."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai.rag.embeddings.factory import build_embedder
+from crewai.rag.embeddings.providers.oci.embedding_callable import OCIEmbeddingFunction
+
+
+class _FakeOCI:
+    def __init__(self) -> None:
+        self.retry = SimpleNamespace(DEFAULT_RETRY_STRATEGY="retry")
+        self.config = SimpleNamespace(
+            from_file=lambda file_location, profile_name: {
+                "file_location": file_location,
+                "profile_name": profile_name,
+            }
+        )
+        self.signer = SimpleNamespace(
+            load_private_key_from_file=lambda *_args, **_kwargs: "private-key"
+        )
+        self.auth = SimpleNamespace(
+            signers=SimpleNamespace(
+                SecurityTokenSigner=lambda token, key: (token, key),
+                InstancePrincipalsSecurityTokenSigner=lambda: "instance-principal",
+                get_resource_principals_signer=lambda: "resource-principal",
+            )
+        )
+        self.generative_ai_inference = SimpleNamespace(
+            GenerativeAiInferenceClient=MagicMock(),
+            models=SimpleNamespace(
+                EmbedTextDetails=_simple_init_class("EmbedTextDetails"),
+                OnDemandServingMode=_simple_init_class("OnDemandServingMode"),
+                DedicatedServingMode=_simple_init_class("DedicatedServingMode"),
+            ),
+        )
+
+
+def _simple_init_class(name: str):
+    class _Simple:
+        output_dimensions = None
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    _Simple.__name__ = name
+    return _Simple
+
+
+@patch("crewai.rag.embeddings.factory.import_and_validate_definition")
+def test_build_embedder_oci(mock_import):
+    """Test building OCI embedder."""
+    mock_provider_class = MagicMock()
+    mock_provider_instance = MagicMock()
+    mock_embedding_function = MagicMock()
+
+    mock_import.return_value = mock_provider_class
+    mock_provider_class.return_value = mock_provider_instance
+    mock_provider_instance.embedding_callable.return_value = mock_embedding_function
+
+    config = {
+        "provider": "oci",
+        "config": {
+            "model_name": "cohere.embed-english-v3.0",
+            "compartment_id": "ocid1.compartment.oc1..test",
+            "region": "us-chicago-1",
+            "auth_profile": "DEFAULT",
+        },
+    }
+
+    build_embedder(config)
+
+    mock_import.assert_called_once_with(
+        "crewai.rag.embeddings.providers.oci.oci_provider.OCIProvider"
+    )
+    call_kwargs = mock_provider_class.call_args.kwargs
+    assert call_kwargs["model_name"] == "cohere.embed-english-v3.0"
+    assert call_kwargs["compartment_id"] == "ocid1.compartment.oc1..test"
+    assert call_kwargs["region"] == "us-chicago-1"
+
+
+def test_oci_embedding_function_batches_requests(monkeypatch):
+    """Test OCI embedding batching and request construction."""
+    fake_oci = _FakeOCI()
+    fake_client = MagicMock()
+    fake_client.embed_text.side_effect = [
+        SimpleNamespace(data=SimpleNamespace(embeddings=[[0.1, 0.2], [0.3, 0.4]])),
+        SimpleNamespace(data=SimpleNamespace(embeddings=[[0.5, 0.6]])),
+    ]
+    fake_oci.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    monkeypatch.setattr(
+        "crewai.rag.embeddings.providers.oci.embedding_callable._get_oci_module",
+        lambda: fake_oci,
+    )
+
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-english-v3.0",
+        compartment_id="ocid1.compartment.oc1..test",
+        region="us-chicago-1",
+        batch_size=2,
+    )
+
+    result = embedder(["a", "b", "c"])
+
+    result_rows = [embedding.tolist() for embedding in result]
+    expected_rows = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+    assert len(result_rows) == len(expected_rows)
+    for actual, expected in zip(result_rows, expected_rows, strict=True):
+        assert actual == pytest.approx(expected)
+    assert fake_client.embed_text.call_count == 2
+    first_request = fake_client.embed_text.call_args_list[0].args[0]
+    assert first_request.compartment_id == "ocid1.compartment.oc1..test"
+    assert first_request.serving_mode.model_id == "cohere.embed-english-v3.0"
+
+
+def test_oci_embedding_function_supports_output_dimensions(monkeypatch):
+    """Test OCI output_dimensions mapping."""
+    fake_oci = _FakeOCI()
+    fake_client = MagicMock()
+    fake_client.embed_text.return_value = SimpleNamespace(
+        data=SimpleNamespace(embeddings=[[0.1, 0.2]])
+    )
+    fake_oci.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    monkeypatch.setattr(
+        "crewai.rag.embeddings.providers.oci.embedding_callable._get_oci_module",
+        lambda: fake_oci,
+    )
+
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-v4.0",
+        compartment_id="ocid1.compartment.oc1..test",
+        output_dimensions=512,
+    )
+
+    embedder(["hello"])
+
+    request = fake_client.embed_text.call_args.args[0]
+    assert request.output_dimensions == 512
+
+
+def test_oci_embedding_function_exposes_serializable_config(monkeypatch):
+    """Test OCI embedding config serialization for ChromaDB compatibility."""
+    fake_oci = _FakeOCI()
+    fake_oci.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        MagicMock()
+    )
+
+    monkeypatch.setattr(
+        "crewai.rag.embeddings.providers.oci.embedding_callable._get_oci_module",
+        lambda: fake_oci,
+    )
+
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-english-v3.0",
+        compartment_id="ocid1.compartment.oc1..test",
+        timeout=(5, 30),
+    )
+
+    assert embedder.get_config() == {
+        "model_name": "cohere.embed-english-v3.0",
+        "compartment_id": "ocid1.compartment.oc1..test",
+        "timeout": [5, 30],
+    }
+
+    rebuilt = OCIEmbeddingFunction.build_from_config(embedder.get_config())
+    assert rebuilt.get_config() == embedder.get_config()
+
+
+def test_oci_embedding_function_supports_image_embeddings(monkeypatch, tmp_path: Path):
+    """Test OCI image embedding request construction."""
+    fake_oci = _FakeOCI()
+    fake_client = MagicMock()
+    fake_client.embed_text.return_value = SimpleNamespace(
+        data=SimpleNamespace(embeddings=[[0.7, 0.8, 0.9]])
+    )
+    fake_oci.generative_ai_inference.GenerativeAiInferenceClient.return_value = (
+        fake_client
+    )
+
+    monkeypatch.setattr(
+        "crewai.rag.embeddings.providers.oci.embedding_callable._get_oci_module",
+        lambda: fake_oci,
+    )
+
+    image_path = tmp_path / "diagram.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-v4.0",
+        compartment_id="ocid1.compartment.oc1..test",
+    )
+
+    result = embedder.embed_image(image_path)
+
+    assert result == pytest.approx([0.7, 0.8, 0.9])
+    request = fake_client.embed_text.call_args.args[0]
+    assert request.input_type == "IMAGE"
+    assert request.inputs[0].startswith("data:image/png;base64,")

--- a/lib/crewai/tests/rag/embeddings/test_oci_embedding_integration.py
+++ b/lib/crewai/tests/rag/embeddings/test_oci_embedding_integration.py
@@ -1,0 +1,66 @@
+"""Live integration tests for OCI embedding provider.
+
+Run with:
+    OCI_AUTH_TYPE=API_KEY OCI_AUTH_PROFILE=API_KEY_AUTH \
+    OCI_COMPARTMENT_ID=<compartment> OCI_REGION=us-chicago-1 \
+    uv run pytest lib/crewai/tests/rag/embeddings/test_oci_embedding_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from crewai.rag.embeddings.providers.oci.embedding_callable import OCIEmbeddingFunction
+
+
+def _skip_unless_live() -> dict[str, str]:
+    compartment = os.getenv("OCI_COMPARTMENT_ID")
+    if not compartment:
+        pytest.skip("OCI_COMPARTMENT_ID not set")
+    region = os.getenv("OCI_REGION")
+    if not region:
+        pytest.skip("OCI_REGION not set")
+    config: dict[str, str] = {
+        "compartment_id": compartment,
+        "region": region,
+    }
+    if os.getenv("OCI_AUTH_TYPE"):
+        config["auth_type"] = os.getenv("OCI_AUTH_TYPE", "API_KEY")
+    if os.getenv("OCI_AUTH_PROFILE"):
+        config["auth_profile"] = os.getenv("OCI_AUTH_PROFILE", "DEFAULT")
+    return config
+
+
+@pytest.fixture()
+def oci_embed_config():
+    return _skip_unless_live()
+
+
+def test_oci_live_text_embedding(oci_embed_config: dict):
+    """Embed a text string and verify we get a non-empty vector."""
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-english-v3.0",
+        input_type="SEARCH_DOCUMENT",
+        **oci_embed_config,
+    )
+    result = embedder(["Hello world"])
+
+    assert len(result) == 1
+    assert len(result[0]) > 0
+
+
+def test_oci_live_batch_embedding(oci_embed_config: dict):
+    """Batch embed multiple texts."""
+    embedder = OCIEmbeddingFunction(
+        model_name="cohere.embed-english-v3.0",
+        input_type="SEARCH_DOCUMENT",
+        **oci_embed_config,
+    )
+    texts = ["The cat sat on the mat", "The dog ran in the park", "Python is great"]
+    result = embedder(texts)
+
+    assert len(result) == 3
+    for vec in result:
+        assert len(vec) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T15:35:51.457693Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1027,6 +1027,15 @@ wheels = [
 ]
 
 [[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,6 +1325,74 @@ wheels = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/4c/4e40cc26347ac8254d3f25b9f94710b8e8df24ee4dddc1ba41907a88a94d/crc32c-2.7.1.tar.gz", hash = "sha256:f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c", size = 45712, upload-time = "2024-09-24T06:20:17.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f8/2c5cc5b8d16c76a66548283d74d1f4979c8970c2a274e63f76fbfaa0cf4e/crc32c-2.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1fd1f9c6b50d7357736676278a1b8c8986737b8a1c76d7eab4baa71d0b6af67f", size = 49668, upload-time = "2024-09-24T06:18:02.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/52/cdebceaed37a5657ee4864881da0f29f4036867dfb79bb058d38d4d737f3/crc32c-2.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:805c2be1bc0e251c48439a62b0422385899c15289483692bc70e78473c1039f1", size = 37151, upload-time = "2024-09-24T06:18:04.173Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/33/6476918b4cac85a18e32dc754e9d653b0dcd96518d661cbbf91bf8aec8cc/crc32c-2.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f4333e62b7844dfde112dbb8489fd2970358eddc3310db21e943a9f6994df749", size = 35370, upload-time = "2024-09-24T06:18:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/8972a70d7c39f37240f554c348fd9e15a4d8d0a548b1bc3139cd4e1cfb66/crc32c-2.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f0fadc741e79dc705e2d9ee967473e8a061d26b04310ed739f1ee292f33674f", size = 54110, upload-time = "2024-09-24T06:18:06.758Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/0b045f84c7acc36312a91211190bf84e73a0bbd30f21cbaf3670c4dba9b2/crc32c-2.7.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91ced31055d26d59385d708bbd36689e1a1d604d4b0ceb26767eb5a83156f85d", size = 51792, upload-time = "2024-09-24T06:18:07.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e2/acaabbc172b7c45ec62f273cd2e214f626e2b4324eca9152dea6095a26f4/crc32c-2.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36ffa999b72e3c17f6a066ae9e970b40f8c65f38716e436c39a33b809bc6ed9f", size = 52884, upload-time = "2024-09-24T06:18:09.449Z" },
+    { url = "https://files.pythonhosted.org/packages/60/40/963ba3d2ec0d8e4a2ceaf90e8f9cb10911a926fe75d4329e013a51343122/crc32c-2.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e80114dd7f462297e54d5da1b9ff472e5249c5a2b406aa51c371bb0edcbf76bd", size = 53888, upload-time = "2024-09-24T06:18:11.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b8/8a093b9dc1792b2cec9805e1428e97be0338a45ac9fae2fd5911613eacb1/crc32c-2.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:676f5b46da268b5190f9fb91b3f037a00d114b411313664438525db876adc71f", size = 52098, upload-time = "2024-09-24T06:18:12.522Z" },
+    { url = "https://files.pythonhosted.org/packages/26/76/a254ddb4ae83b545f6e08af384d62268a99d00f5c58a468754f8416468ce/crc32c-2.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8d0e660c9ed269e90692993a4457a932fc22c9cc96caf79dd1f1a84da85bb312", size = 52716, upload-time = "2024-09-24T06:18:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/6062806e5b6cb8d9af3c62945a5a07fa22c3b4dc59084d2fa2e533f9aaa1/crc32c-2.7.1-cp310-cp310-win32.whl", hash = "sha256:17a2c3f8c6d85b04b5511af827b5dbbda4e672d188c0b9f20a8156e93a1aa7b6", size = 38363, upload-time = "2024-09-24T06:18:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a9/dc935e26c8d7bd4722bc1312ed88f443e6e36816b46835b4464baa3f7c6d/crc32c-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3208764c29688f91a35392073229975dd7687b6cb9f76b919dae442cabcd5126", size = 39795, upload-time = "2024-09-24T06:18:17.182Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/2f37f46368bbfd50edfc11b96f0aa135699034b1b020966c70ebaff3463b/crc32c-2.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19e03a50545a3ef400bd41667d5525f71030488629c57d819e2dd45064f16192", size = 49672, upload-time = "2024-09-24T06:18:18.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b8/e52f7c4b045b871c2984d70f37c31d4861b533a8082912dfd107a96cf7c1/crc32c-2.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c03286b1e5ce9bed7090084f206aacd87c5146b4b10de56fe9e86cbbbf851cf", size = 37155, upload-time = "2024-09-24T06:18:19.373Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ee/0cfa82a68736697f3c7e435ba658c2ef8c997f42b89f6ab4545efe1b2649/crc32c-2.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ebbf144a1a56a532b353e81fa0f3edca4f4baa1bf92b1dde2c663a32bb6a15", size = 35372, upload-time = "2024-09-24T06:18:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/92/c878aaba81c431fcd93a059e9f6c90db397c585742793f0bf6e0c531cc67/crc32c-2.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96b794fd11945298fdd5eb1290a812efb497c14bc42592c5c992ca077458eeba", size = 54879, upload-time = "2024-09-24T06:18:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f5/ab828ab3907095e06b18918408748950a9f726ee2b37be1b0839fb925ee1/crc32c-2.7.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df7194dd3c0efb5a21f5d70595b7a8b4fd9921fbbd597d6d8e7a11eca3e2d27", size = 52588, upload-time = "2024-09-24T06:18:24.463Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2b/9e29e9ac4c4213d60491db09487125db358cd9263490fbadbd55e48fbe03/crc32c-2.7.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d698eec444b18e296a104d0b9bb6c596c38bdcb79d24eba49604636e9d747305", size = 53674, upload-time = "2024-09-24T06:18:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ed/df3c4c14bf1b29f5c9b52d51fb6793e39efcffd80b2941d994e8f7f5f688/crc32c-2.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e07cf10ef852d219d179333fd706d1c415626f1f05e60bd75acf0143a4d8b225", size = 54691, upload-time = "2024-09-24T06:18:26.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/47/4917af3c9c1df2fff28bbfa6492673c9adeae5599dcc207bbe209847489c/crc32c-2.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d2a051f296e6e92e13efee3b41db388931cdb4a2800656cd1ed1d9fe4f13a086", size = 52896, upload-time = "2024-09-24T06:18:28.174Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6f/26fc3dda5835cda8f6cd9d856afe62bdeae428de4c34fea200b0888e8835/crc32c-2.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1738259802978cdf428f74156175da6a5fdfb7256f647fdc0c9de1bc6cd7173", size = 53554, upload-time = "2024-09-24T06:18:29.104Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3e/6f39127f7027c75d130c0ba348d86a6150dff23761fbc6a5f71659f4521e/crc32c-2.7.1-cp311-cp311-win32.whl", hash = "sha256:f7786d219a1a1bf27d0aa1869821d11a6f8e90415cfffc1e37791690d4a848a1", size = 38370, upload-time = "2024-09-24T06:18:30.013Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fb/1587c2705a3a47a3d0067eecf9a6fec510761c96dec45c7b038fb5c8ff46/crc32c-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:887f6844bb3ad35f0778cd10793ad217f7123a5422e40041231b8c4c7329649d", size = 39795, upload-time = "2024-09-24T06:18:31.324Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/02/998dc21333413ce63fe4c1ca70eafe61ca26afc7eb353f20cecdb77d614e/crc32c-2.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f7d1c4e761fe42bf856130daf8b2658df33fe0ced3c43dadafdfeaa42b57b950", size = 49568, upload-time = "2024-09-24T06:18:32.425Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/3e/e3656bfa76e50ef87b7136fef2dbf3c46e225629432fc9184fdd7fd187ff/crc32c-2.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:73361c79a6e4605204457f19fda18b042a94508a52e53d10a4239da5fb0f6a34", size = 37019, upload-time = "2024-09-24T06:18:34.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7d/5ff9904046ad15a08772515db19df43107bf5e3901a89c36a577b5f40ba0/crc32c-2.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd778fc8ac0ed2ffbfb122a9aa6a0e409a8019b894a1799cda12c01534493e0", size = 35373, upload-time = "2024-09-24T06:18:35.02Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/41/4aedc961893f26858ab89fc772d0eaba91f9870f19eaa933999dcacb94ec/crc32c-2.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ef661b34e9f25991fface7f9ad85e81bbc1b3fe3b916fd58c893eabe2fa0b8", size = 54675, upload-time = "2024-09-24T06:18:35.954Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/63/8cabf09b7e39b9fec8f7010646c8b33057fc8d67e6093b3cc15563d23533/crc32c-2.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:571aa4429444b5d7f588e4377663592145d2d25eb1635abb530f1281794fc7c9", size = 52386, upload-time = "2024-09-24T06:18:36.896Z" },
+    { url = "https://files.pythonhosted.org/packages/79/13/13576941bf7cf95026abae43d8427c812c0054408212bf8ed490eda846b0/crc32c-2.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c02a3bd67dea95cdb25844aaf44ca2e1b0c1fd70b287ad08c874a95ef4bb38db", size = 53495, upload-time = "2024-09-24T06:18:38.099Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b6/55ffb26d0517d2d6c6f430ce2ad36ae7647c995c5bfd7abce7f32bb2bad1/crc32c-2.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99d17637c4867672cb8adeea007294e3c3df9d43964369516cfe2c1f47ce500a", size = 54456, upload-time = "2024-09-24T06:18:39.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1a/5562e54cb629ecc5543d3604dba86ddfc7c7b7bf31d64005b38a00d31d31/crc32c-2.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f4a400ac3c69a32e180d8753fd7ec7bccb80ade7ab0812855dce8a208e72495f", size = 52647, upload-time = "2024-09-24T06:18:40.021Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ec/ce4138eaf356cd9aae60bbe931755e5e0151b3eca5f491fce6c01b97fd59/crc32c-2.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:588587772e55624dd9c7a906ec9e8773ae0b6ac5e270fc0bc84ee2758eba90d5", size = 53332, upload-time = "2024-09-24T06:18:40.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/144b42cd838a901175a916078781cb2c3c9f977151c9ba085aebd6d15b22/crc32c-2.7.1-cp312-cp312-win32.whl", hash = "sha256:9f14b60e5a14206e8173dd617fa0c4df35e098a305594082f930dae5488da428", size = 38371, upload-time = "2024-09-24T06:18:42.711Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c4/7929dcd5d9b57db0cce4fe6f6c191049380fc6d8c9b9f5581967f4ec018e/crc32c-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:7c810a246660a24dc818047dc5f89c7ce7b2814e1e08a8e99993f4103f7219e8", size = 39805, upload-time = "2024-09-24T06:18:43.6Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/1a6d60d5b3b5edc8382777b64100343cb4aa6a7e172fae4a6cfcb8ebbbd9/crc32c-2.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:24949bffb06fc411cc18188d33357923cb935273642164d0bb37a5f375654169", size = 49567, upload-time = "2024-09-24T06:18:44.485Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/0dd652d4e950e6348bbf16b964b3325e4ad8220470774128fc0b0dd069cb/crc32c-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d5d326e7e118d4fa60187770d86b66af2fdfc63ce9eeb265f0d3e7d49bebe0b", size = 37018, upload-time = "2024-09-24T06:18:45.434Z" },
+    { url = "https://files.pythonhosted.org/packages/47/02/2bd65fdef10139b6a802d83a7f966b7750fe5ffb1042f7cbe5dbb6403869/crc32c-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba110df60c64c8e2d77a9425b982a520ccdb7abe42f06604f4d98a45bb1fff62", size = 35374, upload-time = "2024-09-24T06:18:46.304Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/3e797d1ed92d357a6a4c5b41cea15a538b27a8fdf18c7863747eb50b73ad/crc32c-2.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c277f9d16a3283e064d54854af0976b72abaa89824955579b2b3f37444f89aae", size = 54641, upload-time = "2024-09-24T06:18:47.207Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/4ddeef755caaa75680c559562b6c71f5910fee4c4f3a2eb5ea8b57f0e48c/crc32c-2.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:881af0478a01331244e27197356929edbdeaef6a9f81b5c6bacfea18d2139289", size = 52338, upload-time = "2024-09-24T06:18:49.31Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cf/32f019be5de9f6e180926a50ee5f08648e686c7d9a59f2c5d0806a77b1c7/crc32c-2.7.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724d5ff4d29ff093a983ae656be3307093706d850ea2a233bf29fcacc335d945", size = 53447, upload-time = "2024-09-24T06:18:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8b/92f3f62f3bafe8f7ab4af7bfb7246dc683fd11ec0d6dfb73f91e09079f69/crc32c-2.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2416c4d88696ac322632555c0f81ab35e15f154bc96055da6cf110d642dbc10", size = 54484, upload-time = "2024-09-24T06:18:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b2/113a50f8781f76af5ac65ffdb907e72bddbe974de8e02247f0d58bc48040/crc32c-2.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:60254251b88ec9b9795215f0f9ec015a6b5eef8b2c5fba1267c672d83c78fc02", size = 52703, upload-time = "2024-09-24T06:18:52.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6c/309229e9acda8cf36a8ff4061d70b54d905f79b7037e16883ce6590a24ab/crc32c-2.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:edefc0e46f3c37372183f70338e5bdee42f6789b62fcd36ec53aa933e9dfbeaf", size = 53367, upload-time = "2024-09-24T06:18:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/6c6324d920396e1bd9f3efbe8753da071be0ca52bd22d6c82d446b8d6975/crc32c-2.7.1-cp313-cp313-win32.whl", hash = "sha256:813af8111218970fe2adb833c5e5239f091b9c9e76f03b4dd91aaba86e99b499", size = 38377, upload-time = "2024-09-24T06:18:54.487Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/f01ccfab538db07ef3f6b4ede46357ff147a81dd4f3c59ca6a34c791a549/crc32c-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:7d9ede7be8e4ec1c9e90aaf6884decbeef10e3473e6ddac032706d710cab5888", size = 39803, upload-time = "2024-09-24T06:18:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/61dcae7568b33acfde70c9d651c7d891c0c578c39cc049107c1cf61f1367/crc32c-2.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db9ac92294284b22521356715784b91cc9094eee42a5282ab281b872510d1831", size = 49386, upload-time = "2024-09-24T06:18:56.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/80f17c089799ab2b4c247443bdd101d6ceda30c46d7f193e16b5ca29c5a0/crc32c-2.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8fcd7f2f29a30dc92af64a9ee3d38bde0c82bd20ad939999427aac94bbd87373", size = 36937, upload-time = "2024-09-24T06:18:57.77Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/5fcfc71a3de493d920fd2590843762a2749981ea56b802b380e5df82309d/crc32c-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5c056ef043393085523e149276a7ce0cb534b872e04f3e20d74d9a94a75c0ad7", size = 35292, upload-time = "2024-09-24T06:18:58.676Z" },
+    { url = "https://files.pythonhosted.org/packages/03/de/fef962e898a953558fe1c55141644553e84ef4190693a31244c59a0856c7/crc32c-2.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0", size = 54223, upload-time = "2024-09-24T06:18:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/21/14/fceca1a6f45c0a1814fe8602a65657b75c27425162445925ba87438cad6b/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb9424ec1a8ca54763155a703e763bcede82e6569fe94762614bb2de1412d4e1", size = 51588, upload-time = "2024-09-24T06:19:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3b/13d40a7dfbf9ef05c84a0da45544ee72080dca4ce090679e5105689984bd/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88732070f6175530db04e0bb36880ac45c33d49f8ac43fa0e50cfb1830049d23", size = 52678, upload-time = "2024-09-24T06:19:02.661Z" },
+    { url = "https://files.pythonhosted.org/packages/36/09/65ffc4fb9fa60ff6714eeb50a92284a4525e5943f0b040b572c0c76368c1/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57a20dfc27995f568f64775eea2bbb58ae269f1a1144561df5e4a4955f79db32", size = 53847, upload-time = "2024-09-24T06:19:03.705Z" },
+    { url = "https://files.pythonhosted.org/packages/24/71/938e926085b7288da052db7c84416f3ce25e71baf7ab5b63824c7bcb6f22/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f7186d098bfd2cff25eac6880b7c7ad80431b90610036131c1c7dd0eab42a332", size = 51860, upload-time = "2024-09-24T06:19:04.726Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d8/4526d5380189d6f2fa27256c204100f30214fe402f47cf6e9fb9a91ab890/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55a77e29a265418fa34bef15bd0f2c60afae5348988aaf35ed163b4bbf93cf37", size = 52508, upload-time = "2024-09-24T06:19:05.731Z" },
+    { url = "https://files.pythonhosted.org/packages/19/30/15f7e35176488b77e5b88751947d321d603fccac273099ace27c7b2d50a6/crc32c-2.7.1-cp313-cp313t-win32.whl", hash = "sha256:ae38a4b6aa361595d81cab441405fbee905c72273e80a1c010fb878ae77ac769", size = 38319, upload-time = "2024-09-24T06:19:07.233Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c4/0b3eee04dac195f4730d102d7a9fbea894ae7a32ce075f84336df96a385d/crc32c-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eee2a43b663feb6c79a6c1c6e5eae339c2b72cfac31ee54ec0209fa736cf7ee5", size = 39781, upload-time = "2024-09-24T06:19:08.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/e0/14d392075db47c53a3890aa110e3640b22fb9736949c47b13d5b5e4599f7/crc32c-2.7.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2e83fedebcdeb80c19e76b7a0e5103528bb062521c40702bf34516a429e81df3", size = 36448, upload-time = "2024-09-24T06:19:50.456Z" },
+    { url = "https://files.pythonhosted.org/packages/03/27/f1dab3066c90e9424d22bc942eecdc2e77267f7e805ddb5a2419bbcbace6/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30004a7383538ef93bda9b22f7b3805bc0aa5625ab2675690e1b676b19417d4b", size = 38184, upload-time = "2024-09-24T06:19:51.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f3/479acfa99803c261cdd6b44f37b55bd77bdbce6163ec1f51b2014b095495/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a01b0983aa87f517c12418f9898ecf2083bf86f4ea04122e053357c3edb0d73f", size = 38256, upload-time = "2024-09-24T06:19:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/4edb9c45457c54d51ca539f850761f31b7ab764177902b6f3247ff8c1b75/crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb2b963c42128b38872e9ed63f04a73ce1ff89a1dfad7ea38add6fe6296497b8", size = 37868, upload-time = "2024-09-24T06:19:54.159Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b0/5680db08eff8f2116a4f9bd949f8bbe9cf260e1c3451228f54c60b110d79/crc32c-2.7.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cdd5e576fee5d255c1e68a4dae4420f21e57e6f05900b38d5ae47c713fc3330d", size = 39826, upload-time = "2024-09-24T06:19:55.4Z" },
+]
+
+[[package]]
 name = "crewai"
 source = { editable = "lib/crewai" }
 dependencies = [
@@ -1393,6 +1470,9 @@ litellm = [
 mem0 = [
     { name = "mem0ai" },
 ]
+oci = [
+    { name = "oci" },
+]
 openpyxl = [
     { name = "openpyxl" },
 ]
@@ -1451,6 +1531,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<2" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
+    { name = "oci", marker = "extra == 'oci'", specifier = ">=2.168.0" },
     { name = "openai", specifier = ">=2.30.0,<3" },
     { name = "openpyxl", specifier = "~=3.1.5" },
     { name = "openpyxl", marker = "extra == 'openpyxl'", specifier = "~=3.1.5" },
@@ -1474,7 +1555,7 @@ requires-dist = [
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "oci", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"
@@ -5437,6 +5518,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/93/76a5fc3833aaa833b4152950d9cdfd328493a48316c24e32ddefe9b8870f/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ba6863230648a9b0e11502d2745d881cf74262720238bc0093c3eabd22a3b24c", size = 3683450, upload-time = "2025-09-16T15:34:49.589Z" },
     { url = "https://files.pythonhosted.org/packages/15/3c/4c389362c187630c42f61ef9214e67fc336e44b8aafc47cf49ba9ab8007d/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:887615da9eeefeb2df849d87c380e04877487aa29dbeb367efc3f17f667470d3", size = 3766628, upload-time = "2025-09-16T15:34:51.937Z" },
     { url = "https://files.pythonhosted.org/packages/03/12/08547e63edf2239ec6660af434602208ab6f394955ef660a6edda13a0bee/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:4eec1fb32ffa4fb9fe9ad584611ff031927a5c22732b56075ee7204f0e35ebdf", size = 3944069, upload-time = "2025-09-16T15:34:54.108Z" },
+]
+
+[[package]]
+name = "oci"
+version = "2.181.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "circuitbreaker" },
+    { name = "crc32c" },
+    { name = "cryptography" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/b3/4f80ae248dc9872bcc2b0e677548f86c2a3fa4df0082bbe00e17058bc988/oci-2.181.1.tar.gz", hash = "sha256:05587d120014238c6d5459328517eb02862f20f10e085a14f2ed48e5ca082672", size = 17489251, upload-time = "2026-07-07T06:10:28.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/bd/7141e3f3b2ae7041a883d97bf3d0d9d9d4745c61b659743ebe3afe5e7624/oci-2.181.1-py3-none-any.whl", hash = "sha256:a7e4424e1c1f917afedfdf1a7b1bc0b99b75683a774e2270afba8ed09fcce95a", size = 35749804, upload-time = "2026-07-07T06:10:20.315Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `OCIEmbeddingFunction`: ChromaDB-compatible embedding callable with batching, config serialization, and image embedding support
- `OCIProvider`: Pydantic-based provider with `AliasChoices` for env var and config key validation
- Factory registration in `embeddings/factory.py` + `types.py` (provider name: `"oci"`)
- Supports text and image embeddings, configurable output dimensions, custom endpoints, all 4 OCI auth modes
- Shared auth via `utilities/oci.py` (from PR 1)

Depends on #4964, #4963, #4962, #4961, #4959. **Draft until all merge.**
Tracking issue: #4944

## Diff breakdown (vs multimodal PR)

| Change | Lines |
|--------|-------|
| `embedding_callable.py` (new) | +181 |
| `oci_provider.py` (new) | +75 |
| `types.py` (new) | +30 |
| `__init__.py` (new) | +17 |
| `factory.py` (registration + overload) | +9 |
| `types.py` (ProviderSpec + Literal) | +3 |
| `test_factory_oci.py` (5 unit tests) | +207 |
| `test_oci_embedding_integration.py` (2 live tests) | +66 |
| **Total** | **+588** |

## Test plan

- [x] 5 unit tests: factory wiring, batching, output dimensions, config serialization, image embeddings
- [x] 2 live integration tests against `cohere.embed-english-v3.0` (API_KEY_AUTH): single text + batch
- [x] All 42 prior LLM unit tests still pass