### PR TITLE
fix: Use defusedxml instead of xml.etree.ElementTree to prevent XXE attacks

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-docx~=1.2.0",
     "youtube-transcript-api~=1.2.2",
     "pymupdf~=1.26.6",
+    "defusedxml>=0.7.1",
 ]
 
 

--- a/lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py
@@ -1,7 +1,7 @@
 from typing import Any
-from xml.etree.ElementTree import ParseError, fromstring, parse
 
 from crewai_tools.rag.base_loader import BaseLoader, LoaderResult
+from defusedxml.ElementTree import ParseError, fromstring, parse
 from crewai_tools.rag.loaders.utils import load_from_url
 from crewai_tools.rag.source_content import SourceContent
 


### PR DESCRIPTION
## Description

The Python xml library is vulnerable to XML External Entity (XXE) attacks. This PR replaces the use of `xml.etree.ElementTree` with `defusedxml.ElementTree` which provides safer alternatives that prevent:

- XML External Entity (XXE) attacks that can leak confidential data
- XML bombs that can cause denial of service

## Changes

- Modified `lib/crewai-tools/src/crewai_tools/rag/loaders/xml_loader.py` to import from `defusedxml.ElementTree` instead of `xml.etree.ElementTree`
- Added `defusedxml>=0.7.1` as a dependency in `pyproject.toml`

## Testing

The defusedxml library provides compatible APIs for `ParseError`, `fromstring`, and `parse` that were being used from the standard library.

Fixes #4865