### PR TITLE
fix: Respect custom trained data file during inference

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1109,9 +1109,10 @@ class Agent(BaseAgent):
 
         return task_prompt
 
-    def _use_trained_data(self, task_prompt: str) -> str:
+    def _use_trained_data(self, task_prompt: str, trained_data_file: str | None = None) -> str:
         """Use trained data for the agent task prompt to improve output."""
-        if data := CrewTrainingHandler(TRAINED_AGENTS_DATA_FILE).load():
+        file_to_load = trained_data_file or TRAINED_AGENTS_DATA_FILE
+        if data := CrewTrainingHandler(file_to_load).load():
             if trained_data_output := data.get(self.role):
                 task_prompt += (
                     "\n\nYou MUST follow these instructions: \n - "

--- a/lib/crewai/src/crewai/agent/utils.py
+++ b/lib/crewai/src/crewai/agent/utils.py
@@ -246,7 +246,8 @@ def apply_training_data(agent: Agent, task_prompt: str) -> str:
     """
     if agent.crew and agent.crew._train:
         return agent._training_handler(task_prompt=task_prompt)
-    return agent._use_trained_data(task_prompt=task_prompt)
+    trained_data_file = agent.crew._trained_data_file if agent.crew else None
+    return agent._use_trained_data(task_prompt=task_prompt, trained_data_file=trained_data_file)
 
 
 def process_tool_results(agent: Agent, result: Any) -> Any:

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -180,6 +180,7 @@ class Crew(FlowTrackable, BaseModel):
     _memory: Memory | MemoryScope | MemorySlice | None = PrivateAttr(default=None)
     _train: bool | None = PrivateAttr(default=False)
     _train_iteration: int | None = PrivateAttr()
+    _trained_data_file: str | None = PrivateAttr(default=None)
     _inputs: dict[str, Any] | None = PrivateAttr(default=None)
     _logging_color: PrinterColor = PrivateAttr(
         default="bold_purple",
@@ -625,6 +626,7 @@ class Crew(FlowTrackable, BaseModel):
     def _setup_for_training(self, filename: str) -> None:
         """Sets up the crew for training."""
         self._train = True
+        self._trained_data_file = filename
 
         for task in self.tasks:
             task.human_input = True


### PR DESCRIPTION
## Summary

When training a crew with a custom filename via `train -f <custom_file>.pkl`, the crew now correctly loads from that same file during inference, instead of always loading from the hardcoded `trained_agents_data.pkl`.

## Problem

The `_use_trained_data()` method in Agent always loaded from `TRAINED_AGENTS_DATA_FILE` constant, ignoring any custom filename provided during training.

## Solution

1. Added `_trained_data_file` attribute to Crew class to store the custom filename
2. Store the filename during `_setup_for_training()`
3. Pass the stored filename to `_use_trained_data()` via the utility function
4. Fall back to default `trained_agents_data.pkl` when no custom file is specified

## Changes

- `src/crewai/crew.py`: Add `_trained_data_file` attribute and store filename during setup
- `src/crewai/agent/core.py`: Add `trained_data_file` parameter to `_use_trained_data()`
- `src/crewai/agent/utils.py`: Retrieve and pass `trained_data_file` from crew

## Backwards Compatibility

Fully backwards compatible. Existing code using default filename continues to work unchanged.

Fixes #4905