### PR TITLE
fix: convert crew.memory to string in telemetry span attribute

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -279,7 +279,7 @@ class Telemetry:
             self._add_attribute(span, "python_version", platform.python_version())
             add_crew_attributes(span, crew, self._add_attribute)
             self._add_attribute(span, "crew_process", crew.process)
-            self._add_attribute(span, "crew_memory", crew.memory)
+            self._add_attribute(span, "crew_memory", str(crew.memory))
             self._add_attribute(span, "crew_number_of_tasks", len(crew.tasks))
             self._add_attribute(span, "crew_number_of_agents", len(crew.agents))
 


### PR DESCRIPTION
## Problem

When using a custom `Memory` instance with an explicitly configured storage backend (e.g. LanceDB), the crew fails to initialize with:

```
Invalid type Memory for attribute 'crew_memory' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This happens because `crew.memory` can be:
- `True` (default Memory)
- `False` (no memory)  
- A `Memory` instance (custom storage)

OpenTelemetry span attributes only accept primitive types. Passing a `Memory` object directly causes the error.

## Root Cause

In `lib/crewai/src/crewai/telemetry/telemetry.py` line 282:
```python
self._add_attribute(span, "crew_memory", crew.memory)
```

When `crew.memory` is a `Memory` instance, this fails the OpenTelemetry type check.

## Fix

Convert to string:
```python
self._add_attribute(span, "crew_memory", str(crew.memory))
```

This works for all three cases:
- `True` → `"True"`
- `False` → `"False"`  
- `Memory(...)` → `"Memory(storage=..., ...)"` (or whatever `__str__` returns)
