### PR TITLE
fix(agents): fix Bedrock Converse API tool arguments dropped in _parse_native_tool_call

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {}) or "{}"
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
The default value `"{}"` (truthy string) in `func_info.get("arguments", "{}")` prevents the fallback to `tool_call.get("input", {})` from activating for Bedrock Converse API responses.

Closes #4972