### PR TITLE
fix(llm): prioritize tool_calls over text_response when available_functions=None

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1234,8 +1234,15 @@ class LLM(BaseLLM):
         # --- 4) Check for tool calls
         tool_calls = getattr(response_message, "tool_calls", [])
 
-        # --- 5) If no tool calls or no available functions, return the text response directly as long as there is a text response
-        if (not tool_calls or not available_functions) and text_response:
+        # --- 5) If there are tool calls but no available functions, return the tool calls
+        # This MUST come before checking for text_response, otherwise a mixed response
+        # (text + tool_calls) with available_functions=None would return the text and
+        # silently discard the tool calls (fixes #4788).
+        if tool_calls and not available_functions:
+            return tool_calls
+
+        # --- 6) If no tool calls, return the text response directly as long as there is a text response
+        if not tool_calls and text_response:
             self._handle_emit_call_events(
                 response=text_response,
                 call_type=LLMCallType.LLM_CALL,
@@ -1244,11 +1251,6 @@ class LLM(BaseLLM):
                 messages=params["messages"],
             )
             return text_response
-
-        # --- 6) If there are tool calls but no available functions, return the tool calls
-        # This allows the caller (e.g., executor) to handle tool execution
-        if tool_calls and not available_functions:
-            return tool_calls
 
         # --- 7) Handle tool calls if present (execute when available_functions provided)
         if tool_calls and available_functions:


### PR DESCRIPTION
## Problem

When a LLM returns both a text response **and** tool calls in the same message, and the executor calls `get_llm_response` with `available_functions=None` (native tool routing mode), the old condition:

```python
# step 5 (old — buggy)
if (not tool_calls or not available_functions) and text_response:
    return text_response  # ← silently drops tool_calls!

# step 6 (old — never reached when there is text)
if tool_calls and not available_functions:
    return tool_calls
```

The `not available_functions` clause in step 5 made it fire even when `tool_calls` were present, causing the executor to receive the text response and treat it as a potential final answer, never executing the tools.

## Fix

Swap the order: check `tool_calls and not available_functions` **first** so the caller always receives tool calls for external execution, then fall through to the text response only when there are no tool calls.

```python
# step 5 (new — correct)
if tool_calls and not available_functions:
    return tool_calls  # executor handles execution

# step 6 (new)
if not tool_calls and text_response:
    return text_response
```

## Impact

Fixes native function calling for any LLM that returns mixed text+tool_call responses (common with Anthropic Claude, Gemini, and newer OpenAI models).

Closes #4788
