### PR TITLE
fix: Bedrock Converse API tool arguments silently dropped (#4972)

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or "{}"
             return call_id, func_name, func_args
         return None
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -879,6 +879,44 @@ class TestNativeToolExecution:
         assert len(tool_messages) == 1
         assert tool_messages[0]["tool_call_id"] == "call_1"
 
+    def test_parse_native_tool_call_bedrock_format(self, mock_dependencies):
+        """Bedrock Converse API returns {name, input, toolUseId} without 'function' key.
+
+        Regression test: func_info.get("arguments", "{}") returned a truthy
+        default string, short-circuiting the 'or' and silently dropping input.
+        Fix: func_info.get("arguments") or tool_call.get("input") or "{}"
+        """
+        executor = AgentExecutor(**mock_dependencies)
+
+        # Bedrock-style tool call (no "function" key, has "name" + "input")
+        bedrock_call = {
+            "name": "search_tool",
+            "input": {"search_query": "hello world"},
+            "toolUseId": "call_bedrock_123",
+        }
+        result = executor._parse_native_tool_call(bedrock_call)
+        assert result is not None
+        call_id, func_name, func_args = result
+        assert func_name == "search_tool"
+        assert call_id == "call_bedrock_123"
+        # The critical assertion: input dict must NOT be dropped
+        assert func_args == {"search_query": "hello world"}
+
+    def test_parse_native_tool_call_openai_dict_format(self, mock_dependencies):
+        """OpenAI-style {function: {name, arguments}} dict still works."""
+        executor = AgentExecutor(**mock_dependencies)
+
+        openai_call = {
+            "id": "call_abc",
+            "function": {"name": "my_tool", "arguments": '{"x": 1}'},
+        }
+        result = executor._parse_native_tool_call(openai_call)
+        assert result is not None
+        call_id, func_name, func_args = result
+        assert func_name == "my_tool"
+        assert call_id == "call_abc"
+        assert func_args == '{"x": 1}'
+
     def test_check_native_todo_completion_requires_current_todo(
         self, mock_dependencies
     ):


### PR DESCRIPTION
## Problem

When using AWS Bedrock with native function calling, **all tool arguments are silently dropped**. Every tool call receives an empty dict `{}` instead of the actual arguments, causing pydantic validation failures on any tool with required parameters.

This affects ALL Bedrock models using native function calling (Claude, Llama, etc.) via the native tool loop code path.

## Root Cause

In `_parse_native_tool_call` (crew_agent_executor.py), the dict-format branch has a truthy default:

```python
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
```

Bedrock Converse API returns `{name, input, toolUseId}` — **no `"function"` key**.

So `func_info` is `{}`, and `func_info.get("arguments", "{}")` returns the default `"{}"` — a **truthy string**. The `or` short-circuits and `tool_call.get("input", {})` is never evaluated.

## Fix

Remove the default so `get()` returns `None` (falsy), allowing the `or` to fall through:

```python
func_args = func_info.get("arguments") or tool_call.get("input") or "{}"
```

## Verification

```
Bedrock format: {"name": "search_tool", "input": {"search_query": "hello"}, "toolUseId": "abc"}
OLD: func_info.get("arguments", "{}") → "{}" (truthy!) → short-circuits → broken
NEW: func_info.get("arguments") → None (falsy) → falls through to tool_call["input"] ✓

OpenAI format: {"function": {"name": "t", "arguments": "{"x": 1}"}}
NEW: func_info.get("arguments") → "{"x": 1}" (truthy) → same as before ✓
```

## Tests Added

- `test_parse_native_tool_call_bedrock_format` — verifies Bedrock input dict is correctly extracted
- `test_parse_native_tool_call_openai_dict_format` — verifies OpenAI format still works

Fixes #4972