### PR TITLE
fix(tools): use LF line endings in generate_tool_specs.py to prevent CRLF diffs on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
On Windows, Python's `open()` in text mode writes CRLF line endings. This causes `generate_tool_specs.py` to regenerate `tool.specs.json` with `\r\n`, making every line appear modified in `git diff` even when no content changed.

Fix: add `newline="\n"` to the `open()` call in `save_to_json()` to force LF output on all platforms.

Closes #4737