### PR TITLE
feat(crew): add opt-in context_strategy='summarized' to reduce inter-task token usage

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -10,6 +10,7 @@ import re
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     cast,
 )
 import uuid
@@ -106,6 +107,7 @@ from crewai.utilities.file_store import clear_files, get_all_files
 from crewai.utilities.formatter import (
     aggregate_raw_outputs_from_task_outputs,
     aggregate_raw_outputs_from_tasks,
+    aggregate_summarized_outputs_from_task_outputs,
 )
 from crewai.utilities.i18n import get_i18n
 from crewai.utilities.llm_utils import create_llm
@@ -258,6 +260,15 @@ class Crew(FlowTrackable, BaseModel):
     output_log_file: bool | str | None = Field(
         default=None,
         description="Path to the log file to be saved",
+    )
+    context_strategy: Literal["full", "summarized"] = Field(
+        default="full",
+        description=(
+            "Strategy for passing prior task outputs as context to subsequent tasks. "
+            "'full' (default) passes the complete raw output. "
+            "'summarized' condenses each output to 2-3 sentences before passing it, "
+            "which reduces token usage in long multi-task crews."
+        ),
     )
     planning: bool | None = Field(
         default=False,
@@ -1487,19 +1498,55 @@ class Crew(FlowTrackable, BaseModel):
                 )
         return tools
 
-    @staticmethod
-    def _get_context(task: Task, task_outputs: list[TaskOutput]) -> str:
+    def _get_context(self, task: Task, task_outputs: list[TaskOutput]) -> str:
         if not task.context:
             return ""
 
-        return (
-            aggregate_raw_outputs_from_task_outputs(task_outputs)
-            if task.context is NOT_SPECIFIED
-            else aggregate_raw_outputs_from_tasks(task.context)
-        )
+        effective_strategy = task.context_strategy or self.context_strategy
+
+        if task.context is NOT_SPECIFIED:
+            if effective_strategy == "summarized":
+                return aggregate_summarized_outputs_from_task_outputs(task_outputs)
+            return aggregate_raw_outputs_from_task_outputs(task_outputs)
+        else:
+            if effective_strategy == "summarized":
+                explicit_outputs = [
+                    t.output for t in task.context if t.output is not None
+                ]
+                return aggregate_summarized_outputs_from_task_outputs(explicit_outputs)
+            return aggregate_raw_outputs_from_tasks(task.context)
+
+    def _generate_context_summary(self, task: Task, output: TaskOutput) -> None:
+        """Generate a condensed summary of a task output for use as context.
+
+        Called after task completion when context_strategy='summarized' is active
+        at the crew or task level. Falls back silently on any LLM error.
+        """
+        if task.agent is None or not hasattr(task.agent, "llm"):
+            return
+        try:
+            prompt = (
+                "Summarize the following task output in 2-3 concise sentences, "
+                "preserving the key facts and conclusions:\n\n"
+                f"{output.raw}"
+            )
+            summary = task.agent.llm.call(messages=prompt)
+            if isinstance(summary, str) and summary.strip():
+                output.context_summary = summary.strip()
+        except Exception:
+            pass  # Fall back to raw output in aggregate_summarized_outputs_from_task_outputs
 
     def _process_task_result(self, task: Task, output: TaskOutput) -> None:
         role = task.agent.role if task.agent is not None else "None"
+
+        effective_strategy = (
+            task.context_strategy
+            if task.context_strategy is not None
+            else self.context_strategy
+        )
+        if effective_strategy == "summarized":
+            self._generate_context_summary(task, output)
+
         if self.output_log_file:
             self._file_handler.log(
                 task_name=task.name,  # type: ignore[arg-type]

--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -14,6 +14,7 @@ import threading
 from typing import (
     Any,
     ClassVar,
+    Literal,
     cast,
     get_args,
     get_origin,
@@ -133,6 +134,14 @@ class Task(BaseModel):
     context: list[Task] | None | _NotSpecified = Field(
         description="Other tasks that will have their output used as context for this task.",
         default=NOT_SPECIFIED,
+    )
+    context_strategy: Literal["full", "summarized"] | None = Field(
+        description=(
+            "Override the crew-level context_strategy for this task. "
+            "'full' uses raw outputs; 'summarized' uses condensed summaries. "
+            "Defaults to None (inherit from crew)."
+        ),
+        default=None,
     )
     async_execution: bool | None = Field(
         description="Whether the task should be executed asynchronously or not.",

--- a/lib/crewai/src/crewai/tasks/task_output.py
+++ b/lib/crewai/src/crewai/tasks/task_output.py
@@ -30,6 +30,10 @@ class TaskOutput(BaseModel):
         description="Expected output of the task", default=None
     )
     summary: str | None = Field(description="Summary of the task", default=None)
+    context_summary: str | None = Field(
+        description="Condensed summary of the raw output used when context_strategy='summarized'",
+        default=None,
+    )
     raw: str = Field(description="Raw output of the task", default="")
     pydantic: BaseModel | None = Field(
         description="Pydantic output of task", default=None

--- a/lib/crewai/src/crewai/utilities/formatter.py
+++ b/lib/crewai/src/crewai/utilities/formatter.py
@@ -26,6 +26,26 @@ def aggregate_raw_outputs_from_task_outputs(task_outputs: list[TaskOutput]) -> s
     return DIVIDERS.join(output.raw for output in task_outputs)
 
 
+def aggregate_summarized_outputs_from_task_outputs(
+    task_outputs: list[TaskOutput],
+) -> str:
+    """Generate condensed string context from summarized task outputs.
+
+    Falls back to raw output for any task that has no context_summary.
+
+    Args:
+        task_outputs: List of TaskOutput objects.
+
+    Returns:
+        A string containing the aggregated context summaries (or raw fallbacks).
+    """
+    parts = [
+        output.context_summary if output.context_summary is not None else output.raw
+        for output in task_outputs
+    ]
+    return DIVIDERS.join(parts)
+
+
 def aggregate_raw_outputs_from_tasks(tasks: list[Task] | _NotSpecified) -> str:
     """Generate string context from the tasks.
 

--- a/lib/crewai/tests/test_context_strategy.py
+++ b/lib/crewai/tests/test_context_strategy.py
@@ -1,0 +1,261 @@
+"""Tests for context_strategy='summarized' feature."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai.agent import Agent
+from crewai.crew import Crew
+from crewai.process import Process
+from crewai.task import Task
+from crewai.tasks.task_output import TaskOutput
+from crewai.utilities.formatter import (
+    aggregate_summarized_outputs_from_task_outputs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(llm_response: str = "summary text") -> Agent:
+    agent = Agent(
+        role="Test Agent",
+        goal="Test goal",
+        backstory="Test backstory",
+        allow_delegation=False,
+    )
+    agent.llm = MagicMock()
+    agent.llm.call.return_value = llm_response
+    return agent
+
+
+def _make_task_output(raw: str, context_summary: str | None = None) -> TaskOutput:
+    return TaskOutput(
+        description="test task",
+        raw=raw,
+        agent="Test Agent",
+        context_summary=context_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# formatter tests
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_summarized_uses_context_summary_when_present():
+    outputs = [
+        _make_task_output("long raw 1", context_summary="short summary 1"),
+        _make_task_output("long raw 2", context_summary="short summary 2"),
+    ]
+    result = aggregate_summarized_outputs_from_task_outputs(outputs)
+    assert "short summary 1" in result
+    assert "short summary 2" in result
+    assert "long raw" not in result
+
+
+def test_aggregate_summarized_falls_back_to_raw_when_no_summary():
+    outputs = [
+        _make_task_output("raw output A", context_summary=None),
+        _make_task_output("raw output B", context_summary="summary B"),
+    ]
+    result = aggregate_summarized_outputs_from_task_outputs(outputs)
+    assert "raw output A" in result
+    assert "summary B" in result
+
+
+def test_aggregate_summarized_empty_list():
+    assert aggregate_summarized_outputs_from_task_outputs([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# TaskOutput tests
+# ---------------------------------------------------------------------------
+
+
+def test_task_output_context_summary_defaults_to_none():
+    output = _make_task_output("some raw output")
+    assert output.context_summary is None
+
+
+def test_task_output_context_summary_can_be_set():
+    output = _make_task_output("some raw output", context_summary="condensed")
+    assert output.context_summary == "condensed"
+
+
+# ---------------------------------------------------------------------------
+# Crew.context_strategy field tests
+# ---------------------------------------------------------------------------
+
+
+def test_crew_context_strategy_defaults_to_full():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+    assert crew.context_strategy == "full"
+
+
+def test_crew_context_strategy_accepts_summarized():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="summarized")
+    assert crew.context_strategy == "summarized"
+
+
+def test_task_context_strategy_defaults_to_none():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    assert task.context_strategy is None
+
+
+# ---------------------------------------------------------------------------
+# Crew._generate_context_summary tests
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_crew(context_strategy: str = "full") -> Crew:
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    return Crew(agents=[agent], tasks=[task], context_strategy=context_strategy)
+
+
+def test_generate_context_summary_sets_field():
+    agent = _make_agent(llm_response="concise summary")
+    task = Task(description="t", expected_output="o", agent=agent)
+    task_mock = MagicMock(spec=task)
+    task_mock.agent = agent
+
+    output = _make_task_output("very long raw output")
+    crew = _make_minimal_crew()
+    crew._generate_context_summary(task_mock, output)
+
+    assert output.context_summary == "concise summary"
+    agent.llm.call.assert_called_once()
+
+
+def test_generate_context_summary_ignores_empty_llm_response():
+    agent = _make_agent(llm_response="   ")
+    task_mock = MagicMock()
+    task_mock.agent = agent
+
+    output = _make_task_output("raw output")
+    crew = _make_minimal_crew()
+    crew._generate_context_summary(task_mock, output)
+
+    assert output.context_summary is None
+
+
+def test_generate_context_summary_swallows_llm_errors():
+    agent = _make_agent()
+    agent.llm.call.side_effect = RuntimeError("LLM unavailable")
+    task_mock = MagicMock()
+    task_mock.agent = agent
+
+    output = _make_task_output("raw output")
+    crew = _make_minimal_crew()
+
+    # Should not raise
+    crew._generate_context_summary(task_mock, output)
+    assert output.context_summary is None
+
+
+def test_generate_context_summary_skips_when_no_agent():
+    task_mock = MagicMock()
+    task_mock.agent = None
+
+    output = _make_task_output("raw output")
+    crew = _make_minimal_crew()
+    crew._generate_context_summary(task_mock, output)
+
+    assert output.context_summary is None
+
+
+# ---------------------------------------------------------------------------
+# Crew._process_task_result — summary generation gated by strategy
+# ---------------------------------------------------------------------------
+
+
+def test_process_task_result_calls_summary_when_strategy_summarized():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    task.context_strategy = None  # inherit from crew
+
+    output = _make_task_output("raw")
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="summarized")
+
+    with patch.object(crew, "_generate_context_summary") as mock_summary:
+        crew._process_task_result(task, output)
+        mock_summary.assert_called_once_with(task, output)
+
+
+def test_process_task_result_skips_summary_when_strategy_full():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+
+    output = _make_task_output("raw")
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="full")
+
+    with patch.object(crew, "_generate_context_summary") as mock_summary:
+        crew._process_task_result(task, output)
+        mock_summary.assert_not_called()
+
+
+def test_process_task_result_task_level_override_wins():
+    """Task-level context_strategy='summarized' triggers summary even if crew is 'full'."""
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+    task.context_strategy = "summarized"
+
+    output = _make_task_output("raw")
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="full")
+
+    with patch.object(crew, "_generate_context_summary") as mock_summary:
+        crew._process_task_result(task, output)
+        mock_summary.assert_called_once_with(task, output)
+
+
+# ---------------------------------------------------------------------------
+# Crew._get_context — routes to correct aggregator
+# ---------------------------------------------------------------------------
+
+
+def test_get_context_full_strategy_uses_raw():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+
+    outputs = [
+        _make_task_output("raw A", context_summary="summary A"),
+        _make_task_output("raw B", context_summary="summary B"),
+    ]
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="full")
+    result = crew._get_context(task, outputs)
+
+    assert "raw A" in result
+    assert "raw B" in result
+
+
+def test_get_context_summarized_strategy_uses_summaries():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent)
+
+    outputs = [
+        _make_task_output("long raw A", context_summary="summary A"),
+        _make_task_output("long raw B", context_summary="summary B"),
+    ]
+    crew = Crew(agents=[agent], tasks=[task], context_strategy="summarized")
+    result = crew._get_context(task, outputs)
+
+    assert "summary A" in result
+    assert "summary B" in result
+    assert "long raw" not in result
+
+
+def test_get_context_returns_empty_when_no_context():
+    agent = _make_agent()
+    task = Task(description="t", expected_output="o", agent=agent, context=None)
+
+    crew = Crew(agents=[agent], tasks=[task])
+    result = crew._get_context(task, [])
+    assert result == ""


### PR DESCRIPTION
## Summary

Fixes #4661.

In multi-task crews, every task's prompt grows unboundedly because all prior task outputs are concatenated verbatim as context. This causes `ContextLengthExceeded` errors and degrades LLM quality in longer crews.

This PR adds an opt-in `context_strategy` field that compresses prior outputs to 2-3 sentence summaries before injecting them as context.

## Changes

- **`TaskOutput`** — adds `context_summary: str | None` field to store the condensed version of each output
- **`formatter.py`** — adds `aggregate_summarized_outputs_from_task_outputs()` that uses `context_summary` when available, falls back to `raw`
- **`Crew`** — adds `context_strategy: Literal["full", "summarized"]` field (default `"full"`, zero breaking changes); updates `_get_context()` to route to the correct aggregator; adds `_generate_context_summary()` called from `_process_task_result()` after each task completes
- **`Task`** — adds `context_strategy: Literal["full", "summarized"] | None` for per-task override of the crew-level setting

## Usage

```python
# Crew-level (all tasks use summaries as context)
crew = Crew(
    agents=[...],
    tasks=[...],
    context_strategy="summarized",
)

# Per-task override (this task gets full context even if crew is summarized)
important_task = Task(
    description="...",
    expected_output="...",
    agent=agent,
    context_strategy="full",
)
```

## Behaviour

1. After each task completes, `_process_task_result` calls `_generate_context_summary` if `context_strategy="summarized"` is active
2. A single LLM call (using the task's own agent LLM) condenses the raw output to 2-3 sentences stored in `TaskOutput.context_summary`
3. On any LLM error the summary is skipped silently — `aggregate_summarized_outputs_from_task_outputs` falls back to `raw` for outputs with no summary
4. `context_strategy="full"` (default) is completely unchanged

## Test plan

- [x] `aggregate_summarized_outputs_from_task_outputs` uses `context_summary` when present, falls back to `raw`
- [x] `TaskOutput.context_summary` defaults to `None`
- [x] `Crew.context_strategy` defaults to `"full"`
- [x] `Task.context_strategy` defaults to `None` (inherit from crew)
- [x] `_generate_context_summary` sets `context_summary` on success
- [x] `_generate_context_summary` ignores empty/whitespace LLM responses
- [x] `_generate_context_summary` swallows LLM errors without raising
- [x] `_generate_context_summary` is a no-op when `task.agent` is `None`
- [x] `_process_task_result` calls summary generation only when strategy is `"summarized"`
- [x] Per-task `context_strategy` overrides crew-level setting
- [x] `_get_context` routes to correct aggregator based on effective strategy