### PR TITLE
fix: preserve Bedrock Converse API tool arguments in _parse_native_tool_call

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", "{}")
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Fix

Fixes #4972

### Problem

When using AWS Bedrock (Converse API) with native function calling, all tool arguments are silently dropped — every tool call receives an empty dict `{}` instead of actual arguments.

### Root Cause

In `_parse_native_tool_call`, the dict-handling branch has:

```python
func_info = tool_call.get("function", {})
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
```

Bedrock returns tool calls as `{"name": "...", "input": {...}, "toolUseId": "..."}` — no `"function"` key. So `func_info` is `{}`, and `func_info.get("arguments", "{}")` returns the default string `"{}"`. Since `"{}"` is truthy, the `or` short-circuits and `tool_call["input"]` is never evaluated.

### Fix

Remove the default value from `.get("arguments")` so it returns `None` when the key is absent, allowing the `or` to fall through to `tool_call.get("input")`:

```python
func_args = func_info.get("arguments") or tool_call.get("input", "{}")
```

### Behavior by provider:

| Provider | `tool_call` structure | Before fix | After fix |
|----------|----------------------|------------|------------|
| OpenAI | `{"function": {"arguments": "{...}"}}` | `"{...}"` ✅ | `"{...}"` ✅ |
| Anthropic (direct) | `{"input": {...}}` (has attr) | Handled earlier | Handled earlier |
| Bedrock (dict) | `{"name": "..", "input": {...}}` | `"{}"` ❌ | `{...}` ✅ |

### Testing

The fix can be verified by running a crew with Bedrock and a tool that has required arguments. Before the fix, all tool calls fail with `Field required [type=missing, input_value={}, input_type=dict]`. After fix, arguments are correctly passed through.