### PR TITLE
fix: save flow plot HTML to CWD instead of temp directory

### DIFF
--- a/lib/crewai/src/crewai/cli/templates/flow/main.py
+++ b/lib/crewai/src/crewai/cli/templates/flow/main.py
@@ -53,7 +53,8 @@ def kickoff():
 
 def plot():
     poem_flow = PoemFlow()
-    poem_flow.plot()
+    path = poem_flow.plot()
+    print(f"Flow visualization saved to {path}")
 
 
 def run_with_trigger():

--- a/lib/crewai/src/crewai/flow/visualization/renderers/interactive.py
+++ b/lib/crewai/src/crewai/flow/visualization/renderers/interactive.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-import tempfile
 from typing import Any, ClassVar
 import webbrowser
 
@@ -403,12 +402,12 @@ def render_interactive(
         extensions=[CSSExtension, JSExtension],
     )
 
-    temp_dir = Path(tempfile.mkdtemp(prefix="crewai_flow_"))
-    output_path = temp_dir / Path(filename).name
+    output_dir = Path.cwd()
+    output_path = output_dir / Path(filename).name
     css_filename = output_path.stem + "_style.css"
-    css_output_path = temp_dir / css_filename
+    css_output_path = output_dir / css_filename
     js_filename = output_path.stem + "_script.js"
-    js_output_path = temp_dir / js_filename
+    js_output_path = output_dir / js_filename
 
     css_file = template_dir / "style.css"
     css_content = css_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

When running `crewai flow plot`, the visualization HTML is saved to a hidden system temp directory (e.g. `/var/folders/.../T/crewai_flow_.../`), but users can't find it because nothing prints the actual path. This breaks CI/CD pipelines trying to capture the HTML as an artifact.

Fixes #4991

## Changes

1. **`render_interactive()`** — Save HTML/CSS/JS to `Path.cwd()` instead of `tempfile.mkdtemp()`. Removed unused `tempfile` import.
2. **Template `plot()`** — Now captures the return path from `poem_flow.plot()` and prints it, so users see the actual absolute path.

## Before

```
$ crewai flow plot
Plotting the Flow
(no output about where file was saved, file in temp dir)
```

## After

```
$ crewai flow plot
Plotting the Flow
Flow visualization saved to /path/to/project/crewai_flow.html
```

The HTML file (and its CSS/JS) are now saved in the current working directory where the user expects them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where `crewai flow plot` writes HTML/CSS/JS artifacts (from a temp dir to the current working directory), which may affect file overwrites and CI artifact collection but is otherwise localized to visualization output.
> 
> **Overview**
> Flow visualization output is now written to the **current working directory** instead of a temporary folder, so generated `*.html` plus its companion CSS/JS files are easy to locate and capture as CI artifacts.
> 
> The flow template’s `plot()` helper now captures the return value from `poem_flow.plot()` and prints the saved path to stdout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e0eadd6653ce01202ef6414c69be570f4ba8962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->