### PR TITLE
fix: prevent SQL injection in SnowflakeSearchTool and NL2SQLTool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/nl2sql/nl2sql_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/nl2sql/nl2sql_tool.py
@@ -54,7 +54,8 @@ class NL2SQLTool(BaseTool):
 
     def _fetch_all_available_columns(self, table_name: str):
         return self.execute_sql(
-            f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table_name}';"  # noqa: S608
+            "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = :table_name;",
+            params={"table_name": table_name},
         )
 
     def _run(self, sql_query: str):
@@ -69,7 +70,7 @@ class NL2SQLTool(BaseTool):
 
         return data
 
-    def execute_sql(self, sql_query: str) -> list | str:
+    def execute_sql(self, sql_query: str, params: dict | None = None) -> list | str:
         if not SQLALCHEMY_AVAILABLE:
             raise ImportError(
                 "sqlalchemy is not installed. Please install it with `pip install crewai-tools[sqlalchemy]`"
@@ -79,7 +80,7 @@ class NL2SQLTool(BaseTool):
         Session = sessionmaker(bind=engine)  # noqa: N806
         session = Session()
         try:
-            result = session.execute(text(sql_query))
+            result = session.execute(text(sql_query), params or {})
             session.commit()
 
             if result.returns_rows:  # type: ignore[attr-defined]

--- a/lib/crewai-tools/src/crewai_tools/tools/snowflake_search_tool/snowflake_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/snowflake_search_tool/snowflake_search_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import logging
+import re
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +37,20 @@ logger = logging.getLogger(__name__)
 _query_cache: dict[str, list[dict[str, Any]]] = {}
 _cache_lock = threading.Lock()
 
+# Snowflake unquoted identifier pattern: starts with letter or underscore,
+# followed by alphanumeric, underscores, or dollar signs.
+SNOWFLAKE_IDENTIFIER_PATTERN = r"^[A-Za-z_][A-Za-z0-9_$]*$"
+
+
+def _validate_identifier(value: str, name: str) -> str:
+    """Validate that a string is a safe Snowflake identifier."""
+    if not re.match(SNOWFLAKE_IDENTIFIER_PATTERN, value):
+        raise ValueError(
+            f"Invalid Snowflake identifier for {name}: {value!r}. "
+            "Must match pattern: letter or underscore, followed by alphanumeric, underscores, or dollar signs."
+        )
+    return value
+
 
 class SnowflakeConfig(BaseModel):
     """Configuration for Snowflake connection."""
@@ -49,8 +64,8 @@ class SnowflakeConfig(BaseModel):
     password: SecretStr | None = Field(None, description="Snowflake password")
     private_key_path: str | None = Field(None, description="Path to private key file")
     warehouse: str | None = Field(None, description="Snowflake warehouse")
-    database: str | None = Field(None, description="Default database")
-    snowflake_schema: str | None = Field(None, description="Default schema")
+    database: str | None = Field(None, description="Default database", pattern=SNOWFLAKE_IDENTIFIER_PATTERN)
+    snowflake_schema: str | None = Field(None, description="Default schema", pattern=SNOWFLAKE_IDENTIFIER_PATTERN)
     role: str | None = Field(None, description="Snowflake role")
     session_parameters: dict[str, Any] | None = Field(
         default_factory=dict, description="Session parameters"
@@ -71,8 +86,8 @@ class SnowflakeSearchToolInput(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     query: str = Field(..., description="SQL query or semantic search query to execute")
-    database: str | None = Field(None, description="Override default database")
-    snowflake_schema: str | None = Field(None, description="Override default schema")
+    database: str | None = Field(None, description="Override default database", pattern=SNOWFLAKE_IDENTIFIER_PATTERN)
+    snowflake_schema: str | None = Field(None, description="Override default schema", pattern=SNOWFLAKE_IDENTIFIER_PATTERN)
     timeout: int | None = Field(300, description="Query timeout in seconds")
 
 
@@ -259,9 +274,13 @@ class SnowflakeSearchTool(BaseTool):
         try:
             # Override database/schema if provided
             if database:
-                await self._execute_query(f"USE DATABASE {database}")
+                _validate_identifier(database, "database")
+                safe_db = database.replace('"', '')
+                await self._execute_query(f'USE DATABASE "{safe_db}"')
             if snowflake_schema:
-                await self._execute_query(f"USE SCHEMA {snowflake_schema}")
+                _validate_identifier(snowflake_schema, "schema")
+                safe_schema = snowflake_schema.replace('"', '')
+                await self._execute_query(f'USE SCHEMA "{safe_schema}"')
 
             return await self._execute_query(query, timeout)
         except Exception as e:

--- a/lib/crewai-tools/tests/tools/snowflake_search_tool_test.py
+++ b/lib/crewai-tools/tests/tools/snowflake_search_tool_test.py
@@ -2,6 +2,10 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 from crewai_tools import SnowflakeConfig, SnowflakeSearchTool
+from crewai_tools.tools.snowflake_search_tool.snowflake_search_tool import (
+    SnowflakeSearchToolInput,
+    _validate_identifier,
+)
 import pytest
 
 
@@ -100,3 +104,137 @@ def test_config_validation():
     # Test missing authentication
     with pytest.raises(ValueError):
         SnowflakeConfig(account="test_account", user="test_user")
+
+
+# SQL Injection Prevention Tests
+class TestIdentifierValidation:
+    """Test that SQL injection payloads are rejected by identifier validation."""
+
+    def test_valid_identifiers(self):
+        """Valid Snowflake identifiers should pass validation."""
+        valid_names = ["my_database", "PRODUCTION", "schema_v2", "DB$123", "_private"]
+        for name in valid_names:
+            assert _validate_identifier(name, "test") == name
+
+    def test_sql_injection_semicolon(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier("test_db; DROP TABLE users; --", "database")
+
+    def test_sql_injection_quotes(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier('test" OR 1=1 --', "database")
+
+    def test_sql_injection_spaces(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier("test db", "database")
+
+    def test_sql_injection_parentheses(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier("test()", "schema")
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier("", "database")
+
+    def test_starts_with_number_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            _validate_identifier("1database", "database")
+
+
+class TestInputSchemaValidation:
+    """Test that SnowflakeSearchToolInput rejects injection payloads at the Pydantic level."""
+
+    def test_valid_input(self):
+        inp = SnowflakeSearchToolInput(
+            query="SELECT 1", database="my_db", snowflake_schema="public"
+        )
+        assert inp.database == "my_db"
+        assert inp.snowflake_schema == "public"
+
+    def test_input_rejects_injection_in_database(self):
+        with pytest.raises(ValueError):
+            SnowflakeSearchToolInput(
+                query="SELECT 1", database="db; DROP TABLE x; --"
+            )
+
+    def test_input_rejects_injection_in_schema(self):
+        with pytest.raises(ValueError):
+            SnowflakeSearchToolInput(
+                query="SELECT 1", snowflake_schema="schema; DROP TABLE x; --"
+            )
+
+    def test_none_values_allowed(self):
+        inp = SnowflakeSearchToolInput(query="SELECT 1")
+        assert inp.database is None
+        assert inp.snowflake_schema is None
+
+
+class TestConfigIdentifierValidation:
+    """Test that SnowflakeConfig also rejects injection payloads in database/schema."""
+
+    def test_config_rejects_injection_in_database(self):
+        with pytest.raises(ValueError):
+            SnowflakeConfig(
+                account="test_account",
+                user="test_user",
+                password="test_pass",
+                database="db; DROP TABLE users; --",
+            )
+
+    def test_config_rejects_injection_in_schema(self):
+        with pytest.raises(ValueError):
+            SnowflakeConfig(
+                account="test_account",
+                user="test_user",
+                password="test_pass",
+                snowflake_schema="schema; DROP TABLE users; --",
+            )
+
+    def test_config_accepts_valid_identifiers(self):
+        config = SnowflakeConfig(
+            account="test_account",
+            user="test_user",
+            password="test_pass",
+            database="PRODUCTION_DB",
+            snowflake_schema="analytics_v2",
+        )
+        assert config.database == "PRODUCTION_DB"
+        assert config.snowflake_schema == "analytics_v2"
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_injection_in_database(snowflake_tool, mock_snowflake_connection):
+    """Defense-in-depth: even if Pydantic is bypassed, _run validates identifiers."""
+    with patch.object(snowflake_tool, "_create_connection") as mock_create_conn:
+        mock_create_conn.return_value = mock_snowflake_connection
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            await snowflake_tool._run(
+                query="SELECT 1",
+                database="db; DROP TABLE users; --",
+            )
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_injection_in_schema(snowflake_tool, mock_snowflake_connection):
+    """Defense-in-depth: even if Pydantic is bypassed, _run validates identifiers."""
+    with patch.object(snowflake_tool, "_create_connection") as mock_create_conn:
+        mock_create_conn.return_value = mock_snowflake_connection
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            await snowflake_tool._run(
+                query="SELECT 1",
+                snowflake_schema="schema; DROP TABLE users; --",
+            )
+
+
+@pytest.mark.asyncio
+async def test_run_uses_quoted_identifiers(snowflake_tool, mock_snowflake_connection):
+    """Valid identifiers should be double-quoted in the USE statements."""
+    with patch.object(snowflake_tool, "_create_connection") as mock_create_conn:
+        mock_create_conn.return_value = mock_snowflake_connection
+        await snowflake_tool._run(
+            query="SELECT 1", database="my_db", snowflake_schema="my_schema"
+        )
+        cursor = mock_snowflake_connection.cursor.return_value
+        calls = [str(c) for c in cursor.execute.call_args_list]
+        assert any('"my_db"' in c for c in calls), f"Expected quoted database in calls: {calls}"
+        assert any('"my_schema"' in c for c in calls), f"Expected quoted schema in calls: {calls}"


### PR DESCRIPTION
## Summary

Fixes SQL injection vulnerabilities in `SnowflakeSearchTool` and `NL2SQLTool` reported in #4993.

**SnowflakeSearchTool** — the `database` and `snowflake_schema` parameters in `_run()` were interpolated directly into `USE DATABASE` / `USE SCHEMA` SQL statements via f-strings with no validation. This PR adds three layers of defense:

- **Pydantic pattern validation** on both `SnowflakeSearchToolInput` and `SnowflakeConfig` fields — rejects anything that isn't a valid Snowflake identifier before it reaches any code path
- **Runtime `_validate_identifier()` check** in `_run()` — defense-in-depth for callers that bypass Pydantic (e.g. direct method calls)
- **Double-quoted identifiers** in the SQL itself with embedded quote stripping — so even if both prior layers are somehow bypassed, Snowflake treats the value as a delimited identifier, not SQL syntax

**NL2SQLTool** — `_fetch_all_available_columns()` was using f-string interpolation to build a WHERE clause with the table name (flagged with `# noqa: S608`). Replaced with SQLAlchemy `text()` bind parameters, which is the standard parameterized query approach. Added a `params` argument to `execute_sql()` to support this.

## Changes

- `snowflake_search_tool.py`: Added `SNOWFLAKE_IDENTIFIER_PATTERN` constant, `_validate_identifier()` helper, pattern validation on input/config fields, quoted identifiers in `_run()`
- `nl2sql_tool.py`: Switched `_fetch_all_available_columns()` to parameterized query, added `params` arg to `execute_sql()`
- `snowflake_search_tool_test.py`: Added comprehensive tests covering identifier validation, Pydantic-level rejection of injection payloads, defense-in-depth runtime checks, and quoted identifier verification

## Test plan

- [x] `TestIdentifierValidation` — validates `_validate_identifier()` accepts valid identifiers and rejects injection payloads (semicolons, quotes, spaces, parens, empty strings, leading numbers)
- [x] `TestInputSchemaValidation` — confirms Pydantic rejects injection in database/schema fields
- [x] `TestConfigIdentifierValidation` — confirms SnowflakeConfig rejects injection in database/schema
- [x] `test_run_rejects_injection_in_database` / `test_run_rejects_injection_in_schema` — defense-in-depth tests at the `_run()` level
- [x] `test_run_uses_quoted_identifiers` — verifies double-quoting in generated SQL

Closes #4993
