### PR TITLE
fix: force LF line endings in generate_tool_specs.py on Windows

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
+++ b/lib/crewai-tools/src/crewai_tools/generate_tool_specs.py
@@ -180,7 +180,7 @@ class ToolSpecExtractor:
         return json_schema
 
     def save_to_json(self, output_path: str) -> None:
-        with open(output_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8", newline="\n") as f:
             json.dump({"tools": self.tools_spec}, f, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
Fixes #4737

On Windows, `open()` defaults to writing CRLF (`\r\n`) line endings. This causes `tool.specs.json` to be written with CRLF on Windows but LF on macOS/Linux, resulting in spurious diffs in version control whenever the file is regenerated on a different OS.

## Fix

Pass `newline="\n"` to the `open()` call in `save_to_json()` to force LF line endings regardless of the host OS.

## Changes

- `lib/crewai-tools/src/crewai_tools/generate_tool_specs.py`: add `newline="\n"` to `open()` in `save_to_json()`