### PR TITLE
fix(agents): restore Bedrock Converse API tool arguments in _parse_native_tool_call

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Problem

Closes #4972

When using AWS Bedrock Converse API with native function calling, **all tool arguments are silently dropped**. Every tool call receives an empty `{}` instead of the actual arguments, causing pydantic validation failures on tools with required parameters.

### Root Cause

In `_parse_native_tool_call`, the `dict` branch handles Bedrock-style tool calls:

```python
# Bedrock Converse format:
# {"name": "my_tool", "input": {"search_query": "test"}, "toolUseId": "abc"}
func_info = tool_call.get("function", {})  # → {} for Bedrock (no "function" key)
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
#           ↑ returns literal string "{}"  ↑ never evaluated — "{}" is truthy!
```

Because `func_info.get("arguments", "{}")` returns the **string** `"{}"` (which is truthy) when the `"arguments"` key is absent, the `or` short-circuit prevents `tool_call.get("input", {})` from ever being reached.

## Solution

Remove the default value so the lookup returns `None` (falsy) when `"arguments"` is absent:

```python
func_args = func_info.get("arguments") or tool_call.get("input", {})
```

Now:
- OpenAI-style dicts (`{"function": {"name": ..., "arguments": "..."}}`): `func_info.get("arguments")` returns the actual arguments string → correct ✓
- Bedrock-style dicts (`{"name": ..., "input": {...}, "toolUseId": ...}`): `func_info.get("arguments")` returns `None` → falls through to `tool_call.get("input", {})` → correct ✓

## Testing

Verified with a minimal Bedrock Converse API integration test using a `BaseTool` that has required parameters.