### PR TITLE
fix: forward max_completion_tokens to Anthropic native provider

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -41,6 +41,7 @@ TOOL_SEARCH_TOOL_TYPES: Final[tuple[str, ...]] = (
     "tool_search_tool_bm25_20251119",
 )
 
+ANTHROPIC_DEFAULT_MAX_TOKENS: Final[int] = 4096
 ANTHROPIC_FILES_API_BETA: Final = "files-api-2025-04-14"
 ANTHROPIC_STRUCTURED_OUTPUTS_BETA: Final = "structured-outputs-2025-11-13"
 
@@ -158,7 +159,8 @@ class AnthropicCompletion(BaseLLM):
         timeout: float | None = None,
         max_retries: int = 2,
         temperature: float | None = None,
-        max_tokens: int = 4096,  # Required for Anthropic
+        max_tokens: int | None = None,
+        max_completion_tokens: int | None = None,
         top_p: float | None = None,
         stop_sequences: list[str] | None = None,
         stream: bool = False,
@@ -178,7 +180,10 @@ class AnthropicCompletion(BaseLLM):
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries
             temperature: Sampling temperature (0-1)
-            max_tokens: Maximum tokens in response (required for Anthropic)
+            max_tokens: Maximum tokens in response (required for Anthropic).
+                Takes precedence over max_completion_tokens.
+            max_completion_tokens: Alias for max_tokens (OpenAI-style parameter name).
+                Used when max_tokens is not explicitly set.
             top_p: Nucleus sampling parameter
             stop_sequences: Stop sequences (Anthropic uses stop_sequences, not stop)
             stream: Enable streaming responses
@@ -213,8 +218,10 @@ class AnthropicCompletion(BaseLLM):
 
         self.async_client = AsyncAnthropic(**async_client_params)
 
-        # Store completion parameters
-        self.max_tokens = max_tokens
+        # Store completion parameters.
+        # Resolve max output tokens: explicit max_tokens wins, then
+        # max_completion_tokens (OpenAI-style alias), then Anthropic default.
+        self.max_tokens = max_tokens or max_completion_tokens or ANTHROPIC_DEFAULT_MAX_TOKENS
         self.top_p = top_p
         self.stream = stream
         self.stop_sequences = stop_sequences or []

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -109,6 +109,56 @@ def test_anthropic_completion_initialization_parameters():
     assert llm.top_p == 0.9
 
 
+def test_anthropic_max_completion_tokens_sent_to_api():
+    """
+    Test that max_completion_tokens (OpenAI-style param) is forwarded to the
+    Anthropic API as max_tokens when max_tokens itself is not set.
+    """
+    llm = LLM(
+        model="anthropic/claude-3-5-sonnet-20241022",
+        max_completion_tokens=150,
+        api_key="test-key",
+    )
+
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+    assert isinstance(llm, AnthropicCompletion)
+
+    params = llm._prepare_completion_params(
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    assert params["max_tokens"] == 150
+
+
+def test_anthropic_max_tokens_takes_precedence_over_max_completion_tokens():
+    """
+    Test that explicit max_tokens takes precedence over max_completion_tokens.
+    """
+    llm = LLM(
+        model="anthropic/claude-3-5-sonnet-20241022",
+        max_tokens=2000,
+        max_completion_tokens=150,
+        api_key="test-key",
+    )
+
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+    assert isinstance(llm, AnthropicCompletion)
+    assert llm.max_tokens == 2000
+
+
+def test_anthropic_default_max_tokens_when_neither_set():
+    """
+    Test that default 4096 is used when neither max_tokens nor max_completion_tokens is set.
+    """
+    llm = LLM(
+        model="anthropic/claude-3-5-sonnet-20241022",
+        api_key="test-key",
+    )
+
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+    assert isinstance(llm, AnthropicCompletion)
+    assert llm.max_tokens == 4096
+
+
 def test_anthropic_specific_parameters():
     """
     Test Anthropic-specific parameters like stop_sequences and streaming


### PR DESCRIPTION
## Summary                                                                             
                                                                                         
  - `max_completion_tokens` (OpenAI-style parameter) is silently ignored by the native Anthropic provider                                                                     
  - The parameter falls into `**kwargs` -> `additional_params` and never reaches `self.max_tokens`
  - All Anthropic API calls use the default 4096 regardless of what the user sets        
  - The LiteLLM fallback path handles this correctly (`llm.py:717`), but the native path does not                                                                               
  - The OpenAI native provider already handles both parameters (`completion.py:203`)     

  ## Fix                                                                                 
                                                                                         
  Accept `max_completion_tokens` in `AnthropicCompletion.__init__` with the same fallback chain: `max_tokens` -> `max_completion_tokens` -> `4096`
                                                                                         
  ## Test plan                                           
                                         
  - [x] `max_completion_tokens=150` flows through to `_prepare_completion_params` as `max_tokens: 150`
  - [x] `max_tokens` takes precedence when both are set                                  
  - [x] Default 4096 preserved when neither is set                                       
  - [x] Existing tests unaffected