### PR TITLE
fix: Bedrock Converse API tool arguments silently dropped — always passes empty dict (#4972)

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or "{}"
             return call_id, func_name, func_args
         return None
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -905,6 +905,88 @@ class TestNativeToolExecution:
         assert executor.check_native_todo_completion() == "todo_satisfied"
 
 
+class TestParseNativeToolCall:
+    """Test _parse_native_tool_call for various tool call formats."""
+
+    @pytest.fixture
+    def executor(self):
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+        llm = Mock()
+        llm.supports_stop_words.return_value = True
+        task = Mock()
+        task.name = "Test"
+        task.description = "Test"
+        task.human_input = False
+        task.response_model = None
+        crew = Mock()
+        crew._memory = None
+        crew.verbose = False
+        crew._train = False
+        agent = Mock()
+        agent.id = "test-agent-id"
+        agent.role = "Test Agent"
+        agent.verbose = False
+        agent.key = "test-key"
+        prompt = {"prompt": "Test"}
+        tools_handler = Mock()
+        tools_handler.cache = None
+        return CrewAgentExecutor(
+            llm=llm,
+            task=task,
+            crew=crew,
+            agent=agent,
+            prompt=prompt,
+            max_iter=10,
+            tools=[],
+            tools_names="",
+            stop_words=[],
+            tools_description="",
+            tools_handler=tools_handler,
+        )
+
+    def test_parses_openai_function_format(self, executor):
+        """OpenAI format: {"function": {"name": "x", "arguments": "{}"}}."""
+        call = {"id": "call_1", "function": {"name": "my_tool", "arguments": '{"q": "hello"}'}}
+        result = executor._parse_native_tool_call(call)
+        assert result is not None
+        call_id, func_name, func_args = result
+        assert call_id == "call_1"
+        assert func_name == "my_tool"
+        assert func_args == '{"q": "hello"}'
+
+    def test_parses_bedrock_format_with_input(self, executor):
+        """Bedrock format: {"name": "...", "input": {...}, "toolUseId": "..."}."""
+        call = {"name": "search", "input": {"query": "test"}, "toolUseId": "bedrock_1"}
+        result = executor._parse_native_tool_call(call)
+        assert result is not None
+        call_id, func_name, func_args = result
+        assert call_id == "bedrock_1"
+        assert func_name == "search"
+        assert func_args == {"query": "test"}
+
+    def test_bedrock_input_not_dropped_when_function_key_missing(self, executor):
+        """Regression: func_info.get('arguments', '{}') returned truthy '{}' preventing
+        fallthrough to tool_call['input']."""
+        call = {"name": "my_tool", "input": {"search_query": "test"}, "toolUseId": "abc"}
+        result = executor._parse_native_tool_call(call)
+        assert result is not None
+        _, func_name, func_args = result
+        assert func_name == "my_tool"
+        # The critical assertion: input args must NOT be dropped
+        assert func_args == {"search_query": "test"}
+        assert func_args != "{}"
+
+    def test_falls_back_to_empty_string_when_no_args(self, executor):
+        """When neither function.arguments nor input is present, fallback to '{}'."""
+        call = {"id": "call_empty", "function": {"name": "noop"}}
+        result = executor._parse_native_tool_call(call)
+        assert result is not None
+        _, func_name, func_args = result
+        assert func_name == "noop"
+        assert func_args == "{}"
+
+
 class TestPlannerObserver:
     def test_observe_fallback_is_conservative_on_llm_error(self):
         llm = Mock()


### PR DESCRIPTION
## Problem

Fixes #4972

When using AWS Bedrock Converse API with native function calling, all tool arguments are silently dropped. Every tool call receives an empty dict `{}` instead of actual arguments, causing pydantic validation failures.

### Root Cause

In `_parse_native_tool_call` (crew_agent_executor.py), the dict-format branch uses:

```python
func_args = func_info.get(arguments, {}) or tool_call.get(input, {})
```

Bedrock returns tool calls as `{name: ..., input: {...}, toolUseId: ...}` — no `function` key. So `func_info` is `{}`, and `func_info.get(arguments, {})` returns the default `{}` (a truthy string). The `or` short-circuits and `tool_call[input]` is never read.

### Fix

```python
# Before:
func_args = func_info.get(arguments, {}) or tool_call.get(input, {})

# After:
func_args = func_info.get(arguments) or tool_call.get(input) or {}
```

Removing the default `{}` from `get(arguments)` makes it return `None` (falsy) when the key is missing, allowing correct fallthrough to `tool_call.get(input)`. The `or {}` at the end preserves the empty-string fallback for the OpenAI case where arguments is truly absent.

## Changes

- **1 line fix** in `lib/crewai/src/crewai/agents/crew_agent_executor.py`
- **4 regression tests** covering:
  - OpenAI function format (existing behavior preserved)
  - Bedrock dict format with input args
  - The specific regression case (input not dropped)
  - No-args fallback to `{}`

## Testing

All 4 new tests pass:

```
lib/crewai/tests/agents/test_agent_executor.py::TestParseNativeToolCall::test_parses_openai_function_format PASSED
lib/crewai/tests/agents/test_agent_executor.py::TestParseNativeToolCall::test_parses_bedrock_format_with_input PASSED
lib/crewai/tests/agents/test_agent_executor.py::TestParseNativeToolCall::test_bedrock_input_not_dropped_when_function_key_missing PASSED
lib/crewai/tests/agents/test_agent_executor.py::TestParseNativeToolCall::test_falls_back_to_empty_string_when_no_args PASSED
```

cc @sajilkumarmk (issue reporter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts native tool-call argument parsing, which directly affects what inputs get passed into tool executions for Bedrock/OpenAI-style calls. Small change but could alter behavior for edge cases where arguments/input are missing or differently shaped.
> 
> **Overview**
> Fixes native tool-call parsing in `CrewAgentExecutor._parse_native_tool_call` so Bedrock Converse-style calls (with `name` + `input` + `toolUseId` and no `function.arguments`) no longer fall back to an empty `'{}'` and silently drop provided arguments.
> 
> Adds focused regression tests covering OpenAI function-call dicts, Bedrock `input` dicts, the specific missing-`function` regression, and the no-args fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eae497338bf857d43566f69642569bf2998ca207. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->