### PR TITLE
fix: save flow plot HTML to current working directory instead of temp directory

### DIFF
--- a/lib/crewai/src/crewai/flow/visualization/renderers/interactive.py
+++ b/lib/crewai/src/crewai/flow/visualization/renderers/interactive.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-import tempfile
 from typing import Any, ClassVar
 import webbrowser
 
@@ -208,7 +207,7 @@ def render_interactive(
 ) -> str:
     """Create interactive HTML visualization of Flow structure.
 
-    Generates three output files in a temporary directory: HTML template,
+    Generates three output files in the current working directory: HTML template,
     CSS stylesheet, and JavaScript. Optionally opens the visualization in
     default browser.
 
@@ -218,7 +217,7 @@ def render_interactive(
         show: Whether to open in browser.
 
     Returns:
-        Absolute path to generated HTML file in temporary directory.
+        Absolute path to generated HTML file in current working directory.
     """
     node_positions = calculate_node_positions(dag)
 
@@ -403,12 +402,13 @@ def render_interactive(
         extensions=[CSSExtension, JSExtension],
     )
 
-    temp_dir = Path(tempfile.mkdtemp(prefix="crewai_flow_"))
-    output_path = temp_dir / Path(filename).name
+    # Save to current working directory instead of temp directory
+    output_dir = Path.cwd()
+    output_path = output_dir / Path(filename).name
     css_filename = output_path.stem + "_style.css"
-    css_output_path = temp_dir / css_filename
+    css_output_path = output_dir / css_filename
     js_filename = output_path.stem + "_script.js"
-    js_output_path = temp_dir / js_filename
+    js_output_path = output_dir / js_filename
 
     css_file = template_dir / "style.css"
     css_content = css_file.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #4991

## Problem
When running `crewai flow plot`, the framework generates the HTML visualization inside a hidden system temporary directory instead of the user's current working directory.

The CLI outputs a misleading message: `Flow visualization saved to guide_creator_flow.html`, leading users to believe the file was saved locally when it was not.

## Solution
Modified `render_interactive()` in `crewai/flow/visualization/renderers/interactive.py` to save files in the current working directory instead of creating a temporary directory.

## Changes
- Changed `tempfile.mkdtemp()` to `Path.cwd()` for output directory
- Updated docstring to reflect the new behavior  
- Removed unused `tempfile` import

## Testing
The existing test `test_visualization_plot_method()` passes with this change. Files are now correctly saved where users expect them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where `crewai flow plot` writes files, which can affect user workflows and may overwrite existing files or fail under restricted permissions. Logic is small and localized to the interactive renderer.
> 
> **Overview**
> Flow interactive plot output is now written to the **current working directory** rather than a generated temp directory, so `crewai flow plot` leaves the HTML/CSS/JS artifacts alongside the user’s project.
> 
> `render_interactive()` was updated to use `Path.cwd()` for `output_dir`, and its docstring/return description were adjusted accordingly; the unused `tempfile` dependency was removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abdfad7490ec90b14506bbe26266f348dae3a799. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->