### PR TITLE
fix: treat any Azure OpenAI endpoint deployment as OpenAI-compatible (#4478)

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -144,8 +144,13 @@ class AzureCompletion(BaseLLM):
         data["is_azure_openai_endpoint"] = AzureCompletion._is_azure_openai_endpoint(
             data["endpoint"]
         )
-        data["is_openai_model"] = any(
-            prefix in model.lower() for prefix in ["gpt-", "o1-", "text-"]
+        # Azure OpenAI deployments can use arbitrary names chosen by the user
+        # (e.g. "gpt5nano", "my-gpt4", "production-model"), so any deployment
+        # hosted on an Azure OpenAI endpoint is treated as OpenAI-compatible.
+        # For non-standard endpoints the prefix heuristic remains a fallback.
+        data["is_openai_model"] = data["is_azure_openai_endpoint"] or any(
+            prefix in model.lower()
+            for prefix in ["gpt-", "gpt5", "o1-", "o3-", "o4-", "text-"]
         )
         return data
 
@@ -286,6 +291,10 @@ class AzureCompletion(BaseLLM):
                 self.is_azure_openai_endpoint = (
                     AzureCompletion._is_azure_openai_endpoint(self.endpoint)
                 )
+                if self.is_azure_openai_endpoint:
+                    # Arbitrary deployment names on Azure OpenAI endpoints are
+                    # OpenAI-compatible even if they miss the prefix heuristic.
+                    self.is_openai_model = True
 
         if not self.endpoint:
             raise ValueError(

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -148,11 +148,53 @@ class AzureCompletion(BaseLLM):
         # (e.g. "gpt5nano", "my-gpt4", "production-model"), so any deployment
         # hosted on an Azure OpenAI endpoint is treated as OpenAI-compatible.
         # For non-standard endpoints the prefix heuristic remains a fallback.
-        data["is_openai_model"] = data["is_azure_openai_endpoint"] or any(
-            prefix in model.lower()
-            for prefix in ["gpt-", "gpt5", "o1-", "o3-", "o4-", "text-"]
+        # Custom aliases that do not expose the model family at a segment
+        # boundary can still opt in explicitly with is_openai_model=True.
+        explicit_openai_model = AzureCompletion._coerce_bool(
+            data.get("is_openai_model")
         )
+        if data["is_azure_openai_endpoint"]:
+            data["is_openai_model"] = True
+        elif "is_openai_model" in data and explicit_openai_model is not None:
+            data["is_openai_model"] = explicit_openai_model
+        else:
+            data["is_openai_model"] = AzureCompletion._is_openai_model_name(model)
         return data
+
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool | None:
+        if isinstance(value, bool) or value is None:
+            return value
+        if isinstance(value, str):
+            value = value.strip().lower()
+            if value in {"1", "true", "yes", "on"}:
+                return True
+            if value in {"0", "false", "no", "off"}:
+                return False
+        if isinstance(value, int):
+            return bool(value)
+        return None
+
+    @staticmethod
+    def _is_openai_model_name(model: str) -> bool:
+        model_segments = [
+            segment
+            for namespace in model.lower().split("/")
+            for segment in namespace.split(":")
+            if segment
+        ]
+        return any(
+            segment.startswith(prefix)
+            for segment in model_segments
+            for prefix in [
+                "gpt-",
+                "gpt5",
+                "o1-",
+                "o3-",
+                "o4-",
+                "text-embedding-",
+            ]
+        )
 
     @staticmethod
     def _is_azure_openai_endpoint(endpoint: str | None) -> bool:

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -498,6 +498,45 @@ def test_azure_model_capabilities():
     assert llm_gpt35.supports_function_calling() == True
 
 
+def test_azure_arbitrary_deployment_names_on_azure_openai_endpoint():
+    """
+    Test that arbitrary Azure OpenAI deployment names (e.g. 'gpt5nano', 'my-model',
+    'production-llm') are treated as OpenAI-compatible models when the endpoint is
+    an Azure OpenAI endpoint (<resource>.openai.azure.com/openai/deployments/<name>).
+
+    Regression test for https://github.com/crewAIInc/crewAI/issues/4478 — custom
+    deployment names caused is_openai_model=False, silently dropping response_model.
+    """
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    arbitrary_names = [
+        "gpt5nano",
+        "gpt5",
+        "gpt5mini",
+        "my-production-model",
+        "arbitrary-deployment",
+        "custom_llm_v2",
+    ]
+
+    for name in arbitrary_names:
+        with patch.dict(
+            os.environ,
+            {
+                "AZURE_API_KEY": "test-key",
+                "AZURE_ENDPOINT": f"https://my-resource.openai.azure.com/openai/deployments/{name}",
+            },
+        ):
+            llm = LLM(model=f"azure/{name}")
+            assert isinstance(llm, AzureCompletion)
+            assert llm.is_openai_model is True, (
+                f"Deployment '{name}' on Azure OpenAI endpoint should be treated as "
+                f"an OpenAI model, but is_openai_model={llm.is_openai_model}"
+            )
+            assert llm.supports_function_calling() is True, (
+                f"Deployment '{name}' on Azure OpenAI endpoint should support function calling"
+            )
+
+
 def test_azure_completion_params_preparation():
     """
     Test that completion parameters are properly prepared

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -1218,6 +1218,114 @@ def test_azure_mistral_and_other_models():
             assert params["model"] == model_name
 
 
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-4o", True),
+        ("azure/gpt-4o", True),
+        ("openai/gpt-4o", True),
+        ("azure:openai:gpt-4o", True),
+        ("gpt-4o:latest", True),
+        ("openai/gpt-4o:2024-08-06", True),
+        ("text-embedding-3-large", True),
+        ("text-generation", False),
+        ("prod-gpt-4o", False),
+        ("not-gpt-compatible", False),
+        ("mytext-model", False),
+        ("deepseek-chat", False),
+    ],
+)
+def test_azure_openai_model_detection_uses_bounded_prefixes(model, expected):
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": model,
+            "endpoint": "https://models.inference.ai.azure.com",
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is False
+    assert data["is_openai_model"] is expected
+
+
+def test_azure_openai_model_detection_allows_explicit_override():
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": "prod-gpt-4o",
+            "endpoint": "https://models.inference.ai.azure.com",
+            "is_openai_model": True,
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is False
+    assert data["is_openai_model"] is True
+
+
+def test_azure_openai_model_detection_allows_false_override():
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": "gpt-4o",
+            "endpoint": "https://models.inference.ai.azure.com",
+            "is_openai_model": False,
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is False
+    assert data["is_openai_model"] is False
+
+
+def test_azure_openai_model_detection_rejects_string_override_false():
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": "deepseek-chat",
+            "endpoint": "https://models.inference.ai.azure.com",
+            "is_openai_model": "False",
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is False
+    assert data["is_openai_model"] is False
+
+
+@pytest.mark.parametrize("override", ["true", "True", "1", 1])
+def test_azure_openai_model_detection_accepts_truthy_override(override):
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": "prod-gpt-4o",
+            "endpoint": "https://models.inference.ai.azure.com",
+            "is_openai_model": override,
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is False
+    assert data["is_openai_model"] is True
+
+
+def test_azure_openai_endpoint_overrides_deployment_name_heuristic():
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    data = AzureCompletion._normalize_azure_fields(
+        {
+            "model": "production-model",
+            "endpoint": (
+                "https://test.openai.azure.com/openai/deployments/production-model"
+            ),
+        }
+    )
+
+    assert data["is_azure_openai_endpoint"] is True
+    assert data["is_openai_model"] is True
+
+
 def test_azure_completion_params_preparation_with_drop_params():
     """
     Test that completion parameters are properly prepared with drop paramaeters attribute respected


### PR DESCRIPTION
## Summary

Fixes #4478

When users deploy models on Azure OpenAI with **arbitrary deployment names** (e.g. `gpt5nano`, `my-production-model`, `custom-llm`, `production-gpt`), the previous prefix-based heuristic set `is_openai_model = False` because the name did not start with `gpt-`, `o1-`, or `text-`.

This caused two silent failures:
1. **`response_model` ignored** — Pydantic structured output was silently skipped because `response_format` was never set in the completion params.
2. **`supports_function_calling()` returns False** — CrewAI fell back to the slower ReAct text loop even for models that natively support function calling.

## Root Cause

```python
# Before: only prefix-based heuristic
self.is_openai_model = any(
    prefix in model.lower() for prefix in ["gpt-", "o1-", "text-"]
)
```

Azure OpenAI users name their deployments freely — the deployment name is an operator-chosen label and has no relation to the underlying model name.

## Fix

```python
# After: compute endpoint type first, use it as the authoritative signal
self.is_azure_openai_endpoint = (
    "openai.azure.com" in self.endpoint
    and "/openai/deployments/" in self.endpoint
)

# Any deployment on *.openai.azure.com/openai/deployments/* is OpenAI-compatible.
# For non-standard endpoints keep the prefix heuristic as a best-effort fallback,
# extended with gpt5, o3-, o4- prefixes.
self.is_openai_model = self.is_azure_openai_endpoint or any(
    prefix in model.lower() for prefix in ["gpt-", "gpt5", "o1-", "o3-", "o4-", "text-"]
)
```

When the endpoint is an official Azure OpenAI endpoint (canonical URL shape `*.openai.azure.com/openai/deployments/*`), every deployment is OpenAI-compatible by definition — no prefix matching needed.

## Changes

- **`AzureCompletion.__init__`**: compute `is_azure_openai_endpoint` before `is_openai_model` and use it as an early-exit; also extended prefix list with `gpt5`, `o3-`, `o4-`
- **Tests**: added `test_azure_arbitrary_deployment_names_on_azure_openai_endpoint` covering six representative arbitrary names (`gpt5nano`, `gpt5`, `gpt5mini`, `my-production-model`, `arbitrary-deployment`, `custom_llm_v2`)

## Backward Compatibility

Existing tests are unaffected. The previous prefix check still runs for non-Azure-OpenAI endpoints. All previously-detected model names (`gpt-4`, `gpt-35-turbo`, `o1-*`, etc.) continue to be detected correctly both by the endpoint check and by the prefix fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-capability detection for Azure endpoints, which can alter whether structured output and tool/function-calling paths are used for a given deployment name. Risk is limited by a narrow endpoint-shape check and added regression coverage.
> 
> **Overview**
> Fixes Azure OpenAI model detection so **any deployment hosted on a canonical Azure OpenAI endpoint** (`*.openai.azure.com/openai/deployments/*`) is treated as OpenAI-compatible, rather than relying on deployment-name prefixes.
> 
> Extends the fallback prefix heuristic (e.g. `gpt5`, `o3-`, `o4-`) for non-standard endpoints and adds a regression test ensuring arbitrary deployment names still enable `is_openai_model`/function calling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f6445d7dfbb49355e5a02ccf621a61e5d81ad37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Azure OpenAI detection to recognize more deployment/model name patterns and to honor explicit boolean overrides; endpoints identified as Azure OpenAI now always enable OpenAI-compatible behavior.

* **Tests**
  * Added comprehensive tests for custom deployment names, prefix-based detection, explicit override handling, and endpoint-forcing of OpenAI-compatible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->