### PR TITLE
fix(bedrock): handle MCP tools with inputSchema in extract_tool_info

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/utils/common.py
+++ b/lib/crewai/src/crewai/llms/providers/utils/common.py
@@ -68,12 +68,14 @@ def extract_tool_info(tool: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
 
         name = function_info.get("name", "")
         description = function_info.get("description", "")
-        parameters = function_info.get("parameters", {})
+        # MCP tools may expose the schema as "inputSchema" instead of "parameters"
+        parameters = function_info.get("parameters") or function_info.get("inputSchema") or {}
     else:
         # Direct format
         name = tool.get("name", "")
         description = tool.get("description", "")
-        parameters = tool.get("parameters", {})
+        # MCP tools may expose the schema as "inputSchema" instead of "parameters"
+        parameters = tool.get("parameters") or tool.get("inputSchema") or {}
 
         # Also check for args_schema (Pydantic format)
         if not parameters and "args_schema" in tool:

--- a/lib/crewai/tests/llms/providers/utils/test_common.py
+++ b/lib/crewai/tests/llms/providers/utils/test_common.py
@@ -1,0 +1,119 @@
+"""Tests for crewai.llms.providers.utils.common.
+
+Focus: extract_tool_info / safe_tool_conversion with MCP-style tools that
+use ``inputSchema`` instead of ``parameters``.
+
+Regression tests for https://github.com/crewAIInc/crewAI/issues/4470.
+"""
+
+import pytest
+
+from crewai.llms.providers.utils.common import extract_tool_info, safe_tool_conversion
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+STANDARD_OPENAI_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+MCP_INPUT_SCHEMA_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "list_resources",
+        "description": "List MCP resources",
+        # MCP servers send inputSchema, not parameters
+        "inputSchema": {
+            "type": "object",
+            "properties": {"filter": {"type": "string"}},
+            "required": [],
+        },
+    },
+}
+
+MCP_DIRECT_INPUT_SCHEMA_TOOL = {
+    "name": "direct_mcp_tool",
+    "description": "Direct-format MCP tool",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"arg1": {"type": "integer"}},
+        "required": ["arg1"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# extract_tool_info tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToolInfo:
+    def test_standard_parameters_key(self):
+        name, desc, params = extract_tool_info(STANDARD_OPENAI_TOOL)
+        assert name == "get_weather"
+        assert "city" in params["properties"]
+
+    def test_mcp_input_schema_in_function_wrapper(self):
+        """Tools with inputSchema inside function wrapper must not return empty params.
+
+        This is the core regression case for issue #4470.
+        """
+        name, desc, params = extract_tool_info(MCP_INPUT_SCHEMA_TOOL)
+        assert name == "list_resources"
+        assert params, "params should not be empty when inputSchema is provided"
+        assert "filter" in params.get("properties", {})
+
+    def test_mcp_input_schema_direct_format(self):
+        """Tools in direct format with inputSchema are handled correctly."""
+        name, desc, params = extract_tool_info(MCP_DIRECT_INPUT_SCHEMA_TOOL)
+        assert name == "direct_mcp_tool"
+        assert params, "params should not be empty when inputSchema is provided"
+        assert "arg1" in params.get("properties", {})
+
+    def test_parameters_takes_precedence_over_input_schema(self):
+        """If both parameters and inputSchema are present, parameters wins."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "ambiguous_tool",
+                "description": "Has both keys",
+                "parameters": {"type": "object", "properties": {"a": {"type": "string"}}},
+                "inputSchema": {"type": "object", "properties": {"b": {"type": "number"}}},
+            },
+        }
+        _, _, params = extract_tool_info(tool)
+        assert "a" in params.get("properties", {})
+        assert "b" not in params.get("properties", {})
+
+    def test_empty_tool_raises(self):
+        with pytest.raises((ValueError, KeyError)):
+            extract_tool_info("not-a-dict")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# safe_tool_conversion tests (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeToolConversion:
+    def test_mcp_tool_via_safe_conversion(self):
+        """safe_tool_conversion must surface MCP tool parameters, not empty dict."""
+        validated_name, desc, params = safe_tool_conversion(MCP_INPUT_SCHEMA_TOOL, "Bedrock")
+        assert validated_name == "list_resources"
+        assert params, "Bedrock tool inputSchema must not be empty after conversion"
+
+    def test_standard_tool_via_safe_conversion(self):
+        validated_name, desc, params = safe_tool_conversion(STANDARD_OPENAI_TOOL, "Bedrock")
+        assert validated_name == "get_weather"
+        assert "city" in params.get("properties", {})


### PR DESCRIPTION
## Description

MCP servers advertise tools using `inputSchema` (not `parameters`) in the function definition:

```json
{
  "type": "function",
  "function": {
    "name": "list_resources",
    "description": "...",
    "inputSchema": {
      "type": "object",
      "properties": { "filter": { "type": "string" } }
    }
  }
}
```

`extract_tool_info()` (in `llms/providers/utils/common.py`) only looked for the `parameters` key, so **all MCP tools arrived at Bedrock with an empty `inputSchema: {}`**, causing Claude Sonnet to ignore all tool inputs and return empty param responses.

## Root Cause

```python
# Before fix — only parameters key is checked:
parameters = function_info.get("parameters", {})  # MCP tools return {} here
```

## Fix

Fall back to `inputSchema` when `parameters` is absent or empty, in both the nested function-wrapper format and the direct tool format. `parameters` still takes precedence when both keys are present:

```python
parameters = function_info.get("parameters") or function_info.get("inputSchema") or {}
```

The fix is applied in `extract_tool_info()` which is shared by all native LLM providers.

## Testing

Added `tests/llms/providers/utils/test_common.py` with 6 tests covering:
- **Core regression**: MCP tool with `inputSchema` inside function wrapper → non-empty params
- MCP tool in direct format with `inputSchema`
- `parameters` takes precedence over `inputSchema` when both present
- Standard OpenAI-format tools still work correctly
- `safe_tool_conversion` end-to-end with MCP tool

Fixes #4470