### PR TITLE
fix: correct off-by-one in _detect_loops() that skips last message

### DIFF
--- a/lib/crewai/src/crewai/experimental/evaluation/metrics/reasoning_metrics.py
+++ b/lib/crewai/src/crewai/experimental/evaluation/metrics/reasoning_metrics.py
@@ -244,8 +244,8 @@ Identify any inefficient reasoning patterns and provide specific suggestions for
 
         # Simple n-gram based similarity detection
         # For a more robust implementation, consider using embedding-based similarity
-        for i in range(len(messages) - 2):
-            for j in range(i + 1, len(messages) - 1):
+        for i in range(len(messages) - 1):
+            for j in range(i + 1, len(messages)):
                 # Check for repeated patterns (simplistic approach)
                 # A more sophisticated approach would use semantic similarity
                 similarity = self._calculate_text_similarity(messages[i], messages[j])


### PR DESCRIPTION
The loop ranges `range(len(messages) - 2)` and `range(i + 1, len(messages) - 1)` exclude the last message from all pairwise similarity comparisons, meaning repeated patterns involving the final message in a sequence are never detected.

Changed to `range(len(messages) - 1)` and `range(i + 1, len(messages))` to ensure all message pairs are compared.