### PR TITLE
fix(llm): forward api_base to InternalInstructor and supports_function_calling for remote Ollama

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2250,8 +2250,15 @@ class LLM(BaseLLM):
 
         try:
             provider = self._get_custom_llm_provider()
+            # Pass api_base so remote Ollama servers are queried at the
+            # configured URL instead of falling back to localhost:11434.
+            kwargs: dict = {"custom_llm_provider": provider}
+            if self.api_base:
+                kwargs["api_base"] = self.api_base
+            elif self.base_url:
+                kwargs["api_base"] = self.base_url
             return litellm.utils.supports_function_calling(
-                self.model, custom_llm_provider=provider
+                self.model, **kwargs
             )
         except Exception as e:
             logging.error(f"Failed to check function calling support: {e!s}")

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -142,9 +142,16 @@ class InternalInstructor(Generic[T]):
 
         if isinstance(self.llm, str):
             model_name = self.llm
+            extra_kwargs: dict = {}
         else:
             model_name = self.llm.model
+            extra_kwargs = {}
+            for attr in ("api_base", "base_url", "api_key", "api_version"):
+                val = getattr(self.llm, attr, None)
+                if val is not None:
+                    extra_kwargs[attr] = val
 
         return self._client.chat.completions.create(  # type: ignore[no-any-return]
-            model=model_name, response_model=self.model, messages=messages
+            model=model_name, response_model=self.model, messages=messages,
+            **extra_kwargs
         )

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1024,3 +1024,22 @@ async def test_usage_info_streaming_with_acall():
     assert llm._token_usage["total_tokens"] > 0
 
     assert len(result) > 0
+
+
+def test_supports_function_calling_passes_api_base():
+    """api_base should be forwarded to litellm.utils.supports_function_calling."""
+    from unittest.mock import patch, MagicMock
+
+    llm = LLM(
+        model="ollama_chat/llama3",
+        api_base="http://my-remote-ollama:11434",
+    )
+
+    with patch("litellm.utils.supports_function_calling", return_value=True) as mock_sfc:
+        result = llm.supports_function_calling()
+
+    assert result is True
+    call_kwargs = mock_sfc.call_args[1]
+    assert call_kwargs.get("api_base") == "http://my-remote-ollama:11434", (
+        "api_base must be forwarded so remote Ollama is queried at the right URL"
+    )


### PR DESCRIPTION
## Summary

Fixes #4694

## Problem

When using CrewAI with a remote Ollama server (not localhost) and a Task with `output_pydantic`, two failures occur:

**Bug 1 — InternalInstructor ignores `api_base`:**
`InternalInstructor.to_pydantic()` called `litellm.completion` through `instructor.from_litellm` without forwarding `api_base`/`base_url`, causing all structured-output requests to fall back to `http://localhost:11434`.

**Bug 2 — `supports_function_calling()` ignores `api_base`:**
`LLM.supports_function_calling()` called `litellm.utils.supports_function_calling()` without `api_base`, so the Ollama capability check hit `localhost:11434` instead of the configured remote URL. This made every remote Ollama model appear not to support function calling, forcing CrewAI into the ReAct text-based loop.

## Fix

1. In `InternalInstructor.to_pydantic()`: collect `api_base`, `base_url`, `api_key`, `api_version` from the LLM object and pass them as `**kwargs` to `instructor`.

2. In `LLM.supports_function_calling()`: forward `api_base` (falling back to `base_url`) to `litellm.utils.supports_function_calling()`.

## Testing

Added `test_supports_function_calling_passes_api_base` that verifies `api_base` is forwarded to `litellm.utils.supports_function_calling`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)