### PR TITLE
fix: pin litellm upper bound to last tested version (1.82.6)

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -83,7 +83,7 @@ voyageai = [
     "voyageai~=0.3.5",
 ]
 litellm = [
-    "litellm>=1.74.9,<3",
+    "litellm>=1.74.9,<=1.82.6",
 ]
 bedrock = [
     "boto3~=1.40.45",


### PR DESCRIPTION
## What
Pin the `litellm` optional dependency upper bound from `<3` to `<=1.82.6`.

## Why
The current specifier `litellm>=1.74.9,<3` allows any future litellm release to be pulled in when customers install `crewai[litellm]`. If litellm ships a breaking change, customers get it immediately with no protection.

By pinning to `<=1.82.6` (current latest on PyPI, known-good), we ensure customers only get litellm versions that have been tested with crewAI. When we want to support newer versions, we bump this bound explicitly after validation.

## Change
```diff
-    "litellm>=1.74.9,<3",
+    "litellm>=1.74.9,<=1.82.6",
```

## Impact
- Customers using `crewai[litellm]` will be locked to versions we've validated
- No impact on customers not using the litellm extra
- Future litellm updates require an explicit version bump PR