### PR TITLE
fix(llm): preserve agent tools when response_model is set

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1193,7 +1193,11 @@ class LLM(BaseLLM):
             str: The response text
         """
         # --- 1) Handle response_model with InternalInstructor for LiteLLM
-        if response_model and self.is_litellm:
+        # Only use the InternalInstructor shortcut when there are no tools.
+        # When tools are present, fall through to the standard litellm.completion
+        # path so that both tools and response_model are sent together — otherwise
+        # the agent's tools are silently discarded (see #4697).
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])
@@ -1338,7 +1342,11 @@ class LLM(BaseLLM):
         Returns:
             str: The response text
         """
-        if response_model and self.is_litellm:
+        # Only use the InternalInstructor shortcut when there are no tools.
+        # When tools are present, fall through to the standard litellm.acompletion
+        # path so that both tools and response_model are sent together — otherwise
+        # the agent's tools are silently discarded (see #4697).
+        if response_model and self.is_litellm and not params.get("tools"):
             from crewai.utilities.internal_instructor import InternalInstructor
 
             messages = params.get("messages", [])

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1024,3 +1024,118 @@ async def test_usage_info_streaming_with_acall():
     assert llm._token_usage["total_tokens"] > 0
 
     assert len(result) > 0
+
+
+def test_tools_not_discarded_when_response_model_set():
+    """Test that agent tools are preserved when response_model is set.
+
+    Regression test for #4697: when both tools and response_model are
+    provided, InternalInstructor must NOT be used because it creates its
+    own litellm call that silently discards the tools.  Instead the
+    standard litellm.completion path should receive both tools and
+    response_model.
+    """
+
+    class MyOutput(BaseModel):
+        name: str
+        value: str
+
+    tool_schema = {
+        "type": "function",
+        "function": {
+            "name": "my_search_tool",
+            "description": "Search for data",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query",
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+    llm = LLM(model="gpt-4o-mini", is_litellm=True)
+
+    messages = [{"role": "user", "content": "Find the name and value"}]
+
+    with patch("litellm.completion") as mocked_completion:
+        # Simulate a structured response from litellm when response_model is set
+        mock_result = MyOutput(name="Alice", value="42")
+        mocked_completion.return_value = mock_result
+
+        result = llm.call(
+            messages,
+            tools=[tool_schema],
+            response_model=MyOutput,
+        )
+
+        # litellm.completion must have been called (not InternalInstructor)
+        mocked_completion.assert_called_once()
+
+        _, kwargs = mocked_completion.call_args
+
+        # The tools must be present in the call to litellm.completion
+        assert "tools" in kwargs, "tools should be passed to litellm.completion"
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["name"] == "my_search_tool"
+
+        # response_model must also be present
+        assert kwargs.get("response_model") is MyOutput
+
+
+@pytest.mark.asyncio
+async def test_tools_not_discarded_when_response_model_set_async():
+    """Async variant: agent tools are preserved when response_model is set.
+
+    Regression test for #4697 (async path).
+    """
+
+    class MyOutput(BaseModel):
+        name: str
+        value: str
+
+    tool_schema = {
+        "type": "function",
+        "function": {
+            "name": "my_search_tool",
+            "description": "Search for data",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query",
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+    llm = LLM(model="gpt-4o-mini", is_litellm=True)
+
+    messages = [{"role": "user", "content": "Find the name and value"}]
+
+    with patch("litellm.acompletion") as mocked_acompletion:
+        mock_result = MyOutput(name="Alice", value="42")
+        mocked_acompletion.return_value = mock_result
+
+        result = await llm.acall(
+            messages,
+            tools=[tool_schema],
+            response_model=MyOutput,
+        )
+
+        mocked_acompletion.assert_called_once()
+
+        _, kwargs = mocked_acompletion.call_args
+
+        assert "tools" in kwargs, "tools should be passed to litellm.acompletion"
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["name"] == "my_search_tool"
+
+        assert kwargs.get("response_model") is MyOutput


### PR DESCRIPTION
## Summary
Fixes #4697

When `supports_function_calling()` is `True` and a task has `output_pydantic` set, `InternalInstructor` intercepts the LLM call and creates its own `litellm.completion` invocation that only sends `messages` and `response_model`. The agent's tools (e.g. `my_search_tool`) are silently discarded, forcing the LLM to return structured output immediately without ever calling any of its tools.

The root cause is in `_handle_non_streaming_response` and `_ahandle_non_streaming_response`: the condition `if response_model and self.is_litellm` unconditionally routes to `InternalInstructor`, regardless of whether `params["tools"]` is populated.

## Changes
- Guard the `InternalInstructor` shortcut with `not params.get("tools")` in both `_handle_non_streaming_response` (sync) and `_ahandle_non_streaming_response` (async)
- When tools are present, fall through to the standard `litellm.completion(**params)` path which sends both tools and `response_model` together
- When no tools are present, behavior is unchanged (InternalInstructor is still used for structured output)
- Added two regression tests (sync + async) that verify `litellm.completion` receives both `tools` and `response_model` when both are provided

## Test plan
- [x] New test `test_tools_not_discarded_when_response_model_set` verifies sync path
- [x] New test `test_tools_not_discarded_when_response_model_set_async` verifies async path
- [x] All existing `test_llm.py` tests pass (4 pre-existing failures due to missing `google-genai` optional dep are unrelated)