### PR TITLE
fix: use None check instead of isinstance for memory in human feedback learn

### DIFF
--- a/lib/crewai/src/crewai/flow/human_feedback.py
+++ b/lib/crewai/src/crewai/flow/human_feedback.py
@@ -374,10 +374,8 @@ def human_feedback(
         ) -> Any:
             """Recall past HITL lessons and use LLM to pre-review the output."""
             try:
-                from crewai.memory.unified_memory import Memory
-
                 mem = flow_instance.memory
-                if not isinstance(mem, Memory):
+                if mem is None:
                     return method_output
                 query = f"human feedback lessons for {func.__name__}: {method_output!s}"
                 matches = mem.recall(query, source=learn_source)
@@ -412,10 +410,8 @@ def human_feedback(
         ) -> None:
             """Extract generalizable lessons from output + feedback, store in memory."""
             try:
-                from crewai.memory.unified_memory import Memory
-
                 mem = flow_instance.memory
-                if not isinstance(mem, Memory):
+                if mem is None:
                     return
                 llm_inst = _resolve_llm_instance()
                 prompt = _get_hitl_prompt("hitl_distill_user").format(
@@ -448,7 +444,7 @@ def human_feedback(
                         ]
 
                 if lessons:
-                    mem.remember_many(lessons, source=learn_source)
+                    mem.remember_many(lessons, source=learn_source)  # type: ignore[union-attr]
             except Exception:  # noqa: S110
                 pass  # non-critical: don't fail the flow because lesson storage failed
 


### PR DESCRIPTION
## Summary
- replace `isinstance(mem, Memory)` with `mem is None` in HITL learn helpers
- the isinstance check caused early returns when memory was a valid non-Memory object
- fixes `test_learn_true_pre_reviews_with_past_lessons` and `test_learn_true_stores_distilled_lessons`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small logic change in HITL learning path that only affects when lesson recall/storage is skipped, and falls back safely when memory is absent.
> 
> **Overview**
> Fixes HITL `learn` mode in `human_feedback` by **stopping the strict `Memory` type check** and instead only skipping lesson recall/storage when `flow_instance.memory` is `None`.
> 
> This prevents valid non-`Memory` memory implementations from being ignored during pre-review and lesson distillation, and adds a typing suppression where `remember_many` is called.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 268b0364b8451ccbf03a9eb1adb4b8e335377893. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->