### PR TITLE
fix: populate task metadata (task_name, task_id, task_index) in streaming chunks

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -704,7 +704,7 @@ class Crew(FlowTrackable, BaseModel):
         get_env_context()
         if self.stream:
             enable_agent_streaming(self.agents)
-            ctx = StreamingContext()
+            ctx = StreamingContext(tasks=self.tasks)
 
             def run_crew() -> None:
                 """Execute the crew and capture the result."""
@@ -830,7 +830,7 @@ class Crew(FlowTrackable, BaseModel):
 
         if self.stream:
             enable_agent_streaming(self.agents)
-            ctx = StreamingContext(use_async=True)
+            ctx = StreamingContext(use_async=True, tasks=self.tasks)
 
             async def run_crew() -> None:
                 try:
@@ -901,7 +901,7 @@ class Crew(FlowTrackable, BaseModel):
         """
         if self.stream:
             enable_agent_streaming(self.agents)
-            ctx = StreamingContext(use_async=True)
+            ctx = StreamingContext(use_async=True, tasks=self.tasks)
 
             async def run_crew() -> None:
                 try:

--- a/lib/crewai/src/crewai/crews/utils.py
+++ b/lib/crewai/src/crewai/crews/utils.py
@@ -347,11 +347,18 @@ def prepare_kickoff(
 class StreamingContext:
     """Container for streaming state and holders used during crew execution."""
 
-    def __init__(self, use_async: bool = False) -> None:
+    def __init__(
+        self,
+        use_async: bool = False,
+        tasks: list[Any] | None = None,
+    ) -> None:
         """Initialize streaming context.
 
         Args:
             use_async: Whether to use async streaming mode.
+            tasks: Optional list of Task objects used to build a
+                task-id-to-index mapping so that stream chunks carry
+                the correct ``task_index``.
         """
         self.result_holder: list[CrewOutput] = []
         self.current_task_info: TaskInfo = {
@@ -361,8 +368,18 @@ class StreamingContext:
             "agent_role": "",
             "agent_id": "",
         }
+        # Build a task_id -> index mapping so the stream handler can
+        # resolve task_index from the event's task_id.
+        task_id_to_index: dict[str, int] | None = None
+        if tasks:
+            task_id_to_index = {
+                str(t.id): idx for idx, t in enumerate(tasks)
+            }
         self.state: StreamingState = create_streaming_state(
-            self.current_task_info, self.result_holder, use_async=use_async
+            self.current_task_info,
+            self.result_holder,
+            use_async=use_async,
+            task_id_to_index=task_id_to_index,
         )
         self.output_holder: list[CrewStreamingOutput | FlowStreamingOutput] = []
 
@@ -370,8 +387,14 @@ class StreamingContext:
 class ForEachStreamingContext:
     """Container for streaming state used in for_each crew execution methods."""
 
-    def __init__(self) -> None:
-        """Initialize for_each streaming context."""
+    def __init__(self, tasks: list[Any] | None = None) -> None:
+        """Initialize for_each streaming context.
+
+        Args:
+            tasks: Optional list of Task objects used to build a
+                task-id-to-index mapping so that stream chunks carry
+                the correct ``task_index``.
+        """
         self.result_holder: list[list[CrewOutput]] = [[]]
         self.current_task_info: TaskInfo = {
             "index": 0,
@@ -380,8 +403,16 @@ class ForEachStreamingContext:
             "agent_role": "",
             "agent_id": "",
         }
+        task_id_to_index: dict[str, int] | None = None
+        if tasks:
+            task_id_to_index = {
+                str(t.id): idx for idx, t in enumerate(tasks)
+            }
         self.state: StreamingState = create_streaming_state(
-            self.current_task_info, self.result_holder, use_async=True
+            self.current_task_info,
+            self.result_holder,
+            use_async=True,
+            task_id_to_index=task_id_to_index,
         )
         self.output_holder: list[CrewStreamingOutput | FlowStreamingOutput] = []
 
@@ -414,7 +445,7 @@ async def run_for_each_async(
     crew_copies = [crew.copy() for _ in inputs]
 
     if crew.stream:
-        ctx = ForEachStreamingContext()
+        ctx = ForEachStreamingContext(tasks=crew.tasks)
 
         async def run_all_crews() -> None:
             try:

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -71,24 +71,39 @@ def _extract_tool_call_info(
 def _create_stream_chunk(
     event: LLMStreamChunkEvent,
     current_task_info: TaskInfo,
+    task_id_to_index: dict[str, int] | None = None,
 ) -> StreamChunk:
     """Create a StreamChunk from an LLM stream chunk event.
 
     Args:
         event: The LLM stream chunk event to process.
         current_task_info: Task context info.
+        task_id_to_index: Optional mapping from task UUID to task index.
 
     Returns:
         A StreamChunk populated with event and task info.
     """
     chunk_type, tool_call_chunk = _extract_tool_call_info(event)
 
+    # Prefer event-level task/agent metadata (populated from from_task/from_agent
+    # in LLMEventBase.__init__) over the current_task_info fallback, consistent
+    # with how agent_role and agent_id are already resolved.
+    task_id = event.task_id or current_task_info["id"]
+    task_name = event.task_name or current_task_info["name"]
+
+    # Resolve task_index: look up from the task_id_to_index mapping when the
+    # event carries a task_id, otherwise fall back to current_task_info.
+    if task_id and task_id_to_index and task_id in task_id_to_index:
+        task_index = task_id_to_index[task_id]
+    else:
+        task_index = current_task_info["index"]
+
     return StreamChunk(
         content=event.chunk,
         chunk_type=chunk_type,
-        task_index=current_task_info["index"],
-        task_name=current_task_info["name"],
-        task_id=current_task_info["id"],
+        task_index=task_index,
+        task_name=task_name,
+        task_id=task_id,
         agent_role=event.agent_role or current_task_info["agent_role"],
         agent_id=event.agent_id or current_task_info["agent_id"],
         tool_call=tool_call_chunk,
@@ -100,6 +115,7 @@ def _create_stream_handler(
     sync_queue: queue.Queue[StreamChunk | None | Exception],
     async_queue: asyncio.Queue[StreamChunk | None | Exception] | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
+    task_id_to_index: dict[str, int] | None = None,
 ) -> Callable[[Any, BaseEvent], None]:
     """Create a stream handler function.
 
@@ -108,6 +124,7 @@ def _create_stream_handler(
         sync_queue: Synchronous queue for chunks.
         async_queue: Optional async queue for chunks.
         loop: Optional event loop for async operations.
+        task_id_to_index: Optional mapping from task UUID to task index.
 
     Returns:
         Handler function that can be registered with the event bus.
@@ -123,7 +140,7 @@ def _create_stream_handler(
         if not isinstance(event, LLMStreamChunkEvent):
             return
 
-        chunk = _create_stream_chunk(event, current_task_info)
+        chunk = _create_stream_chunk(event, current_task_info, task_id_to_index)
 
         if async_queue is not None and loop is not None:
             loop.call_soon_threadsafe(async_queue.put_nowait, chunk)
@@ -165,6 +182,7 @@ def create_streaming_state(
     current_task_info: TaskInfo,
     result_holder: list[Any],
     use_async: bool = False,
+    task_id_to_index: dict[str, int] | None = None,
 ) -> StreamingState:
     """Create and register streaming state.
 
@@ -172,6 +190,7 @@ def create_streaming_state(
         current_task_info: Task context info.
         result_holder: List to hold the final result.
         use_async: Whether to use async queue.
+        task_id_to_index: Optional mapping from task UUID to task index.
 
     Returns:
         Initialized StreamingState with registered handler.
@@ -184,7 +203,9 @@ def create_streaming_state(
         async_queue = asyncio.Queue()
         loop = asyncio.get_event_loop()
 
-    handler = _create_stream_handler(current_task_info, sync_queue, async_queue, loop)
+    handler = _create_stream_handler(
+        current_task_info, sync_queue, async_queue, loop, task_id_to_index
+    )
     crewai_event_bus.register_handler(LLMStreamChunkEvent, handler)
 
     return StreamingState(

--- a/lib/crewai/tests/test_streaming.py
+++ b/lib/crewai/tests/test_streaming.py
@@ -100,6 +100,93 @@ class TestStreamChunk:
         assert chunk.tool_call.tool_name == "search"
 
 
+class TestCreateStreamChunkTaskMetadata:
+    """Tests for _create_stream_chunk populating task metadata from events.
+
+    Regression tests for https://github.com/crewAIInc/crewAI/issues/4347
+    where streaming chunks were missing task_name, task_id, and task_index
+    because the values were only read from the (empty) current_task_info
+    dict instead of from the LLMStreamChunkEvent.
+    """
+
+    def test_task_name_and_id_from_event(self) -> None:
+        """task_name and task_id should come from the event when available."""
+        from crewai.utilities.streaming import TaskInfo, _create_stream_chunk
+
+        empty_info: TaskInfo = {
+            "index": 0,
+            "name": "",
+            "id": "",
+            "agent_role": "",
+            "agent_id": "",
+        }
+        event = LLMStreamChunkEvent(
+            type="llm_stream_chunk",
+            chunk="hello",
+            call_id="c1",
+            task_id="uuid-task-1",
+            task_name="My Task",
+            agent_id="uuid-agent-1",
+            agent_role="Researcher",
+        )
+
+        chunk = _create_stream_chunk(event, empty_info)
+        assert chunk.task_id == "uuid-task-1"
+        assert chunk.task_name == "My Task"
+        assert chunk.agent_id == "uuid-agent-1"
+        assert chunk.agent_role == "Researcher"
+
+    def test_task_index_resolved_via_mapping(self) -> None:
+        """task_index should be looked up from task_id_to_index mapping."""
+        from crewai.utilities.streaming import TaskInfo, _create_stream_chunk
+
+        empty_info: TaskInfo = {
+            "index": 0,
+            "name": "",
+            "id": "",
+            "agent_role": "",
+            "agent_id": "",
+        }
+        mapping = {"uuid-task-0": 0, "uuid-task-1": 1, "uuid-task-2": 2}
+
+        event = LLMStreamChunkEvent(
+            type="llm_stream_chunk",
+            chunk="hello",
+            call_id="c1",
+            task_id="uuid-task-2",
+            task_name="Third Task",
+        )
+
+        chunk = _create_stream_chunk(event, empty_info, task_id_to_index=mapping)
+        assert chunk.task_index == 2
+        assert chunk.task_id == "uuid-task-2"
+        assert chunk.task_name == "Third Task"
+
+    def test_fallback_to_current_task_info(self) -> None:
+        """When the event has no task metadata, fall back to current_task_info."""
+        from crewai.utilities.streaming import TaskInfo, _create_stream_chunk
+
+        info: TaskInfo = {
+            "index": 3,
+            "name": "Fallback Task",
+            "id": "fallback-id",
+            "agent_role": "Fallback Agent",
+            "agent_id": "fallback-agent-id",
+        }
+        event = LLMStreamChunkEvent(
+            type="llm_stream_chunk",
+            chunk="data",
+            call_id="c2",
+        )
+
+        chunk = _create_stream_chunk(event, info)
+        assert chunk.task_index == 3
+        assert chunk.task_name == "Fallback Task"
+        assert chunk.task_id == "fallback-id"
+        assert chunk.agent_role == "Fallback Agent"
+        assert chunk.agent_id == "fallback-agent-id"
+
+
 class TestCrewStreamingOutput:
     """Tests for CrewStreamingOutput functionality."""
 


### PR DESCRIPTION
## Summary
Fixes #4347

When using `Crew(stream=True)`, the emitted `StreamChunk` objects always had empty `task_name`, `task_id`, and a hardcoded `task_index` of `0`, regardless of which task was executing. This made it impossible for consumers to attribute streamed output to a specific task.

**Root cause:** `_create_stream_chunk` read task metadata exclusively from a `current_task_info` dict that was initialised with blank values and never updated during task execution. Meanwhile, the `LLMStreamChunkEvent` already carried the correct `task_name`, `task_id`, `agent_role`, and `agent_id` (populated from `from_task`/`from_agent` in `LLMEventBase.__init__`), but these event-level fields were ignored for the task fields — even though `agent_role` and `agent_id` were already correctly resolved from the event with a fallback pattern.

## Changes

- **`streaming.py` — `_create_stream_chunk`**: Now prefers `event.task_name` / `event.task_id` over the `current_task_info` fallback, consistent with how `agent_role` and `agent_id` are already resolved. Also accepts an optional `task_id_to_index` mapping to resolve `task_index` from the event's `task_id`.
- **`streaming.py` — `_create_stream_handler` / `create_streaming_state`**: Thread the `task_id_to_index` mapping through to the handler closure.
- **`crews/utils.py` — `StreamingContext` / `ForEachStreamingContext`**: Accept an optional `tasks` list and build the `{task_id: index}` mapping at construction time.
- **`crew.py`**: Pass `tasks=self.tasks` when constructing `StreamingContext` at each `kickoff` / `kickoff_async` / `akickoff` entry point.

## Test plan
- [x] 3 new unit tests in `test_streaming.py::TestCreateStreamChunkTaskMetadata`:
  - `test_task_name_and_id_from_event` — verifies event-sourced metadata populates the chunk
  - `test_task_index_resolved_via_mapping` — verifies task_index lookup from task_id_to_index
  - `test_fallback_to_current_task_info` — verifies fallback when event has no task metadata
- [x] All 28 existing streaming unit tests pass
- [x] All 8 streaming integration tests pass
- [x] `test_crew_kickoff_streaming_usage_metrics` passes