### PR TITLE
ci: add crewai-tools to mypy strict type checks

### DIFF
--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --all-groups --all-extras
 
       - name: Run type checks
-        run: uv run mypy lib/crewai/src/crewai/
+        run: uv run mypy lib/crewai/src/crewai/ lib/crewai-tools/src/crewai_tools/
 
       - name: Save uv caches
         if: steps.cache-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that broadens static type checking to an additional package; main impact is potential new CI failures/longer runtime.
> 
> **Overview**
> Expands the GitHub Actions `type-checker` workflow to run `mypy` against both `lib/crewai` and `lib/crewai-tools` instead of just `lib/crewai`, ensuring `crewai-tools` is covered by the same strict type-checking in the matrix job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da856a6e2931027753f8f803f8376676ad18f98a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->