### PR TITLE
fix: resolve mypy errors in crewai-files and type check all packages

### DIFF
--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --all-groups --all-extras
 
       - name: Run type checks
-        run: uv run mypy lib/crewai/src/crewai/ lib/crewai-tools/src/crewai_tools/
+        run: uv run mypy lib/
 
       - name: Save uv caches
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/lib/crewai-files/src/crewai_files/formatting/api.py
+++ b/lib/crewai-files/src/crewai_files/formatting/api.py
@@ -122,7 +122,7 @@ def format_multimodal_content(
         return content_blocks
 
     # Use API-specific constraints for OpenAI
-    constraints_key = provider_type
+    constraints_key: str = provider_type
     if api == "responses" and "openai" in provider_type.lower():
         constraints_key = "openai_responses"
 
@@ -187,7 +187,7 @@ async def aformat_multimodal_content(
         return content_blocks
 
     # Use API-specific constraints for OpenAI
-    constraints_key = provider_type
+    constraints_key: str = provider_type
     if api == "responses" and "openai" in provider_type.lower():
         constraints_key = "openai_responses"
 

--- a/lib/crewai-files/src/crewai_files/processing/constraints.py
+++ b/lib/crewai-files/src/crewai_files/processing/constraints.py
@@ -15,6 +15,7 @@ from crewai_files.core.types import (
 ProviderName = Literal[
     "anthropic",
     "openai",
+    "openai_responses",
     "gemini",
     "bedrock",
     "azure",

--- a/lib/crewai-files/src/crewai_files/processing/transformers.py
+++ b/lib/crewai-files/src/crewai_files/processing/transformers.py
@@ -120,7 +120,7 @@ def optimize_image(
 
     with Image.open(io.BytesIO(content)) as img:
         if img.mode in ("RGBA", "LA", "P"):
-            img = img.convert("RGB")
+            img = img.convert("RGB")  # type: ignore[assignment]
             output_format = "JPEG"
         else:
             output_format = img.format or "JPEG"

--- a/lib/crewai-files/src/crewai_files/processing/validators.py
+++ b/lib/crewai-files/src/crewai_files/processing/validators.py
@@ -85,7 +85,7 @@ def _get_audio_duration(content: bytes, filename: str | None = None) -> float | 
         Duration in seconds or None if tinytag unavailable.
     """
     try:
-        from tinytag import TinyTag  # type: ignore[import-untyped]
+        from tinytag import TinyTag
     except ImportError:
         logger.warning(
             "tinytag not installed - cannot validate audio duration. "


### PR DESCRIPTION
## Summary
- fix 5 strict mypy errors in crewai-files (missing `openai_responses` in ProviderName literal, Image type mismatch, stale type:ignore)
- simplify CI type-checker to run `mypy lib/` covering all packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI mypy scope and small typing-only fixes (Literal update, annotations, and type-ignore adjustments) with no runtime behavior changes expected.
> 
> **Overview**
> Updates the GitHub Actions type-check workflow to run `mypy` across `lib/` instead of targeting only `crewai` and `crewai-tools`.
> 
> Fixes strict mypy issues in `crewai-files` by adding `openai_responses` to the `ProviderName` Literal, tightening `constraints_key` typing in the formatting API, and adjusting image/audio typing suppressions (Pillow `convert()` assignment and `tinytag` import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dac321f81991754f3a94de1c920272a1d8357c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->