### PR TITLE
fix: missing router edges for @listen + @human_feedback(emit=...) methods

### DIFF
--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -778,11 +778,19 @@ class FlowMeta(type):
                         and attr_value.__is_router__
                     ):
                         routers.add(attr_name)
-                        possible_returns = get_possible_return_constants(attr_value)
-                        if possible_returns:
-                            router_paths[attr_name] = possible_returns
+                        # First check for explicit __router_paths__ (set by @human_feedback(emit=[...]))
+                        if (
+                            hasattr(attr_value, "__router_paths__")
+                            and attr_value.__router_paths__
+                        ):
+                            router_paths[attr_name] = attr_value.__router_paths__
                         else:
-                            router_paths[attr_name] = []
+                            # Fall back to source code analysis for @router methods
+                            possible_returns = get_possible_return_constants(attr_value)
+                            if possible_returns:
+                                router_paths[attr_name] = possible_returns
+                            else:
+                                router_paths[attr_name] = []
 
                 # Handle start methods that are also routers (e.g., @human_feedback with emit)
                 if (

--- a/lib/crewai/tests/test_flow_serializer.py
+++ b/lib/crewai/tests/test_flow_serializer.py
@@ -224,6 +224,58 @@ class TestHumanFeedbackMethods:
         assert method_map["handle_approved"]["has_human_feedback"] is False
         assert method_map["handle_rejected"]["has_human_feedback"] is False
 
+    def test_listen_plus_human_feedback_router_edges(self):
+        """Test that @listen + @human_feedback(emit=...) generates router edges.
+
+        This is the pattern used in the whitepaper generator:
+        a listener method that also acts as a router via @human_feedback(emit=[...]).
+        The serializer must generate edges from this method to listeners of its emit paths.
+        """
+
+        class ReviewFlow(Flow):
+            @start()
+            def generate(self):
+                return "content"
+
+            @listen(generate)
+            @human_feedback(
+                message="Review this:",
+                emit=["approved", "needs_changes", "cancelled"],
+                llm="gpt-4o-mini",
+            )
+            def review(self):
+                return "review result"
+
+            @listen("approved")
+            def handle_approved(self):
+                return "done"
+
+            @listen("needs_changes")
+            def handle_changes(self):
+                return "regenerating"
+
+            @listen("cancelled")
+            def handle_cancelled(self):
+                return "cancelled"
+
+        structure = flow_structure(ReviewFlow)
+
+        method_map = {m["name"]: m for m in structure["methods"]}
+        edge_set = {(e["from_method"], e["to_method"], e.get("condition")) for e in structure["edges"]}
+
+        # review should be detected as a router with the emit paths
+        assert method_map["review"]["type"] == "router"
+        assert set(method_map["review"]["router_paths"]) == {"approved", "needs_changes", "cancelled"}
+        assert method_map["review"]["has_human_feedback"] is True
+
+        # Should have listen edge: generate -> review
+        assert ("generate", "review", None) in edge_set
+
+        # Should have route edges from review to each listener
+        assert ("review", "handle_approved", "approved") in edge_set
+        assert ("review", "handle_changes", "needs_changes") in edge_set
+        assert ("review", "handle_cancelled", "cancelled") in edge_set
+
 
 class TestCrewReferences:
     """Test detection of Crew references in method bodies."""


### PR DESCRIPTION
## Problem

When a Flow method uses both `@listen` and `@human_feedback(emit=[...])`, the flow serializer fails to generate router edges from that method to the listeners of its emit paths. This causes the Studio Flow Run Tab to show disconnected nodes.

**Example:** The whitepaper generator's `review_infographic` has `@listen(generate_whitepaper)` + `@human_feedback(emit=['approved', 'needs_changes', 'cancelled'])`. The edges to `handle_cancelled`, `send_slack_notification`, and `classify_feedback` were all missing — 6 edges invisible in the UI.

## Root Cause

In `FlowMeta.__init_subclass__`, when a listener method is also a router, the metaclass called `get_possible_return_constants()` to detect router paths via source code analysis. This works for plain `@router` methods (which have explicit return statements), but fails for `@human_feedback(emit=[...])` methods where the paths come from the decorator parameter, stored as `__router_paths__`.

The fix for `@start + @human_feedback` already existed (line 796), but the same fix was missing for `@listen + @human_feedback`.

## Fix

Check `__router_paths__` first (set by `@human_feedback`), fall back to `get_possible_return_constants()` for plain `@router` methods.

## Test

Added test: `@listen` + `@human_feedback(emit=[...])` generates correct router edges — verifies the exact pattern from the whitepaper generator.