### PR TITLE
Fix for agent memory saving

### DIFF
--- a/lib/crewai/src/crewai/memory/memory_scope.py
+++ b/lib/crewai/src/crewai/memory/memory_scope.py
@@ -79,6 +79,30 @@ class MemoryScope(BaseModel):
             private=private,
         )
 
+    def remember_many(
+      self,
+      contents: list[str],
+      scope: str | None = "/",
+      categories: list[str] | None = None,
+      metadata: dict[str, Any] | None = None,
+      importance: float | None = None,
+      source: str | None = None,
+      private: bool = False,
+      agent_role: str | None = None,
+    ) -> list[MemoryRecord]:
+      """Remember multiple items; scope is relative to this scope's root."""
+      path = self._scope_path(scope)
+      return self._memory.remember_many(
+        contents,
+        scope=path,
+        categories=categories,
+        metadata=metadata,
+        importance=importance,
+        source=source,
+        private=private,
+        agent_role=agent_role,
+      )
+
     def recall(
         self,
         query: str,


### PR DESCRIPTION
Fix: Add a remember_many() method to the MemoryScope class that delegates to self._memory.remember_many(...) with the scoped path, following the exact same pattern as the existing remember() method.

Problem: When you pass memory=memory.scope("/agent/...") to an Agent, CrewAI's internal code calls remember_many() after every task to persist results. But MemoryScope never implemented remember_many() — only the parent Memory class has it.

Symptom: [ERROR]: Failed to save kickoff result to memory: 'MemoryScope' object has no attribute 'remember_many' — memories are silently never saved after agent tasks.