### PR TITLE
chore: run ruff check and format on all files in CI

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,15 +8,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fetch Target Branch
-        run: git fetch origin $TARGET_BRANCH --depth=1
 
       - name: Restore global uv cache
         id: cache-restore
@@ -40,23 +33,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups --all-extras --no-install-project
 
-      - name: Get Changed Python Files
-        id: changed-files
-        run: |
-          merge_base=$(git merge-base origin/"$TARGET_BRANCH" HEAD)
-          changed_files=$(git diff --name-only --diff-filter=ACMRTUB "$merge_base" | grep '\.py$' || true)
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$changed_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Ruff check
+        run: uv run ruff check lib/
 
-      - name: Run Ruff on Changed Files
-        if: ${{ steps.changed-files.outputs.files != '' }}
-        run: |
-         echo "${{ steps.changed-files.outputs.files }}" \
-           | tr ' ' '\n' \
-           | grep -v 'src/crewai/cli/templates/' \
-           | grep -v '/tests/' \
-           | xargs -I{} uv run ruff check "{}"
+      - name: Ruff format
+        run: uv run ruff format --check lib/
 
       - name: Save uv caches
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/lib/crewai/src/crewai/memory/memory_scope.py
+++ b/lib/crewai/src/crewai/memory/memory_scope.py
@@ -80,28 +80,28 @@ class MemoryScope(BaseModel):
         )
 
     def remember_many(
-      self,
-      contents: list[str],
-      scope: str | None = "/",
-      categories: list[str] | None = None,
-      metadata: dict[str, Any] | None = None,
-      importance: float | None = None,
-      source: str | None = None,
-      private: bool = False,
-      agent_role: str | None = None,
+        self,
+        contents: list[str],
+        scope: str | None = "/",
+        categories: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        importance: float | None = None,
+        source: str | None = None,
+        private: bool = False,
+        agent_role: str | None = None,
     ) -> list[MemoryRecord]:
-      """Remember multiple items; scope is relative to this scope's root."""
-      path = self._scope_path(scope)
-      return self._memory.remember_many(
-        contents,
-        scope=path,
-        categories=categories,
-        metadata=metadata,
-        importance=importance,
-        source=source,
-        private=private,
-        agent_role=agent_role,
-      )
+        """Remember multiple items; scope is relative to this scope's root."""
+        path = self._scope_path(scope)
+        return self._memory.remember_many(
+            contents,
+            scope=path,
+            categories=categories,
+            metadata=metadata,
+            importance=importance,
+            source=source,
+            private=private,
+            agent_role=agent_role,
+        )
 
     def recall(
         self,


### PR DESCRIPTION
## Summary
- Lint workflow now runs `ruff check` and `ruff format --check` on all of `lib/` instead of only changed files
- Removes template and test directory exclusions
- Fixes existing formatting issue in `memory_scope.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only linting scope change plus a formatting-only tweak; main impact is potentially longer lint jobs and new lint failures on previously-unchecked files.
> 
> **Overview**
> CI linting is updated to run `ruff check` and `ruff format --check` over all of `lib/` instead of computing and linting only changed Python files (removing the target-branch fetch and related exclusions).
> 
> Also applies a small `ruff`-driven formatting fix in `MemoryScope.remember_many` with no functional behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9357822a2e43d5767e2efb7f47946ea7d73e4263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->