### PR TITLE
fix: prevent output_pydantic from injecting tool schema when LLM lacks function calling

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -370,28 +370,15 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     verbose=self.agent.verbose,
                 )
                 if self.response_model is not None:
+                    answer_str = answer if isinstance(answer, str) else str(answer)
                     try:
-                        if isinstance(answer, BaseModel):
-                            output_json = answer.model_dump_json()
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=output_json,
-                            )
-                        else:
-                            self.response_model.model_validate_json(answer)
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=answer,
-                            )
-                    except ValidationError:
-                        # If validation fails, convert BaseModel to JSON string for parsing
-                        answer_str = (
-                            answer.model_dump_json()
-                            if isinstance(answer, BaseModel)
-                            else str(answer)
+                        self.response_model.model_validate_json(answer_str)
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer_str,
+                            text=answer_str,
                         )
+                    except ValidationError:
                         formatted_answer = process_llm_response(
                             answer_str, self.use_stop_words
                         )  # type: ignore[assignment]
@@ -1216,28 +1203,15 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 )
 
                 if self.response_model is not None:
+                    answer_str = answer if isinstance(answer, str) else str(answer)
                     try:
-                        if isinstance(answer, BaseModel):
-                            output_json = answer.model_dump_json()
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=output_json,
-                            )
-                        else:
-                            self.response_model.model_validate_json(answer)
-                            formatted_answer = AgentFinish(
-                                thought="",
-                                output=answer,
-                                text=answer,
-                            )
-                    except ValidationError:
-                        # If validation fails, convert BaseModel to JSON string for parsing
-                        answer_str = (
-                            answer.model_dump_json()
-                            if isinstance(answer, BaseModel)
-                            else str(answer)
+                        self.response_model.model_validate_json(answer_str)
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer_str,
+                            text=answer_str,
                         )
+                    except ValidationError:
                         formatted_answer = process_llm_response(
                             answer_str, self.use_stop_words
                         )  # type: ignore[assignment]

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -352,6 +352,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
 
                 enforce_rpm_limit(self.request_within_rpm_limit)
 
+                # In ReAct mode the LLM does NOT support native function
+                # calling, so we must NOT pass response_model — instructor
+                # would inject the Pydantic schema as a tool/function, which
+                # models without function-calling support cannot handle.
+                # The task-level convert_to_model() handles the final
+                # text → Pydantic conversion after the ReAct loop finishes.
                 answer = get_llm_response(
                     llm=self.llm,
                     messages=self.messages,
@@ -359,11 +365,10 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     printer=self._printer,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )
-                # breakpoint()
                 if self.response_model is not None:
                     try:
                         if isinstance(answer, BaseModel):
@@ -1192,6 +1197,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
 
                 enforce_rpm_limit(self.request_within_rpm_limit)
 
+                # In ReAct mode the LLM does NOT support native function
+                # calling, so we must NOT pass response_model — instructor
+                # would inject the Pydantic schema as a tool/function, which
+                # models without function-calling support cannot handle.
+                # The task-level convert_to_model() handles the final
+                # text → Pydantic conversion after the ReAct loop finishes.
                 answer = await aget_llm_response(
                     llm=self.llm,
                     messages=self.messages,
@@ -1199,7 +1210,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     printer=self._printer,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )

--- a/lib/crewai/tests/agents/test_react_response_model.py
+++ b/lib/crewai/tests/agents/test_react_response_model.py
@@ -11,7 +11,7 @@ The fix: _invoke_loop_react() must pass response_model=None so the LLM
 produces plain text that the ReAct parser can handle normally.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -138,3 +138,58 @@ class TestReActResponseModel:
 
                 spy_react.assert_called_once()
                 spy_native.assert_not_called()
+
+    def test_react_path_with_valid_json_string_bypasses_fallback_parser(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """Valid JSON strings should be returned directly in ReAct mode."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew, response_model=MyOutput
+        )
+
+        valid_json = '{"answer": "hello"}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.get_llm_response",
+            return_value=valid_json,
+        ), patch(
+            "crewai.agents.crew_agent_executor.process_llm_response"
+        ) as mock_process:
+            result = executor._invoke_loop_react()
+
+        mock_process.assert_not_called()
+        assert result.output == valid_json
+        assert result.text == valid_json
+
+    @pytest.mark.asyncio
+    async def test_async_react_path_with_valid_json_string_bypasses_fallback_parser(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """Async ReAct mode should treat valid JSON strings the same way."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew, response_model=MyOutput
+        )
+
+        valid_json = '{"answer": "hello"}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.aget_llm_response",
+            new=AsyncMock(return_value=valid_json),
+        ), patch(
+            "crewai.agents.crew_agent_executor.process_llm_response"
+        ) as mock_process:
+            result = await executor._ainvoke_loop_react()
+
+        mock_process.assert_not_called()
+        assert result.output == valid_json
+        assert result.text == valid_json

--- a/lib/crewai/tests/agents/test_react_response_model.py
+++ b/lib/crewai/tests/agents/test_react_response_model.py
@@ -1,0 +1,140 @@
+"""Tests for output_pydantic behavior in ReAct mode (no function calling).
+
+Regression test for https://github.com/crewAIInc/crewAI/issues/4695
+When a Task has output_pydantic set and the LLM does NOT support native
+function calling, the executor falls back to the ReAct text-based loop.
+Previously, response_model was still forwarded to the LLM call, which caused
+instructor to inject the Pydantic schema as a tool — something models
+without function-calling support cannot handle.
+
+The fix: _invoke_loop_react() must pass response_model=None so the LLM
+produces plain text that the ReAct parser can handle normally.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+
+@pytest.fixture
+def mock_llm():
+    """Create an LLM mock that does NOT support function calling."""
+    llm = MagicMock()
+    llm.supports_stop_words.return_value = True
+    llm.supports_function_calling.return_value = False
+    llm.stop = []
+    return llm
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock()
+    agent.role = "Test Agent"
+    agent.key = "test_agent_key"
+    agent.verbose = False
+    agent.id = "test_agent_id"
+    return agent
+
+
+@pytest.fixture
+def mock_task():
+    task = MagicMock()
+    task.description = "Test task"
+    return task
+
+
+@pytest.fixture
+def mock_crew():
+    crew = MagicMock()
+    crew.verbose = False
+    crew._train = False
+    return crew
+
+
+def _make_executor(mock_llm, mock_agent, mock_task, mock_crew, response_model):
+    """Build a CrewAgentExecutor with the given response_model."""
+    return CrewAgentExecutor(
+        llm=mock_llm,
+        task=mock_task,
+        crew=mock_crew,
+        agent=mock_agent,
+        prompt={"prompt": "Test {input} {tool_names} {tools}"},
+        max_iter=3,
+        tools=[],
+        tools_names="",
+        stop_words=["Observation:"],
+        tools_description="",
+        tools_handler=MagicMock(),
+        response_model=response_model,
+    )
+
+
+class TestReActResponseModel:
+    """Ensure response_model is NOT forwarded in ReAct mode."""
+
+    def test_react_path_passes_response_model_none(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """When LLM lacks function-calling, _invoke_loop_react must NOT send
+        response_model to get_llm_response.
+        """
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew,
+            response_model=MyOutput,
+        )
+        # The executor should store the response_model
+        assert executor.response_model is MyOutput
+
+        final_text = 'Final Answer: {"answer": "hello"}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.get_llm_response",
+            return_value=final_text,
+        ) as mock_get:
+            result = executor._invoke_loop_react()
+
+            # The critical assertion: response_model passed to get_llm_response
+            # MUST be None — never the Pydantic model — in ReAct mode.
+            call_kwargs = mock_get.call_args.kwargs
+            assert call_kwargs["response_model"] is None, (
+                "response_model must be None in ReAct mode to prevent "
+                "instructor from injecting the schema as a tool"
+            )
+
+    def test_react_path_selected_when_no_function_calling(
+        self, mock_llm, mock_agent, mock_task, mock_crew
+    ):
+        """Verify the executor chooses _invoke_loop_react when
+        supports_function_calling() returns False."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            value: int
+
+        executor = _make_executor(
+            mock_llm, mock_agent, mock_task, mock_crew,
+            response_model=MyOutput,
+        )
+
+        final_text = 'Final Answer: {"value": 42}'
+
+        with patch(
+            "crewai.agents.crew_agent_executor.get_llm_response",
+            return_value=final_text,
+        ):
+            with patch.object(
+                executor, "_invoke_loop_react", wraps=executor._invoke_loop_react
+            ) as spy_react, patch.object(
+                executor, "_invoke_loop_native_tools"
+            ) as spy_native:
+                executor.invoke({"input": "test", "tool_names": "", "tools": ""})
+
+                spy_react.assert_called_once()
+                spy_native.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #4695

When a Task has `output_pydantic` set and the LLM does **not** support native function calling (e.g., Ollama models), the executor correctly falls back to the ReAct text-based loop. However, `response_model` was still forwarded to the LLM call, causing `InternalInstructor` to inject the Pydantic schema as a tool via `instructor.from_litellm(completion)` in `Mode.TOOLS` mode — which models without function-calling support cannot handle.

## Root Cause

`_invoke_loop_react()` and `_ainvoke_loop_react()` both passed `self.response_model` to `get_llm_response()` / `aget_llm_response()`. This triggered the instructor path in `LLM._process_call_params()` (line 1153), which wraps the LLM with `instructor.from_litellm(completion)` using the default `Mode.TOOLS` — injecting the Pydantic model as a native tool regardless of whether the model actually supports function calling.

## Fix

Pass `response_model=None` in both `_invoke_loop_react()` and `_ainvoke_loop_react()`. The task-level `convert_to_model()` in `task.py` (line 1021-1040) already handles text → Pydantic conversion after the ReAct loop finishes, so instructor-based extraction is unnecessary and harmful in this code path.

## Changes

- **`lib/crewai/src/crewai/agents/crew_agent_executor.py`**: Set `response_model=None` in both sync and async ReAct loops
- **`lib/crewai/tests/agents/test_react_response_model.py`**: Added 2 regression tests:
  - Verifies `response_model=None` is passed to `get_llm_response` in ReAct mode  
  - Verifies `_invoke_loop_react` is selected (not native tools) when function calling is unsupported

## Test Results

- 2 new tests pass ✅
- 29 existing sync executor tests pass ✅
- No regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `output_pydantic` is handled in the ReAct execution path, which can affect structured output behavior for models without native tool/function calling. Risk is mitigated by added regression tests covering the selection of ReAct mode and ensuring `response_model` is not forwarded.
> 
> **Overview**
> Prevents `output_pydantic` from being forwarded to the LLM call when the executor falls back to the ReAct text loop, by forcing `response_model=None` in both sync and async ReAct invocations so non-function-calling models don’t receive an injected tool schema.
> 
> Adds regression tests ensuring ReAct mode is chosen when `supports_function_calling()` is false and that `get_llm_response` is called with `response_model=None` in this path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16be9acaa748a405be2069c878e0f4f63e9ce8e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

> ⚠️ This reopens #4828 which was accidentally closed due to fork deletion.