### PR TITLE
feat: add request_id to HumanFeedbackRequestedEvent

### DIFF
--- a/lib/crewai/src/crewai/events/types/flow_events.py
+++ b/lib/crewai/src/crewai/events/types/flow_events.py
@@ -201,9 +201,12 @@ class HumanFeedbackReceivedEvent(FlowEvent):
         method_name: Name of the method that received feedback.
         feedback: The raw text feedback provided by the human.
         outcome: The collapsed outcome string (if emit was specified).
+        request_id: Platform-assigned identifier for this feedback request,
+            used for correlating the response back to its originating request.
     """
 
     method_name: str
     feedback: str
     outcome: str | None = None
+    request_id: str | None = None
     type: str = "human_feedback_received"


### PR DESCRIPTION
Allow platforms to attach a correlation identifier to human feedback requests so downstream consumers can deterministically match spans to their corresponding feedback records

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema extension: adds an optional field to emitted flow events, with minimal behavioral impact, but downstream consumers with strict event validation may need to tolerate the new attribute.
> 
> **Overview**
> Adds an optional `request_id` field to `HumanFeedbackRequestedEvent` and `HumanFeedbackReceivedEvent` (with updated docstrings) so platforms can attach a correlation identifier that follows the feedback lifecycle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0dfbb73e6f1fe4bfc190afef2cda69df69eaff6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->