### PR TITLE
fix(security): replace eval() with safe parsing in template code

### DIFF
--- a/lib/crewai/src/crewai/cli/templates/AGENTS.md
+++ b/lib/crewai/src/crewai/cli/templates/AGENTS.md
@@ -765,12 +765,33 @@ class CustomSearchTool(BaseTool):
 
 ### Using @tool Decorator
 ```python
+import ast
+import operator
 from crewai.tools import tool
 
 @tool("Calculator")
 def calculator(expression: str) -> str:
-    """Evaluates a mathematical expression and returns the result."""
-    return str(eval(expression))
+    """Safely evaluates a mathematical expression and returns the result."""
+    # Whitelist of safe arithmetic operators
+    ops = {
+        ast.Add: operator.add, ast.Sub: operator.sub,
+        ast.Mult: operator.mul, ast.Div: operator.truediv,
+        ast.Pow: operator.pow, ast.USub: operator.neg,
+    }
+
+    def _safe_eval(node):
+        if isinstance(node, ast.Expression):
+            return _safe_eval(node.body)
+        elif isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        elif isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_safe_eval(node.left), _safe_eval(node.right))
+        elif isinstance(node, ast.UnaryOp) and type(node.op) in ops:
+            return ops[type(node.op)](_safe_eval(node.operand))
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    tree = ast.parse(expression, mode="eval")
+    return str(_safe_eval(tree))
 ```
 
 ### Built-in Tools (install with `uv add crewai-tools`)


### PR DESCRIPTION
## Summary

- Replace unsafe `eval()` call in the Calculator tool template (`AGENTS.md`) with an AST-based safe math evaluator
- The safe evaluator uses a whitelist approach: only arithmetic operators (`+`, `-`, `*`, `/`, `**`, unary `-`) and numeric literals (`int`, `float`) are allowed
- All function calls, imports, attribute access, and other Python constructs are rejected with a `ValueError`

## Security Impact

The `crewai create` command ships this template into new projects. The `eval()` call enables arbitrary code execution via indirect prompt injection (e.g., a malicious document tricks the LLM into calling `calculator("__import__('os').system('rm -rf /')")`).

**Before (vulnerable):**
```python
@tool("Calculator")
def calculator(expression: str) -> str:
    return str(eval(expression))  # arbitrary code execution
```

**After (safe):**
```python
@tool("Calculator")
def calculator(expression: str) -> str:
    # AST-based evaluator that only allows arithmetic on numeric literals
    ...
    tree = ast.parse(expression, mode="eval")
    return str(_safe_eval(tree))
```

## Testing

Verified the safe evaluator handles:
- Valid expressions: `2 + 3`, `10 * 5`, `100 / 4`, `2 ** 10`, `-5 + 3`, `(2 + 3) * 4`
- Blocked attacks: `__import__('os').system(...)`, `open('/etc/passwd').read()`, list comprehensions

## Test plan

- [ ] Verify `crewai create` still generates valid projects with the updated template
- [ ] Verify the Calculator tool example works for arithmetic expressions
- [ ] Verify malicious expressions are rejected

Fixes #5056

🤖 Generated with [Claude Code](https://claude.com/claude-code)