### PR TITLE
fix: auto-use qdrant-edge on Windows where lancedb has no wheels (#5045)

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "uv~=0.9.13",
     "aiosqlite~=0.21.0",
     "pyyaml~=6.0",
-    "lancedb>=0.29.2,<0.30.1",
+    "lancedb>=0.29.2,<0.30.1; sys_platform != 'win32'",
+    "qdrant-edge-py>=0.6.0; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 import contextvars
 from datetime import datetime
@@ -68,7 +69,7 @@ class Memory(BaseModel):
         description="LLM for analysis (model name or BaseLLM instance).",
     )
     storage: Annotated[StorageBackend | str, PlainValidator(_passthrough)] = Field(
-        default="lancedb",
+        default="qdrant-edge" if sys.platform == "win32" else "lancedb",
         description="Storage backend instance or path string.",
     )
     embedder: Any = Field(


### PR DESCRIPTION
## Problem

`crewai install` fails on Windows because `lancedb` (a hard dependency) does not publish Windows wheels — only Linux and macOS are supported.

Reported in #5045.

## Solution

**1. Platform-conditional dependency (`pyproject.toml`)**

- `lancedb>=0.29.2` is now installed only on non-Windows platforms (`sys_platform != "win32"`)
- `qdrant-edge-py>=0.6.0` is automatically installed on Windows (`sys_platform == "win32"`)

**2. Auto-detect default storage backend (`unified_memory.py`)**

- The `Memory.storage` field now defaults to `"qdrant-edge"` on Windows and `"lancedb"` everywhere else
- This uses `sys.platform` at class definition time, so no runtime overhead

## Changes

- `lib/crewai/pyproject.toml` — make lancedb conditional, add qdrant-edge-py for Windows
- `lib/crewai/src/crewai/memory/unified_memory.py` — import `sys`, change default storage to platform-aware

## Notes

- CrewAI already has full qdrant-edge storage support (`qdrant_edge_storage.py`), so this just wires it as the default on Windows
- Users on Windows can still explicitly set `storage="lancedb"` if they install it manually
- No behavior change on Linux or macOS

Closes #5045

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packaging and default memory backend selection on Windows, which can impact installation and persistence/recall behavior for Windows users. Non-Windows behavior should remain unchanged aside from dependency markers.
> 
> **Overview**
> Fixes Windows installs by making the vector-store dependency platform-specific: `lancedb` is now excluded on `win32` and `qdrant-edge-py` is installed instead.
> 
> Updates `Memory` in `unified_memory.py` to default `storage` to `qdrant-edge` on Windows (and `lancedb` elsewhere), aligning runtime defaults with the new dependency behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 181a62100fa48c33f0abd306cec8f41d18787d84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->