### PR TITLE
fix: bust uv cache for freshly published packages in enterprise release

### DIFF
--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -1167,6 +1167,8 @@ def _release_enterprise(version: str, is_prerelease: bool, dry_run: bool) -> Non
                 "crewai",
                 "--refresh-package",
                 "crewai-tools",
+                "--refresh-package",
+                "crewai-files",
             ],
             cwd=repo_dir,
         )


### PR DESCRIPTION
## Summary
- Adds `--refresh-package crewai --refresh-package crewai-tools` to the `uv sync` call in `_release_enterprise`
- Fixes enterprise release phase failing because uv's cached index doesn't yet include the just-published package version on PyPI

## Test plan
- [ ] Run `uv run devtools release` and verify the enterprise phase `uv sync` succeeds without stale cache issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the enterprise release automation to force-refresh specific packages during `uv sync`, reducing failures from stale dependency index/cache without impacting runtime code paths.
> 
> **Overview**
> Ensures the enterprise release workflow reliably picks up freshly published PyPI versions by changing the `uv sync` step in `_release_enterprise` to pass `--refresh-package` for `crewai`, `crewai-tools`, and `crewai-files` (instead of a plain `uv sync`). This busts `uv`'s cache during the post-publish workspace sync so the just-released packages resolve correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4054ecf5340df5bf45d2cedd7ce4a67506ad22c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->