### PR TITLE
fix: pin Node to LTS 22 in docs broken links workflow

### DIFF
--- a/.github/workflows/docs-broken-links.yml
+++ b/.github/workflows/docs-broken-links.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "latest"
+          node-version: "22"
 
       - name: Install Mintlify CLI
         run: npm i -g mintlify


### PR DESCRIPTION
## Summary
- Pins `node-version` from `latest` (25.8.2) to `22` (LTS) in the docs broken links workflow
- Mintlify doesn't support Node 25+, causing the workflow to fail

## Test plan
- [ ] Verify the docs broken links workflow passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the runtime version for the docs link-check job; impact is limited to workflow execution and tool compatibility.
> 
> **Overview**
> Pins the `docs-broken-links` GitHub Actions workflow to use Node `22` instead of `latest`, stabilizing the Mintlify broken-link check by avoiding unsupported newer Node releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e4dd8d41d706007be7ab565a99c6497a7e61faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->