### PR TITLE
fix(mcp): prevent UnboundLocalError and log warning when native MCP returns no tools

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -374,11 +374,18 @@ class MCPToolResolver:
                             "MCP connection failed due to event loop cleanup issues. "
                             "This may be due to authentication errors or server unavailability."
                         ) from e
+                    raise
                 except asyncio.CancelledError as e:
                     raise ConnectionError(
                         "MCP connection was cancelled. This may indicate an authentication "
                         "error or server unavailability."
                     ) from e
+
+            if not tools_list:
+                self._logger.log(
+                    "warning", f"No tools discovered from MCP server: {server_name}"
+                )
+                return [], []
 
             if mcp_config.tool_filter:
                 filtered_tools = []
@@ -400,6 +407,13 @@ class MCPToolResolver:
                     else:
                         filtered_tools.append(tool)
                 tools_list = filtered_tools
+
+                if not tools_list:
+                    self._logger.log(
+                        "warning",
+                        f"All tools filtered out from MCP server: {server_name}",
+                    )
+                    return [], []
 
             def _client_factory() -> MCPClient:
                 transport, _ = self._create_transport(mcp_config)


### PR DESCRIPTION
Closes #5116

## Problem

`MCPToolResolver._resolve_native()` has two issues:

1. **UnboundLocalError**: When the MCP server connection raises a `RuntimeError` that doesn't contain "cancel scope" or "task" in its message, the exception is silently swallowed (not re-raised). This leaves `tools_list` unassigned, causing `UnboundLocalError: cannot access local variable 'tools_list' where it is not associated with a value` at the iteration loop (line 412).

2. **No warning for empty tools**: When the MCP server returns no tools (or `tool_filter` removes all tools), no warning is logged. In contrast, `_resolve_external()` logs a clear warning: `"No tools discovered from MCP server: {server_url}"`.

## Fix

1. **Re-raise unrecognized RuntimeError**: Added `raise` at the end of the `RuntimeError` handler so that non-cancel-scope errors propagate instead of being silently swallowed.

2. **Log warning and return early**: Added checks after getting `tools_list` and after tool filtering to log a warning and return `([], [])` when no tools are available, matching `_resolve_external()` behavior.

## Changes

- `lib/crewai/src/crewai/mcp/tool_resolver.py`: +14 lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow and logging changes in MCP native tool discovery; main impact is different error propagation and earlier returns when no tools are available.
> 
> **Overview**
> Fixes native MCP tool resolution to avoid silently swallowing unexpected `RuntimeError`s during discovery (preventing an `UnboundLocalError` later) by re-raising unrecognized runtime errors.
> 
> Adds explicit empty-results handling: logs a warning and returns `([], [])` when the MCP server returns no tools, and when `tool_filter` removes all tools, aligning behavior with external MCP resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42cbee540559b0ea315f2b08873bfac4bfb80c6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->