### PR TITLE
docs: update changelog and version for v1.13.0rc1

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -5,6 +5,22 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="27 مارس 2026">
+  ## v1.13.0rc1
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0rc1)
+
+  ## ما الذي تغير
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار لـ v1.13.0a2
+
+  ## المساهمون
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="27 مارس 2026">
   ## v1.13.0a2
 
   [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a2)

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -5,6 +5,22 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="Mar 27, 2026">
+  ## v1.13.0rc1
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0rc1)
+
+  ## What's Changed
+
+  ### Documentation
+  - Update changelog and version for v1.13.0a2
+
+  ## Contributors
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="Mar 27, 2026">
   ## v1.13.0a2
 
   [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a2)

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -5,6 +5,22 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="2026년 3월 27일">
+  ## v1.13.0rc1
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0rc1)
+
+  ## 변경 사항
+
+  ### 문서
+  - v1.13.0a2의 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="2026년 3월 27일">
   ## v1.13.0a2
 
   [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a2)

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -5,6 +5,22 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="27 mar 2026">
+  ## v1.13.0rc1
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0rc1)
+
+  ## O que Mudou
+
+  ### Documentação
+  - Atualizar changelog e versão para v1.13.0a2
+
+  ## Contribuidores
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="27 mar 2026">
   ## v1.13.0a2
 
   [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a2)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates changelog content without impacting runtime code.
> 
> **Overview**
> Adds a new `v1.13.0rc1` changelog entry dated Mar 27, 2026 across the Arabic, English, Korean, and pt-BR docs, including the GitHub release link, a brief “Documentation” change note, and contributor attribution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf6c713dff327a3922c5a399bde291aeb523c27c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->