### PR TITLE
feat(a2a): add TOTP second-factor authentication for A2A server/client [WIP - untested]

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     # Authentication and Security
     "python-dotenv~=1.1.1",
     "pyjwt>=2.9.0,<3",
+    "pyotp>=2.9.0",
     # TUI
     "textual>=7.5.0",
     # Configuration and Utils

--- a/lib/crewai/src/crewai/a2a/auth/__init__.py
+++ b/lib/crewai/src/crewai/a2a/auth/__init__.py
@@ -18,6 +18,7 @@ from crewai.a2a.auth.server_schemes import (
     ServerAuthScheme,
     SimpleTokenAuth,
 )
+from crewai.a2a.auth.totp_scheme import TOTPClientAuthScheme, TOTPServerAuthScheme
 
 
 __all__ = [
@@ -35,4 +36,6 @@ __all__ = [
     "ServerAuthScheme",
     "SimpleTokenAuth",
     "TLSConfig",
+    "TOTPClientAuthScheme",
+    "TOTPServerAuthScheme",
 ]

--- a/lib/crewai/src/crewai/a2a/auth/__init__.py
+++ b/lib/crewai/src/crewai/a2a/auth/__init__.py
@@ -20,6 +20,11 @@ from crewai.a2a.auth.server_schemes import (
 )
 from crewai.a2a.auth.totp_scheme import TOTPClientAuthScheme, TOTPServerAuthScheme
 
+try:
+    from crewai.a2a.auth.totp_scheme import TOTPCallContextBuilder
+except ImportError:
+    pass
+
 
 __all__ = [
     "APIKeyAuth",
@@ -36,6 +41,7 @@ __all__ = [
     "ServerAuthScheme",
     "SimpleTokenAuth",
     "TLSConfig",
+    "TOTPCallContextBuilder",
     "TOTPClientAuthScheme",
     "TOTPServerAuthScheme",
 ]

--- a/lib/crewai/src/crewai/a2a/auth/totp_scheme.py
+++ b/lib/crewai/src/crewai/a2a/auth/totp_scheme.py
@@ -1,0 +1,249 @@
+"""TOTP (Time-based One-Time Password) authentication for A2A protocol.
+
+Provides second-factor authentication using TOTP codes alongside bearer tokens.
+Supports both per-peer seeds (identified by bearer token) and shared seed mode.
+
+Server-side: Validates X-TOTP header against configured seeds.
+Client-side: Injects X-TOTP header on outgoing requests.
+
+Requires: pyotp>=2.9.0
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import MutableMapping
+import logging
+import os
+from typing import Annotated, ClassVar
+
+import httpx
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, SecretStr
+
+from crewai.a2a.auth.client_schemes import ClientAuthScheme
+from crewai.a2a.auth.server_schemes import (
+    HTTP_401_UNAUTHORIZED,
+    AuthenticatedUser,
+    HTTPException,
+    ServerAuthScheme,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_secret_str(v: str | SecretStr | None) -> SecretStr | None:
+    """Coerce string to SecretStr."""
+    if v is None or isinstance(v, SecretStr):
+        return v
+    return SecretStr(v)
+
+
+CoercedSecretStr = Annotated[SecretStr, BeforeValidator(_coerce_secret_str)]
+
+TOTP_HEADER = "X-TOTP"
+
+
+class TOTPServerAuthScheme(ServerAuthScheme):
+    """TOTP second-factor authentication for A2A server.
+
+    Validates incoming requests by requiring both a valid bearer token and a
+    valid TOTP code in the X-TOTP header. The bearer token is validated by a
+    delegate ServerAuthScheme, then the TOTP code is checked against the seed
+    associated with the authenticated peer.
+
+    Supports two modes:
+    - Per-peer seeds: Map bearer tokens to peer names, each with their own TOTP seed.
+    - Shared seed: A single TOTP seed used for all peers.
+
+    Fails closed: missing or invalid TOTP code always results in 401.
+
+    Attributes:
+        delegate: The underlying auth scheme that validates the bearer token.
+        shared_seed: A single TOTP seed for all peers (simple deployment mode).
+        peer_seeds: Per-peer TOTP seeds keyed by peer name.
+        token_to_peer: Maps bearer tokens to peer names for per-peer seed lookup.
+        valid_window: Number of time steps to allow for clock drift (default: 1 = ±30s).
+    """
+
+    delegate: ServerAuthScheme = Field(
+        description="Underlying auth scheme for bearer token validation",
+    )
+    shared_seed: CoercedSecretStr | None = Field(
+        default=None,
+        description="Single TOTP seed for all peers. Mutually exclusive with peer_seeds.",
+    )
+    peer_seeds: dict[str, CoercedSecretStr] | None = Field(
+        default=None,
+        description="Per-peer TOTP seeds keyed by peer name.",
+    )
+    token_to_peer: dict[str, str] | None = Field(
+        default=None,
+        description="Maps bearer tokens to peer names for per-peer seed lookup.",
+    )
+    valid_window: int = Field(
+        default=1,
+        description="Number of time steps to allow for clock drift (1 = ±30s)",
+        ge=0,
+    )
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    async def authenticate(self, token: str) -> AuthenticatedUser:
+        """Authenticate bearer token via delegate, then validate TOTP.
+
+        Note: This method validates the bearer token only. TOTP validation
+        requires the X-TOTP header, which must be checked separately via
+        authenticate_with_totp().
+
+        Args:
+            token: The bearer token to authenticate.
+
+        Returns:
+            AuthenticatedUser on successful authentication.
+
+        Raises:
+            HTTPException: If authentication fails.
+        """
+        return await self.delegate.authenticate(token)
+
+    async def authenticate_with_totp(self, token: str, totp_code: str | None) -> AuthenticatedUser:
+        """Authenticate bearer token and validate TOTP code.
+
+        Args:
+            token: The bearer token to authenticate.
+            totp_code: The TOTP code from the X-TOTP header.
+
+        Returns:
+            AuthenticatedUser on successful authentication.
+
+        Raises:
+            HTTPException: If bearer token or TOTP validation fails.
+        """
+        import pyotp
+
+        # First validate the bearer token via delegate
+        user = await self.delegate.authenticate(token)
+
+        # TOTP code is required
+        if not totp_code:
+            logger.debug(
+                "TOTP authentication failed",
+                extra={"reason": "missing_totp_header", "scheme": "totp"},
+            )
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Missing X-TOTP header",
+            )
+
+        # Resolve the seed
+        seed = self._resolve_seed(token)
+        if seed is None:
+            logger.warning(
+                "TOTP authentication failed",
+                extra={"reason": "no_seed_configured", "scheme": "totp"},
+            )
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="TOTP not configured for this peer",
+            )
+
+        # Validate the TOTP code
+        totp = pyotp.TOTP(seed)
+        if not totp.verify(totp_code, valid_window=self.valid_window):
+            logger.debug(
+                "TOTP authentication failed",
+                extra={"reason": "invalid_totp_code", "scheme": "totp"},
+            )
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+        return AuthenticatedUser(
+            token=user.token,
+            scheme="totp",
+            claims=user.claims,
+        )
+
+    def _resolve_seed(self, token: str) -> str | None:
+        """Resolve the TOTP seed for the given token.
+
+        Checks per-peer seeds first (via token_to_peer mapping), then
+        falls back to shared_seed.
+
+        Args:
+            token: The bearer token to look up.
+
+        Returns:
+            The TOTP seed string, or None if not configured.
+        """
+        # Try per-peer lookup
+        if self.peer_seeds and self.token_to_peer:
+            peer = self.token_to_peer.get(token)
+            if peer and peer in self.peer_seeds:
+                return self.peer_seeds[peer].get_secret_value()
+
+        # Fall back to shared seed
+        if self.shared_seed:
+            return self.shared_seed.get_secret_value()
+
+        return None
+
+
+class TOTPClientAuthScheme(ClientAuthScheme):
+    """TOTP client authentication scheme for A2A protocol.
+
+    Injects an X-TOTP header with a valid TOTP code on every outgoing request.
+    Designed to be used alongside a bearer token auth scheme.
+
+    Attributes:
+        delegate: The underlying client auth scheme (e.g., BearerTokenAuth).
+        seed: TOTP seed for code generation. Falls back to A2A_TOTP_SEED env var.
+    """
+
+    delegate: ClientAuthScheme = Field(
+        description="Underlying client auth scheme for bearer token injection",
+    )
+    seed: CoercedSecretStr | None = Field(
+        default=None,
+        description="TOTP seed for code generation. Falls back to A2A_TOTP_SEED env var.",
+    )
+
+    def _get_seed(self) -> str | None:
+        """Get the TOTP seed value."""
+        if self.seed:
+            return self.seed.get_secret_value()
+        return os.environ.get("A2A_TOTP_SEED")
+
+    async def apply_auth(
+        self, client: httpx.AsyncClient, headers: MutableMapping[str, str]
+    ) -> MutableMapping[str, str]:
+        """Apply delegate auth and inject X-TOTP header.
+
+        Args:
+            client: HTTP client for making auth requests.
+            headers: Current request headers.
+
+        Returns:
+            Updated headers with authentication and TOTP code applied.
+
+        Raises:
+            ValueError: If no TOTP seed is configured.
+        """
+        import pyotp
+
+        # Apply delegate auth first (e.g., bearer token)
+        headers = await self.delegate.apply_auth(client, headers)
+
+        # Generate and inject TOTP code
+        seed = self._get_seed()
+        if seed is None:
+            raise ValueError(
+                "No TOTP seed configured. Set seed parameter or A2A_TOTP_SEED env var."
+            )
+
+        totp = pyotp.TOTP(seed)
+        headers[TOTP_HEADER] = totp.now()
+
+        return headers

--- a/lib/crewai/src/crewai/a2a/auth/totp_scheme.py
+++ b/lib/crewai/src/crewai/a2a/auth/totp_scheme.py
@@ -11,6 +11,7 @@ Requires: pyotp>=2.9.0
 
 from __future__ import annotations
 
+import asyncio
 from abc import abstractmethod
 from collections.abc import MutableMapping
 import logging
@@ -247,3 +248,108 @@ class TOTPClientAuthScheme(ClientAuthScheme):
         headers[TOTP_HEADER] = totp.now()
 
         return headers
+
+
+# ---------------------------------------------------------------------------
+# CallContextBuilder integration
+# ---------------------------------------------------------------------------
+
+try:
+    from a2a.server.apps.jsonrpc import CallContextBuilder
+    from a2a.server.context import ServerCallContext, User
+    from starlette.requests import Request
+
+    class _TOTPAuthenticatedUser(User):
+        """Authenticated user representation for TOTP-validated requests."""
+
+        def __init__(self, user: AuthenticatedUser) -> None:
+            self._user = user
+
+        @property
+        def is_authenticated(self) -> bool:
+            return True
+
+        @property
+        def user_name(self) -> str:
+            return self._user.token or ""
+
+    class TOTPCallContextBuilder(CallContextBuilder):
+        """CallContextBuilder that validates TOTP alongside bearer token auth.
+
+        Extracts the bearer token from the Authorization header and the TOTP
+        code from the X-TOTP header, then validates both via the underlying
+        TOTPServerAuthScheme.
+
+        The ``build()`` method is synchronous (per the CallContextBuilder
+        interface) but the auth scheme is async. This is bridged via
+        ``asyncio.run()`` in a fresh event loop when no loop is running, or
+        via a new thread when called from within an existing async context.
+
+        Attributes:
+            auth_scheme: The TOTP server auth scheme to validate against.
+        """
+
+        def __init__(self, auth_scheme: TOTPServerAuthScheme) -> None:
+            self.auth_scheme = auth_scheme
+
+        def build(self, request: Request) -> ServerCallContext:
+            """Build a ServerCallContext by validating bearer + TOTP headers.
+
+            Args:
+                request: The incoming Starlette request.
+
+            Returns:
+                ServerCallContext with authenticated user on success.
+
+            Raises:
+                HTTPException: 401 on missing/invalid credentials.
+            """
+            # Extract bearer token
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                logger.debug(
+                    "TOTP context build failed",
+                    extra={"reason": "missing_authorization_header", "scheme": "totp"},
+                )
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Missing or invalid Authorization header",
+                )
+            token = auth_header[7:]  # Strip "Bearer "
+
+            # Extract TOTP code
+            totp_code = request.headers.get(TOTP_HEADER)
+
+            # Run async authentication in sync context
+            authenticated_user = self._run_async(
+                self.auth_scheme.authenticate_with_totp(token, totp_code)
+            )
+
+            return ServerCallContext(
+                user=_TOTPAuthenticatedUser(authenticated_user),
+            )
+
+        @staticmethod
+        def _run_async(coro):  # noqa: ANN001, ANN205
+            """Run an async coroutine from a synchronous context.
+
+            Uses ``asyncio.run()`` when no event loop is running.
+            Falls back to running in a separate thread when called
+            from within an existing async event loop.
+            """
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # No running loop — safe to use asyncio.run
+                return asyncio.run(coro)
+
+            # Already inside an async context — run in a new thread
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, coro)
+                return future.result()
+
+except ImportError:
+    # a2a-sdk not installed — CallContextBuilder unavailable
+    pass

--- a/lib/crewai/tests/a2a/test_totp_auth.py
+++ b/lib/crewai/tests/a2a/test_totp_auth.py
@@ -1,0 +1,190 @@
+"""Tests for TOTP authentication scheme."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pyotp
+import pytest
+
+from crewai.a2a.auth.server_schemes import AuthenticatedUser, SimpleTokenAuth
+from crewai.a2a.auth.totp_scheme import (
+    TOTPClientAuthScheme,
+    TOTPServerAuthScheme,
+)
+from crewai.a2a.auth.client_schemes import BearerTokenAuth
+
+
+# --- Fixtures ---
+
+SHARED_SEED = pyotp.random_base32()
+PEER_SEED_MRPINK = pyotp.random_base32()
+PEER_SEED_CHARLIE = pyotp.random_base32()
+VALID_TOKEN = "valid-bearer-token"
+MRPINK_TOKEN = "mrpink-token"
+CHARLIE_TOKEN = "charlie-token"
+
+
+@pytest.fixture
+def shared_seed_scheme() -> TOTPServerAuthScheme:
+    """TOTP server scheme with a single shared seed."""
+    return TOTPServerAuthScheme(
+        delegate=SimpleTokenAuth(token=VALID_TOKEN),
+        shared_seed=SHARED_SEED,
+    )
+
+
+@pytest.fixture
+def per_peer_scheme() -> TOTPServerAuthScheme:
+    """TOTP server scheme with per-peer seeds."""
+    return TOTPServerAuthScheme(
+        delegate=SimpleTokenAuth(token=MRPINK_TOKEN),
+        peer_seeds={
+            "mrpink": PEER_SEED_MRPINK,
+            "charlie": PEER_SEED_CHARLIE,
+        },
+        token_to_peer={
+            MRPINK_TOKEN: "mrpink",
+            CHARLIE_TOKEN: "charlie",
+        },
+    )
+
+
+# --- Server Tests ---
+
+
+@pytest.mark.asyncio
+async def test_valid_token_valid_totp(shared_seed_scheme: TOTPServerAuthScheme) -> None:
+    """Valid bearer token + valid TOTP → authenticated."""
+    totp = pyotp.TOTP(SHARED_SEED)
+    code = totp.now()
+
+    result = await shared_seed_scheme.authenticate_with_totp(VALID_TOKEN, code)
+
+    assert isinstance(result, AuthenticatedUser)
+    assert result.scheme == "totp"
+    assert result.token == VALID_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_valid_token_missing_totp(shared_seed_scheme: TOTPServerAuthScheme) -> None:
+    """Valid bearer token + missing TOTP → 401."""
+    with pytest.raises(Exception) as exc_info:
+        await shared_seed_scheme.authenticate_with_totp(VALID_TOKEN, None)
+    assert exc_info.value.status_code == 401
+    assert "Missing X-TOTP" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_valid_token_wrong_totp(shared_seed_scheme: TOTPServerAuthScheme) -> None:
+    """Valid bearer token + wrong TOTP → 401."""
+    with pytest.raises(Exception) as exc_info:
+        await shared_seed_scheme.authenticate_with_totp(VALID_TOKEN, "000000")
+    assert exc_info.value.status_code == 401
+    assert "Invalid TOTP" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_valid_token_expired_totp(shared_seed_scheme: TOTPServerAuthScheme) -> None:
+    """Valid bearer token + expired TOTP (outside valid_window) → 401."""
+    # Generate a code from 5 minutes ago (well outside valid_window=1 = ±30s)
+    import time
+
+    totp = pyotp.TOTP(SHARED_SEED)
+    old_time = int(time.time()) - 300  # 5 minutes ago
+    code = totp.at(old_time)
+
+    with pytest.raises(Exception) as exc_info:
+        await shared_seed_scheme.authenticate_with_totp(VALID_TOKEN, code)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_token(shared_seed_scheme: TOTPServerAuthScheme) -> None:
+    """Invalid bearer token → 401 (before TOTP check)."""
+    totp = pyotp.TOTP(SHARED_SEED)
+    code = totp.now()
+
+    with pytest.raises(Exception) as exc_info:
+        await shared_seed_scheme.authenticate_with_totp("bad-token", code)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_per_peer_seed_lookup(per_peer_scheme: TOTPServerAuthScheme) -> None:
+    """Per-peer seed lookup works correctly."""
+    totp = pyotp.TOTP(PEER_SEED_MRPINK)
+    code = totp.now()
+
+    result = await per_peer_scheme.authenticate_with_totp(MRPINK_TOKEN, code)
+
+    assert isinstance(result, AuthenticatedUser)
+    assert result.scheme == "totp"
+
+
+@pytest.mark.asyncio
+async def test_per_peer_wrong_seed_fails(per_peer_scheme: TOTPServerAuthScheme) -> None:
+    """Using charlie's TOTP code with mrpink's token → 401."""
+    totp = pyotp.TOTP(PEER_SEED_CHARLIE)
+    code = totp.now()
+
+    with pytest.raises(Exception) as exc_info:
+        await per_peer_scheme.authenticate_with_totp(MRPINK_TOKEN, code)
+    assert exc_info.value.status_code == 401
+
+
+# --- Client Tests ---
+
+
+@pytest.mark.asyncio
+async def test_client_injects_totp_header() -> None:
+    """Client scheme correctly injects X-TOTP header."""
+    seed = pyotp.random_base32()
+    client_scheme = TOTPClientAuthScheme(
+        delegate=BearerTokenAuth(token="my-token"),
+        seed=seed,
+    )
+
+    async with httpx.AsyncClient() as client:
+        headers: dict[str, str] = {}
+        result = await client_scheme.apply_auth(client, headers)
+
+    assert "X-TOTP" in result
+    assert "Authorization" in result
+    assert result["Authorization"] == "Bearer my-token"
+
+    # Verify the injected code is valid
+    totp = pyotp.TOTP(seed)
+    assert totp.verify(result["X-TOTP"], valid_window=1)
+
+
+@pytest.mark.asyncio
+async def test_client_env_seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client scheme reads seed from env var."""
+    seed = pyotp.random_base32()
+    monkeypatch.setenv("A2A_TOTP_SEED", seed)
+
+    client_scheme = TOTPClientAuthScheme(
+        delegate=BearerTokenAuth(token="my-token"),
+    )
+
+    async with httpx.AsyncClient() as client:
+        headers: dict[str, str] = {}
+        result = await client_scheme.apply_auth(client, headers)
+
+    assert "X-TOTP" in result
+    totp = pyotp.TOTP(seed)
+    assert totp.verify(result["X-TOTP"], valid_window=1)
+
+
+@pytest.mark.asyncio
+async def test_client_no_seed_raises() -> None:
+    """Client scheme raises ValueError when no seed configured."""
+    client_scheme = TOTPClientAuthScheme(
+        delegate=BearerTokenAuth(token="my-token"),
+    )
+
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(ValueError, match="No TOTP seed configured"):
+            await client_scheme.apply_auth(client, {})

--- a/lib/crewai/tests/a2a/test_totp_auth.py
+++ b/lib/crewai/tests/a2a/test_totp_auth.py
@@ -10,6 +10,7 @@ import pytest
 
 from crewai.a2a.auth.server_schemes import AuthenticatedUser, SimpleTokenAuth
 from crewai.a2a.auth.totp_scheme import (
+    TOTPCallContextBuilder,
     TOTPClientAuthScheme,
     TOTPServerAuthScheme,
 )
@@ -188,3 +189,65 @@ async def test_client_no_seed_raises() -> None:
     async with httpx.AsyncClient() as client:
         with pytest.raises(ValueError, match="No TOTP seed configured"):
             await client_scheme.apply_auth(client, {})
+
+
+# --- CallContextBuilder Tests ---
+
+
+def _make_request(headers: dict[str, str]) -> MagicMock:
+    """Create a mock Starlette Request with the given headers."""
+    request = MagicMock()
+    request.headers = headers
+    return request
+
+
+class TestTOTPCallContextBuilder:
+    """Tests for TOTPCallContextBuilder."""
+
+    def test_valid_bearer_and_totp(self, shared_seed_scheme: TOTPServerAuthScheme) -> None:
+        """Valid bearer token + valid TOTP → builds context successfully."""
+        totp = pyotp.TOTP(SHARED_SEED)
+        code = totp.now()
+
+        builder = TOTPCallContextBuilder(auth_scheme=shared_seed_scheme)
+        request = _make_request({
+            "Authorization": f"Bearer {VALID_TOKEN}",
+            "X-TOTP": code,
+        })
+
+        ctx = builder.build(request)
+
+        assert ctx.user.is_authenticated is True
+        assert ctx.user.user_name == VALID_TOKEN
+
+    def test_missing_authorization_header(self, shared_seed_scheme: TOTPServerAuthScheme) -> None:
+        """Missing Authorization header → 401."""
+        builder = TOTPCallContextBuilder(auth_scheme=shared_seed_scheme)
+        request = _make_request({"X-TOTP": "123456"})
+
+        with pytest.raises(Exception) as exc_info:
+            builder.build(request)
+        assert exc_info.value.status_code == 401
+
+    def test_missing_totp_header(self, shared_seed_scheme: TOTPServerAuthScheme) -> None:
+        """Missing X-TOTP header → 401."""
+        builder = TOTPCallContextBuilder(auth_scheme=shared_seed_scheme)
+        request = _make_request({"Authorization": f"Bearer {VALID_TOKEN}"})
+
+        with pytest.raises(Exception) as exc_info:
+            builder.build(request)
+        assert exc_info.value.status_code == 401
+        assert "Missing X-TOTP" in str(exc_info.value.detail)
+
+    def test_invalid_totp_code(self, shared_seed_scheme: TOTPServerAuthScheme) -> None:
+        """Invalid TOTP code → 401."""
+        builder = TOTPCallContextBuilder(auth_scheme=shared_seed_scheme)
+        request = _make_request({
+            "Authorization": f"Bearer {VALID_TOKEN}",
+            "X-TOTP": "000000",
+        })
+
+        with pytest.raises(Exception) as exc_info:
+            builder.build(request)
+        assert exc_info.value.status_code == 401
+        assert "Invalid TOTP" in str(exc_info.value.detail)

--- a/lib/crewai/tests/a2a/test_totp_smoke.py
+++ b/lib/crewai/tests/a2a/test_totp_smoke.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+TOTP A2A Auth — standalone smoke test
+Run this script. It starts a minimal A2A server with TOTP enabled,
+then hits it with curl-equivalent requests to verify each scenario.
+
+Requirements:
+  pip install pyotp a2a-sdk httpx starlette uvicorn --break-system-packages
+
+Usage:
+  python3 test_totp_smoke.py
+"""
+
+import asyncio
+import os
+import sys
+import threading
+import time
+
+import pyotp
+import httpx
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+BEARER_TOKEN = "test-bearer-token-abc123"
+TOTP_SEED    = pyotp.random_base32()   # fresh seed each run
+PORT         = 18200
+BASE_URL     = f"http://127.0.0.1:{PORT}"
+
+# ── Minimal A2A server with TOTP ───────────────────────────────────────────────
+def start_server():
+    """Start a minimal Starlette A2A server with TOTP auth in a background thread."""
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+    import uvicorn
+
+    async def handle(request: Request):
+        auth = request.headers.get("authorization", "")
+        totp_code = request.headers.get("x-totp", "")
+
+        # Validate bearer
+        if auth != f"Bearer {BEARER_TOKEN}":
+            return JSONResponse({"error": "bad token"}, status_code=401)
+
+        # Validate TOTP
+        totp = pyotp.TOTP(TOTP_SEED)
+        if not totp_code or not totp.verify(totp_code, valid_window=1):
+            return JSONResponse({"error": "bad totp"}, status_code=401)
+
+        return JSONResponse({"status": "ok", "message": "authenticated"})
+
+    app = Starlette(routes=[Route("/a2a", handle, methods=["POST"])])
+    config = uvicorn.Config(app, host="127.0.0.1", port=PORT, log_level="error")
+    server = uvicorn.Server(config)
+
+    t = threading.Thread(target=server.run, daemon=True)
+    t.start()
+    time.sleep(1.0)  # let it bind
+
+# ── Test cases ─────────────────────────────────────────────────────────────────
+async def run_tests():
+    totp = pyotp.TOTP(TOTP_SEED)
+    passed = 0
+    failed = 0
+
+    async with httpx.AsyncClient() as client:
+
+        async def check(label, expected_status, headers):
+            resp = await client.post(f"{BASE_URL}/a2a", headers=headers, json={})
+            ok = resp.status_code == expected_status
+            icon = "✅" if ok else "❌"
+            print(f"  {icon} [{resp.status_code}] {label}")
+            return ok
+
+        print("\n=== TOTP A2A Auth Smoke Test ===\n")
+        print(f"  Seed: {TOTP_SEED}")
+        print(f"  Current code: {totp.now()}\n")
+
+        results = await asyncio.gather(
+            check(
+                "Valid bearer + valid TOTP → 200",
+                200,
+                {"Authorization": f"Bearer {BEARER_TOKEN}", "X-TOTP": totp.now()}
+            ),
+            check(
+                "Valid bearer + NO TOTP → 401",
+                401,
+                {"Authorization": f"Bearer {BEARER_TOKEN}"}
+            ),
+            check(
+                "Valid bearer + WRONG TOTP → 401",
+                401,
+                {"Authorization": f"Bearer {BEARER_TOKEN}", "X-TOTP": "000000"}
+            ),
+            check(
+                "NO bearer + valid TOTP → 401",
+                401,
+                {"X-TOTP": totp.now()}
+            ),
+            check(
+                "No headers at all → 401",
+                401,
+                {}
+            ),
+        )
+
+    passed = sum(results)
+    failed = len(results) - passed
+    print(f"\n  {passed}/{len(results)} passed", "🎉" if failed == 0 else "⚠️")
+    return failed == 0
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    # Install deps if missing
+    try:
+        import uvicorn
+    except ImportError:
+        print("Installing dependencies...")
+        os.system(f"{sys.executable} -m pip install uvicorn starlette --break-system-packages -q")
+        import uvicorn
+
+    print("Starting test server...")
+    start_server()
+
+    success = asyncio.run(run_tests())
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Motivation

In agent mesh deployments (multiple A2A agents communicating peer-to-peer), a stolen bearer token alone should not be sufficient to impersonate an agent or issue dangerous commands. TOTP as a second factor ensures that even if a token is compromised, an attacker cannot authenticate without the shared TOTP seed.

## What This Adds

### `TOTPServerAuthScheme` (server-side validation)
- Wraps an existing `ServerAuthScheme` (e.g., `SimpleTokenAuth`) as a delegate for bearer token validation
- Requires an `X-TOTP` header with a valid 6-digit TOTP code on every request
- **Per-peer seeds**: Map bearer tokens → peer names → individual TOTP seeds (`{"mrpink": "SEED1", "charlie": "SEED2"}`)
- **Shared seed mode**: Single seed for simpler deployments
- Validates via `pyotp.TOTP(seed).verify(code, valid_window=1)` — allows ±30s clock drift
- Fails closed: missing header = 401, wrong/expired code = 401

### `TOTPClientAuthScheme` (client-side injection)
- Wraps an existing `ClientAuthScheme` (e.g., `BearerTokenAuth`) as a delegate
- Automatically generates and injects `X-TOTP: <code>` header on every outgoing request
- Reads seed from config or `A2A_TOTP_SEED` env var

### Usage Example

```python
from crewai.a2a.auth import TOTPServerAuthScheme, SimpleTokenAuth

# Server with per-peer TOTP
server_auth = TOTPServerAuthScheme(
    delegate=SimpleTokenAuth(token="bearer-token"),
    peer_seeds={"mrpink": "JBSWY3DPEHPK3PXP", "charlie": "KZQW6ZTBNFXHG33N"},
    token_to_peer={"bearer-token-mrpink": "mrpink", "bearer-token-charlie": "charlie"},
)

# Client with TOTP
from crewai.a2a.auth import TOTPClientAuthScheme, BearerTokenAuth

client_auth = TOTPClientAuthScheme(
    delegate=BearerTokenAuth(token="my-bearer-token"),
    seed="JBSWY3DPEHPK3PXP",
)
```

## Design Notes

- `valid_window=1` allows ±30 seconds of clock drift between agents — sufficient for well-configured systems while limiting replay attack windows
- Delegate pattern: wraps existing auth schemes rather than replacing them, so TOTP composes with any `ServerAuthScheme`/`ClientAuthScheme`
- `authenticate_with_totp()` is a separate method from `authenticate()` since the base ABC signature only passes the token — server middleware needs to extract and pass the X-TOTP header separately
- Seeds use `SecretStr` (via `CoercedSecretStr`) to prevent accidental logging

## Changes

- `src/crewai/a2a/auth/totp_scheme.py` — new file with both schemes
- `src/crewai/a2a/auth/__init__.py` — exports updated
- `pyproject.toml` — added `pyotp>=2.9.0` dependency
- `tests/a2a/test_totp_auth.py` — comprehensive tests

## Tests Cover

- Valid token + valid TOTP → success
- Valid token + missing TOTP → 401
- Valid token + wrong TOTP → 401
- Valid token + expired TOTP (5 min old) → 401
- Invalid bearer token → 401
- Per-peer seed lookup (correct and incorrect peer)
- Client header injection with validation
- Client env var fallback
- Client missing seed → ValueError