### PR TITLE
fix: resolve empty arguments for Bedrock native tool calls

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input") or "{}"
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary
- Fix `_parse_native_tool_call` to correctly read Bedrock tool arguments
- The `or`-chain fallback was broken because `get("arguments", "{}")` returns a truthy default, preventing fallthrough to `tool_call.get("input")` where Bedrock places arguments

## Problem
All AWS Bedrock models (Nova, Claude via Bedrock) always receive empty `{}` arguments when using native tool calling. Two independent issues report this: #4972 and #4748.

## Fix
```python
# Before (broken)
func_info.get("arguments", "{}") or tool_call.get("input", {})

# After (fixed)  
func_info.get("arguments") or tool_call.get("input") or "{}"
```

## Test plan
- [ ] Verify OpenAI-format tool calls still parse correctly
- [ ] Verify Bedrock-format tool calls now receive proper arguments
- [ ] Verify fallback to `"{}"` works when neither key is present

Fixes #4972, Fixes #4748

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change in native tool-call parsing; main concern is any provider relying on the previous default `"{}"` masking missing arguments.
> 
> **Overview**
> Fixes native tool-call argument parsing in `CrewAgentExecutor._parse_native_tool_call` so dict-style calls (notably AWS Bedrock) correctly fall back from `function.arguments` to the top-level `input` payload instead of always defaulting to an empty `{}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2d040123cecc9a2e71bfbaa3a782693b7848f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->