### PR TITLE
fix: log warning when native MCP config returns no tools

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -354,6 +354,7 @@ class MCPToolResolver:
                 ) from e
 
         try:
+            tools_list: list[dict[str, Any]] = []
             try:
                 asyncio.get_running_loop()
                 import concurrent.futures
@@ -400,6 +401,13 @@ class MCPToolResolver:
                     else:
                         filtered_tools.append(tool)
                 tools_list = filtered_tools
+
+            if not tools_list:
+                self._logger.log(
+                    "warning",
+                    f"No tools discovered from MCP server: {server_name}",
+                )
+                return cast(list[BaseTool], []), []
 
             def _client_factory() -> MCPClient:
                 transport, _ = self._create_transport(mcp_config)

--- a/lib/crewai/tests/mcp/test_amp_mcp.py
+++ b/lib/crewai/tests/mcp/test_amp_mcp.py
@@ -503,3 +503,112 @@ class TestResolveExternalToolFilter:
         tools = resolver._resolve_external("https://mcp.example.com/api#nonexistent")
 
         assert len(tools) == 0
+
+
+class TestResolveNativeNoToolsWarning:
+    """Tests that _resolve_native logs a warning when no tools are discovered."""
+
+    @pytest.fixture
+    def agent(self):
+        return Agent(
+            role="Test Agent",
+            goal="Test goal",
+            backstory="Test backstory",
+        )
+
+    @pytest.fixture
+    def resolver(self, agent):
+        return MCPToolResolver(agent=agent, logger=agent._logger)
+
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_logs_warning_when_server_returns_no_tools(
+        self, mock_client_class, resolver
+    ):
+        """_resolve_native should log a warning when the MCP server returns no tools."""
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[])
+        mock_client.connected = False
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        config = MCPServerHTTP(
+            url="https://empty.mcp.com/api",
+            headers={"Authorization": "Bearer token"},
+        )
+
+        with patch.object(resolver._logger, "log") as mock_log:
+            tools, clients = resolver._resolve_native(config)
+
+            assert tools == []
+            assert clients == []
+            mock_log.assert_any_call(
+                "warning",
+                "No tools discovered from MCP server: empty_mcp_com_api",
+            )
+
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_logs_warning_when_tool_filter_removes_all_tools(
+        self, mock_client_class, resolver
+    ):
+        """_resolve_native should log a warning when tool_filter removes all tools."""
+        tool_definitions = [
+            {
+                "name": "search",
+                "description": "Search tool",
+                "inputSchema": {},
+            },
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=tool_definitions)
+        mock_client.connected = False
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        config = MCPServerHTTP(
+            url="https://filtered.mcp.com/api",
+            headers={"Authorization": "Bearer token"},
+            tool_filter=lambda ctx, tool: False,  # reject all tools
+        )
+
+        with patch.object(resolver._logger, "log") as mock_log:
+            tools, clients = resolver._resolve_native(config)
+
+            assert tools == []
+            assert clients == []
+            mock_log.assert_any_call(
+                "warning",
+                "No tools discovered from MCP server: filtered_mcp_com_api",
+            )
+
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_no_unbound_local_error_on_failed_async_run(
+        self, mock_client_class, resolver
+    ):
+        """tools_list should be initialized to [] to prevent UnboundLocalError."""
+        mock_client = AsyncMock()
+        mock_client.connected = False
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        # Simulate a RuntimeError that does NOT match the "cancel scope"/"task" pattern
+        mock_client.list_tools = AsyncMock(
+            side_effect=RuntimeError("some unexpected error")
+        )
+        mock_client_class.return_value = mock_client
+
+        config = MCPServerHTTP(
+            url="https://failing.mcp.com/api",
+            headers={"Authorization": "Bearer token"},
+        )
+
+        with patch.object(resolver._logger, "log") as mock_log:
+            tools, clients = resolver._resolve_native(config)
+
+            assert tools == []
+            assert clients == []
+            mock_log.assert_any_call(
+                "warning",
+                "No tools discovered from MCP server: failing_mcp_com_api",
+            )


### PR DESCRIPTION
## Summary

- **Initialize `tools_list = []`** before the async event-loop block in `_resolve_native()` to prevent `UnboundLocalError` when `asyncio.run()` raises a `RuntimeError` that falls through without assignment
- **Add `logger.warning()`** after tool listing + filtering in `_resolve_native()`, matching the existing pattern in `_resolve_external()`, so users get a clear diagnostic when their native MCP server (Stdio/HTTP/SSE) returns no tools or when `tool_filter` removes all of them
- **Add 3 tests** covering: empty server response, filter removing all tools, and the `UnboundLocalError` scenario

Closes #5116

## Test plan

- [ ] `TestResolveNativeNoToolsWarning::test_logs_warning_when_server_returns_no_tools` — verifies warning is logged when MCP server returns empty tool list
- [ ] `TestResolveNativeNoToolsWarning::test_logs_warning_when_tool_filter_removes_all_tools` — verifies warning is logged when `tool_filter` rejects every tool
- [ ] `TestResolveNativeNoToolsWarning::test_no_unbound_local_error_on_failed_async_run` — verifies no `UnboundLocalError` when `asyncio.run()` raises an unmatched `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts native MCP tool discovery to handle empty results/edge-case errors more gracefully and adds tests; no protocol or execution-path changes when tools are present.
> 
> **Overview**
> Native MCP tool resolution (`_resolve_native`) now initializes `tools_list` defensively and **logs a warning + returns empty** when the server returns no tools (or when `tool_filter` removes them all), aligning behavior with external MCP URL resolution.
> 
> Adds tests to verify the warning is emitted for empty discovery, filter-all scenarios, and to prevent `UnboundLocalError` when async discovery fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e973cabdcacfadbe10636bd259974bec80d27a09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->