### PR TITLE
docs: add Aegis governance integration to observability

### DIFF
--- a/docs/ar/observability/aegis.mdx
+++ b/docs/ar/observability/aegis.mdx
@@ -1,0 +1,67 @@
+---
+title: تكامل Aegis
+description: أضف الحوكمة واكتشاف حقن الموجهات وإخفاء المعلومات الشخصية إلى CrewAI باستخدام Aegis
+icon: shield-halved
+mode: "wide"
+---
+
+# دمج Aegis مع CrewAI
+
+يوضح هذا الدليل كيفية دمج **Aegis** مع **CrewAI** لإضافة حواجز حماية الحوكمة -- بما في ذلك اكتشاف حقن الموجهات وإخفاء المعلومات الشخصية والسياسة كرمز -- إلى سير عمل الوكلاء الخاص بك.
+
+> **ما هو Aegis؟** [Aegis](https://github.com/Acacian/aegis) هو نظام حوكمة مفتوح المصدر لوكلاء الذكاء الاصطناعي. يوفر أدوات قياس تلقائية للأطر الشائعة، واكتشاف حقن الموجهات (107 أنماط)، وإخفاء المعلومات الشخصية، وتنفيذ السياسة كرمز، ومسار تدقيق كامل. التثبيت عبر PyPI: `pip install agent-aegis`.
+
+## البدء
+
+### الخطوة 1: تثبيت التبعيات
+
+```python
+%pip install agent-aegis crewai crewai_tools
+```
+
+### الخطوة 2: تهيئة Aegis
+
+```python
+import aegis
+
+aegis.auto_instrument()
+```
+
+### الخطوة 3: إنشاء تطبيق CrewAI
+
+أنشئ تطبيق CrewAI كالمعتاد. يعترض Aegis بشفافية مكالمات LLM لفرض سياسات الحوكمة.
+
+```python
+from crewai import Agent, Task, Crew
+
+researcher = Agent(
+    role="Researcher",
+    goal="البحث عن معلومات دقيقة حول حوكمة الذكاء الاصطناعي",
+    backstory="أنت باحث خبير في أمان الذكاء الاصطناعي.",
+)
+
+task = Task(
+    description="ابحث عن أحدث الاتجاهات في حوكمة وكلاء الذكاء الاصطناعي.",
+    expected_output="ملخص موجز لاتجاهات حوكمة الذكاء الاصطناعي.",
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task], share_crew=False)
+result = crew.kickoff()
+```
+
+## الميزات الرئيسية
+
+| الميزة | الوصف |
+|---|---|
+| **أدوات القياس التلقائية** | إعداد بسطر واحد |
+| **اكتشاف حقن الموجهات** | 107 أنماط اكتشاف |
+| **إخفاء المعلومات الشخصية** | إخفاء تلقائي للبريد الإلكتروني والهاتف |
+| **السياسة كرمز** | سياسات حوكمة قائمة على YAML |
+| **مسار التدقيق** | سجل كامل لجميع تفاعلات LLM |
+
+## المراجع
+
+- [وثائق Aegis](https://acacian.github.io/aegis/)
+- [Aegis على PyPI](https://pypi.org/project/agent-aegis/)
+- [مستودع GitHub لـ Aegis](https://github.com/Acacian/aegis)

--- a/docs/ar/observability/overview.mdx
+++ b/docs/ar/observability/overview.mdx
@@ -58,6 +58,10 @@ mode: "wide"
   <Card title="Weave" icon="network-wired" href="/ar/observability/weave">
     منصة Weights & Biases لتتبع وتقييم تطبيقات الذكاء الاصطناعي.
   </Card>
+
+  <Card title="Aegis" icon="shield-halved" href="/ar/observability/aegis">
+    نظام حوكمة مع اكتشاف حقن الموجهات وإخفاء المعلومات الشخصية والسياسة كرمز.
+  </Card>
 </CardGroup>
 
 ### التقييم وضمان الجودة

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -315,6 +315,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -785,6 +786,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -1254,6 +1256,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -1723,6 +1726,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -2191,6 +2195,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -2659,6 +2664,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -3128,6 +3134,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/aegis",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -3614,6 +3621,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -4068,6 +4076,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -4522,6 +4531,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -4976,6 +4986,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -5429,6 +5440,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -5882,6 +5894,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -6336,6 +6349,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/aegis",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -6832,6 +6846,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -7298,6 +7313,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -7764,6 +7780,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -8230,6 +8247,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -8695,6 +8713,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -9160,6 +9179,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -9626,6 +9646,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/aegis",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -10122,6 +10143,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -10588,6 +10610,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -11054,6 +11077,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -11520,6 +11544,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -11985,6 +12010,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -12450,6 +12476,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -12916,6 +12943,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/aegis",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",

--- a/docs/en/observability/aegis.mdx
+++ b/docs/en/observability/aegis.mdx
@@ -1,0 +1,115 @@
+---
+title: Aegis Integration
+description: Add governance, prompt injection detection, and PII masking to CrewAI with Aegis
+icon: shield-halved
+mode: "wide"
+---
+
+# Integrate Aegis with CrewAI
+
+This guide shows how to integrate **Aegis** with **CrewAI** to add governance guardrails -- including prompt injection detection, PII masking, and policy-as-code -- to your agent workflows.
+
+> **What is Aegis?** [Aegis](https://github.com/Acacian/aegis) is an open-source governance runtime for AI agents. It provides auto-instrumentation for popular frameworks, prompt injection detection (107 patterns), PII masking, policy-as-code enforcement, and a complete audit trail. Install via PyPI: `pip install agent-aegis`.
+
+## Get Started
+
+We'll walk through instrumenting a CrewAI application with Aegis governance.
+
+### Step 1: Install Dependencies
+
+```python
+%pip install agent-aegis crewai crewai_tools
+```
+
+### Step 2: Initialize Aegis
+
+Aegis auto-instruments CrewAI with a single call. No manual patching required.
+
+```python
+import aegis
+
+# Auto-instrument all supported frameworks (CrewAI, LangChain, etc.)
+aegis.auto_instrument()
+```
+
+### Step 3: Create a CrewAI Application
+
+Create your CrewAI application as usual. Aegis transparently intercepts LLM calls to enforce governance policies.
+
+```python
+from crewai import Agent, Task, Crew
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find accurate information about AI governance",
+    backstory="You're an expert researcher specializing in AI safety.",
+)
+
+task = Task(
+    description="Research the latest trends in AI agent governance.",
+    expected_output="A concise summary of AI governance trends.",
+    agent=researcher,
+)
+
+crew = Crew(
+    agents=[researcher],
+    tasks=[task],
+    share_crew=False,
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+### Step 4: Configure Governance Policies
+
+Aegis supports policy-as-code via YAML configuration:
+
+```yaml
+# policy.yaml
+version: "1.0"
+guardrails:
+  injection_detection:
+    enabled: true
+    action: block
+  pii_masking:
+    enabled: true
+    mask_types: [email, phone, ssn]
+  cost_limit:
+    max_cost_per_request: 0.50
+```
+
+Load the policy when initializing:
+
+```python
+import aegis
+
+aegis.auto_instrument()
+instance = aegis.init(policy_path="policy.yaml")
+```
+
+### Step 5: Review the Audit Trail
+
+Every LLM interaction is logged to the audit trail. You can query it programmatically:
+
+```python
+instance = aegis.get()
+# Access audit logs for compliance and debugging
+```
+
+## Key Features
+
+| Feature | Description |
+|---|---|
+| **Auto-instrumentation** | One-line setup, no code changes to your CrewAI app |
+| **Prompt Injection Detection** | 107 detection patterns, blocks malicious inputs |
+| **PII Masking** | Automatically redacts emails, phone numbers, SSNs |
+| **Policy-as-Code** | YAML-based governance policies |
+| **Audit Trail** | Complete log of all LLM interactions |
+| **Cost Controls** | Per-request and per-session cost limits |
+
+## References
+
+- [Aegis Documentation](https://acacian.github.io/aegis/)
+- [Aegis on PyPI](https://pypi.org/project/agent-aegis/)
+- [Aegis GitHub Repository](https://github.com/Acacian/aegis)

--- a/docs/en/observability/overview.mdx
+++ b/docs/en/observability/overview.mdx
@@ -58,6 +58,10 @@ Observability is crucial for understanding how your CrewAI agents perform, ident
   <Card title="Weave" icon="network-wired" href="/en/observability/weave">
     Weights & Biases platform for tracking and evaluating AI applications.
   </Card>
+
+  <Card title="Aegis" icon="shield-halved" href="/en/observability/aegis">
+    Governance runtime with prompt injection detection, PII masking, and policy-as-code.
+  </Card>
 </CardGroup>
 
 ### Evaluation & Quality Assurance

--- a/docs/ko/observability/aegis.mdx
+++ b/docs/ko/observability/aegis.mdx
@@ -1,0 +1,68 @@
+---
+title: Aegis 통합
+description: Aegis로 CrewAI에 거버넌스, 프롬프트 인젝션 탐지, PII 마스킹을 추가하세요
+icon: shield-halved
+mode: "wide"
+---
+
+# CrewAI와 Aegis 통합
+
+이 가이드는 **Aegis**를 **CrewAI**와 통합하여 프롬프트 인젝션 탐지, PII 마스킹, 정책 기반 코드(policy-as-code) 등의 거버넌스 가드레일을 에이전트 워크플로우에 추가하는 방법을 설명합니다.
+
+> **Aegis란?** [Aegis](https://github.com/Acacian/aegis)는 AI 에이전트를 위한 오픈소스 거버넌스 런타임입니다. 주요 프레임워크 자동 계측, 프롬프트 인젝션 탐지(107개 패턴), PII 마스킹, 정책 기반 코드 적용, 전체 감사 추적 기능을 제공합니다. PyPI를 통해 설치: `pip install agent-aegis`.
+
+## 시작하기
+
+### 1단계: 의존성 설치
+
+```python
+%pip install agent-aegis crewai crewai_tools
+```
+
+### 2단계: Aegis 초기화
+
+```python
+import aegis
+
+# 지원되는 모든 프레임워크 자동 계측 (CrewAI, LangChain 등)
+aegis.auto_instrument()
+```
+
+### 3단계: CrewAI 애플리케이션 생성
+
+평소처럼 CrewAI 애플리케이션을 생성하세요. Aegis가 투명하게 LLM 호출을 가로채 거버넌스 정책을 적용합니다.
+
+```python
+from crewai import Agent, Task, Crew
+
+researcher = Agent(
+    role="Researcher",
+    goal="AI 거버넌스에 대한 정확한 정보를 찾기",
+    backstory="AI 안전 전문 연구원입니다.",
+)
+
+task = Task(
+    description="AI 에이전트 거버넌스의 최신 트렌드를 연구하세요.",
+    expected_output="AI 거버넌스 트렌드에 대한 간결한 요약.",
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task], share_crew=False)
+result = crew.kickoff()
+```
+
+## 주요 기능
+
+| 기능 | 설명 |
+|---|---|
+| **자동 계측** | 한 줄 설정, CrewAI 앱 코드 변경 불필요 |
+| **프롬프트 인젝션 탐지** | 107개 탐지 패턴으로 악성 입력 차단 |
+| **PII 마스킹** | 이메일, 전화번호, SSN 자동 마스킹 |
+| **정책 기반 코드** | YAML 기반 거버넌스 정책 |
+| **감사 추적** | 모든 LLM 상호작용의 완전한 로그 |
+
+## 참고
+
+- [Aegis 문서](https://acacian.github.io/aegis/)
+- [Aegis PyPI](https://pypi.org/project/agent-aegis/)
+- [Aegis GitHub](https://github.com/Acacian/aegis)

--- a/docs/ko/observability/overview.mdx
+++ b/docs/ko/observability/overview.mdx
@@ -58,6 +58,10 @@ mode: "wide"
   <Card title="Weave" icon="network-wired" href="/ko/observability/weave">
     AI 애플리케이션의 추적 및 평가를 위한 Weights & Biases 플랫폼.
   </Card>
+
+  <Card title="Aegis" icon="shield-halved" href="/ko/observability/aegis">
+    프롬프트 인젝션 탐지, PII 마스킹, 정책 기반 코드를 제공하는 거버넌스 런타임.
+  </Card>
 </CardGroup>
 
 ### 평가 및 품질 보증

--- a/docs/pt-BR/observability/aegis.mdx
+++ b/docs/pt-BR/observability/aegis.mdx
@@ -1,0 +1,68 @@
+---
+title: Integração Aegis
+description: Adicione governança, detecção de injeção de prompt e mascaramento de PII ao CrewAI com Aegis
+icon: shield-halved
+mode: "wide"
+---
+
+# Integrar Aegis com CrewAI
+
+Este guia mostra como integrar o **Aegis** com o **CrewAI** para adicionar guardrails de governança -- incluindo detecção de injeção de prompt, mascaramento de PII e política como código -- aos seus fluxos de trabalho de agentes.
+
+> **O que é o Aegis?** [Aegis](https://github.com/Acacian/aegis) é um runtime de governança de código aberto para agentes de IA. Ele fornece auto-instrumentação para frameworks populares, detecção de injeção de prompt (107 padrões), mascaramento de PII, aplicação de política como código e trilha de auditoria completa. Instale via PyPI: `pip install agent-aegis`.
+
+## Começando
+
+### Passo 1: Instalar Dependências
+
+```python
+%pip install agent-aegis crewai crewai_tools
+```
+
+### Passo 2: Inicializar o Aegis
+
+```python
+import aegis
+
+# Auto-instrumentar todos os frameworks suportados (CrewAI, LangChain, etc.)
+aegis.auto_instrument()
+```
+
+### Passo 3: Criar uma Aplicação CrewAI
+
+Crie sua aplicação CrewAI normalmente. O Aegis intercepta chamadas LLM de forma transparente para aplicar políticas de governança.
+
+```python
+from crewai import Agent, Task, Crew
+
+researcher = Agent(
+    role="Researcher",
+    goal="Encontrar informações precisas sobre governança de IA",
+    backstory="Você é um pesquisador especialista em segurança de IA.",
+)
+
+task = Task(
+    description="Pesquise as últimas tendências em governança de agentes de IA.",
+    expected_output="Um resumo conciso das tendências de governança de IA.",
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task], share_crew=False)
+result = crew.kickoff()
+```
+
+## Recursos Principais
+
+| Recurso | Descrição |
+|---|---|
+| **Auto-instrumentação** | Configuração em uma linha, sem alterações no código |
+| **Detecção de Injeção de Prompt** | 107 padrões de detecção |
+| **Mascaramento de PII** | Mascara automaticamente emails, telefones, SSNs |
+| **Política como Código** | Políticas de governança baseadas em YAML |
+| **Trilha de Auditoria** | Log completo de todas as interações LLM |
+
+## Referências
+
+- [Documentação Aegis](https://acacian.github.io/aegis/)
+- [Aegis no PyPI](https://pypi.org/project/agent-aegis/)
+- [Repositório GitHub do Aegis](https://github.com/Acacian/aegis)

--- a/docs/pt-BR/observability/overview.mdx
+++ b/docs/pt-BR/observability/overview.mdx
@@ -58,6 +58,10 @@ A observabilidade é fundamental para entender como seus agentes CrewAI estão d
   <Card title="Weave" icon="network-wired" href="/pt-BR/observability/weave">
     Plataforma Weights & Biases para acompanhamento e avaliação de aplicações de IA.
   </Card>
+
+  <Card title="Aegis" icon="shield-halved" href="/pt-BR/observability/aegis">
+    Runtime de governança com detecção de injeção de prompt, mascaramento de PII e política como código.
+  </Card>
 </CardGroup>
 
 ### Avaliação & Garantia de Qualidade


### PR DESCRIPTION
## Summary
- Add Aegis observability/governance integration page (`docs/en/observability/aegis.mdx`)
- Add Korean translation (`docs/ko/observability/aegis.mdx`)
- Add Card to observability overview pages (en, ko)
- Add navigation entries to `docs.json` (en, ko, pt-BR, ar)

## What is Aegis?
[Aegis](https://github.com/Acacian/aegis) is an open-source governance runtime for AI agents.
It auto-instruments CrewAI (and other frameworks) to add:
- Prompt injection detection (107 patterns)
- PII masking (email, phone, SSN)
- Policy-as-code (YAML-based)
- Complete audit trail

PyPI: https://pypi.org/project/agent-aegis/

> Note: This PR was generated with LLM assistance (label `llm-generated` requested but may not be available on this repository).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add new pages and navigation links; no runtime or API behavior is modified.
> 
> **Overview**
> Adds new **Aegis governance integration** documentation pages under Observability (including `en`, `ar`, `ko`, and `pt-BR` content) describing how to auto-instrument CrewAI and apply governance features like prompt-injection detection, PII masking, policy-as-code, and audit trails.
> 
> Updates the Observability overview pages to surface Aegis via a new card, and extends `docs.json` navigation so the new `*/observability/aegis` pages appear in sidebars across the supported locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d61cbf35f8976dd28d83e18d5698dfa2d0ce9bba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->