### PR TITLE
docs: file upload support for flows and platform

### DIFF
--- a/docs/ar/concepts/files.mdx
+++ b/docs/ar/concepts/files.mdx
@@ -134,8 +134,8 @@ result = flow.kickoff(
 )
 ```
 
-<Note type="info" title="CrewAI Platform Integration">
-When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+<Note type="info" title="تكامل منصة CrewAI">
+عند النشر على منصة CrewAI، تحصل الحقول من نوع الملف مثل `ImageFile` و `PDFFile` وغيرها في حالة التدفق تلقائيًا على واجهة رفع ملفات. يمكن للمستخدمين سحب وإفلات الملفات مباشرة في واجهة المنصة. يتم تخزين الملفات بشكل آمن وتمريرها إلى الوكلاء باستخدام تحسينات خاصة بالمزود (base64 مضمّن، أو واجهات برمجة لرفع الملفات، أو مراجع URL حسب المزود). للاطلاع على أمثلة استخدام API، راجع [مدخلات الملفات في التدفقات](/ar/concepts/flows#مدخلات-الملفات).
 </Note>
 
 ### مع الوكلاء المستقلين

--- a/docs/ar/concepts/files.mdx
+++ b/docs/ar/concepts/files.mdx
@@ -134,6 +134,10 @@ result = flow.kickoff(
 )
 ```
 
+<Note type="info" title="CrewAI Platform Integration">
+When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+</Note>
+
 ### مع الوكلاء المستقلين
 
 مرر الملفات مباشرة إلى تشغيل الوكيل:

--- a/docs/ar/concepts/files.mdx
+++ b/docs/ar/concepts/files.mdx
@@ -117,20 +117,28 @@ task = Task(
 
 ### مع التدفقات
 
-مرر الملفات إلى التدفقات، والتي تنتقل تلقائيًا إلى الأطقم:
+تعمل الحقول من نوع الملف (`File`، `ImageFile`، `PDFFile`) في مخطط حالة التدفق كإشارة لواجهة المنصة. عند النشر، تُعرض هذه الحقول كمناطق سحب وإفلات لرفع الملفات. يمكن أيضًا تمرير الملفات عبر `input_files` في API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile
+from crewai_files import File, ImageFile
+from pydantic import BaseModel
 
-class AnalysisFlow(Flow):
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform UI
+    cover_image: ImageFile   # Image-specific dropzone
+    title: str = ""
+
+class AnalysisFlow(Flow[MyState]):
     @start()
     def analyze(self):
+        # Files are automatically populated in state
+        content = self.state.document.read()
         return self.analysis_crew.kickoff()
 
 flow = AnalysisFlow()
 result = flow.kickoff(
-    input_files={"image": ImageFile(source="data.png")}
+    input_files={"document": File(source="report.pdf")}
 )
 ```
 

--- a/docs/ar/concepts/flows.mdx
+++ b/docs/ar/concepts/flows.mdx
@@ -341,9 +341,9 @@ flow.kickoff()
 
 من خلال توفير خيارات إدارة الحالة غير المهيكلة والمهيكلة، تمكّن تدفقات CrewAI المطورين من بناء سير عمل ذكاء اصطناعي مرن ومتين في آن واحد، ملبيةً مجموعة واسعة من متطلبات التطبيقات.
 
-### File Inputs
+### مدخلات الملفات
 
-When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+عند استخدام الحالة المهيكلة، يمكنك تضمين حقول من نوع الملف باستخدام فئات من `crewai-files`. هذا يتيح رفع الملفات كجزء من مدخلات التدفق الخاص بك:
 
 ```python
 from crewai.flow.flow import Flow, start
@@ -363,21 +363,21 @@ class OnboardingFlow(Flow[OnboardingState]):
         return self.state.document
 ```
 
-When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+عند النشر على **منصة CrewAI**، تُعرض الحقول من نوع الملف تلقائيًا كمناطق سحب وإفلات لرفع الملفات في واجهة المستخدم. يمكن للمستخدمين سحب وإفلات الملفات، والتي تُمرر بعد ذلك إلى التدفق الخاص بك.
 
-**Kicking off with files via API:**
+**بدء التشغيل مع الملفات عبر API:**
 
-The `/kickoff` endpoint auto-detects the request format:
-- **JSON body** → normal kickoff
-- **multipart/form-data** → file upload + kickoff
+تكتشف نقطة النهاية `/kickoff` تنسيق الطلب تلقائيًا:
+- **جسم JSON** ← بدء تشغيل عادي
+- **multipart/form-data** ← رفع ملف + بدء تشغيل
 
-API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+يمكن لمستخدمي API أيضًا تمرير سلاسل URL مباشرة إلى الحقول من نوع الملف — يقوم Pydantic بتحويلها تلقائيًا.
 
-### API Usage
+### استخدام API
 
-#### Option 1: Multipart kickoff (recommended)
+#### الخيار 1: بدء تشغيل multipart (موصى به)
 
-Send files directly with the kickoff request:
+أرسل الملفات مباشرة مع طلب بدء التشغيل:
 
 ```bash
 # With files (multipart) — same endpoint
@@ -387,9 +387,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -F 'cover_image=@/path/to/photo.jpg'
 ```
 
-Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+يتم تخزين الملفات تلقائيًا وتحويلها إلى كائنات `FileInput`. يتلقى الوكيل الملف مع تحسين خاص بالمزود (base64 مضمّن، أو API لرفع الملفات، أو مرجع URL حسب مزود LLM).
 
-#### Option 2: JSON kickoff (no files)
+#### الخيار 2: بدء تشغيل JSON (بدون ملفات)
 
 ```bash
 # Without files (JSON) — same endpoint
@@ -399,9 +399,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}}'
 ```
 
-#### Option 3: Separate upload + kickoff
+#### الخيار 3: رفع منفصل + بدء تشغيل
 
-This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+هذا بديل لرفع multipart عندما تحتاج إلى رفع الملفات بشكل منفصل عن طلب بدء التشغيل. ارفع الملفات أولاً، ثم أشِر إليها بواسطة URL:
 
 ```bash
 # Step 1: Upload
@@ -418,11 +418,11 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
 ```
 
-See the Platform API documentation for full `/files` endpoint details.
+راجع وثائق Platform API للحصول على تفاصيل كاملة حول نقطة النهاية `/files`.
 
-#### On CrewAI Platform
+#### على منصة CrewAI
 
-When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+عند استخدام واجهة المنصة، تُعرض الحقول من نوع الملف تلقائيًا كمناطق سحب وإفلات للرفع. لا حاجة لاستدعاءات API — فقط أفلِت الملف وانقر على تشغيل.
 
 ## استمرارية التدفق
 

--- a/docs/ar/concepts/flows.mdx
+++ b/docs/ar/concepts/flows.mdx
@@ -341,6 +341,89 @@ flow.kickoff()
 
 من خلال توفير خيارات إدارة الحالة غير المهيكلة والمهيكلة، تمكّن تدفقات CrewAI المطورين من بناء سير عمل ذكاء اصطناعي مرن ومتين في آن واحد، ملبيةً مجموعة واسعة من متطلبات التطبيقات.
 
+### File Inputs
+
+When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+
+```python
+from crewai.flow.flow import Flow, start
+from crewai_files import ImageFile, PDFFile
+from pydantic import BaseModel
+
+class OnboardingState(BaseModel):
+    document: PDFFile        # File upload
+    cover_image: ImageFile   # Image upload
+    title: str = ""          # Text input
+
+class OnboardingFlow(Flow[OnboardingState]):
+    @start()
+    def process_upload(self):
+        # Access files directly from state
+        print(f"Processing: {self.state.title}")
+        return self.state.document
+```
+
+When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+
+**Kicking off with files via API:**
+
+The `/kickoff` endpoint auto-detects the request format:
+- **JSON body** → normal kickoff
+- **multipart/form-data** → file upload + kickoff
+
+API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+
+### API Usage
+
+#### Option 1: Multipart kickoff (recommended)
+
+Send files directly with the kickoff request:
+
+```bash
+# With files (multipart) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"company_name": "Einstein"}' \
+  -F 'cover_image=@/path/to/photo.jpg'
+```
+
+Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+
+#### Option 2: JSON kickoff (no files)
+
+```bash
+# Without files (JSON) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}}'
+```
+
+#### Option 3: Separate upload + kickoff
+
+This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/photo.jpg' \
+  -F 'field_name=cover_image'
+# Returns: {"url": "https://...", "field_name": "cover_image"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
+```
+
+See the Platform API documentation for full `/files` endpoint details.
+
+#### On CrewAI Platform
+
+When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+
 ## استمرارية التدفق
 
 يتيح مزخرف @persist الاستمرارية التلقائية للحالة في تدفقات CrewAI، مما يسمح لك بالحفاظ على حالة التدفق عبر عمليات إعادة التشغيل أو تنفيذات سير العمل المختلفة. يمكن تطبيق هذا المزخرف على مستوى الفئة أو مستوى الدالة، مما يوفر مرونة في كيفية إدارة استمرارية الحالة.

--- a/docs/ar/concepts/flows.mdx
+++ b/docs/ar/concepts/flows.mdx
@@ -343,27 +343,28 @@ flow.kickoff()
 
 ### مدخلات الملفات
 
-عند استخدام الحالة المهيكلة، يمكنك تضمين حقول من نوع الملف باستخدام فئات من `crewai-files`. هذا يتيح رفع الملفات كجزء من مدخلات التدفق الخاص بك:
+عند استخدام الحالة المهيكلة، يمكنك تضمين حقول من نوع الملف باستخدام فئات من `crewai-files`. تعمل الحقول من نوع الملف في حالة التدفق كإشارة للمنصة — فهي تُعرض تلقائيًا كمناطق سحب وإفلات لرفع الملفات في واجهة علامة تبويب Run ويتم تعبئتها عند رفع الملفات عبر المنصة أو تمريرها عبر `input_files` في API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile, PDFFile
+from crewai_files import File, ImageFile, PDFFile
 from pydantic import BaseModel
 
-class OnboardingState(BaseModel):
-    document: PDFFile        # File upload
-    cover_image: ImageFile   # Image upload
-    title: str = ""          # Text input
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform
+    title: str = ""
 
-class OnboardingFlow(Flow[OnboardingState]):
+class MyFlow(Flow[MyState]):
     @start()
-    def process_upload(self):
-        # Access files directly from state
-        print(f"Processing: {self.state.title}")
-        return self.state.document
+    def process(self):
+        # File object is automatically populated in state
+        # when uploaded via Platform UI or passed via API
+        content = self.state.document.read()
+        print(f"Processing {self.state.title}: {len(content)} bytes")
+        return content
 ```
 
-عند النشر على **منصة CrewAI**، تُعرض الحقول من نوع الملف تلقائيًا كمناطق سحب وإفلات لرفع الملفات في واجهة المستخدم. يمكن للمستخدمين سحب وإفلات الملفات، والتي تُمرر بعد ذلك إلى التدفق الخاص بك.
+عند النشر على **منصة CrewAI**، تُعرض الحقول من نوع الملف (`File`، `ImageFile`، `PDFFile` من `crewai-files`) تلقائيًا كمناطق سحب وإفلات لرفع الملفات في واجهة المستخدم. يمكن للمستخدمين سحب وإفلات الملفات، والتي تُملأ بعد ذلك في حالة التدفق الخاص بك.
 
 **بدء التشغيل مع الملفات عبر API:**
 

--- a/docs/ar/enterprise/guides/kickoff-crew.mdx
+++ b/docs/ar/enterprise/guides/kickoff-crew.mdx
@@ -86,6 +86,60 @@ curl -H "Authorization: Bearer YOUR_CREW_TOKEN" https://your-crew-url.crewai.com
 
 رمز الحامل متاح في علامة تبويب Status في صفحة تفاصيل طاقمك.
 
+## رفع الملفات
+
+عندما يتضمن طاقمك أو تدفقك حقول حالة من نوع الملف (باستخدام `ImageFile` أو `PDFFile` أو `File` من `crewai-files`)، تُعرض هذه الحقول تلقائيًا كمناطق سحب وإفلات لرفع الملفات في واجهة علامة تبويب Run. يمكن للمستخدمين سحب وإفلات الملفات مباشرة، وتتولى المنصة التخزين والتسليم إلى وكلائك.
+
+### بدء تشغيل Multipart (موصى به)
+
+أرسل الملفات مباشرة مع طلب بدء التشغيل باستخدام `multipart/form-data`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"title": "Report"}' \
+  -F 'document=@/path/to/file.pdf'
+```
+
+يتم تخزين الملفات تلقائيًا وتحويلها إلى كائنات ملفات. يتلقى الوكيل الملف مع تحسين خاص بالمزود (base64 مضمّن، أو API لرفع الملفات، أو مرجع URL حسب مزود LLM).
+
+### بدء تشغيل JSON مع عناوين URL للملفات
+
+إذا كانت لديك ملفات مستضافة بالفعل على عناوين URL، مررها عبر `input_files`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inputs": {"title": "Report"},
+    "input_files": {"document": "https://example.com/file.pdf"}
+  }'
+```
+
+### رفع منفصل + بدء تشغيل
+
+ارفع الملفات أولاً، ثم أشِر إليها بواسطة URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/file.pdf' \
+  -F 'field_name=document'
+# Returns: {"url": "https://...", "field_name": "document"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"title": "Report"}, "input_files": {"document": "https://..."}}'
+```
+
+<Note type="info">
+يعمل رفع الملفات بنفس الطريقة لكل من الطواقم والتدفقات. عرّف حقول من نوع الملف في مخطط حالتك، وستتولى واجهة المنصة وAPI الرفع تلقائيًا.
+</Note>
+
 ### التحقق من صحة الطاقم
 
 قبل تنفيذ العمليات، يمكنك التحقق من أن طاقمك يعمل بشكل صحيح:

--- a/docs/en/concepts/files.mdx
+++ b/docs/en/concepts/files.mdx
@@ -135,7 +135,7 @@ result = flow.kickoff(
 ```
 
 <Note type="info" title="CrewAI Platform Integration">
-When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider).
+When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
 </Note>
 
 ### With Standalone Agents

--- a/docs/en/concepts/files.mdx
+++ b/docs/en/concepts/files.mdx
@@ -117,20 +117,28 @@ task = Task(
 
 ### With Flows
 
-Pass files to flows, which automatically inherit to crews:
+File-typed fields (`File`, `ImageFile`, `PDFFile`) in your flow's state schema serve as the signal to the Platform UI. When deployed, these fields render as file upload dropzones. Files can also be passed via `input_files` in the API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile
+from crewai_files import File, ImageFile
+from pydantic import BaseModel
 
-class AnalysisFlow(Flow):
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform UI
+    cover_image: ImageFile   # Image-specific dropzone
+    title: str = ""
+
+class AnalysisFlow(Flow[MyState]):
     @start()
     def analyze(self):
+        # Files are automatically populated in state
+        content = self.state.document.read()
         return self.analysis_crew.kickoff()
 
 flow = AnalysisFlow()
 result = flow.kickoff(
-    input_files={"image": ImageFile(source="data.png")}
+    input_files={"document": File(source="report.pdf")}
 )
 ```
 

--- a/docs/en/concepts/files.mdx
+++ b/docs/en/concepts/files.mdx
@@ -134,6 +134,10 @@ result = flow.kickoff(
 )
 ```
 
+<Note type="info" title="CrewAI Platform Integration">
+When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider).
+</Note>
+
 ### With Standalone Agents
 
 Pass files directly to agent kickoff:

--- a/docs/en/concepts/flows.mdx
+++ b/docs/en/concepts/flows.mdx
@@ -384,7 +384,7 @@ Send files directly with the kickoff request:
 curl -X POST https://your-deployment.crewai.com/kickoff \
   -H 'Authorization: Bearer YOUR_TOKEN' \
   -F 'inputs={"company_name": "Einstein"}' \
-  -F 'cnh_image=@/path/to/document.jpg'
+  -F 'cover_image=@/path/to/photo.jpg'
 ```
 
 Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
@@ -401,22 +401,24 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
 
 #### Option 3: Separate upload + kickoff
 
-Upload files first, then reference them:
+This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
 
 ```bash
 # Step 1: Upload
 curl -X POST https://your-deployment.crewai.com/files \
   -H 'Authorization: Bearer YOUR_TOKEN' \
-  -F 'file=@/path/to/document.jpg' \
-  -F 'field_name=cnh_image'
-# Returns: {"url": "https://...", "field_name": "cnh_image"}
+  -F 'file=@/path/to/photo.jpg' \
+  -F 'field_name=cover_image'
+# Returns: {"url": "https://...", "field_name": "cover_image"}
 
 # Step 2: Kickoff with URL
 curl -X POST https://your-deployment.crewai.com/kickoff \
   -H 'Authorization: Bearer YOUR_TOKEN' \
   -H 'Content-Type: application/json' \
-  -d '{"inputs": {"company_name": "Einstein"}, "inputFiles": {"cnh_image": "https://..."}}'
+  -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
 ```
+
+See the Platform API documentation for full `/files` endpoint details.
 
 #### On CrewAI Platform
 

--- a/docs/en/concepts/flows.mdx
+++ b/docs/en/concepts/flows.mdx
@@ -366,8 +366,10 @@ class OnboardingFlow(Flow[OnboardingState]):
 When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
 
 **Kicking off with files via API:**
-- **Multipart**: `POST /kickoff/multipart` with files embedded in the request
-- **Separate upload**: `POST /files` first to upload files, then `POST /kickoff` with the returned URLs
+
+The `/kickoff` endpoint auto-detects the request format:
+- **JSON body** → normal kickoff
+- **multipart/form-data** → file upload + kickoff
 
 API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
 
@@ -378,7 +380,8 @@ API users can also pass URL strings directly to file-typed fields—Pydantic coe
 Send files directly with the kickoff request:
 
 ```bash
-curl -X POST https://your-deployment.crewai.com/kickoff/multipart \
+# With files (multipart) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
   -H 'Authorization: Bearer YOUR_TOKEN' \
   -F 'inputs={"company_name": "Einstein"}' \
   -F 'cnh_image=@/path/to/document.jpg'
@@ -386,7 +389,17 @@ curl -X POST https://your-deployment.crewai.com/kickoff/multipart \
 
 Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
 
-#### Option 2: Separate upload + kickoff
+#### Option 2: JSON kickoff (no files)
+
+```bash
+# Without files (JSON) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}}'
+```
+
+#### Option 3: Separate upload + kickoff
 
 Upload files first, then reference them:
 

--- a/docs/en/concepts/flows.mdx
+++ b/docs/en/concepts/flows.mdx
@@ -343,27 +343,28 @@ By providing both unstructured and structured state management options, CrewAI F
 
 ### File Inputs
 
-When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+When using structured state, you can include file-typed fields using classes from `crewai-files`. File-typed fields in your flow state serve as the signal to the Platform—they automatically render as file upload dropzones in the Run tab UI and get populated when files are uploaded via the Platform or passed via `input_files` in the API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile, PDFFile
+from crewai_files import File, ImageFile, PDFFile
 from pydantic import BaseModel
 
-class OnboardingState(BaseModel):
-    document: PDFFile        # File upload
-    cover_image: ImageFile   # Image upload
-    title: str = ""          # Text input
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform
+    title: str = ""
 
-class OnboardingFlow(Flow[OnboardingState]):
+class MyFlow(Flow[MyState]):
     @start()
-    def process_upload(self):
-        # Access files directly from state
-        print(f"Processing: {self.state.title}")
-        return self.state.document
+    def process(self):
+        # File object is automatically populated in state
+        # when uploaded via Platform UI or passed via API
+        content = self.state.document.read()
+        print(f"Processing {self.state.title}: {len(content)} bytes")
+        return content
 ```
 
-When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+When deployed on **CrewAI Platform**, file-typed fields (`File`, `ImageFile`, `PDFFile` from `crewai-files`) automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then populated into your flow's state.
 
 **Kicking off with files via API:**
 

--- a/docs/en/concepts/flows.mdx
+++ b/docs/en/concepts/flows.mdx
@@ -341,6 +341,36 @@ flow.kickoff()
 
 By providing both unstructured and structured state management options, CrewAI Flows empowers developers to build AI workflows that are both flexible and robust, catering to a wide range of application requirements.
 
+### File Inputs
+
+When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+
+```python
+from crewai.flow.flow import Flow, start
+from crewai_files import ImageFile, PDFFile
+from pydantic import BaseModel
+
+class OnboardingState(BaseModel):
+    document: PDFFile        # File upload
+    cover_image: ImageFile   # Image upload
+    title: str = ""          # Text input
+
+class OnboardingFlow(Flow[OnboardingState]):
+    @start()
+    def process_upload(self):
+        # Access files directly from state
+        print(f"Processing: {self.state.title}")
+        return self.state.document
+```
+
+When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+
+**Kicking off with files via API:**
+- **Multipart**: `POST /kickoff/multipart` with files embedded in the request
+- **Separate upload**: `POST /files` first to upload files, then `POST /kickoff` with the returned URLs
+
+API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+
 ## Flow Persistence
 
 The @persist decorator enables automatic state persistence in CrewAI Flows, allowing you to maintain flow state across restarts or different workflow executions. This decorator can be applied at either the class level or method level, providing flexibility in how you manage state persistence.

--- a/docs/en/concepts/flows.mdx
+++ b/docs/en/concepts/flows.mdx
@@ -371,6 +371,44 @@ When deployed on **CrewAI Platform**, file-typed fields automatically render as 
 
 API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
 
+### API Usage
+
+#### Option 1: Multipart kickoff (recommended)
+
+Send files directly with the kickoff request:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff/multipart \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"company_name": "Einstein"}' \
+  -F 'cnh_image=@/path/to/document.jpg'
+```
+
+Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+
+#### Option 2: Separate upload + kickoff
+
+Upload files first, then reference them:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/document.jpg' \
+  -F 'field_name=cnh_image'
+# Returns: {"url": "https://...", "field_name": "cnh_image"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}, "inputFiles": {"cnh_image": "https://..."}}'
+```
+
+#### On CrewAI Platform
+
+When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+
 ## Flow Persistence
 
 The @persist decorator enables automatic state persistence in CrewAI Flows, allowing you to maintain flow state across restarts or different workflow executions. This decorator can be applied at either the class level or method level, providing flexibility in how you manage state persistence.

--- a/docs/en/enterprise/guides/kickoff-crew.mdx
+++ b/docs/en/enterprise/guides/kickoff-crew.mdx
@@ -86,6 +86,60 @@ curl -H "Authorization: Bearer YOUR_CREW_TOKEN" https://your-crew-url.crewai.com
 
 Your bearer token is available on the Status tab of your crew's detail page.
 
+## File Uploads
+
+When your crew or flow includes file-typed state fields (using `ImageFile`, `PDFFile`, or `File` from `crewai-files`), these fields automatically render as file upload dropzones in the Run tab UI. Users can drag and drop files directly, and the Platform handles storage and delivery to your agents.
+
+### Multipart Kickoff (Recommended)
+
+Send files directly with the kickoff request using `multipart/form-data`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"title": "Report"}' \
+  -F 'document=@/path/to/file.pdf'
+```
+
+Files are automatically stored and converted to file objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+
+### JSON Kickoff with File URLs
+
+If you have files already hosted at URLs, pass them via `input_files`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inputs": {"title": "Report"},
+    "input_files": {"document": "https://example.com/file.pdf"}
+  }'
+```
+
+### Separate Upload + Kickoff
+
+Upload files first, then reference them by URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/file.pdf' \
+  -F 'field_name=document'
+# Returns: {"url": "https://...", "field_name": "document"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"title": "Report"}, "input_files": {"document": "https://..."}}'
+```
+
+<Note type="info">
+File uploads work the same way for both crews and flows. Define file-typed fields in your state schema, and the Platform UI and API will handle uploads automatically.
+</Note>
+
 ### Checking Crew Health
 
 Before executing operations, you can verify that your crew is running properly:

--- a/docs/ko/concepts/files.mdx
+++ b/docs/ko/concepts/files.mdx
@@ -134,6 +134,10 @@ result = flow.kickoff(
 )
 ```
 
+<Note type="info" title="CrewAI Platform Integration">
+When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+</Note>
+
 ### 단독 에이전트와 함께
 
 에이전트 킥오프에 직접 파일을 전달합니다:

--- a/docs/ko/concepts/files.mdx
+++ b/docs/ko/concepts/files.mdx
@@ -134,8 +134,8 @@ result = flow.kickoff(
 )
 ```
 
-<Note type="info" title="CrewAI Platform Integration">
-When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+<Note type="info" title="CrewAI 플랫폼 통합">
+CrewAI 플랫폼에 배포하면 flow 상태의 `ImageFile`, `PDFFile` 및 기타 파일 타입 필드가 자동으로 파일 업로드 UI를 갖게 됩니다. 사용자는 플랫폼 인터페이스에서 직접 파일을 드래그 앤 드롭할 수 있습니다. 파일은 안전하게 저장되고 프로바이더별 최적화(인라인 base64, 파일 업로드 API 또는 프로바이더에 따른 URL 참조)를 사용하여 에이전트에 전달됩니다. API 사용 예제는 [Flows의 파일 입력](/ko/concepts/flows#파일-입력)을 참조하세요.
 </Note>
 
 ### 단독 에이전트와 함께

--- a/docs/ko/concepts/files.mdx
+++ b/docs/ko/concepts/files.mdx
@@ -117,20 +117,28 @@ task = Task(
 
 ### Flow와 함께
 
-flow에 파일을 전달하면 자동으로 crew에 상속됩니다:
+flow의 상태 스키마에 있는 파일 타입 필드(`File`, `ImageFile`, `PDFFile`)는 플랫폼 UI에 대한 신호 역할을 합니다. 배포 시 이러한 필드는 파일 업로드 드롭존으로 렌더링됩니다. 파일은 API에서 `input_files`를 통해서도 전달할 수 있습니다.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile
+from crewai_files import File, ImageFile
+from pydantic import BaseModel
 
-class AnalysisFlow(Flow):
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform UI
+    cover_image: ImageFile   # Image-specific dropzone
+    title: str = ""
+
+class AnalysisFlow(Flow[MyState]):
     @start()
     def analyze(self):
+        # Files are automatically populated in state
+        content = self.state.document.read()
         return self.analysis_crew.kickoff()
 
 flow = AnalysisFlow()
 result = flow.kickoff(
-    input_files={"image": ImageFile(source="data.png")}
+    input_files={"document": File(source="report.pdf")}
 )
 ```
 

--- a/docs/ko/concepts/flows.mdx
+++ b/docs/ko/concepts/flows.mdx
@@ -334,9 +334,9 @@ flow.kickoff()
 
 CrewAI Flows는 비구조적 및 구조적 상태 관리 옵션을 모두 제공함으로써, 개발자들이 다양한 애플리케이션 요구 사항에 맞춰 유연하면서도 견고한 AI 워크플로를 구축할 수 있도록 지원합니다.
 
-### File Inputs
+### 파일 입력
 
-When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+구조화된 상태를 사용할 때, `crewai-files`의 클래스를 사용하여 파일 타입 필드를 포함할 수 있습니다. 이를 통해 flow의 입력으로 파일 업로드가 가능합니다:
 
 ```python
 from crewai.flow.flow import Flow, start
@@ -356,21 +356,21 @@ class OnboardingFlow(Flow[OnboardingState]):
         return self.state.document
 ```
 
-When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+**CrewAI 플랫폼**에 배포하면 파일 타입 필드가 UI에서 자동으로 파일 업로드 드롭존으로 렌더링됩니다. 사용자는 파일을 드래그 앤 드롭할 수 있으며, 해당 파일은 flow로 전달됩니다.
 
-**Kicking off with files via API:**
+**API를 통한 파일 포함 시작:**
 
-The `/kickoff` endpoint auto-detects the request format:
-- **JSON body** → normal kickoff
-- **multipart/form-data** → file upload + kickoff
+`/kickoff` 엔드포인트는 요청 형식을 자동으로 감지합니다:
+- **JSON body** → 일반 kickoff
+- **multipart/form-data** → 파일 업로드 + kickoff
 
-API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+API 사용자는 파일 타입 필드에 URL 문자열을 직접 전달할 수도 있습니다 — Pydantic이 자동으로 변환합니다.
 
-### API Usage
+### API 사용법
 
-#### Option 1: Multipart kickoff (recommended)
+#### 옵션 1: Multipart kickoff (권장)
 
-Send files directly with the kickoff request:
+kickoff 요청과 함께 파일을 직접 전송합니다:
 
 ```bash
 # With files (multipart) — same endpoint
@@ -380,9 +380,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -F 'cover_image=@/path/to/photo.jpg'
 ```
 
-Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+파일은 자동으로 저장되고 `FileInput` 객체로 변환됩니다. 에이전트는 프로바이더별 최적화(LLM 프로바이더에 따라 인라인 base64, 파일 업로드 API 또는 URL 참조)와 함께 파일을 수신합니다.
 
-#### Option 2: JSON kickoff (no files)
+#### 옵션 2: JSON kickoff (파일 없음)
 
 ```bash
 # Without files (JSON) — same endpoint
@@ -392,9 +392,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}}'
 ```
 
-#### Option 3: Separate upload + kickoff
+#### 옵션 3: 분리된 업로드 + kickoff
 
-This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+kickoff 요청과 별도로 파일을 업로드해야 할 때 multipart 업로드의 대안입니다. 먼저 파일을 업로드한 다음 URL로 참조합니다:
 
 ```bash
 # Step 1: Upload
@@ -411,11 +411,11 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
 ```
 
-See the Platform API documentation for full `/files` endpoint details.
+`/files` 엔드포인트에 대한 자세한 내용은 플랫폼 API 문서를 참조하세요.
 
-#### On CrewAI Platform
+#### CrewAI 플랫폼에서
 
-When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+플랫폼 UI를 사용할 때 파일 타입 필드는 자동으로 드래그 앤 드롭 업로드 영역으로 렌더링됩니다. API 호출이 필요 없습니다 — 파일을 드롭하고 실행을 클릭하면 됩니다.
 
 ## 플로우 지속성
 

--- a/docs/ko/concepts/flows.mdx
+++ b/docs/ko/concepts/flows.mdx
@@ -334,6 +334,89 @@ flow.kickoff()
 
 CrewAI Flows는 비구조적 및 구조적 상태 관리 옵션을 모두 제공함으로써, 개발자들이 다양한 애플리케이션 요구 사항에 맞춰 유연하면서도 견고한 AI 워크플로를 구축할 수 있도록 지원합니다.
 
+### File Inputs
+
+When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+
+```python
+from crewai.flow.flow import Flow, start
+from crewai_files import ImageFile, PDFFile
+from pydantic import BaseModel
+
+class OnboardingState(BaseModel):
+    document: PDFFile        # File upload
+    cover_image: ImageFile   # Image upload
+    title: str = ""          # Text input
+
+class OnboardingFlow(Flow[OnboardingState]):
+    @start()
+    def process_upload(self):
+        # Access files directly from state
+        print(f"Processing: {self.state.title}")
+        return self.state.document
+```
+
+When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+
+**Kicking off with files via API:**
+
+The `/kickoff` endpoint auto-detects the request format:
+- **JSON body** → normal kickoff
+- **multipart/form-data** → file upload + kickoff
+
+API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+
+### API Usage
+
+#### Option 1: Multipart kickoff (recommended)
+
+Send files directly with the kickoff request:
+
+```bash
+# With files (multipart) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"company_name": "Einstein"}' \
+  -F 'cover_image=@/path/to/photo.jpg'
+```
+
+Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+
+#### Option 2: JSON kickoff (no files)
+
+```bash
+# Without files (JSON) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}}'
+```
+
+#### Option 3: Separate upload + kickoff
+
+This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/photo.jpg' \
+  -F 'field_name=cover_image'
+# Returns: {"url": "https://...", "field_name": "cover_image"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
+```
+
+See the Platform API documentation for full `/files` endpoint details.
+
+#### On CrewAI Platform
+
+When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+
 ## 플로우 지속성
 
 @persist 데코레이터는 CrewAI 플로우에서 자동 상태 지속성을 활성화하여, 플로우 상태를 재시작이나 다른 워크플로우 실행 간에도 유지할 수 있도록 합니다. 이 데코레이터는 클래스 수준이나 메서드 수준 모두에 적용할 수 있어, 상태 지속성을 관리하는 데 유연성을 제공합니다.

--- a/docs/ko/concepts/flows.mdx
+++ b/docs/ko/concepts/flows.mdx
@@ -336,27 +336,28 @@ CrewAI Flows는 비구조적 및 구조적 상태 관리 옵션을 모두 제공
 
 ### 파일 입력
 
-구조화된 상태를 사용할 때, `crewai-files`의 클래스를 사용하여 파일 타입 필드를 포함할 수 있습니다. 이를 통해 flow의 입력으로 파일 업로드가 가능합니다:
+구조화된 상태를 사용할 때, `crewai-files`의 클래스를 사용하여 파일 타입 필드를 포함할 수 있습니다. flow 상태의 파일 타입 필드는 플랫폼에 대한 신호 역할을 합니다 — Run 탭 UI에서 자동으로 파일 업로드 드롭존으로 렌더링되며, 플랫폼을 통해 파일을 업로드하거나 API에서 `input_files`를 통해 전달할 때 자동으로 채워집니다.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile, PDFFile
+from crewai_files import File, ImageFile, PDFFile
 from pydantic import BaseModel
 
-class OnboardingState(BaseModel):
-    document: PDFFile        # File upload
-    cover_image: ImageFile   # Image upload
-    title: str = ""          # Text input
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform
+    title: str = ""
 
-class OnboardingFlow(Flow[OnboardingState]):
+class MyFlow(Flow[MyState]):
     @start()
-    def process_upload(self):
-        # Access files directly from state
-        print(f"Processing: {self.state.title}")
-        return self.state.document
+    def process(self):
+        # File object is automatically populated in state
+        # when uploaded via Platform UI or passed via API
+        content = self.state.document.read()
+        print(f"Processing {self.state.title}: {len(content)} bytes")
+        return content
 ```
 
-**CrewAI 플랫폼**에 배포하면 파일 타입 필드가 UI에서 자동으로 파일 업로드 드롭존으로 렌더링됩니다. 사용자는 파일을 드래그 앤 드롭할 수 있으며, 해당 파일은 flow로 전달됩니다.
+**CrewAI 플랫폼**에 배포하면 파일 타입 필드(`crewai-files`의 `File`, `ImageFile`, `PDFFile`)가 UI에서 자동으로 파일 업로드 드롭존으로 렌더링됩니다. 사용자는 파일을 드래그 앤 드롭할 수 있으며, 해당 파일은 flow의 상태에 자동으로 채워집니다.
 
 **API를 통한 파일 포함 시작:**
 

--- a/docs/ko/enterprise/guides/kickoff-crew.mdx
+++ b/docs/ko/enterprise/guides/kickoff-crew.mdx
@@ -86,6 +86,60 @@ curl -H "Authorization: Bearer YOUR_CREW_TOKEN" https://your-crew-url.crewai.com
 
 베어러 토큰은 crew의 상세 페이지의 Status 탭에서 확인할 수 있습니다.
 
+## 파일 업로드
+
+crew나 flow에 파일 타입 상태 필드(`crewai-files`의 `ImageFile`, `PDFFile`, 또는 `File` 사용)가 포함되어 있으면, 이러한 필드는 Run 탭 UI에서 자동으로 파일 업로드 드롭존으로 렌더링됩니다. 사용자는 파일을 직접 드래그 앤 드롭할 수 있으며, 플랫폼이 저장 및 에이전트 전달을 처리합니다.
+
+### Multipart Kickoff (권장)
+
+`multipart/form-data`를 사용하여 kickoff 요청과 함께 파일을 직접 전송합니다:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"title": "Report"}' \
+  -F 'document=@/path/to/file.pdf'
+```
+
+파일은 자동으로 저장되고 파일 객체로 변환됩니다. 에이전트는 프로바이더별 최적화(LLM 프로바이더에 따라 인라인 base64, 파일 업로드 API 또는 URL 참조)와 함께 파일을 수신합니다.
+
+### 파일 URL을 포함한 JSON Kickoff
+
+이미 URL에 호스팅된 파일이 있다면 `input_files`를 통해 전달합니다:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inputs": {"title": "Report"},
+    "input_files": {"document": "https://example.com/file.pdf"}
+  }'
+```
+
+### 분리된 업로드 + Kickoff
+
+먼저 파일을 업로드한 다음 URL로 참조합니다:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/file.pdf' \
+  -F 'field_name=document'
+# Returns: {"url": "https://...", "field_name": "document"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"title": "Report"}, "input_files": {"document": "https://..."}}'
+```
+
+<Note type="info">
+파일 업로드는 crew와 flow 모두에서 동일하게 작동합니다. 상태 스키마에 파일 타입 필드를 정의하면 플랫폼 UI와 API가 자동으로 업로드를 처리합니다.
+</Note>
+
 ### 크루 상태 확인
 
 작업을 실행하기 전에 크루가 정상적으로 실행되고 있는지 확인할 수 있습니다:

--- a/docs/pt-BR/concepts/files.mdx
+++ b/docs/pt-BR/concepts/files.mdx
@@ -134,8 +134,8 @@ result = flow.kickoff(
 )
 ```
 
-<Note type="info" title="CrewAI Platform Integration">
-When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+<Note type="info" title="Integração com a Plataforma CrewAI">
+Quando implantado na Plataforma CrewAI, campos tipados como arquivo como `ImageFile`, `PDFFile` e outros no estado do seu flow recebem automaticamente uma interface de upload de arquivos. Os usuários podem arrastar e soltar arquivos diretamente na interface da Plataforma. Os arquivos são armazenados de forma segura e passados para os agentes usando otimizações específicas do provedor (base64 inline, APIs de upload de arquivo ou referências por URL dependendo do provedor). Para exemplos de uso da API, consulte [Entradas de Arquivos em Flows](/pt-BR/concepts/flows#entradas-de-arquivos).
 </Note>
 
 ### Com Agentes Standalone

--- a/docs/pt-BR/concepts/files.mdx
+++ b/docs/pt-BR/concepts/files.mdx
@@ -134,6 +134,10 @@ result = flow.kickoff(
 )
 ```
 
+<Note type="info" title="CrewAI Platform Integration">
+When deployed on CrewAI Platform, `ImageFile`, `PDFFile`, and other file-typed fields in your flow state automatically get a file upload UI. Users can drag and drop files directly in the Platform interface. Files are stored securely and passed to agents using provider-specific optimizations (inline base64, file upload APIs, or URL references depending on the provider). For API usage examples, see [File Inputs in Flows](/concepts/flows#file-inputs).
+</Note>
+
 ### Com Agentes Standalone
 
 Passe arquivos diretamente no kickoff do agente:

--- a/docs/pt-BR/concepts/files.mdx
+++ b/docs/pt-BR/concepts/files.mdx
@@ -117,20 +117,28 @@ task = Task(
 
 ### Com Flows
 
-Passe arquivos para flows, que automaticamente herdam para crews:
+Campos tipados como arquivo (`File`, `ImageFile`, `PDFFile`) no esquema de estado do seu flow servem como sinal para a interface da Plataforma. Quando implantado, esses campos são renderizados como zonas de upload de arquivos. Arquivos também podem ser passados via `input_files` na API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile
+from crewai_files import File, ImageFile
+from pydantic import BaseModel
 
-class AnalysisFlow(Flow):
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform UI
+    cover_image: ImageFile   # Image-specific dropzone
+    title: str = ""
+
+class AnalysisFlow(Flow[MyState]):
     @start()
     def analyze(self):
+        # Files are automatically populated in state
+        content = self.state.document.read()
         return self.analysis_crew.kickoff()
 
 flow = AnalysisFlow()
 result = flow.kickoff(
-    input_files={"image": ImageFile(source="data.png")}
+    input_files={"document": File(source="report.pdf")}
 )
 ```
 

--- a/docs/pt-BR/concepts/flows.mdx
+++ b/docs/pt-BR/concepts/flows.mdx
@@ -173,6 +173,89 @@ Cada estado nos flows do CrewAI recebe automaticamente um identificador único (
 
 Ao oferecer as duas opções de gerenciamento de estado, o CrewAI Flows permite que desenvolvedores criem fluxos de IA que sejam ao mesmo tempo flexíveis e robustos, atendendo a uma ampla variedade de requisitos de aplicação.
 
+### File Inputs
+
+When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+
+```python
+from crewai.flow.flow import Flow, start
+from crewai_files import ImageFile, PDFFile
+from pydantic import BaseModel
+
+class OnboardingState(BaseModel):
+    document: PDFFile        # File upload
+    cover_image: ImageFile   # Image upload
+    title: str = ""          # Text input
+
+class OnboardingFlow(Flow[OnboardingState]):
+    @start()
+    def process_upload(self):
+        # Access files directly from state
+        print(f"Processing: {self.state.title}")
+        return self.state.document
+```
+
+When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+
+**Kicking off with files via API:**
+
+The `/kickoff` endpoint auto-detects the request format:
+- **JSON body** → normal kickoff
+- **multipart/form-data** → file upload + kickoff
+
+API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+
+### API Usage
+
+#### Option 1: Multipart kickoff (recommended)
+
+Send files directly with the kickoff request:
+
+```bash
+# With files (multipart) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"company_name": "Einstein"}' \
+  -F 'cover_image=@/path/to/photo.jpg'
+```
+
+Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+
+#### Option 2: JSON kickoff (no files)
+
+```bash
+# Without files (JSON) — same endpoint
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}}'
+```
+
+#### Option 3: Separate upload + kickoff
+
+This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/photo.jpg' \
+  -F 'field_name=cover_image'
+# Returns: {"url": "https://...", "field_name": "cover_image"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
+```
+
+See the Platform API documentation for full `/files` endpoint details.
+
+#### On CrewAI Platform
+
+When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+
 ## Persistência de Flow
 
 O decorador @persist permite a persistência automática do estado nos flows do CrewAI, garantindo que você mantenha o estado do flow entre reinicializações ou execuções diferentes do workflow. Esse decorador pode ser aplicado tanto ao nível de classe, quanto ao nível de método, oferecendo flexibilidade sobre como gerenciar a persistência do estado.

--- a/docs/pt-BR/concepts/flows.mdx
+++ b/docs/pt-BR/concepts/flows.mdx
@@ -173,9 +173,9 @@ Cada estado nos flows do CrewAI recebe automaticamente um identificador único (
 
 Ao oferecer as duas opções de gerenciamento de estado, o CrewAI Flows permite que desenvolvedores criem fluxos de IA que sejam ao mesmo tempo flexíveis e robustos, atendendo a uma ampla variedade de requisitos de aplicação.
 
-### File Inputs
+### Entradas de Arquivos
 
-When using structured state, you can include file-typed fields using classes from `crewai-files`. This enables file uploads as part of your flow's input:
+Ao usar estado estruturado, você pode incluir campos tipados como arquivo usando classes do `crewai-files`. Isso habilita uploads de arquivos como parte da entrada do seu flow:
 
 ```python
 from crewai.flow.flow import Flow, start
@@ -195,21 +195,21 @@ class OnboardingFlow(Flow[OnboardingState]):
         return self.state.document
 ```
 
-When deployed on **CrewAI Platform**, file-typed fields automatically render as file upload dropzones in the UI. Users can drag and drop files, which are then passed to your flow.
+Quando implantado na **Plataforma CrewAI**, campos tipados como arquivo são renderizados automaticamente como zonas de upload de arquivos na interface. Os usuários podem arrastar e soltar arquivos, que são então passados para o seu flow.
 
-**Kicking off with files via API:**
+**Iniciando com arquivos via API:**
 
-The `/kickoff` endpoint auto-detects the request format:
-- **JSON body** → normal kickoff
-- **multipart/form-data** → file upload + kickoff
+O endpoint `/kickoff` detecta automaticamente o formato da requisição:
+- **Corpo JSON** → kickoff normal
+- **multipart/form-data** → upload de arquivo + kickoff
 
-API users can also pass URL strings directly to file-typed fields—Pydantic coerces them automatically.
+Usuários da API também podem passar strings de URL diretamente para campos tipados como arquivo — o Pydantic as converte automaticamente.
 
-### API Usage
+### Uso da API
 
-#### Option 1: Multipart kickoff (recommended)
+#### Opção 1: Kickoff multipart (recomendado)
 
-Send files directly with the kickoff request:
+Envie arquivos diretamente com a requisição de kickoff:
 
 ```bash
 # With files (multipart) — same endpoint
@@ -219,9 +219,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -F 'cover_image=@/path/to/photo.jpg'
 ```
 
-Files are automatically stored and converted to `FileInput` objects. The agent receives the file with provider-specific optimization (inline base64, file upload API, or URL reference depending on the LLM provider).
+Os arquivos são armazenados automaticamente e convertidos em objetos `FileInput`. O agente recebe o arquivo com otimização específica do provedor (base64 inline, API de upload de arquivo ou referência por URL dependendo do provedor LLM).
 
-#### Option 2: JSON kickoff (no files)
+#### Opção 2: Kickoff JSON (sem arquivos)
 
 ```bash
 # Without files (JSON) — same endpoint
@@ -231,9 +231,9 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}}'
 ```
 
-#### Option 3: Separate upload + kickoff
+#### Opção 3: Upload separado + kickoff
 
-This is an alternative to multipart upload when you need to upload files separately from the kickoff request. Upload files first, then reference them by URL:
+Esta é uma alternativa ao upload multipart quando você precisa fazer upload dos arquivos separadamente da requisição de kickoff. Faça o upload dos arquivos primeiro e depois referencie-os por URL:
 
 ```bash
 # Step 1: Upload
@@ -250,11 +250,11 @@ curl -X POST https://your-deployment.crewai.com/kickoff \
   -d '{"inputs": {"company_name": "Einstein"}, "input_files": {"cover_image": "https://..."}}'
 ```
 
-See the Platform API documentation for full `/files` endpoint details.
+Consulte a documentação da API da Plataforma para detalhes completos do endpoint `/files`.
 
-#### On CrewAI Platform
+#### Na Plataforma CrewAI
 
-When using the Platform UI, file-typed fields automatically render as drag-and-drop upload zones. No API calls needed—just drop the file and click Run.
+Ao usar a interface da Plataforma, campos tipados como arquivo são renderizados automaticamente como zonas de arrastar e soltar para upload. Nenhuma chamada de API é necessária — basta soltar o arquivo e clicar em Executar.
 
 ## Persistência de Flow
 

--- a/docs/pt-BR/concepts/flows.mdx
+++ b/docs/pt-BR/concepts/flows.mdx
@@ -175,27 +175,28 @@ Ao oferecer as duas opções de gerenciamento de estado, o CrewAI Flows permite 
 
 ### Entradas de Arquivos
 
-Ao usar estado estruturado, você pode incluir campos tipados como arquivo usando classes do `crewai-files`. Isso habilita uploads de arquivos como parte da entrada do seu flow:
+Ao usar estado estruturado, você pode incluir campos tipados como arquivo usando classes do `crewai-files`. Campos tipados como arquivo no estado do seu flow servem como sinal para a Plataforma — eles são renderizados automaticamente como zonas de upload de arquivos na aba Run da interface e são preenchidos quando arquivos são enviados via Plataforma ou passados via `input_files` na API.
 
 ```python
 from crewai.flow.flow import Flow, start
-from crewai_files import ImageFile, PDFFile
+from crewai_files import File, ImageFile, PDFFile
 from pydantic import BaseModel
 
-class OnboardingState(BaseModel):
-    document: PDFFile        # File upload
-    cover_image: ImageFile   # Image upload
-    title: str = ""          # Text input
+class MyState(BaseModel):
+    document: File           # Renders as file dropzone in Platform
+    title: str = ""
 
-class OnboardingFlow(Flow[OnboardingState]):
+class MyFlow(Flow[MyState]):
     @start()
-    def process_upload(self):
-        # Access files directly from state
-        print(f"Processing: {self.state.title}")
-        return self.state.document
+    def process(self):
+        # File object is automatically populated in state
+        # when uploaded via Platform UI or passed via API
+        content = self.state.document.read()
+        print(f"Processing {self.state.title}: {len(content)} bytes")
+        return content
 ```
 
-Quando implantado na **Plataforma CrewAI**, campos tipados como arquivo são renderizados automaticamente como zonas de upload de arquivos na interface. Os usuários podem arrastar e soltar arquivos, que são então passados para o seu flow.
+Quando implantado na **Plataforma CrewAI**, campos tipados como arquivo (`File`, `ImageFile`, `PDFFile` do `crewai-files`) são renderizados automaticamente como zonas de upload de arquivos na interface. Os usuários podem arrastar e soltar arquivos, que são então preenchidos no estado do seu flow.
 
 **Iniciando com arquivos via API:**
 

--- a/docs/pt-BR/enterprise/guides/kickoff-crew.mdx
+++ b/docs/pt-BR/enterprise/guides/kickoff-crew.mdx
@@ -86,6 +86,60 @@ curl -H "Authorization: Bearer YOUR_CREW_TOKEN" https://your-crew-url.crewai.com
 
 Seu bearer token está disponível na aba Status na página de detalhes do seu crew.
 
+## Upload de Arquivos
+
+Quando seu crew ou flow inclui campos de estado tipados como arquivo (usando `ImageFile`, `PDFFile` ou `File` do `crewai-files`), esses campos são renderizados automaticamente como zonas de upload de arquivos na aba Run da interface. Os usuários podem arrastar e soltar arquivos diretamente, e a Plataforma gerencia o armazenamento e entrega para seus agentes.
+
+### Kickoff Multipart (Recomendado)
+
+Envie arquivos diretamente com a requisição de kickoff usando `multipart/form-data`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'inputs={"title": "Report"}' \
+  -F 'document=@/path/to/file.pdf'
+```
+
+Os arquivos são armazenados automaticamente e convertidos em objetos de arquivo. O agente recebe o arquivo com otimização específica do provedor (base64 inline, API de upload de arquivo ou referência por URL dependendo do provedor LLM).
+
+### Kickoff JSON com URLs de Arquivos
+
+Se você já tem arquivos hospedados em URLs, passe-os via `input_files`:
+
+```bash
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inputs": {"title": "Report"},
+    "input_files": {"document": "https://example.com/file.pdf"}
+  }'
+```
+
+### Upload Separado + Kickoff
+
+Faça upload dos arquivos primeiro e depois referencie-os por URL:
+
+```bash
+# Step 1: Upload
+curl -X POST https://your-deployment.crewai.com/files \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F 'file=@/path/to/file.pdf' \
+  -F 'field_name=document'
+# Returns: {"url": "https://...", "field_name": "document"}
+
+# Step 2: Kickoff with URL
+curl -X POST https://your-deployment.crewai.com/kickoff \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"inputs": {"title": "Report"}, "input_files": {"document": "https://..."}}'
+```
+
+<Note type="info">
+O upload de arquivos funciona da mesma forma tanto para crews quanto para flows. Defina campos tipados como arquivo no seu esquema de estado, e a interface da Plataforma e a API tratarão os uploads automaticamente.
+</Note>
+
 ### Verificando o Status do Crew
 
 Antes de executar operações, você pode verificar se seu crew está funcionando corretamente:


### PR DESCRIPTION
Updated docs for file upload support.

- `flows.mdx`: New 'File Inputs' section — using crewai-files types in state, Platform auto-rendering, multipart kickoff API
- `files.mdx`: Platform integration note in 'With Flows' section

Replaces #5136 (closed) with updated architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime code or behavior changes.
> 
> **Overview**
> Documents **file upload support in CrewAI Platform for flows** across locales (EN/AR/KO/PT-BR), clarifying that file-typed state fields (`File`/`ImageFile`/`PDFFile`) automatically render as upload dropzones and are populated into flow state.
> 
> Adds a new *File Inputs* section to `flows.mdx` with API guidance for `/kickoff` (JSON vs `multipart/form-data`), plus an enterprise guide section describing multipart kickoff, passing file URLs via `input_files`, and the separate `/files` upload + kickoff flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c4b6e99fabce2f4b566be01c4ebc6e93efa855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->