### PR TITLE
fix(llm): use validated messages variable instead of raw params access

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1121,7 +1121,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
                 usage=None,
             )
             return structured_response
@@ -1277,7 +1277,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
                 usage=None,
             )
             return structured_response


### PR DESCRIPTION
Fixes #5164

Both `_handle_non_streaming_response` and `_ahandle_non_streaming_response` extract and validate messages with `params.get("messages", [])`, but then pass `params["messages"]` to `_handle_emit_call_events`. This would raise a confusing `KeyError` instead of the intended `ValueError` if the key is missing.

Changed `params["messages"]` to `messages` on both lines (sync and async).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small bug fix that only changes which `messages` value is passed into LLM call-completed events, avoiding `KeyError` when `params` lacks `messages`.
> 
> **Overview**
> Fixes non-streaming LLM event emission for `response_model` calls (sync and async) by passing the already-extracted/validated `messages` variable into `_handle_emit_call_events` instead of directly indexing `params["messages"]`.
> 
> This prevents a confusing `KeyError` when `messages` are missing and preserves the intended validation error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca46bf569ddaead7ee789fdd3a6be0d5a38a2d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->