### PR TITLE
fix: result_as_answer should not apply to tool errors

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -990,8 +990,10 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
 
         if hook_blocked:
             result = f"Tool execution blocked by hook. Tool: {func_name}"
+            is_error = True
         elif max_usage_reached and original_tool:
             result = f"Tool '{func_name}' has reached its usage limit of {original_tool.max_usage_count} times and cannot be used anymore."
+            is_error = True
         elif not from_cache and func_name in available_functions:
             try:
                 raw_result = available_functions[func_name](**(args_dict or {}))

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -899,6 +899,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_args, func_name, call_id, original_tool
         )
         if parse_error is not None:
+            parse_error["is_error"] = True
             return parse_error
 
         if original_tool is None:
@@ -920,6 +921,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             max_usage_reached = True
 
         from_cache = False
+        is_error = True  # "Tool not found" is the default error state
         result: str = "Tool not found"
         input_str = json.dumps(args_dict) if args_dict else ""
         if self.tools_handler and self.tools_handler.cache:
@@ -933,6 +935,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                     else cached_result
                 )
                 from_cache = True
+                is_error = False
 
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
         started_at = datetime.now()
@@ -1011,6 +1014,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 result = (
                     str(raw_result) if not isinstance(raw_result, str) else raw_result
                 )
+                is_error = False
             except Exception as e:
                 result = f"Error executing tool: {e}"
                 if self.task:
@@ -1072,6 +1076,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             "result": result,
             "from_cache": from_cache,
             "original_tool": original_tool,
+            "is_error": is_error,
         }
 
     def _append_tool_result_and_check_finality(
@@ -1082,6 +1087,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
         result = cast(str, execution_result["result"])
         from_cache = cast(bool, execution_result["from_cache"])
         original_tool = execution_result["original_tool"]
+        is_error = cast(bool, execution_result.get("is_error", False))
 
         tool_message: LLMMessage = {
             "role": "tool",
@@ -1098,8 +1104,11 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 color="green",
             )
 
+        # result_as_answer only applies to successful tool outputs.
+        # If the tool errored, let the agent reflect on the error instead.
         if (
-            original_tool
+            not is_error
+            and original_tool
             and hasattr(original_tool, "result_as_answer")
             and original_tool.result_as_answer
         ):

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1108,8 +1108,12 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
 
         # result_as_answer only applies to successful tool outputs.
         # If the tool errored, let the agent reflect on the error instead.
+        # Two checks: (1) is_error flag from exception/parse failures,
+        # (2) string-based detection for tools that return error strings
+        # without raising exceptions (e.g., "Error performing search: ...").
         if (
             not is_error
+            and not self._looks_like_tool_error(result)
             and original_tool
             and hasattr(original_tool, "result_as_answer")
             and original_tool.result_as_answer
@@ -1120,6 +1124,20 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
                 text=result,
             )
         return None
+
+    @staticmethod
+    def _looks_like_tool_error(result: str) -> bool:
+        """Check if a tool result string looks like an error.
+
+        Many built-in crewAI tools return error strings (e.g., 'Error
+        performing search: ...') instead of raising exceptions. This
+        heuristic catches those cases so result_as_answer doesn't treat
+        them as final agent output.
+        """
+        if not result:
+            return False
+        stripped = result.strip()
+        return stripped.startswith("Error ") or stripped.startswith("I encountered an error")
 
     async def ainvoke(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Execute the agent asynchronously with given inputs.


### PR DESCRIPTION
Closes #5156

## Problem

When a tool with `result_as_answer=True` encounters an error, the error message is unconditionally returned as the agent's final answer. This prevents the agent from reflecting on the error and potentially retrying.

For example, a code execution tool with `result_as_answer=True` that raises `SyntaxError` would produce:
```
Error executing tool: SyntaxError('invalid syntax')
```
as the final agent output — instead of letting the agent see the error and try to fix it.

## Root Cause

`_append_tool_result_and_check_finality()` checks `result_as_answer=True` unconditionally:

```python
if (
    original_tool
    and hasattr(original_tool, "result_as_answer")
    and original_tool.result_as_answer
):
    return AgentFinish(...)  # Always returns, even on error
```

There is no distinction between successful tool outputs and error results.

## Fix

Track an `is_error` flag through `_execute_single_native_tool_call()` and check it before returning `AgentFinish`.

### Error paths (is_error=True):
- JSON parse failure in tool arguments
- Tool not found
- Hook blocked execution
- Max usage limit reached
- Exception during tool execution

### Success paths (is_error=False):
- Cached result available
- Tool executed successfully

### The check becomes:
```python
if (
    not is_error
    and original_tool
    and hasattr(original_tool, "result_as_answer")
    and original_tool.result_as_answer
):
    return AgentFinish(...)
```

When `is_error=True`, the method returns `None`, allowing the agent loop to continue and let the LLM reflect on the error.

**1 file changed, +10/-1**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native tool-calling finalize logic so error outputs no longer short-circuit the agent loop; this can alter when agents stop vs. retry/reflect, impacting behavior for tools relying on `result_as_answer`. Logic is localized but affects core execution flow for tool calls.
> 
> **Overview**
> Prevents tools with `result_as_answer=True` from returning **error outputs** as the agent’s final answer during native tool calling.
> 
> The executor now propagates an `is_error` flag from `_execute_single_native_tool_call()` (covering parse failures, missing tools, hook blocks, usage-limit blocks, and exceptions) and adds a heuristic `_looks_like_tool_error()` check, so `_append_tool_result_and_check_finality()` only returns `AgentFinish` for *successful* tool results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c273dffa4adfb491ee2343f8fc143ee50b3083d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->