### PR TITLE
feat: add command allowlist validation for MCP stdio transport

### DIFF
--- a/lib/crewai/src/crewai/mcp/config.py
+++ b/lib/crewai/src/crewai/mcp/config.py
@@ -7,6 +7,7 @@ various transport types, similar to OpenAI's Agents SDK.
 from pydantic import BaseModel, Field
 
 from crewai.mcp.filters import ToolFilter
+from crewai.mcp.transports.stdio import DEFAULT_ALLOWED_COMMANDS
 
 
 class MCPServerStdio(BaseModel):
@@ -43,6 +44,14 @@ class MCPServerStdio(BaseModel):
     tool_filter: ToolFilter | None = Field(
         default=None,
         description="Optional tool filter for filtering available tools.",
+    )
+    allowed_commands: frozenset[str] | None = Field(
+        default=DEFAULT_ALLOWED_COMMANDS,
+        description=(
+            "Optional frozenset of allowed command basenames for security validation. "
+            "Defaults to common runtimes (python, node, npx, uvx, uv, deno, docker). "
+            "Set to None to disable the allowlist check."
+        ),
     )
     cache_tools_list: bool = Field(
         default=False,

--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -292,6 +292,7 @@ class MCPToolResolver:
                 command=mcp_config.command,
                 args=mcp_config.args,
                 env=mcp_config.env,
+                allowed_commands=mcp_config.allowed_commands,
             )
             server_name = f"{mcp_config.command}_{'_'.join(mcp_config.args)}"
         elif isinstance(mcp_config, MCPServerHTTP):

--- a/lib/crewai/src/crewai/mcp/transports/__init__.py
+++ b/lib/crewai/src/crewai/mcp/transports/__init__.py
@@ -3,11 +3,12 @@
 from crewai.mcp.transports.base import BaseTransport, TransportType
 from crewai.mcp.transports.http import HTTPTransport
 from crewai.mcp.transports.sse import SSETransport
-from crewai.mcp.transports.stdio import StdioTransport
+from crewai.mcp.transports.stdio import DEFAULT_ALLOWED_COMMANDS, StdioTransport
 
 
 __all__ = [
     "BaseTransport",
+    "DEFAULT_ALLOWED_COMMANDS",
     "HTTPTransport",
     "SSETransport",
     "StdioTransport",

--- a/lib/crewai/src/crewai/mcp/transports/stdio.py
+++ b/lib/crewai/src/crewai/mcp/transports/stdio.py
@@ -9,6 +9,22 @@ from typing_extensions import Self
 
 from crewai.mcp.transports.base import BaseTransport, TransportType
 
+# Default allowlist for common MCP server runtimes.
+# Covers the vast majority of MCP server launch commands.
+# Pass ``allowed_commands=None`` to disable validation entirely.
+DEFAULT_ALLOWED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "python",
+        "python3",
+        "node",
+        "npx",
+        "uvx",
+        "uv",
+        "deno",
+        "docker",
+    }
+)
+
 
 class StdioTransport(BaseTransport):
     """Stdio transport for connecting to local MCP servers.
@@ -34,6 +50,7 @@ class StdioTransport(BaseTransport):
         command: str,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        allowed_commands: frozenset[str] | None = DEFAULT_ALLOWED_COMMANDS,
         **kwargs: Any,
     ) -> None:
         """Initialize stdio transport.
@@ -42,9 +59,24 @@ class StdioTransport(BaseTransport):
             command: Command to execute (e.g., "python", "node", "npx").
             args: Command arguments (e.g., ["server.py"] or ["-y", "@mcp/server"]).
             env: Environment variables to pass to the process.
+            allowed_commands: Optional frozenset of allowed command basenames.
+                Defaults to ``DEFAULT_ALLOWED_COMMANDS`` which includes common
+                runtimes (python, node, npx, uvx, uv, deno, docker).  Pass
+                ``None`` to disable the check entirely.
             **kwargs: Additional transport options.
         """
         super().__init__(**kwargs)
+
+        if allowed_commands is not None:
+            base_command = os.path.basename(command)
+            if base_command not in allowed_commands:
+                raise ValueError(
+                    f"Command '{command}' is not in the allowed commands list: "
+                    f"{sorted(allowed_commands)}. "
+                    f"To allow this command, add it to allowed_commands or pass "
+                    f"allowed_commands=None to disable this check."
+                )
+
         self.command = command
         self.args = args or []
         self.env = env or {}

--- a/lib/crewai/src/crewai/mcp/transports/stdio.py
+++ b/lib/crewai/src/crewai/mcp/transports/stdio.py
@@ -69,6 +69,8 @@ class StdioTransport(BaseTransport):
 
         if allowed_commands is not None:
             base_command = os.path.basename(command)
+            # Strip extension for Windows compatibility (e.g., python.exe -> python)
+            base_command = os.path.splitext(base_command)[0]
             if base_command not in allowed_commands:
                 raise ValueError(
                     f"Command '{command}' is not in the allowed commands list: "

--- a/lib/crewai/tests/mcp/test_stdio_config.py
+++ b/lib/crewai/tests/mcp/test_stdio_config.py
@@ -1,7 +1,5 @@
 """Tests for MCPServerStdio allowed_commands config integration."""
 
-import pytest
-
 from crewai.mcp.config import MCPServerStdio
 from crewai.mcp.transports.stdio import DEFAULT_ALLOWED_COMMANDS
 

--- a/lib/crewai/tests/mcp/test_stdio_config.py
+++ b/lib/crewai/tests/mcp/test_stdio_config.py
@@ -1,0 +1,30 @@
+"""Tests for MCPServerStdio allowed_commands config integration."""
+
+import pytest
+
+from crewai.mcp.config import MCPServerStdio
+from crewai.mcp.transports.stdio import DEFAULT_ALLOWED_COMMANDS
+
+
+class TestMCPServerStdioConfig:
+    """Tests for the allowed_commands field on MCPServerStdio."""
+
+    def test_default_allowed_commands(self):
+        """MCPServerStdio should default to DEFAULT_ALLOWED_COMMANDS."""
+        config = MCPServerStdio(command="python", args=["server.py"])
+        assert config.allowed_commands == DEFAULT_ALLOWED_COMMANDS
+
+    def test_custom_allowed_commands(self):
+        """Users can override allowed_commands in config."""
+        custom = frozenset({"my-runtime"})
+        config = MCPServerStdio(
+            command="my-runtime", args=[], allowed_commands=custom
+        )
+        assert config.allowed_commands == custom
+
+    def test_none_allowed_commands(self):
+        """Users can disable the allowlist via config."""
+        config = MCPServerStdio(
+            command="anything", args=[], allowed_commands=None
+        )
+        assert config.allowed_commands is None

--- a/lib/crewai/tests/mcp/test_stdio_transport.py
+++ b/lib/crewai/tests/mcp/test_stdio_transport.py
@@ -1,0 +1,93 @@
+"""Tests for StdioTransport command allowlist validation."""
+
+import pytest
+
+from crewai.mcp.transports.stdio import DEFAULT_ALLOWED_COMMANDS, StdioTransport
+
+
+class TestStdioTransportAllowlist:
+    """Tests for the command allowlist feature."""
+
+    def test_default_allowed_commands_contains_common_runtimes(self):
+        """DEFAULT_ALLOWED_COMMANDS should include all common MCP server runtimes."""
+        expected = {"python", "python3", "node", "npx", "uvx", "uv", "deno", "docker"}
+        assert expected == DEFAULT_ALLOWED_COMMANDS
+
+    def test_allowed_command_passes_validation(self):
+        """Commands in the default allowlist should be accepted."""
+        for cmd in DEFAULT_ALLOWED_COMMANDS:
+            transport = StdioTransport(command=cmd, args=["server.py"])
+            assert transport.command == cmd
+
+    def test_allowed_command_with_full_path(self):
+        """Full paths to allowed commands should pass (basename is checked)."""
+        transport = StdioTransport(command="/usr/bin/python3", args=["server.py"])
+        assert transport.command == "/usr/bin/python3"
+
+    def test_disallowed_command_raises_value_error(self):
+        """Commands not in the allowlist should raise ValueError."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            StdioTransport(command="malicious-binary", args=["--evil"])
+
+    def test_disallowed_command_with_full_path_raises(self):
+        """Full paths to disallowed commands should also be rejected."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            StdioTransport(command="/tmp/evil/script", args=[])
+
+    def test_allowed_commands_none_disables_validation(self):
+        """Setting allowed_commands=None should disable the check entirely."""
+        transport = StdioTransport(
+            command="any-custom-binary",
+            args=["--flag"],
+            allowed_commands=None,
+        )
+        assert transport.command == "any-custom-binary"
+
+    def test_custom_allowlist(self):
+        """Users should be able to pass a custom allowlist."""
+        custom = frozenset({"my-server", "python"})
+
+        # Allowed
+        transport = StdioTransport(
+            command="my-server", args=[], allowed_commands=custom
+        )
+        assert transport.command == "my-server"
+
+        # Not allowed
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            StdioTransport(command="node", args=[], allowed_commands=custom)
+
+    def test_extended_allowlist(self):
+        """Users should be able to extend the default allowlist."""
+        extended = DEFAULT_ALLOWED_COMMANDS | frozenset({"my-custom-runtime"})
+
+        transport = StdioTransport(
+            command="my-custom-runtime", args=[], allowed_commands=extended
+        )
+        assert transport.command == "my-custom-runtime"
+
+        # Original defaults still work
+        transport2 = StdioTransport(
+            command="python", args=["server.py"], allowed_commands=extended
+        )
+        assert transport2.command == "python"
+
+    def test_error_message_includes_sorted_allowed_commands(self):
+        """The error message should list the allowed commands for discoverability."""
+        with pytest.raises(ValueError) as exc_info:
+            StdioTransport(command="bad-cmd", args=[])
+
+        error_msg = str(exc_info.value)
+        assert "bad-cmd" in error_msg
+        assert "allowed_commands=None" in error_msg
+
+    def test_args_and_env_still_work(self):
+        """Existing args and env functionality should be unaffected."""
+        transport = StdioTransport(
+            command="python",
+            args=["server.py", "--port", "8080"],
+            env={"API_KEY": "test123"},
+        )
+        assert transport.command == "python"
+        assert transport.args == ["server.py", "--port", "8080"]
+        assert transport.env == {"API_KEY": "test123"}


### PR DESCRIPTION
## Summary

Adds an optional `allowed_commands` parameter to `StdioTransport` that validates the command basename against an allowlist before spawning a subprocess. This provides a defense-in-depth layer against configuration-driven command injection, especially as MCP server discovery becomes more dynamic (marketplace, shared configs, agent-generated configs).

Closes #5080

## Changes

### `lib/crewai/src/crewai/mcp/transports/stdio.py`
- Added `DEFAULT_ALLOWED_COMMANDS` frozenset containing common MCP server runtimes: `python`, `python3`, `node`, `npx`, `uvx`, `uv`, `deno`, `docker`
- Added `allowed_commands` parameter to `StdioTransport.__init__()`
- Validates `os.path.basename(command)` against the allowlist (cross-platform friendly)
- Raises `ValueError` with a clear message if the command is not allowed

### `lib/crewai/src/crewai/mcp/config.py`
- Added `allowed_commands` field to `MCPServerStdio` config model (defaults to `DEFAULT_ALLOWED_COMMANDS`)

### `lib/crewai/src/crewai/mcp/tool_resolver.py`
- Passes `allowed_commands` from config through to `StdioTransport`

### Tests (13 new tests, all passing)
- `test_stdio_transport.py`: Validates allowlist behavior — default commands, full paths, disallowed commands, custom allowlists, extended allowlists, opt-out via `None`, error messages
- `test_stdio_config.py`: Validates config model integration

## Design Decisions

- **Basename-only validation**: Checks `os.path.basename(command)` rather than full paths for cross-platform compatibility
- **Opt-out available**: Pass `allowed_commands=None` to disable the check entirely
- **Extensible**: Users can extend the default set with `DEFAULT_ALLOWED_COMMANDS | frozenset({"my-runtime"})`
- **No breaking change**: The default allowlist covers all currently documented MCP server examples
- **Zero overhead**: Simple set membership check, no I/O or external calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds runtime validation that can now raise `ValueError` when launching stdio-based MCP servers, which may break existing configs using non-allowlisted binaries unless they opt out or extend the allowlist. The change is security-motivated but touches subprocess launch configuration paths.
> 
> **Overview**
> Adds a **command allowlist** to the MCP stdio execution path to reduce risk of configuration-driven subprocess abuse.
> 
> `StdioTransport` now validates the *basename* of `command` against `DEFAULT_ALLOWED_COMMANDS` (with an opt-out via `allowed_commands=None`), and `MCPServerStdio` exposes/passes through this new `allowed_commands` setting via `MCPToolResolver`. The transports package exports `DEFAULT_ALLOWED_COMMANDS`, and new tests cover default/custom/disabled allowlists and error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7780565f1b68c0e697f7b0bbb74dc9bcfac9a51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->