### PR TITLE
chore: remove unused third_party LLM directory

### DIFF
--- a/lib/crewai/src/crewai/llms/third_party/__init__.py
+++ b/lib/crewai/src/crewai/llms/third_party/__init__.py
@@ -1,1 +1,0 @@
-"""Third-party LLM implementations for crewAI."""


### PR DESCRIPTION
## Summary
- Removes `lib/crewai/src/crewai/llms/third_party/` which contained only an empty `__init__.py`
- No code references or imports this directory

## Test plan
- [x] Verified no imports reference `third_party` in the `llms` package
- [x] Pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes an unused, unreferenced package stub with no functional code changes.
> 
> **Overview**
> Removes the unused `lib/crewai/src/crewai/llms/third_party/` package by deleting its (empty) `__init__.py`, eliminating a dead directory with no references in the `llms` module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 707c97715e6f0cd3a23febcba1365dee9d678e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->