### PR TITLE
fix: use validated messages variable instead of params["messages"] in LLM handlers

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1171,7 +1171,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
             )
             return structured_response
 
@@ -1315,7 +1315,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
             )
             return structured_response
 


### PR DESCRIPTION
## Summary

- Replace `params["messages"]` with the already-validated `messages` local variable in `_handle_non_streaming_response()` and `_ahandle_non_streaming_response()`

## Problem

In both handler methods, messages are safely extracted early via:
```python
messages = params.get("messages", [])
if not messages:
    raise ValueError("Messages are required when using response_model")
```

But the subsequent `_handle_emit_call_events()` call in the InternalInstructor code path uses `params["messages"]` directly (lines 1174 and 1318). If the `messages` key is missing from `params`, this raises a confusing `KeyError` instead of the helpful `ValueError` that was intended.

## Fix

Replace `params["messages"]` with the `messages` local variable (already validated) in the two affected `_handle_emit_call_events()` calls within the `response_model and self.is_litellm` branches.

Fixes #5164

## Test plan

- [ ] Verify calling `_handle_non_streaming_response` with params dict missing `messages` key and `response_model` set raises `ValueError`, not `KeyError`
- [ ] Verify normal operation (params with `messages` key) is unaffected
- [ ] Existing test suite passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that only affects event emission in the LiteLLM `response_model` path and prevents an unintended `KeyError` when `messages` is missing.
> 
> **Overview**
> Fixes the LiteLLM `response_model` path in `_handle_non_streaming_response()` and `_ahandle_non_streaming_response()` to pass the validated local `messages` list into `_handle_emit_call_events()`.
> 
> This avoids raising a `KeyError` from `params["messages"]` and preserves the intended `ValueError` when `messages` is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 007a9f9bc918e5a14454bce06154dbc95ebd789b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->