### PR TITLE
fix(deps): cap lancedb below 0.30.1 for Windows compatibility

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "uv~=0.9.13",
     "aiosqlite~=0.21.0",
     "pyyaml~=6.0",
-    "lancedb>=0.29.2",
+    "lancedb>=0.29.2,<0.30.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ requires-dist = [
     { name = "json-repair", specifier = "~=0.25.2" },
     { name = "json5", specifier = "~=0.10.0" },
     { name = "jsonref", specifier = "~=1.1.0" },
-    { name = "lancedb", specifier = ">=0.29.2" },
+    { name = "lancedb", specifier = ">=0.29.2,<0.30.1" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.74.9,<=1.82.6" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = "~=0.1.94" },


### PR DESCRIPTION
## Summary
- `lancedb` 0.30.1 dropped the `win_amd64` wheel, causing `uv run crewai run` to fail on Windows with: `Distribution lancedb==0.30.1 can't be installed because it doesn't have a source distribution or wheel for the current platform`
- Caps the dependency to `>=0.29.2,<0.30.1` so uv resolves to a version that still ships Windows binaries (0.29.2 and 0.30.0 both have `win_amd64` wheels)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency constraint/lockfile update only, with no runtime code changes. Main risk is that projects needing `lancedb>=0.30.1` features will be unable to upgrade until a compatible wheel is available.
> 
> **Overview**
> Caps the `lancedb` dependency to `>=0.29.2,<0.30.1` in `lib/crewai/pyproject.toml` and mirrors the same constraint in `uv.lock`.
> 
> This prevents `uv` from resolving to `lancedb==0.30.1`, which lacks a Windows wheel and breaks installs/runs on Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb064b1f8cf1c393304a17477ec6a3881f441569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->