### PR TITLE
fix: add warning log and prevent UnboundLocalError in MCPToolResolver._resolve_native

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -353,6 +353,8 @@ class MCPToolResolver:
                     f"Error during setup client and list tools: {e}"
                 ) from e
 
+        tools_list: list[dict[str, Any]] = []
+
         try:
             try:
                 asyncio.get_running_loop()
@@ -380,6 +382,13 @@ class MCPToolResolver:
                         "error or server unavailability."
                     ) from e
 
+            if not tools_list:
+                self._logger.log(
+                    "warning",
+                    f"No tools discovered from native MCP server: {server_name}",
+                )
+                return [], []
+
             if mcp_config.tool_filter:
                 filtered_tools = []
                 for tool in tools_list:
@@ -400,6 +409,13 @@ class MCPToolResolver:
                     else:
                         filtered_tools.append(tool)
                 tools_list = filtered_tools
+
+                if not tools_list:
+                    self._logger.log(
+                        "warning",
+                        f"All tools were filtered out by tool_filter for native MCP server: {server_name}",
+                    )
+                    return [], []
 
             def _client_factory() -> MCPClient:
                 transport, _ = self._create_transport(mcp_config)


### PR DESCRIPTION
Fixes #5116

## Problem

`MCPToolResolver._resolve_native()` has two issues:
1. **UnboundLocalError**: If the connection fails in a way that doesn't raise, `tools_list` is never assigned, causing `UnboundLocalError` at line 412
2. **Silent empty results**: When the MCP server returns no tools or `tool_filter` removes all tools, no warning is logged (unlike `_resolve_external()` which logs clearly)

## Fix

1. Initialize `tools_list: list[dict[str, Any]] = []` before the try block to prevent `UnboundLocalError`
2. Add warning log + early return when `tools_list` is empty after discovery
3. Add warning log + early return when `tools_list` is empty after filtering

This matches the existing behavior in `_resolve_external()` which already logs `"No tools discovered from MCP server: {server_url}"`.

## Changes

- `lib/crewai/src/crewai/mcp/tool_resolver.py`: 16 lines added (initialization + 2 warning checks)