### PR TITLE
docs: update changelog and version for v1.13.0a3

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,38 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="1 أبريل 2026">
+  ## v1.13.0a3
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a3)
+
+  ## ما الذي تغير
+
+  ### الميزات
+  - إصدار بيانات استخدام الرمز في LLMCallCompletedEvent
+  - استخراج ونشر بيانات الأداة إلى AMP
+
+  ### إصلاح الأخطاء
+  - التعامل مع نماذج GPT-5.x التي لا تدعم معلمة API `stop`
+
+  ### الوثائق
+  - إصلاح عدم الدقة في قدرات الوكيل عبر جميع اللغات
+  - إضافة نظرة عامة على قدرات الوكيل وتحسين وثائق المهارات
+  - إضافة دليل شامل لتكوين SSO
+  - تحديث سجل التغييرات والإصدار لـ v1.13.0rc1
+
+  ### إعادة الهيكلة
+  - تحويل Flow إلى Pydantic BaseModel
+  - تحويل فئات LLM إلى Pydantic BaseModel
+  - استبدال InstanceOf[T] بتعليقات نوع عادية
+  - إزالة الطرق غير المستخدمة
+
+  ## المساهمون
+
+  @dependabot[bot], @greysonlalonde, @iris-clawd, @lorenzejay, @lucasgomide, @thiagomoretto
+
+</Update>
+
 <Update label="27 مارس 2026">
   ## v1.13.0rc1
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,38 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Apr 01, 2026">
+  ## v1.13.0a3
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a3)
+
+  ## What's Changed
+
+  ### Features
+  - Emit token usage data in LLMCallCompletedEvent
+  - Extract and publish tool metadata to AMP
+
+  ### Bug Fixes
+  - Handle GPT-5.x models not supporting the `stop` API parameter
+
+  ### Documentation
+  - Fix inaccuracies in agent-capabilities across all languages
+  - Add Agent Capabilities overview and improve Skills documentation
+  - Add comprehensive SSO configuration guide
+  - Update changelog and version for v1.13.0rc1
+
+  ### Refactoring
+  - Convert Flow to Pydantic BaseModel
+  - Convert LLM classes to Pydantic BaseModel
+  - Replace InstanceOf[T] with plain type annotations
+  - Remove unused methods
+
+  ## Contributors
+
+  @dependabot[bot], @greysonlalonde, @iris-clawd, @lorenzejay, @lucasgomide, @thiagomoretto
+
+</Update>
+
 <Update label="Mar 27, 2026">
   ## v1.13.0rc1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,38 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 4월 1일">
+  ## v1.13.0a3
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a3)
+
+  ## 변경 사항
+
+  ### 기능
+  - LLMCallCompletedEvent에서 토큰 사용 데이터 발행
+  - 도구 메타데이터를 AMP로 추출 및 게시
+
+  ### 버그 수정
+  - `stop` API 매개변수를 지원하지 않는 GPT-5.x 모델 처리
+
+  ### 문서
+  - 모든 언어에서 에이전트 기능의 부정확성 수정
+  - 에이전트 기능 개요 추가 및 기술 문서 개선
+  - 포괄적인 SSO 구성 가이드 추가
+  - v1.13.0rc1에 대한 변경 로그 및 버전 업데이트
+
+  ### 리팩토링
+  - Flow를 Pydantic BaseModel로 변환
+  - LLM 클래스를 Pydantic BaseModel로 변환
+  - InstanceOf[T]를 일반 타입 주석으로 교체
+  - 사용되지 않는 메서드 제거
+
+  ## 기여자
+
+  @dependabot[bot], @greysonlalonde, @iris-clawd, @lorenzejay, @lucasgomide, @thiagomoretto
+
+</Update>
+
 <Update label="2026년 3월 27일">
   ## v1.13.0rc1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,38 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="01 abr 2026">
+  ## v1.13.0a3
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.13.0a3)
+
+  ## O que Mudou
+
+  ### Recursos
+  - Emitir dados de uso de token no LLMCallCompletedEvent
+  - Extrair e publicar metadados de ferramentas no AMP
+
+  ### Correções de Bugs
+  - Lidar com modelos GPT-5.x que não suportam o parâmetro de API `stop`
+
+  ### Documentação
+  - Corrigir imprecisões nas capacidades do agente em todas as línguas
+  - Adicionar visão geral das Capacidades do Agente e melhorar a documentação de Habilidades
+  - Adicionar um guia abrangente de configuração de SSO
+  - Atualizar o changelog e a versão para v1.13.0rc1
+
+  ### Refatoração
+  - Converter Flow para Pydantic BaseModel
+  - Converter classes LLM para Pydantic BaseModel
+  - Substituir InstanceOf[T] por anotações de tipo simples
+  - Remover métodos não utilizados
+
+  ## Contribuidores
+
+  @dependabot[bot], @greysonlalonde, @iris-clawd, @lorenzejay, @lucasgomide, @thiagomoretto
+
+</Update>
+
 <Update label="27 mar 2026">
   ## v1.13.0rc1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates release notes across locales without affecting runtime behavior.
> 
> **Overview**
> Adds a new `v1.13.0a3` release section to the localized changelogs (`docs/en`, `docs/ar`, `docs/ko`, `docs/pt-BR`), including the GitHub release link, categorized highlights (features/bug fixes/docs/refactors), and updated contributor lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddfbfb7e8f427c0da799050494f73f51171ed4b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->