### PR TITLE
docs: document /stop/{kickoff_id} endpoint for cancelling executions

### DIFF
--- a/docs/ar/api-reference/stop.mdx
+++ b/docs/ar/api-reference/stop.mdx
@@ -1,0 +1,8 @@
+---
+title: "POST /stop/{kickoff_id}"
+description: "إيقاف تنفيذ الطاقم الجاري"
+openapi: "/enterprise-api.en.yaml POST /stop/{kickoff_id}"
+mode: "wide"
+---
+
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -495,7 +495,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -964,7 +965,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -1433,7 +1435,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -1902,7 +1905,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -2372,7 +2376,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -2840,7 +2845,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -3311,7 +3317,8 @@
                       "en/api-reference/inputs",
                       "en/api-reference/kickoff",
                       "en/api-reference/resume",
-                      "en/api-reference/status"
+                      "en/api-reference/status",
+                      "en/api-reference/stop"
                     ]
                   }
                 ]
@@ -3796,7 +3803,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -4250,7 +4258,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -4704,7 +4713,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -5158,7 +5168,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -5611,7 +5622,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -6064,7 +6076,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -6518,7 +6531,8 @@
                       "pt-BR/api-reference/inputs",
                       "pt-BR/api-reference/kickoff",
                       "pt-BR/api-reference/resume",
-                      "pt-BR/api-reference/status"
+                      "pt-BR/api-reference/status",
+                      "pt-BR/api-reference/stop"
                     ]
                   }
                 ]
@@ -7015,7 +7029,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -7481,7 +7496,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -7947,7 +7963,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -8413,7 +8430,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -8878,7 +8896,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -9343,7 +9362,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -9809,7 +9829,8 @@
                       "ko/api-reference/inputs",
                       "ko/api-reference/kickoff",
                       "ko/api-reference/resume",
-                      "ko/api-reference/status"
+                      "ko/api-reference/status",
+                      "ko/api-reference/stop"
                     ]
                   }
                 ]
@@ -10306,7 +10327,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -10772,7 +10794,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -11238,7 +11261,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -11704,7 +11728,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -12169,7 +12194,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -12634,7 +12660,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]
@@ -13100,7 +13127,8 @@
                       "ar/api-reference/inputs",
                       "ar/api-reference/kickoff",
                       "ar/api-reference/resume",
-                      "ar/api-reference/status"
+                      "ar/api-reference/status",
+                      "ar/api-reference/stop"
                     ]
                   }
                 ]

--- a/docs/en/api-reference/stop.mdx
+++ b/docs/en/api-reference/stop.mdx
@@ -1,0 +1,8 @@
+---
+title: "POST /stop/{kickoff_id}"
+description: "Stop a running crew execution"
+openapi: "/enterprise-api.en.yaml POST /stop/{kickoff_id}"
+mode: "wide"
+---
+
+

--- a/docs/en/enterprise/guides/kickoff-crew.mdx
+++ b/docs/en/enterprise/guides/kickoff-crew.mdx
@@ -146,6 +146,36 @@ curl -X GET \
   https://your-crew-url.crewai.com/status/abcd1234-5678-90ef-ghij-klmnopqrstuv
 ```
 
+## Stopping a Running Execution
+
+You can stop or cancel a running crew or flow execution at any time using the stop endpoint. This is useful when you need to abort a long-running execution or cancel one that is no longer needed.
+
+### Stop an Execution
+
+Send a POST request with the `kickoff_id` of the execution you want to stop:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_CREW_TOKEN" \
+  https://your-crew-url.crewai.com/stop/abcd1234-5678-90ef-ghij-klmnopqrstuv
+```
+
+**Success Response:**
+
+```json
+{"status": "stopped", "kickoffId": "abcd1234-5678-90ef-ghij-klmnopqrstuv"}
+```
+
+**Error Response** (when the execution has already finished):
+
+```json
+{"detail": "Cannot stop execution. Current state: SUCCESS"}
+```
+
+<Note>
+  You cannot stop executions that have already completed (`SUCCESS`), failed (`FAILURE`), or been revoked (`REVOKED`). The API returns a `400` status code in those cases.
+</Note>
+
 ## Handling Executions
 
 ### Long-Running Executions

--- a/docs/enterprise-api.base.yaml
+++ b/docs/enterprise-api.base.yaml
@@ -36,6 +36,7 @@ info:
     1. **Discover inputs** using `GET /inputs`
     2. **Start execution** using `POST /kickoff`
     3. **Monitor progress** using `GET /{kickoff_id}/status`
+    4. **Stop execution** (if needed) using `POST /stop/{kickoff_id}`
   version: 1.0.0
   contact:
     name: CrewAI Support
@@ -284,6 +285,56 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /stop/{kickoff_id}:
+    post:
+      summary: Stop Crew Execution
+      description: |
+        **📋 Reference Example Only** - *This shows the request format. To test with your actual crew, copy the cURL example and replace the URL + token with your real values.*
+
+        Stops or cancels a running crew or flow execution. The execution must be in an active state
+        (not SUCCESS, FAILURE, or REVOKED).
+      operationId: stopCrewExecution
+      parameters:
+        - name: kickoff_id
+          in: path
+          required: true
+          description: The kickoff ID of the execution to stop
+          schema:
+            type: string
+            format: uuid
+            example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+      responses:
+        "200":
+          description: Successfully stopped the execution
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StopExecutionResponse"
+              example:
+                status: "stopped"
+                kickoffId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+        "400":
+          description: Execution is already in a terminal state (SUCCESS, FAILURE, or REVOKED)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                detail: "Cannot stop execution. Current state: SUCCESS"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          description: Kickoff ID not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Execution not found"
+                message: "No execution found with ID: abcd1234-5678-90ef-ghij-klmnopqrstuv"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /resume:
     post:
       summary: Resume Crew Execution with Human Feedback
@@ -507,6 +558,19 @@ components:
           type: number
           description: Time taken to execute this task in seconds
           example: 45.2
+
+    StopExecutionResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["stopped"]
+          description: Indicates the execution was successfully stopped
+          example: "stopped"
+        kickoffId:
+          type: string
+          description: The kickoff ID of the stopped execution
+          example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
 
     Error:
       type: object

--- a/docs/enterprise-api.en.yaml
+++ b/docs/enterprise-api.en.yaml
@@ -36,6 +36,7 @@ info:
     1. **Discover inputs** using `GET /inputs`
     2. **Start execution** using `POST /kickoff`
     3. **Monitor progress** using `GET /{kickoff_id}/status`
+    4. **Stop execution** (if needed) using `POST /stop/{kickoff_id}`
   version: 1.0.0
   contact:
     name: CrewAI Support
@@ -284,6 +285,56 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /stop/{kickoff_id}:
+    post:
+      summary: Stop Crew Execution
+      description: |
+        **📋 Reference Example Only** - *This shows the request format. To test with your actual crew, copy the cURL example and replace the URL + token with your real values.*
+
+        Stops or cancels a running crew or flow execution. The execution must be in an active state
+        (not SUCCESS, FAILURE, or REVOKED).
+      operationId: stopCrewExecution
+      parameters:
+        - name: kickoff_id
+          in: path
+          required: true
+          description: The kickoff ID of the execution to stop
+          schema:
+            type: string
+            format: uuid
+            example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+      responses:
+        "200":
+          description: Successfully stopped the execution
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StopExecutionResponse"
+              example:
+                status: "stopped"
+                kickoffId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+        "400":
+          description: Execution is already in a terminal state (SUCCESS, FAILURE, or REVOKED)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                detail: "Cannot stop execution. Current state: SUCCESS"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          description: Kickoff ID not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Execution not found"
+                message: "No execution found with ID: abcd1234-5678-90ef-ghij-klmnopqrstuv"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /resume:
     post:
       summary: Resume Crew Execution with Human Feedback
@@ -507,6 +558,19 @@ components:
           type: number
           description: Time taken to execute this task in seconds
           example: 45.2
+
+    StopExecutionResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["stopped"]
+          description: Indicates the execution was successfully stopped
+          example: "stopped"
+        kickoffId:
+          type: string
+          description: The kickoff ID of the stopped execution
+          example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
 
     Error:
       type: object

--- a/docs/enterprise-api.ko.yaml
+++ b/docs/enterprise-api.ko.yaml
@@ -120,6 +120,46 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /stop/{kickoff_id}:
+    post:
+      summary: 실행 중지
+      description: |
+        **📋 참조 예제만 제공** - *요청 형식을 보여줍니다. 실제 호출은 cURL 예제를 복사해 URL과 토큰을 교체하세요.*
+
+        실행 중인 crew 또는 flow 실행을 중지하거나 취소합니다. 실행이 활성 상태여야 합니다
+        (SUCCESS, FAILURE, REVOKED 상태가 아닌 경우).
+      operationId: stopCrewExecution
+      parameters:
+        - name: kickoff_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: 실행을 성공적으로 중지
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StopExecutionResponse'
+        '400':
+          description: 실행이 이미 종료 상태 (SUCCESS, FAILURE, REVOKED)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Kickoff ID를 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /resume:
     post:
       summary: Resume Crew Execution with Human Feedback
@@ -313,6 +353,15 @@ components:
           type: string
         execution_time:
           type: number
+
+    StopExecutionResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["stopped"]
+        kickoffId:
+          type: string
 
     Error:
       type: object

--- a/docs/enterprise-api.pt-BR.yaml
+++ b/docs/enterprise-api.pt-BR.yaml
@@ -36,6 +36,7 @@ info:
     1. **Descubra os inputs** usando `GET /inputs`
     2. **Inicie a execução** usando `POST /kickoff`
     3. **Monitore o progresso** usando `GET /{kickoff_id}/status`
+    4. **Pare a execução** (se necessário) usando `POST /stop/{kickoff_id}`
   version: 1.0.0
   contact:
     name: CrewAI Suporte
@@ -145,6 +146,46 @@ paths:
                   - $ref: "#/components/schemas/ExecutionRunning"
                   - $ref: "#/components/schemas/ExecutionCompleted"
                   - $ref: "#/components/schemas/ExecutionError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          description: Kickoff ID não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /stop/{kickoff_id}:
+    post:
+      summary: Parar Execução da Crew
+      description: |
+        **📋 Exemplo de Referência** - *Mostra o formato da requisição. Para testar com sua crew real, copie o cURL e substitua URL + token.*
+
+        Para ou cancela uma execução de crew ou flow em andamento. A execução deve estar em um estado ativo
+        (não SUCCESS, FAILURE ou REVOKED).
+      operationId: stopCrewExecution
+      parameters:
+        - name: kickoff_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Execução parada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StopExecutionResponse"
+        "400":
+          description: Execução já em estado terminal (SUCCESS, FAILURE ou REVOKED)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":
@@ -350,6 +391,15 @@ components:
           type: string
         execution_time:
           type: number
+
+    StopExecutionResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["stopped"]
+        kickoffId:
+          type: string
 
     Error:
       type: object

--- a/docs/ko/api-reference/stop.mdx
+++ b/docs/ko/api-reference/stop.mdx
@@ -1,0 +1,8 @@
+---
+title: "POST /stop/{kickoff_id}"
+description: "실행 중인 크루 실행 중지"
+openapi: "/enterprise-api.ko.yaml POST /stop/{kickoff_id}"
+mode: "wide"
+---
+
+

--- a/docs/pt-BR/api-reference/stop.mdx
+++ b/docs/pt-BR/api-reference/stop.mdx
@@ -1,0 +1,8 @@
+---
+title: "POST /stop/{kickoff_id}"
+description: "Parar uma execução de crew em andamento"
+openapi: "/enterprise-api.pt-BR.yaml POST /stop/{kickoff_id}"
+mode: "wide"
+---
+
+


### PR DESCRIPTION
Document the existing `/stop/{kickoff_id}` API endpoint that allows stopping running crew and flow executions. This endpoint exists in crewAI-enterprise but was not previously documented in the public docs or OpenAPI spec.

## Changes

- **`docs/en/enterprise/guides/kickoff-crew.mdx`**: Added "Stopping a Running Execution" section with API usage examples, success/error responses, and notes about terminal states.
- **`docs/enterprise-api.base.yaml`** and **`docs/enterprise-api.en.yaml`**: Added `/stop/{kickoff_id}` endpoint to OpenAPI spec with full request/response documentation and `StopExecutionResponse` schema.
- **`docs/enterprise-api.ko.yaml`**: Added localized stop endpoint and schema (Korean).
- **`docs/enterprise-api.pt-BR.yaml`**: Added localized stop endpoint and schema (Brazilian Portuguese).
- Updated API workflow descriptions to include the stop step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/OpenAPI-only updates with no runtime code changes. Main risk is mismatched endpoint behavior across locales/specs if the documented responses/status codes diverge from the implementation.
> 
> **Overview**
> Documents the existing `POST /stop/{kickoff_id}` endpoint for cancelling a running crew/flow execution, including request/response examples and terminal-state constraints.
> 
> Adds the `/stop/{kickoff_id}` path and `StopExecutionResponse` schema to the OpenAPI specs (`enterprise-api.base.yaml`/`enterprise-api.en.yaml`) and localizes the endpoint in `enterprise-api.ko.yaml` and `enterprise-api.pt-BR.yaml`, plus new API reference pages (`*/api-reference/stop.mdx`) and navigation entries in `docs.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0650d1947cb438ee7d8d99c6d72400d165bd46de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->