### PR TITLE
docs: remove Arabic locale from navigation to fix auto-redirect (CON-49)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3351,7 +3351,7 @@
               "icon": "globe"
             },
             {
-              "anchor": "F\u00f3rum",
+              "anchor": "Fórum",
               "href": "https://community.crewai.com",
               "icon": "discourse"
             },
@@ -3373,7 +3373,7 @@
             "default": true,
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -3385,11 +3385,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -3400,7 +3400,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -3436,14 +3436,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -3451,7 +3451,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -3485,7 +3485,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -3519,7 +3519,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -3600,7 +3600,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -3675,7 +3675,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -3707,7 +3707,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -3782,11 +3782,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -3811,11 +3811,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -3828,7 +3828,7 @@
             "version": "v1.12.1",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -3840,11 +3840,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -3855,7 +3855,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -3891,14 +3891,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -3906,7 +3906,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -3939,7 +3939,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -3973,7 +3973,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -4054,7 +4054,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -4129,7 +4129,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -4161,7 +4161,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -4236,11 +4236,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -4265,11 +4265,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -4282,7 +4282,7 @@
             "version": "v1.12.0",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -4294,11 +4294,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -4309,7 +4309,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -4345,14 +4345,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -4360,7 +4360,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -4393,7 +4393,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -4427,7 +4427,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -4508,7 +4508,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -4583,7 +4583,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -4615,7 +4615,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -4690,11 +4690,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -4719,11 +4719,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -4736,7 +4736,7 @@
             "version": "v1.11.1",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -4748,11 +4748,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -4763,7 +4763,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -4799,14 +4799,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -4814,7 +4814,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -4847,7 +4847,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -4881,7 +4881,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -4962,7 +4962,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -5037,7 +5037,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -5069,7 +5069,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -5144,11 +5144,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -5173,11 +5173,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -5190,7 +5190,7 @@
             "version": "v1.11.0",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -5202,11 +5202,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -5217,7 +5217,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -5253,14 +5253,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -5268,7 +5268,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -5300,7 +5300,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -5334,7 +5334,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -5415,7 +5415,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -5490,7 +5490,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -5522,7 +5522,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -5597,11 +5597,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -5626,11 +5626,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -5643,7 +5643,7 @@
             "version": "v1.10.1",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -5655,11 +5655,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -5670,7 +5670,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -5706,14 +5706,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -5721,7 +5721,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -5753,7 +5753,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -5787,7 +5787,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -5868,7 +5868,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -5943,7 +5943,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -5975,7 +5975,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -6050,11 +6050,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -6079,11 +6079,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -6096,7 +6096,7 @@
             "version": "v1.10.0",
             "tabs": [
               {
-                "tab": "In\u00edcio",
+                "tab": "Início",
                 "icon": "house",
                 "groups": [
                   {
@@ -6108,11 +6108,11 @@
                 ]
               },
               {
-                "tab": "Documenta\u00e7\u00e3o",
+                "tab": "Documentação",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/introduction",
                       "pt-BR/installation",
@@ -6123,7 +6123,7 @@
                     "group": "Guias",
                     "pages": [
                       {
-                        "group": "Estrat\u00e9gia",
+                        "group": "Estratégia",
                         "icon": "compass",
                         "pages": [
                           "pt-BR/guides/concepts/evaluating-use-cases"
@@ -6159,14 +6159,14 @@
                         ]
                       },
                       {
-                        "group": "Ferramentas de Codifica\u00e7\u00e3o",
+                        "group": "Ferramentas de Codificação",
                         "icon": "terminal",
                         "pages": [
                           "pt-BR/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "Avan\u00e7ado",
+                        "group": "Avançado",
                         "icon": "gear",
                         "pages": [
                           "pt-BR/guides/advanced/customizing-prompts",
@@ -6174,7 +6174,7 @@
                         ]
                       },
                       {
-                        "group": "Migra\u00e7\u00e3o",
+                        "group": "Migração",
                         "icon": "shuffle",
                         "pages": [
                           "pt-BR/guides/migration/migrating-from-langgraph"
@@ -6207,7 +6207,7 @@
                     ]
                   },
                   {
-                    "group": "Integra\u00e7\u00e3o MCP",
+                    "group": "Integração MCP",
                     "pages": [
                       "pt-BR/mcp/overview",
                       "pt-BR/mcp/dsl-integration",
@@ -6241,7 +6241,7 @@
                         ]
                       },
                       {
-                        "group": "Web Scraping & Navega\u00e7\u00e3o",
+                        "group": "Web Scraping & Navegação",
                         "icon": "globe",
                         "pages": [
                           "pt-BR/tools/web-scraping/overview",
@@ -6322,7 +6322,7 @@
                         ]
                       },
                       {
-                        "group": "Automa\u00e7\u00e3o",
+                        "group": "Automação",
                         "icon": "bolt",
                         "pages": [
                           "pt-BR/tools/automation/overview",
@@ -6397,7 +6397,7 @@
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/enterprise/introduction"
                     ]
@@ -6429,7 +6429,7 @@
                     ]
                   },
                   {
-                    "group": "Documenta\u00e7\u00e3o de Integra\u00e7\u00e3o",
+                    "group": "Documentação de Integração",
                     "pages": [
                       "pt-BR/enterprise/integrations/asana",
                       "pt-BR/enterprise/integrations/box",
@@ -6504,11 +6504,11 @@
                 ]
               },
               {
-                "tab": "Refer\u00eancia da API",
+                "tab": "Referência da API",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "Come\u00e7ando",
+                    "group": "Começando",
                     "pages": [
                       "pt-BR/api-reference/introduction",
                       "pt-BR/api-reference/inputs",
@@ -6533,11 +6533,11 @@
                 ]
               },
               {
-                "tab": "Notas de Vers\u00e3o",
+                "tab": "Notas de Versão",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "Notas de Vers\u00e3o",
+                    "group": "Notas de Versão",
                     "pages": [
                       "pt-BR/changelog"
                     ]
@@ -6553,17 +6553,17 @@
         "global": {
           "anchors": [
             {
-              "anchor": "\uc6f9\uc0ac\uc774\ud2b8",
+              "anchor": "웹사이트",
               "href": "https://crewai.com",
               "icon": "globe"
             },
             {
-              "anchor": "\ud3ec\ub7fc",
+              "anchor": "포럼",
               "href": "https://community.crewai.com",
               "icon": "discourse"
             },
             {
-              "anchor": "\ube14\ub85c\uadf8",
+              "anchor": "블로그",
               "href": "https://blog.crewai.com",
               "icon": "newspaper"
             },
@@ -6580,11 +6580,11 @@
             "default": true,
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -6592,11 +6592,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -6604,31 +6604,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -6636,21 +6636,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -6658,7 +6658,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -6667,7 +6667,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -6692,7 +6692,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -6704,11 +6704,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -6728,7 +6728,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -6748,7 +6748,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -6770,7 +6770,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -6785,7 +6785,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -6799,7 +6799,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -6818,7 +6818,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -6853,7 +6853,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -6890,17 +6890,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -6911,7 +6911,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -6920,13 +6920,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -6977,7 +6977,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -6993,7 +6993,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -7001,11 +7001,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -7017,11 +7017,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -7030,11 +7030,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -7047,11 +7047,11 @@
             "version": "v1.12.1",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -7059,11 +7059,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -7071,31 +7071,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -7103,21 +7103,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -7125,7 +7125,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -7134,7 +7134,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -7158,7 +7158,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -7170,11 +7170,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -7194,7 +7194,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -7214,7 +7214,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -7236,7 +7236,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -7251,7 +7251,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -7265,7 +7265,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -7284,7 +7284,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -7319,7 +7319,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -7356,17 +7356,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -7377,7 +7377,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -7386,13 +7386,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -7443,7 +7443,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -7459,7 +7459,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -7467,11 +7467,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -7483,11 +7483,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -7496,11 +7496,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -7513,11 +7513,11 @@
             "version": "v1.12.0",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -7525,11 +7525,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -7537,31 +7537,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -7569,21 +7569,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -7591,7 +7591,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -7600,7 +7600,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -7624,7 +7624,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -7636,11 +7636,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -7660,7 +7660,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -7680,7 +7680,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -7702,7 +7702,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -7717,7 +7717,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -7731,7 +7731,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -7750,7 +7750,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -7785,7 +7785,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -7822,17 +7822,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -7843,7 +7843,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -7852,13 +7852,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -7909,7 +7909,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -7925,7 +7925,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -7933,11 +7933,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -7949,11 +7949,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -7962,11 +7962,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -7979,11 +7979,11 @@
             "version": "v1.11.1",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -7991,11 +7991,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -8003,31 +8003,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -8035,21 +8035,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -8057,7 +8057,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -8066,7 +8066,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -8090,7 +8090,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -8102,11 +8102,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -8126,7 +8126,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -8146,7 +8146,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -8168,7 +8168,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -8183,7 +8183,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -8197,7 +8197,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -8216,7 +8216,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -8251,7 +8251,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -8288,17 +8288,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -8309,7 +8309,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -8318,13 +8318,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -8375,7 +8375,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -8391,7 +8391,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -8399,11 +8399,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -8415,11 +8415,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -8428,11 +8428,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -8445,11 +8445,11 @@
             "version": "v1.11.0",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -8457,11 +8457,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -8469,31 +8469,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -8501,21 +8501,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -8523,7 +8523,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -8532,7 +8532,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -8555,7 +8555,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -8567,11 +8567,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -8591,7 +8591,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -8611,7 +8611,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -8633,7 +8633,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -8648,7 +8648,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -8662,7 +8662,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -8681,7 +8681,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -8716,7 +8716,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -8753,17 +8753,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -8774,7 +8774,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -8783,13 +8783,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -8840,7 +8840,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -8856,7 +8856,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -8864,11 +8864,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -8880,11 +8880,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -8893,11 +8893,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -8910,11 +8910,11 @@
             "version": "v1.10.1",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -8922,11 +8922,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -8934,31 +8934,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -8966,21 +8966,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -8988,7 +8988,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -8997,7 +8997,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -9020,7 +9020,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -9032,11 +9032,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -9056,7 +9056,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -9076,7 +9076,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -9098,7 +9098,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -9113,7 +9113,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -9127,7 +9127,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -9146,7 +9146,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -9181,7 +9181,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -9218,17 +9218,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -9239,7 +9239,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -9248,13 +9248,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -9305,7 +9305,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -9321,7 +9321,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -9329,11 +9329,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -9345,11 +9345,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -9358,11 +9358,11 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
                     ]
@@ -9375,11 +9375,11 @@
             "version": "v1.10.0",
             "tabs": [
               {
-                "tab": "\ud648",
+                "tab": "홈",
                 "icon": "house",
                 "groups": [
                   {
-                    "group": "\ud658\uc601\ud569\ub2c8\ub2e4",
+                    "group": "환영합니다",
                     "pages": [
                       "ko/index"
                     ]
@@ -9387,11 +9387,11 @@
                 ]
               },
               {
-                "tab": "\uae30\uc220 \ubb38\uc11c",
+                "tab": "기술 문서",
                 "icon": "book-open",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/introduction",
                       "ko/installation",
@@ -9399,31 +9399,31 @@
                     ]
                   },
                   {
-                    "group": "\uac00\uc774\ub4dc",
+                    "group": "가이드",
                     "pages": [
                       {
-                        "group": "\uc804\ub7b5",
+                        "group": "전략",
                         "icon": "compass",
                         "pages": [
                           "ko/guides/concepts/evaluating-use-cases"
                         ]
                       },
                       {
-                        "group": "\uc5d0\uc774\uc804\ud2b8 (Agents)",
+                        "group": "에이전트 (Agents)",
                         "icon": "user",
                         "pages": [
                           "ko/guides/agents/crafting-effective-agents"
                         ]
                       },
                       {
-                        "group": "\ud06c\ub8e8 (Crews)",
+                        "group": "크루 (Crews)",
                         "icon": "users",
                         "pages": [
                           "ko/guides/crews/first-crew"
                         ]
                       },
                       {
-                        "group": "\ud50c\ub85c\uc6b0 (Flows)",
+                        "group": "플로우 (Flows)",
                         "icon": "code-branch",
                         "pages": [
                           "ko/guides/flows/first-flow",
@@ -9431,21 +9431,21 @@
                         ]
                       },
                       {
-                        "group": "\ub3c4\uad6c",
+                        "group": "도구",
                         "icon": "wrench",
                         "pages": [
                           "ko/guides/tools/publish-custom-tools"
                         ]
                       },
                       {
-                        "group": "\ucf54\ub529 \ub3c4\uad6c",
+                        "group": "코딩 도구",
                         "icon": "terminal",
                         "pages": [
                           "ko/guides/coding-tools/agents-md"
                         ]
                       },
                       {
-                        "group": "\uace0\uae09",
+                        "group": "고급",
                         "icon": "gear",
                         "pages": [
                           "ko/guides/advanced/customizing-prompts",
@@ -9453,7 +9453,7 @@
                         ]
                       },
                       {
-                        "group": "\ub9c8\uc774\uadf8\ub808\uc774\uc158",
+                        "group": "마이그레이션",
                         "icon": "shuffle",
                         "pages": [
                           "ko/guides/migration/migrating-from-langgraph"
@@ -9462,7 +9462,7 @@
                     ]
                   },
                   {
-                    "group": "\ud575\uc2ec \uac1c\ub150",
+                    "group": "핵심 개념",
                     "pages": [
                       "ko/concepts/agents",
                       "ko/concepts/tasks",
@@ -9486,7 +9486,7 @@
                     ]
                   },
                   {
-                    "group": "MCP \ud1b5\ud569",
+                    "group": "MCP 통합",
                     "pages": [
                       "ko/mcp/overview",
                       "ko/mcp/dsl-integration",
@@ -9498,11 +9498,11 @@
                     ]
                   },
                   {
-                    "group": "\ub3c4\uad6c (Tools)",
+                    "group": "도구 (Tools)",
                     "pages": [
                       "ko/tools/overview",
                       {
-                        "group": "\ud30c\uc77c & \ubb38\uc11c",
+                        "group": "파일 & 문서",
                         "icon": "folder-open",
                         "pages": [
                           "ko/tools/file-document/overview",
@@ -9522,7 +9522,7 @@
                         ]
                       },
                       {
-                        "group": "\uc6f9 \uc2a4\ud06c\ub798\ud551 & \ube0c\ub77c\uc6b0\uc9d5",
+                        "group": "웹 스크래핑 & 브라우징",
                         "icon": "globe",
                         "pages": [
                           "ko/tools/web-scraping/overview",
@@ -9542,7 +9542,7 @@
                         ]
                       },
                       {
-                        "group": "\uac80\uc0c9 \ubc0f \uc5f0\uad6c",
+                        "group": "검색 및 연구",
                         "icon": "magnifying-glass",
                         "pages": [
                           "ko/tools/search-research/overview",
@@ -9564,7 +9564,7 @@
                         ]
                       },
                       {
-                        "group": "\ub370\uc774\ud130\ubca0\uc774\uc2a4 & \ub370\uc774\ud130",
+                        "group": "데이터베이스 & 데이터",
                         "icon": "database",
                         "pages": [
                           "ko/tools/database-data/overview",
@@ -9579,7 +9579,7 @@
                         ]
                       },
                       {
-                        "group": "\uc778\uacf5\uc9c0\ub2a5 & \uba38\uc2e0\ub7ec\ub2dd",
+                        "group": "인공지능 & 머신러닝",
                         "icon": "brain",
                         "pages": [
                           "ko/tools/ai-ml/overview",
@@ -9593,7 +9593,7 @@
                         ]
                       },
                       {
-                        "group": "\ud074\ub77c\uc6b0\ub4dc & \uc2a4\ud1a0\ub9ac\uc9c0",
+                        "group": "클라우드 & 스토리지",
                         "icon": "cloud",
                         "pages": [
                           "ko/tools/cloud-storage/overview",
@@ -9612,7 +9612,7 @@
                         ]
                       },
                       {
-                        "group": "\uc790\ub3d9\ud654",
+                        "group": "자동화",
                         "icon": "bolt",
                         "pages": [
                           "ko/tools/automation/overview",
@@ -9647,7 +9647,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5",
+                    "group": "학습",
                     "pages": [
                       "ko/learn/overview",
                       "ko/learn/llm-selection-guide",
@@ -9684,17 +9684,17 @@
                 ]
               },
               {
-                "tab": "\uc5d4\ud130\ud504\ub77c\uc774\uc988",
+                "tab": "엔터프라이즈",
                 "icon": "briefcase",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/enterprise/introduction"
                     ]
                   },
                   {
-                    "group": "\ube4c\ub4dc",
+                    "group": "빌드",
                     "pages": [
                       "ko/enterprise/features/automations",
                       "ko/enterprise/features/crew-studio",
@@ -9705,7 +9705,7 @@
                     ]
                   },
                   {
-                    "group": "\uc6b4\uc601",
+                    "group": "운영",
                     "pages": [
                       "ko/enterprise/features/traces",
                       "ko/enterprise/features/webhook-streaming",
@@ -9714,13 +9714,13 @@
                     ]
                   },
                   {
-                    "group": "\uad00\ub9ac",
+                    "group": "관리",
                     "pages": [
                       "ko/enterprise/features/rbac"
                     ]
                   },
                   {
-                    "group": "\ud1b5\ud569 \ubb38\uc11c",
+                    "group": "통합 문서",
                     "pages": [
                       "ko/enterprise/integrations/asana",
                       "ko/enterprise/integrations/box",
@@ -9771,7 +9771,7 @@
                     ]
                   },
                   {
-                    "group": "\ud2b8\ub9ac\uac70",
+                    "group": "트리거",
                     "pages": [
                       "ko/enterprise/guides/automation-triggers",
                       "ko/enterprise/guides/gmail-trigger",
@@ -9787,7 +9787,7 @@
                     ]
                   },
                   {
-                    "group": "\ud559\uc2b5 \uc790\uc6d0",
+                    "group": "학습 자원",
                     "pages": [
                       "ko/enterprise/resources/frequently-asked-questions"
                     ]
@@ -9795,11 +9795,11 @@
                 ]
               },
               {
-                "tab": "API \ub808\ud37c\ub7f0\uc2a4",
+                "tab": "API 레퍼런스",
                 "icon": "magnifying-glass",
                 "groups": [
                   {
-                    "group": "\uc2dc\uc791 \uc548\ub0b4",
+                    "group": "시작 안내",
                     "pages": [
                       "ko/api-reference/introduction",
                       "ko/api-reference/inputs",
@@ -9811,11 +9811,11 @@
                 ]
               },
               {
-                "tab": "\uc608\uc2dc",
+                "tab": "예시",
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "\uc608\uc2dc",
+                    "group": "예시",
                     "pages": [
                       "ko/examples/example",
                       "ko/examples/cookbooks"
@@ -9824,3304 +9824,13 @@
                 ]
               },
               {
-                "tab": "\ubcc0\uacbd \ub85c\uadf8",
+                "tab": "변경 로그",
                 "icon": "clock",
                 "groups": [
                   {
-                    "group": "\ub9b4\ub9ac\uc2a4 \ub178\ud2b8",
+                    "group": "릴리스 노트",
                     "pages": [
                       "ko/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "language": "ar",
-        "global": {
-          "anchors": [
-            {
-              "anchor": "\u0627\u0644\u0645\u0648\u0642\u0639",
-              "href": "https://crewai.com",
-              "icon": "globe"
-            },
-            {
-              "anchor": "\u0627\u0644\u0645\u0646\u062a\u062f\u0649",
-              "href": "https://community.crewai.com",
-              "icon": "discourse"
-            },
-            {
-              "anchor": "\u0627\u0644\u0645\u062f\u0648\u0651\u0646\u0629",
-              "href": "https://blog.crewai.com",
-              "icon": "newspaper"
-            },
-            {
-              "anchor": "CrewGPT",
-              "href": "https://chatgpt.com/g/g-qqTuUWsBY-crewai-assistant",
-              "icon": "robot"
-            }
-          ]
-        },
-        "versions": [
-          {
-            "version": "v1.12.2",
-            "default": true,
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/agent-capabilities",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/skills",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.12.1",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/skills",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.12.0",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/skills",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.11.1",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/skills",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.11.0",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.10.1",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.10.0",
-            "tabs": [
-              {
-                "tab": "\u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
-                "icon": "house",
-                "groups": [
-                  {
-                    "group": "\u0645\u0631\u062d\u0628\u0627\u064b",
-                    "pages": [
-                      "ar/index"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u0642\u0646\u064a\u0629 \u0627\u0644\u062a\u0648\u062b\u064a\u0642",
-                "icon": "book-open",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/introduction",
-                      "ar/installation",
-                      "ar/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0644\u0651\u0629",
-                    "pages": [
-                      {
-                        "group": "\u0627\u0644\u0627\u0633\u062a\u0631\u0627\u062a\u064a\u062c\u064a\u0629",
-                        "icon": "compass",
-                        "pages": [
-                          "ar/guides/concepts/evaluating-use-cases"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0648\u0643\u0644\u0627\u0621",
-                        "icon": "user",
-                        "pages": [
-                          "ar/guides/agents/crafting-effective-agents"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0637\u0648\u0627\u0642\u0645",
-                        "icon": "users",
-                        "pages": [
-                          "ar/guides/crews/first-crew"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062f\u0641\u0642\u0627\u062a",
-                        "icon": "code-branch",
-                        "pages": [
-                          "ar/guides/flows/first-flow",
-                          "ar/guides/flows/mastering-flow-state"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                        "icon": "wrench",
-                        "pages": [
-                          "ar/guides/tools/publish-custom-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0623\u062f\u0648\u0627\u062a \u0627\u0644\u0628\u0631\u0645\u062c\u0629",
-                        "icon": "terminal",
-                        "pages": [
-                          "ar/guides/coding-tools/agents-md"
-                        ]
-                      },
-                      {
-                        "group": "\u0645\u062a\u0642\u062f\u0651\u0645",
-                        "icon": "gear",
-                        "pages": [
-                          "ar/guides/advanced/customizing-prompts",
-                          "ar/guides/advanced/fingerprinting"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u0631\u062d\u064a\u0644",
-                        "icon": "shuffle",
-                        "pages": [
-                          "ar/guides/migration/migrating-from-langgraph"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0641\u0627\u0647\u064a\u0645 \u0627\u0644\u0623\u0633\u0627\u0633\u064a\u0629",
-                    "pages": [
-                      "ar/concepts/agents",
-                      "ar/concepts/tasks",
-                      "ar/concepts/crews",
-                      "ar/concepts/flows",
-                      "ar/concepts/production-architecture",
-                      "ar/concepts/knowledge",
-                      "ar/concepts/skills",
-                      "ar/concepts/llms",
-                      "ar/concepts/files",
-                      "ar/concepts/processes",
-                      "ar/concepts/collaboration",
-                      "ar/concepts/training",
-                      "ar/concepts/memory",
-                      "ar/concepts/reasoning",
-                      "ar/concepts/planning",
-                      "ar/concepts/testing",
-                      "ar/concepts/cli",
-                      "ar/concepts/tools",
-                      "ar/concepts/event-listener"
-                    ]
-                  },
-                  {
-                    "group": "\u062a\u0643\u0627\u0645\u0644 MCP",
-                    "pages": [
-                      "ar/mcp/overview",
-                      "ar/mcp/dsl-integration",
-                      "ar/mcp/stdio",
-                      "ar/mcp/sse",
-                      "ar/mcp/streamable-http",
-                      "ar/mcp/multiple-servers",
-                      "ar/mcp/security"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0623\u062f\u0648\u0627\u062a",
-                    "pages": [
-                      "ar/tools/overview",
-                      {
-                        "group": "\u0627\u0644\u0645\u0644\u0641\u0627\u062a \u0648\u0627\u0644\u0645\u0633\u062a\u0646\u062f\u0627\u062a",
-                        "icon": "folder-open",
-                        "pages": [
-                          "ar/tools/file-document/overview",
-                          "ar/tools/file-document/filereadtool",
-                          "ar/tools/file-document/filewritetool",
-                          "ar/tools/file-document/pdfsearchtool",
-                          "ar/tools/file-document/docxsearchtool",
-                          "ar/tools/file-document/mdxsearchtool",
-                          "ar/tools/file-document/xmlsearchtool",
-                          "ar/tools/file-document/txtsearchtool",
-                          "ar/tools/file-document/jsonsearchtool",
-                          "ar/tools/file-document/csvsearchtool",
-                          "ar/tools/file-document/directorysearchtool",
-                          "ar/tools/file-document/directoryreadtool",
-                          "ar/tools/file-document/ocrtool",
-                          "ar/tools/file-document/pdf-text-writing-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0633\u062a\u062e\u0631\u0627\u062c \u0628\u064a\u0627\u0646\u0627\u062a \u0627\u0644\u0648\u064a\u0628",
-                        "icon": "globe",
-                        "pages": [
-                          "ar/tools/web-scraping/overview",
-                          "ar/tools/web-scraping/scrapewebsitetool",
-                          "ar/tools/web-scraping/scrapeelementfromwebsitetool",
-                          "ar/tools/web-scraping/scrapflyscrapetool",
-                          "ar/tools/web-scraping/seleniumscrapingtool",
-                          "ar/tools/web-scraping/scrapegraphscrapetool",
-                          "ar/tools/web-scraping/spidertool",
-                          "ar/tools/web-scraping/browserbaseloadtool",
-                          "ar/tools/web-scraping/hyperbrowserloadtool",
-                          "ar/tools/web-scraping/stagehandtool",
-                          "ar/tools/web-scraping/firecrawlcrawlwebsitetool",
-                          "ar/tools/web-scraping/firecrawlscrapewebsitetool",
-                          "ar/tools/web-scraping/oxylabsscraperstool",
-                          "ar/tools/web-scraping/brightdata-tools"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0628\u062d\u062b \u0648\u0627\u0644\u0627\u0633\u062a\u0643\u0634\u0627\u0641",
-                        "icon": "magnifying-glass",
-                        "pages": [
-                          "ar/tools/search-research/overview",
-                          "ar/tools/search-research/serperdevtool",
-                          "ar/tools/search-research/bravesearchtool",
-                          "ar/tools/search-research/exasearchtool",
-                          "ar/tools/search-research/linkupsearchtool",
-                          "ar/tools/search-research/githubsearchtool",
-                          "ar/tools/search-research/websitesearchtool",
-                          "ar/tools/search-research/codedocssearchtool",
-                          "ar/tools/search-research/youtubechannelsearchtool",
-                          "ar/tools/search-research/youtubevideosearchtool",
-                          "ar/tools/search-research/tavilysearchtool",
-                          "ar/tools/search-research/tavilyextractortool",
-                          "ar/tools/search-research/arxivpapertool",
-                          "ar/tools/search-research/serpapi-googlesearchtool",
-                          "ar/tools/search-research/serpapi-googleshoppingtool",
-                          "ar/tools/search-research/databricks-query-tool"
-                        ]
-                      },
-                      {
-                        "group": "\u0642\u0648\u0627\u0639\u062f \u0627\u0644\u0628\u064a\u0627\u0646\u0627\u062a",
-                        "icon": "database",
-                        "pages": [
-                          "ar/tools/database-data/overview",
-                          "ar/tools/database-data/mysqltool",
-                          "ar/tools/database-data/pgsearchtool",
-                          "ar/tools/database-data/snowflakesearchtool",
-                          "ar/tools/database-data/nl2sqltool",
-                          "ar/tools/database-data/qdrantvectorsearchtool",
-                          "ar/tools/database-data/weaviatevectorsearchtool",
-                          "ar/tools/database-data/mongodbvectorsearchtool",
-                          "ar/tools/database-data/singlestoresearchtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0648\u0627\u0644\u062a\u0639\u0644\u0651\u0645 \u0627\u0644\u0622\u0644\u064a",
-                        "icon": "brain",
-                        "pages": [
-                          "ar/tools/ai-ml/overview",
-                          "ar/tools/ai-ml/dalletool",
-                          "ar/tools/ai-ml/visiontool",
-                          "ar/tools/ai-ml/aimindtool",
-                          "ar/tools/ai-ml/llamaindextool",
-                          "ar/tools/ai-ml/langchaintool",
-                          "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u062a\u062e\u0632\u064a\u0646 \u0627\u0644\u0633\u062d\u0627\u0628\u064a",
-                        "icon": "cloud",
-                        "pages": [
-                          "ar/tools/cloud-storage/overview",
-                          "ar/tools/cloud-storage/s3readertool",
-                          "ar/tools/cloud-storage/s3writertool",
-                          "ar/tools/cloud-storage/bedrockkbretriever"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "ar/tools/integration/overview",
-                          "ar/tools/integration/bedrockinvokeagenttool",
-                          "ar/tools/integration/crewaiautomationtool"
-                        ]
-                      },
-                      {
-                        "group": "\u0627\u0644\u0623\u062a\u0645\u062a\u0629",
-                        "icon": "bolt",
-                        "pages": [
-                          "ar/tools/automation/overview",
-                          "ar/tools/automation/apifyactorstool",
-                          "ar/tools/automation/composiotool",
-                          "ar/tools/automation/multiontool",
-                          "ar/tools/automation/zapieractionstool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Observability",
-                    "pages": [
-                      "ar/observability/tracing",
-                      "ar/observability/overview",
-                      "ar/observability/arize-phoenix",
-                      "ar/observability/braintrust",
-                      "ar/observability/datadog",
-                      "ar/observability/galileo",
-                      "ar/observability/langdb",
-                      "ar/observability/langfuse",
-                      "ar/observability/langtrace",
-                      "ar/observability/maxim",
-                      "ar/observability/mlflow",
-                      "ar/observability/neatlogs",
-                      "ar/observability/openlit",
-                      "ar/observability/opik",
-                      "ar/observability/patronus-evaluation",
-                      "ar/observability/portkey",
-                      "ar/observability/weave"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/learn/overview",
-                      "ar/learn/llm-selection-guide",
-                      "ar/learn/conditional-tasks",
-                      "ar/learn/coding-agents",
-                      "ar/learn/create-custom-tools",
-                      "ar/learn/custom-llm",
-                      "ar/learn/custom-manager-agent",
-                      "ar/learn/customizing-agents",
-                      "ar/learn/dalle-image-generation",
-                      "ar/learn/force-tool-output-as-result",
-                      "ar/learn/hierarchical-process",
-                      "ar/learn/human-input-on-execution",
-                      "ar/learn/human-in-the-loop",
-                      "ar/learn/human-feedback-in-flows",
-                      "ar/learn/kickoff-async",
-                      "ar/learn/kickoff-for-each",
-                      "ar/learn/llm-connections",
-                      "ar/learn/multimodal-agents",
-                      "ar/learn/replay-tasks-from-latest-crew-kickoff",
-                      "ar/learn/sequential-process",
-                      "ar/learn/using-annotations",
-                      "ar/learn/execution-hooks",
-                      "ar/learn/llm-hooks",
-                      "ar/learn/tool-hooks"
-                    ]
-                  },
-                  {
-                    "group": "Telemetry",
-                    "pages": [
-                      "ar/telemetry"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u0645\u0624\u0633\u0633\u0627\u062a",
-                "icon": "briefcase",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/enterprise/introduction"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0628\u0646\u0627\u0621",
-                    "pages": [
-                      "ar/enterprise/features/automations",
-                      "ar/enterprise/features/crew-studio",
-                      "ar/enterprise/features/marketplace",
-                      "ar/enterprise/features/agent-repositories",
-                      "ar/enterprise/features/tools-and-integrations",
-                      "ar/enterprise/features/pii-trace-redactions"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0639\u0645\u0644\u064a\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/features/traces",
-                      "ar/enterprise/features/webhook-streaming",
-                      "ar/enterprise/features/hallucination-guardrail",
-                      "ar/enterprise/features/flow-hitl-management"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0625\u062f\u0627\u0631\u0629",
-                    "pages": [
-                      "ar/enterprise/features/rbac"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u062a\u0643\u0627\u0645\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/integrations/asana",
-                      "ar/enterprise/integrations/box",
-                      "ar/enterprise/integrations/clickup",
-                      "ar/enterprise/integrations/github",
-                      "ar/enterprise/integrations/gmail",
-                      "ar/enterprise/integrations/google_calendar",
-                      "ar/enterprise/integrations/google_contacts",
-                      "ar/enterprise/integrations/google_docs",
-                      "ar/enterprise/integrations/google_drive",
-                      "ar/enterprise/integrations/google_sheets",
-                      "ar/enterprise/integrations/google_slides",
-                      "ar/enterprise/integrations/hubspot",
-                      "ar/enterprise/integrations/jira",
-                      "ar/enterprise/integrations/linear",
-                      "ar/enterprise/integrations/microsoft_excel",
-                      "ar/enterprise/integrations/microsoft_onedrive",
-                      "ar/enterprise/integrations/microsoft_outlook",
-                      "ar/enterprise/integrations/microsoft_sharepoint",
-                      "ar/enterprise/integrations/microsoft_teams",
-                      "ar/enterprise/integrations/microsoft_word",
-                      "ar/enterprise/integrations/notion",
-                      "ar/enterprise/integrations/salesforce",
-                      "ar/enterprise/integrations/shopify",
-                      "ar/enterprise/integrations/slack",
-                      "ar/enterprise/integrations/stripe",
-                      "ar/enterprise/integrations/zendesk"
-                    ]
-                  },
-                  {
-                    "group": "How-To Guides",
-                    "pages": [
-                      "ar/enterprise/guides/build-crew",
-                      "ar/enterprise/guides/prepare-for-deployment",
-                      "ar/enterprise/guides/deploy-to-amp",
-                      "ar/enterprise/guides/private-package-registry",
-                      "ar/enterprise/guides/kickoff-crew",
-                      "ar/enterprise/guides/update-crew",
-                      "ar/enterprise/guides/enable-crew-studio",
-                      "ar/enterprise/guides/capture_telemetry_logs",
-                      "ar/enterprise/guides/azure-openai-setup",
-                      "ar/enterprise/guides/tool-repository",
-                      "ar/enterprise/guides/custom-mcp-server",
-                      "ar/enterprise/guides/react-component-export",
-                      "ar/enterprise/guides/team-management",
-                      "ar/enterprise/guides/human-in-the-loop",
-                      "ar/enterprise/guides/webhook-automation"
-                    ]
-                  },
-                  {
-                    "group": "\u0627\u0644\u0645\u0634\u063a\u0651\u0644\u0627\u062a",
-                    "pages": [
-                      "ar/enterprise/guides/automation-triggers",
-                      "ar/enterprise/guides/gmail-trigger",
-                      "ar/enterprise/guides/google-calendar-trigger",
-                      "ar/enterprise/guides/google-drive-trigger",
-                      "ar/enterprise/guides/outlook-trigger",
-                      "ar/enterprise/guides/onedrive-trigger",
-                      "ar/enterprise/guides/microsoft-teams-trigger",
-                      "ar/enterprise/guides/slack-trigger",
-                      "ar/enterprise/guides/hubspot-trigger",
-                      "ar/enterprise/guides/salesforce-trigger",
-                      "ar/enterprise/guides/zapier-trigger"
-                    ]
-                  },
-                  {
-                    "group": "\u0645\u0648\u0627\u0631\u062f \u0627\u0644\u062a\u0639\u0644\u0651\u0645",
-                    "pages": [
-                      "ar/enterprise/resources/frequently-asked-questions"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "API \u0627\u0644\u0645\u0631\u062c\u0639",
-                "icon": "magnifying-glass",
-                "groups": [
-                  {
-                    "group": "\u0627\u0644\u0628\u062f\u0621",
-                    "pages": [
-                      "ar/api-reference/introduction",
-                      "ar/api-reference/inputs",
-                      "ar/api-reference/kickoff",
-                      "ar/api-reference/resume",
-                      "ar/api-reference/status"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0623\u0645\u062b\u0644\u0629",
-                "icon": "code",
-                "groups": [
-                  {
-                    "group": "\u0623\u0645\u062b\u0644\u0629",
-                    "pages": [
-                      "ar/examples/example",
-                      "ar/examples/cookbooks"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "\u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a \u0627\u0644\u0633\u062c\u0644\u0627\u062a",
-                "icon": "clock",
-                "groups": [
-                  {
-                    "group": "\u0633\u062c\u0644 \u0627\u0644\u062a\u063a\u064a\u064a\u0631\u0627\u062a",
-                    "pages": [
-                      "ar/changelog"
                     ]
                   }
                 ]


### PR DESCRIPTION
## What

Removes the Arabic (`ar`) language entry from the `navigation.languages` array in `docs/docs.json`.

## Why

Mintlify auto-detects browser locale via `Accept-Language` headers and routes users to the corresponding localized pages. After Arabic translations were added to the docs navigation config, users whose browsers include Arabic in their language preferences are being automatically redirected to `/ar/` pages — even when they don't want Arabic content. This causes confusion for users who expect English documentation (CON-49).

## Impact

- **Arabic translation files** in `docs/ar/` are **preserved** and can be re-enabled later if needed
- Only the Mintlify language switcher and auto-locale routing are affected
- No content is deleted — this simply removes Arabic from the active navigation config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects docs locale selection/auto-routing but does not modify or delete documentation content.
> 
> **Overview**
> **Removes Arabic (`ar`) from `docs/docs.json` `navigation.languages`**, effectively disabling Arabic in the Mintlify language switcher and preventing automatic locale redirects to `/ar/` pages.
> 
> Arabic content under `docs/ar/` is left intact for potential re-enablement later.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff04e37c9e82cc63487851cb056b12a1e259f62e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->