### PR TITLE
fix: forward base_url to instructor client for custom OpenAI-compatible endpoints

### DIFF
--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -104,19 +104,21 @@ class InternalInstructor(Generic[T]):
         else:
             provider = "openai"  # Default fallback
 
-        # Forward base_url and api_key when the LLM targets a custom endpoint
-        # (e.g. vLLM, Ollama, Azure OpenAI, or any OpenAI-compatible server).
-        # instructor.from_provider() creates a fresh OpenAI client that
-        # ignores these settings, so we must build the client explicitly.
-        base_url: str | None = getattr(self.llm, "base_url", None) or getattr(
-            self.llm, "api_base", None
-        )
-        if base_url:
-            from openai import OpenAI
+        # Forward base_url and api_key when the LLM targets a custom OpenAI-compatible
+        # endpoint (e.g. vLLM, Ollama, Azure OpenAI).  For non-OpenAI providers
+        # (anthropic, google, etc.) we still use from_provider() which handles
+        # provider-specific client construction.
+        _openai_compatible = {"openai", "azure", "deepseek", "groq", "together", "ollama"}
+        if provider.lower() in _openai_compatible:
+            base_url: str | None = getattr(self.llm, "base_url", None) or getattr(
+                self.llm, "api_base", None
+            )
+            if base_url:
+                from openai import OpenAI
 
-            api_key: str = getattr(self.llm, "api_key", None) or "not-needed"
-            openai_client = OpenAI(base_url=base_url, api_key=api_key)
-            return instructor.from_openai(openai_client)
+                api_key: str = getattr(self.llm, "api_key", None) or "not-needed"
+                openai_client = OpenAI(base_url=base_url, api_key=api_key)
+                return instructor.from_openai(openai_client)
 
         return instructor.from_provider(f"{provider}/{model_string}")
 

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -76,6 +76,12 @@ class InternalInstructor(Generic[T]):
     def _create_instructor_client(self) -> Any:
         """Create instructor client using the modern from_provider pattern.
 
+        When the LLM is configured with a custom ``base_url`` (e.g. a
+        self-hosted vLLM, Ollama, or Azure OpenAI endpoint), this method
+        constructs an explicit ``openai.OpenAI`` client with the correct
+        endpoint and wraps it with ``instructor.from_openai()``.  Otherwise
+        it falls back to ``instructor.from_provider()``.
+
         Returns:
             Instructor client configured for the LLM provider
 
@@ -97,6 +103,20 @@ class InternalInstructor(Generic[T]):
             provider = self.llm.provider
         else:
             provider = "openai"  # Default fallback
+
+        # Forward base_url and api_key when the LLM targets a custom endpoint
+        # (e.g. vLLM, Ollama, Azure OpenAI, or any OpenAI-compatible server).
+        # instructor.from_provider() creates a fresh OpenAI client that
+        # ignores these settings, so we must build the client explicitly.
+        base_url: str | None = getattr(self.llm, "base_url", None) or getattr(
+            self.llm, "api_base", None
+        )
+        if base_url:
+            from openai import OpenAI
+
+            api_key: str = getattr(self.llm, "api_key", None) or "not-needed"
+            openai_client = OpenAI(base_url=base_url, api_key=api_key)
+            return instructor.from_openai(openai_client)
 
         return instructor.from_provider(f"{provider}/{model_string}")
 


### PR DESCRIPTION
Closes #5204

## Problem

When a task uses `output_pydantic` or `output_json` and the LLM has a custom `base_url` (vLLM, Ollama, Azure OpenAI, any self-hosted OpenAI-compatible endpoint), the structured output request hits `api.openai.com` instead of the configured endpoint — resulting in `ConnectTimeout` / `ConverterError`.

**Root cause**: `_create_instructor_client()` calls `instructor.from_provider(f"{provider}/{model_string}")`, which creates a fresh `openai.OpenAI` client defaulting to `api.openai.com`. The `base_url` and `api_key` from the LLM object are never forwarded.

## Fix

When `base_url` (or `api_base`) is set on the LLM, build an explicit `openai.OpenAI(base_url=..., api_key=...)` client and wrap it with `instructor.from_openai()`:

```python
base_url: str | None = getattr(self.llm, "base_url", None) or getattr(
    self.llm, "api_base", None
)
if base_url:
    from openai import OpenAI
    api_key: str = getattr(self.llm, "api_key", None) or "not-needed"
    openai_client = OpenAI(base_url=base_url, api_key=api_key)
    return instructor.from_openai(openai_client)

return instructor.from_provider(f"{provider}/{model_string}")
```

- When `base_url` is set → explicit client with correct endpoint ✅
- When `base_url` is not set → existing `from_provider()` path unchanged ✅

## Scope

**1 file changed, +20 lines** in `lib/crewai/src/crewai/utilities/internal_instructor.py`.

Affects anyone using `output_pydantic` / `output_json` with custom OpenAI-compatible endpoints. The agent's main LLM calls are unaffected (they go through the `LLM` class directly).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `InternalInstructor` builds the underlying OpenAI client for structured outputs, which can affect request routing/auth and may break if provider detection or `base_url` handling is wrong. Scope is small and largely preserves existing `from_provider()` behavior when no custom endpoint is configured.
> 
> **Overview**
> Fixes structured-output calls (`output_pydantic`/`output_json`) to respect custom OpenAI-compatible endpoints by detecting `base_url`/`api_base` on the LLM and constructing an explicit `openai.OpenAI(base_url=..., api_key=...)` wrapped via `instructor.from_openai()`.
> 
> Keeps the existing `instructor.from_provider("{provider}/{model}")` path for non-OpenAI providers and for cases where no custom endpoint is set, limiting behavioral changes to the custom-endpoint scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c38b16cbaba043bb7fb550e3fadc5050a85bb64b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->