### PR TITLE
debug: add delegation scope verification for hierarchical trace nesting

### DIFF
--- a/lib/crewai/src/crewai/tools/agent_tools/base_agent_tools.py
+++ b/lib/crewai/src/crewai/tools/agent_tools/base_agent_tools.py
@@ -127,18 +127,16 @@ class BaseAgentTool(BaseTool):
             logger.debug(
                 f"Created task for agent '{self.sanitize_agent_name(selected_agent.role)}': {task}"
             )
-            # DEBUG: Verify parent event ID propagation during delegation
             parent_id_before = get_current_parent_id()
             logger.debug(
-                f"[DELEGATION SCOPE] Before execute_task - parent_event_id: {parent_id_before}, "
-                f"delegating to agent: {self.sanitize_agent_name(selected_agent.role)}"
+                f"Delegation starting: parent_event_id={parent_id_before}, "
+                f"target_agent={self.sanitize_agent_name(selected_agent.role)}"
             )
             result = selected_agent.execute_task(task_with_assigned_agent, context)
-            # DEBUG: Verify scope chain after delegation completes
             parent_id_after = get_current_parent_id()
             logger.debug(
-                f"[DELEGATION SCOPE] After execute_task - parent_event_id: {parent_id_after}, "
-                f"delegation complete for agent: {self.sanitize_agent_name(selected_agent.role)}"
+                f"Delegation complete: parent_event_id={parent_id_after}, "
+                f"target_agent={self.sanitize_agent_name(selected_agent.role)}"
             )
             return result
         except Exception as e:


### PR DESCRIPTION
Adds logging to verify parent_event_id propagation during hierarchical crew delegation.

**Context:** In hierarchical crews, delegated agent spans appear flat in the trace tree instead of nested under the tool_usage span. This PR adds debug logging to verify the OSS scope chain is correct.

Log format: `[DELEGATION SCOPE] current_parent=<event_id> delegating_to=<agent_role>`

**Next steps:** Once we confirm the parent_event_id is correct in OSS, the fix moves to the enterprise OTel handler timing (separate PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds debug-only logging around delegated `execute_task` calls and does not change task selection or execution behavior.
> 
> **Overview**
> Adds delegation-scope verification logs in `BaseAgentTool._execute` by capturing `get_current_parent_id()` immediately before and after `selected_agent.execute_task`.
> 
> This helps confirm whether hierarchical delegation preserves the expected parent event ID for trace nesting, without altering the delegation logic or returned results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3edebea20671681a2ee8e25a00ba0387207f8c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->