### PR TITLE
fix: return all MCP tool content items instead of only the first one

### DIFF
--- a/lib/crewai/src/crewai/mcp/client.py
+++ b/lib/crewai/src/crewai/mcp/client.py
@@ -600,10 +600,13 @@ class MCPClient:
         # Extract result content
         if hasattr(result, "content") and result.content:
             if isinstance(result.content, list) and len(result.content) > 0:
-                content_item = result.content[0]
-                if hasattr(content_item, "text"):
-                    return _MCPToolResult(str(content_item.text), is_error)
-                return _MCPToolResult(str(content_item), is_error)
+                parts: list[str] = []
+                for content_item in result.content:
+                    if hasattr(content_item, "text"):
+                        parts.append(str(content_item.text))
+                    else:
+                        parts.append(str(content_item))
+                return _MCPToolResult("\n".join(parts), is_error)
             return _MCPToolResult(str(result.content), is_error)
 
         return _MCPToolResult(str(result), is_error)


### PR DESCRIPTION
## Problem

`MCPClient._call_tool_impl` only returns the first element of `result.content`
when the MCP server responds with a list of content items. Any additional items
in the array are silently discarded, causing data loss for tools that return
multi-part responses (e.g. multiple text blocks, mixed text/image results).

## Before

```python
content_item = result.content[0]
if hasattr(content_item, "text"):
    return _MCPToolResult(str(content_item.text), is_error)
return _MCPToolResult(str(content_item), is_error)
```
Only result.content[0] is used — the rest is thrown away.

## After

```python
parts: list[str] = []
for content_item in result.content:
    if hasattr(content_item, "text"):
        parts.append(str(content_item.text))
    else:
        parts.append(str(content_item))
return _MCPToolResult("\n".join(parts), is_error)
```

Iterates over all content items and joins them with \n.

## Impact
Tools returning a single content item behave exactly the same as before.
Tools returning multiple content items now have their full response preserved.