### PR TITLE
docs: add MLflow AI Gateway as LLM provider

### DIFF
--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -1189,6 +1189,43 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="MLflow AI Gateway">
+    [MLflow AI Gateway](https://mlflow.org/docs/latest/llms/gateway/index.html) is a database-backed LLM proxy built into the MLflow tracking server (MLflow ≥ 3.0). It provides a unified OpenAI-compatible API across dozens of providers — OpenAI, Anthropic, Gemini, Mistral, Bedrock, Ollama, and more — with built-in secrets management, fallback/retry, traffic splitting, and budget tracking.
+
+    **Start the MLflow server:**
+    ```bash
+    pip install mlflow
+    mlflow server --host 127.0.0.1 --port 5000
+    ```
+
+    Create a gateway endpoint in the MLflow UI at `http://localhost:5000` under **AI Gateway → Create Endpoint**. Provider API keys are stored encrypted on the server — no env vars needed in your application.
+
+    Example usage in your CrewAI project:
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/my-chat-endpoint",  # "openai/" prefix + your MLflow endpoint name
+        base_url="http://localhost:5000/gateway/openai/v1",
+        api_key="unused",  # provider keys are managed by the MLflow server
+    )
+    ```
+
+    <Info>
+      MLflow AI Gateway features:
+      - Route to any provider without changing agent code
+      - Provider API keys stored encrypted on the server
+      - Automatic fallback to backup models on failure
+      - Per-endpoint token budget limits
+      - Built-in usage tracing via MLflow experiments
+    </Info>
+
+    **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses

--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -1191,17 +1191,17 @@ In this section, you'll find detailed examples that help you select, configure, 
   </Accordion>
 
   <Accordion title="MLflow AI Gateway">
-    [MLflow AI Gateway](https://mlflow.org/docs/latest/llms/gateway/index.html) is a database-backed LLM proxy built into the MLflow tracking server (MLflow ≥ 3.0). It provides a unified OpenAI-compatible API across dozens of providers — OpenAI, Anthropic, Gemini, Mistral, Bedrock, Ollama, and more — with built-in secrets management, fallback/retry, traffic splitting, and budget tracking.
+    [MLflow AI Gateway](https://mlflow.org/docs/latest/genai/governance/ai-gateway/) is a database-backed LLM proxy built into the MLflow tracking server (MLflow ≥ 3.0). It provides a unified OpenAI-compatible API across dozens of providers — OpenAI, Anthropic, Gemini, Mistral, Bedrock, Ollama, and more — with built-in secrets management, fallback/retry, traffic splitting, and budget tracking.
 
-    **Start the MLflow server:**
+    **1. Install MLflow and start the server:**
     ```bash
-    pip install mlflow
+    pip install mlflow[genai]
     mlflow server --host 127.0.0.1 --port 5000
     ```
 
-    Create a gateway endpoint in the MLflow UI at `http://localhost:5000` under **AI Gateway → Create Endpoint**. Provider API keys are stored encrypted on the server — no env vars needed in your application.
+    **2. Create a gateway endpoint** in the MLflow UI at [http://localhost:5000](http://localhost:5000). Navigate to **AI Gateway → Create Endpoint**, select a provider and model, and enter your provider API key (stored encrypted on the server). See the [MLflow AI Gateway documentation](https://mlflow.org/docs/latest/genai/governance/ai-gateway/endpoints/) for details.
 
-    Example usage in your CrewAI project:
+    **3. Use in your CrewAI project:**
     ```python Code
     from crewai import LLM
 


### PR DESCRIPTION
## Summary

Adds an **MLflow AI Gateway** Accordion entry to `docs/en/concepts/llms.mdx`, showing how to use it as an OpenAI-compatible LLM backend in CrewAI.

English only — translations for ar, ko, and pt-BR are welcome as a follow-up.

**Note:** This PR should be labeled `llm-generated` per the contributing guide — we cannot add labels from a fork.

## What is MLflow AI Gateway?

[MLflow AI Gateway](https://mlflow.org/docs/latest/genai/governance/ai-gateway/) is a database-backed LLM proxy built into the MLflow tracking server (MLflow ≥ 3.0). It provides a unified OpenAI-compatible API across dozens of providers with encrypted secrets management, fallback/retry, traffic splitting, and per-endpoint token budgets.

## Changes

- Single Accordion section added to `docs/en/concepts/llms.mdx` with:
  - Brief description of MLflow AI Gateway
  - Setup instructions (start MLflow server, create endpoint in UI)
  - Code example using `LLM(model="openai/<endpoint-name>", base_url="...")`
  - Note about LiteLLM dependency

## AI Disclosure

This pull request was AI-assisted by Claude. All content was reviewed and validated by a human contributor.