### PR TITLE
fix: correct typos in i18n and task error messages

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -653,7 +653,7 @@ class Task(BaseModel):
             self.agent = agent
             if not agent:
                 raise Exception(
-                    f"The task '{self.description}' has no agent assigned, therefore it can't be executed directly and should be executed in a Crew using a specific process that support that, like hierarchical."
+                    f"The task '{self.description}' has no agent assigned, therefore it can't be executed directly and should be executed in a Crew using a specific process that supports that, like hierarchical."
                 )
 
             self.prompt_context = context
@@ -775,7 +775,7 @@ class Task(BaseModel):
             self.agent = agent
             if not agent:
                 raise Exception(
-                    f"The task '{self.description}' has no agent assigned, therefore it can't be executed directly and should be executed in a Crew using a specific process that support that, like hierarchical."
+                    f"The task '{self.description}' has no agent assigned, therefore it can't be executed directly and should be executed in a Crew using a specific process that supports that, like hierarchical."
                 )
 
             self.prompt_context = context

--- a/lib/crewai/src/crewai/utilities/i18n.py
+++ b/lib/crewai/src/crewai/utilities/i18n.py
@@ -20,7 +20,7 @@ class I18N(BaseModel):
     _prompts: dict[str, dict[str, str]] = PrivateAttr()
     prompt_file: str | None = Field(
         default=None,
-        description="Path to the prompt_file file to load",
+        description="Path to the prompt_file to load",
     )
 
     @model_validator(mode="after")
@@ -125,7 +125,7 @@ class I18N(BaseModel):
         try:
             return self._prompts[kind][key]
         except Exception as e:
-            raise Exception(f"Prompt for '{kind}':'{key}'  not found.") from e
+            raise Exception(f"Prompt for '{kind}':'{key}' not found.") from e
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Three small fixes in user-facing strings:

1. **i18n.py line 23**: duplicate word "Path to the prompt_file file to load" → "Path to the prompt_file to load"
2. **i18n.py line 128**: double space in error message "'{key}'  not found" → "'{key}' not found"
3. **task.py lines 576, 690**: grammar "process that support that" → "process that supports that"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to user-facing string typos in exceptions and field descriptions, with no behavioral or logic changes.
> 
> **Overview**
> Fixes minor typos in user-facing strings.
> 
> Updates the “no agent assigned” exception message in `Task._execute_core` and `Task._aexecute_core` to correct grammar, and cleans up wording/spacing in `I18N.prompt_file`’s field description and the missing-prompt exception message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f77cd9eebc304ef4f1619f60d1229d26eba9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->