### PR TITLE
docs: Add demo video to Skills concept page

### DIFF
--- a/docs/en/concepts/skills.mdx
+++ b/docs/en/concepts/skills.mdx
@@ -22,6 +22,14 @@ You often need **both**: skills for expertise, tools for action. They are config
 
 ---
 
+## Video Demo
+
+Watch a walkthrough of how to build and use skills in CrewAI:
+
+<iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
+
+---
+
 ## Quick Start
 
 ### 1. Create a Skill Directory


### PR DESCRIPTION
Adds an embedded Loom video demo to the Skills documentation page, showing a walkthrough of how to build and use skills in CrewAI.

The video is placed in a new "Video Demo" section between the Overview and Quick Start sections for easy discoverability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is the external iframe embed affecting page rendering or content security policies.
> 
> **Overview**
> Adds a new **Video Demo** section to `docs/en/concepts/skills.mdx`, embedding a Loom walkthrough iframe between the Overview and Quick Start sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d25902de135ac77b39bfd7f6158609310bf0d49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->