### PR TITLE
docs: Add coding agent skills demo video to getting started pages

### DIFF
--- a/docs/ar/installation.mdx
+++ b/docs/ar/installation.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### شاهد: بناء Agents و Flows في CrewAI باستخدام Coding Agent Skills
 
-شاهد عرضًا توضيحيًا عمليًا لبناء وكلاء وتدفقات CrewAI باستخدام مهارات وكيل البرمجة:
+قم بتثبيت مهارات وكيل البرمجة الخاصة بنا (Claude Code، Codex، ...) لتشغيل وكلاء البرمجة بسرعة مع CrewAI.
+
+يمكنك تثبيتها باستخدام `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/ar/introduction.mdx
+++ b/docs/ar/introduction.mdx
@@ -18,7 +18,9 @@ mode: "wide"
 
 ### شاهد: بناء Agents و Flows في CrewAI باستخدام Coding Agent Skills
 
-شاهد عرضًا توضيحيًا عمليًا لبناء وكلاء وتدفقات CrewAI باستخدام مهارات وكيل البرمجة:
+قم بتثبيت مهارات وكيل البرمجة الخاصة بنا (Claude Code، Codex، ...) لتشغيل وكلاء البرمجة بسرعة مع CrewAI.
+
+يمكنك تثبيتها باستخدام `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/ar/quickstart.mdx
+++ b/docs/ar/quickstart.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### شاهد: بناء Agents و Flows في CrewAI باستخدام Coding Agent Skills
 
-شاهد عرضًا توضيحيًا عمليًا لبناء وكلاء وتدفقات CrewAI باستخدام مهارات وكيل البرمجة:
+قم بتثبيت مهارات وكيل البرمجة الخاصة بنا (Claude Code، Codex، ...) لتشغيل وكلاء البرمجة بسرعة مع CrewAI.
+
+يمكنك تثبيتها باستخدام `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### Watch: Building CrewAI Agents & Flows with Coding Agent Skills
 
-See a hands-on demo of building CrewAI agents and flows using coding agent skills:
+Install our coding agent skills (Claude Code, Codex, ...) to quickly get your coding agents up and running with CrewAI.
+
+You can install it with `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/en/introduction.mdx
+++ b/docs/en/introduction.mdx
@@ -18,7 +18,9 @@ With over 100,000 developers certified through our community courses, CrewAI is 
 
 ### Watch: Building CrewAI Agents & Flows with Coding Agent Skills
 
-See a hands-on demo of building CrewAI agents and flows using coding agent skills:
+Install our coding agent skills (Claude Code, Codex, ...) to quickly get your coding agents up and running with CrewAI.
+
+You can install it with `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### Watch: Building CrewAI Agents & Flows with Coding Agent Skills
 
-See a hands-on demo of building CrewAI agents and flows using coding agent skills:
+Install our coding agent skills (Claude Code, Codex, ...) to quickly get your coding agents up and running with CrewAI.
+
+You can install it with `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/ko/installation.mdx
+++ b/docs/ko/installation.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### 영상: 코딩 에이전트 스킬을 활용한 CrewAI Agents & Flows 구축
 
-코딩 에이전트 스킬을 사용하여 CrewAI 에이전트와 플로우를 구축하는 실습 데모를 시청하세요:
+코딩 에이전트 스킬(Claude Code, Codex 등)을 설치하여 CrewAI로 코딩 에이전트를 빠르게 시작하세요.
+
+`npx skills add crewaiinc/skills` 명령어로 설치할 수 있습니다
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/ko/introduction.mdx
+++ b/docs/ko/introduction.mdx
@@ -18,7 +18,9 @@ mode: "wide"
 
 ### 영상: 코딩 에이전트 스킬을 활용한 CrewAI Agents & Flows 구축
 
-코딩 에이전트 스킬을 사용하여 CrewAI 에이전트와 플로우를 구축하는 실습 데모를 시청하세요:
+코딩 에이전트 스킬(Claude Code, Codex 등)을 설치하여 CrewAI로 코딩 에이전트를 빠르게 시작하세요.
+
+`npx skills add crewaiinc/skills` 명령어로 설치할 수 있습니다
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/ko/quickstart.mdx
+++ b/docs/ko/quickstart.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### 영상: 코딩 에이전트 스킬을 활용한 CrewAI Agents & Flows 구축
 
-코딩 에이전트 스킬을 사용하여 CrewAI 에이전트와 플로우를 구축하는 실습 데모를 시청하세요:
+코딩 에이전트 스킬(Claude Code, Codex 등)을 설치하여 CrewAI로 코딩 에이전트를 빠르게 시작하세요.
+
+`npx skills add crewaiinc/skills` 명령어로 설치할 수 있습니다
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/pt-BR/installation.mdx
+++ b/docs/pt-BR/installation.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### Assista: Construindo Agents e Flows CrewAI com Coding Agent Skills
 
-Veja uma demonstração prática de como construir agentes e fluxos CrewAI usando coding agent skills:
+Instale nossas coding agent skills (Claude Code, Codex, ...) para colocar seus agentes de código para funcionar rapidamente com o CrewAI.
+
+Você pode instalar com `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/pt-BR/introduction.mdx
+++ b/docs/pt-BR/introduction.mdx
@@ -18,7 +18,9 @@ Com mais de 100.000 desenvolvedores certificados em nossos cursos comunitários,
 
 ### Assista: Construindo Agents e Flows CrewAI com Coding Agent Skills
 
-Veja uma demonstração prática de como construir agentes e fluxos CrewAI usando coding agent skills:
+Instale nossas coding agent skills (Claude Code, Codex, ...) para colocar seus agentes de código para funcionar rapidamente com o CrewAI.
+
+Você pode instalar com `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/pt-BR/quickstart.mdx
+++ b/docs/pt-BR/quickstart.mdx
@@ -7,7 +7,9 @@ mode: "wide"
 
 ### Assista: Construindo Agents e Flows CrewAI com Coding Agent Skills
 
-Veja uma demonstração prática de como construir agentes e fluxos CrewAI usando coding agent skills:
+Instale nossas coding agent skills (Claude Code, Codex, ...) para colocar seus agentes de código para funcionar rapidamente com o CrewAI.
+
+Você pode instalar com `npx skills add crewaiinc/skills`
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 


### PR DESCRIPTION
## Summary

Adds a Loom demo video embed to the getting started pages (introduction, quickstart, and installation) showing how to build CrewAI agents and flows using coding agent skills.

## Changes

- Added video embed to `introduction.mdx`, `quickstart.mdx`, and `installation.mdx` across all 4 languages:
  - English (`docs/en/`)
  - Korean (`docs/ko/`)
  - Portuguese (`docs/pt-BR/`)
  - Arabic (`docs/ar/`)
- Video: [Loom demo](https://www.loom.com/share/befb9f68b81f42ad8112bfdd95a780af)
- Contextual heading and description text translated for each language

## Notes

- This replaces #5236 which incorrectly placed the video on the Skills concept page. That PR has been closed.
- The video demonstrates coding agent skills for *building with CrewAI* (not the agent skills feature itself).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an external Loom iframe embed; main risk is broken/blocked embeds or layout regressions in docs pages.
> 
> **Overview**
> Adds a new **“Coding Agent Skills” demo** callout to the top of `introduction.mdx`, `quickstart.mdx`, and `installation.mdx` in `en`, `ar`, `ko`, and `pt-BR`, including an `npx skills add crewaiinc/skills` install snippet.
> 
> Embeds the same Loom video via an `<iframe>` on each page to demonstrate building CrewAI Agents/Flows with coding agent skills.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed6bb90684717a2b46f54fe0298e1f622681590c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->