### PR TITLE
fix: remove seo indexing field causing Arabic page rendering

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15035,7 +15035,6 @@
     }
   },
   "seo": {
-    "indexing": "all",
     "metatags": {
       "og:type": "website",
       "og:site_name": "CrewAI Documentation",


### PR DESCRIPTION
## Summary
- Removes `"indexing": "all"` from `docs/docs.json` SEO config, which was causing doc pages (e.g. LiteLLM) to render in Arabic despite English being the default language.

## Test plan
- [ ] Verify affected doc pages (e.g. LiteLLM) no longer render in Arabic by default after deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single SEO config field in `docs/docs.json` with no code logic changes; impact is limited to documentation site metadata/rendering behavior.
> 
> **Overview**
> Removes the `seo.indexing` field from `docs/docs.json`, leaving only `seo.metatags`.
> 
> This change is intended to prevent incorrect language rendering on some documentation pages by eliminating the problematic indexing configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a22e62c905fa98ddec27a44b16fd7cf9005a2af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->