### PR TITLE
fix: correct log level and remove redundant warning prefixes

### DIFF
--- a/lib/crewai/src/crewai/events/listeners/tracing/trace_batch_manager.py
+++ b/lib/crewai/src/crewai/events/listeners/tracing/trace_batch_manager.py
@@ -437,7 +437,7 @@ class TraceBatchManager:
                 self.batch_sequence = 0
 
         except Exception as e:
-            logger.error(f"Warning: Error during cleanup: {e}")
+            logger.warning(f"Error during cleanup: {e}")
 
     def has_events(self) -> bool:
         """Check if there are events in the buffer"""

--- a/lib/crewai/src/crewai/experimental/evaluation/testing.py
+++ b/lib/crewai/src/crewai/experimental/evaluation/testing.py
@@ -47,7 +47,7 @@ def assert_experiment_no_regression(comparison_result: dict[str, list[str]]) -> 
     missing_tests = comparison_result.get("missing_tests", [])
     if missing_tests:
         warnings.warn(
-            f"Warning: {len(missing_tests)} tests from the baseline are missing in the current run: {missing_tests}",
+            f"{len(missing_tests)} tests from the baseline are missing in the current run: {missing_tests}",
             UserWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
## Summary
- Change `logger.error` to `logger.warning` for cleanup errors in trace_batch_manager (cleanup is best-effort, and the message was prefixed with "Warning:" contradicting `error` level)
- Remove redundant `Warning:` prefix from `warnings.warn()` call in testing.py — `warnings.warn` already renders as `UserWarning: ...`, producing double-warning output

## Test plan
- [ ] Verify log output is clean and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts log/warning message severity and text, with no behavior or data-flow changes.
> 
> **Overview**
> Reduces log noise by downgrading trace batch cleanup exception reporting from `logger.error` to `logger.warning` in `trace_batch_manager.py`.
> 
> Cleans up experiment evaluation output by removing the redundant `Warning:` prefix from the `warnings.warn()` message in `testing.py`, avoiding duplicated warning text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434d87c424e864c62f383f88b849d9080f2915bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->