### PR TITLE
fix: correct typos and misleading error messages in tools and CLI

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -593,10 +593,10 @@ class BrightDataDatasetTool(BaseTool):
                 )
             )
         except TimeoutError as e:
-            return f"Timeout Exception occured in method : get_dataset_data_async. Details - {e!s}"
+            return f"Timeout Exception occurred in method : get_dataset_data_async. Details - {e!s}"
         except BrightDataDatasetToolException as e:
             return (
-                f"Exception occured in method : get_dataset_data_async. Details - {e!s}"
+                f"Exception occurred in method : get_dataset_data_async. Details - {e!s}"
             )
         except Exception as e:
             return f"Bright Data API error: {e!s}"

--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -1153,7 +1153,7 @@ def _create_tag_and_release(
         try:
             run_command(["git", "tag", "-a", tag_name, "-m", release_notes])
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]✗[/red] Created tag {tag_name}: {e}")
+            console.print(f"[red]✗[/red] Failed to create tag {tag_name}: {e}")
             sys.exit(1)
     console.print(f"[green]✓[/green] Created tag {tag_name}")
 
@@ -1161,7 +1161,7 @@ def _create_tag_and_release(
         try:
             run_command(["git", "push", "origin", tag_name])
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]✗[/red] Pushed tag {tag_name}: {e}")
+            console.print(f"[red]✗[/red] Failed to push tag {tag_name}: {e}")
             sys.exit(1)
     console.print(f"[green]✓[/green] Pushed tag {tag_name}")
 
@@ -1182,7 +1182,7 @@ def _create_tag_and_release(
 
             run_command(gh_cmd)
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]✗[/red] Created GitHub Release: {e}")
+            console.print(f"[red]✗[/red] Failed to create GitHub Release: {e}")
             sys.exit(1)
 
     release_type = "prerelease" if is_prerelease else "release"
@@ -1635,7 +1635,7 @@ def _trigger_pypi_publish(tag_name: str, wait: bool = False) -> None:
                 ]
             )
         except subprocess.CalledProcessError as e:
-            console.print(f"[red]✗[/red] Triggered PyPI publish workflow: {e}")
+            console.print(f"[red]✗[/red] Failed to trigger PyPI publish workflow: {e}")
             sys.exit(1)
     console.print("[green]✓[/green] Triggered PyPI publish workflow")
 
@@ -1868,7 +1868,7 @@ def tag(dry_run: bool, no_edit: bool) -> None:
                 try:
                     run_command(["git", "checkout", "main"])
                 except subprocess.CalledProcessError as e:
-                    console.print(f"[red]✗[/red] Checked out main branch: {e}")
+                    console.print(f"[red]✗[/red] Failed to check out main branch: {e}")
                     sys.exit(1)
             console.print("[green]✓[/green] On main branch")
 
@@ -1876,7 +1876,7 @@ def tag(dry_run: bool, no_edit: bool) -> None:
                 try:
                     run_command(["git", "pull"])
                 except subprocess.CalledProcessError as e:
-                    console.print(f"[red]✗[/red] Pulled latest changes: {e}")
+                    console.print(f"[red]✗[/red] Failed to pull latest changes: {e}")
                     sys.exit(1)
             console.print("[green]✓[/green] main branch up to date")
 


### PR DESCRIPTION
## Summary
- Fix `occured` → `occurred` typo in brightdata_dataset.py (2 instances)
- Fix misleading error messages in devtools CLI where error handlers use success-tense wording (e.g., `Created tag` in error context → `Failed to create tag`)

## Test plan
- [ ] Verify CLI error messages clearly indicate failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to user-facing exception strings in tool/CLI error handlers with no functional logic or API behavior changes.
> 
> **Overview**
> Improves user-facing error output by fixing `occured` → `occurred` in `BrightDataDatasetTool._run` exception messages.
> 
> Updates several `crewai_devtools` CLI failure handlers (tag creation/push, GitHub release creation, main branch checkout/pull, and PyPI workflow trigger) to print *failure* wording instead of success-tense messages when commands error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2654d67cd5a762f94e2630d6eaa521daece5bb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->