### PR TITLE
fix: remove erroneous $ in BrightData SERP search URL f-strings

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
@@ -131,10 +131,10 @@ class BrightDataSearchTool(BaseTool):
 
     def get_search_url(self, engine: str, query: str) -> str:
         if engine == "yandex":
-            return f"https://yandex.com/search/?text=${query}"
+            return f"https://yandex.com/search/?text={query}"
         if engine == "bing":
-            return f"https://www.bing.com/search?q=${query}"
-        return f"https://www.google.com/search?q=${query}"
+            return f"https://www.bing.com/search?q={query}"
+        return f"https://www.google.com/search?q={query}"
 
     def _run(
         self,


### PR DESCRIPTION
## Summary

Fixes #5269

The `get_search_url()` method in `BrightDataSearchTool` was using JavaScript template literal syntax (`${query}`) instead of Python f-string syntax (`{query}`). This caused every search URL to contain a literal `$` before the query string, e.g. `?q=$test` instead of `?q=test`.

All three search engine paths (Google, Bing, Yandex) had the same issue.

## Changes

- Removed the `$` prefix from all three f-string interpolations in `get_search_url()` (lines 134, 136, 137 of `brightdata_serp.py`)

That's it — three characters removed. No behavioral changes beyond fixing the URLs.

## Test plan

- [x] Verified no other `${...}` patterns exist in the BrightData tool files
- [x] Confirmed the fix produces correct URLs by inspection:
  ```python
  >>> query = "AI+news"
  >>> f"https://www.google.com/search?q={query}"
  'https://www.google.com/search?q=AI+news'
  ```
- [ ] Existing CI should pass (no test changes)