### PR TITLE
fix: rename loop variable to avoid shadowing provider parameter in create_crew()

### DIFF
--- a/lib/crewai/src/crewai/cli/create_crew.py
+++ b/lib/crewai/src/crewai/cli/create_crew.py
@@ -211,12 +211,12 @@ def create_crew(
                 return
 
         existing_provider = None
-        for provider, env_keys in ENV_VARS.items():
+        for env_provider, env_keys in ENV_VARS.items():
             if any(
                 "key_name" in details and details["key_name"] in env_vars
                 for details in env_keys
             ):
-                existing_provider = provider
+                existing_provider = env_provider
                 break
 
         if existing_provider:


### PR DESCRIPTION
## Summary

Fixes #5270

In `create_crew()`, the for-loop `for provider, env_keys in ENV_VARS.items()` was reusing the name `provider`, which shadows the function parameter passed from the CLI's `--provider` flag. Renamed the loop variable to `env_provider` so the original parameter value is preserved.

The parameter isn't currently read after the loop (the function uses `selected_provider` from interactive selection), so this is a latent bug rather than a visible one today. But shadowing function parameters with loop variables is a classic Python gotcha that makes the code fragile and would trip up anyone trying to use `provider` later in the function.

## Changes

- Renamed `provider` → `env_provider` in the for-loop on line 214 and the assignment on line 219

## Test plan

- [x] All 15 existing tests in `test_create_crew.py` pass
- [x] Verified no other references to the loop variable need updating
- [ ] Existing CI should pass (no test changes)