### PR TITLE
fix: Bedrock tool call arguments no longer silently dropped (closes #5275)

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -847,7 +847,7 @@ class CrewAgentExecutor(CrewAgentExecutorMixin):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
Fixes #5275

## Problem

When using crewAI with AWS Bedrock LLMs (e.g. Amazon Nova Pro), tool arguments were silently discarded. The LLM correctly called the tool with the right arguments, but the tool received an empty dict `{}`.

## Root Cause

Line 850 in `crew_agent_executor.py`:
```python
func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
```

Bedrock's Converse API returns tool calls as `{"name": "X", "toolUseId": "Y", "input": {...}}` — no "function" wrapper. So `func_info = {}`, and `func_info.get("arguments", "{}")` returns the default string `"{}"` which is truthy, preventing the `or` from falling through to `tool_call.get("input", {})`.

## Fix

Changed default from `"{}"` to `None`:
```python
func_args = func_info.get("arguments") or tool_call.get("input", {})
```

With `None` as default, `func_info.get("arguments")` returns `None` (falsy) when no "function" wrapper exists, so the `or` correctly falls through to the Bedrock input format.
