### PR TITLE
Fix shared LLM stop words mutation causing cross-agent state pollution

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -142,12 +142,14 @@ class CrewAgentExecutor(BaseAgentExecutor):
         if not self.after_llm_call_hooks:
             self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
         if self.llm and not isinstance(self.llm, str):
-            existing_stop = getattr(self.llm, "stop", [])
-            self.llm.stop = list(
+            # Compute effective stop words without mutating the shared LLM.
+            # We store the original value and only apply merged stop words
+            # around each invoke/ainvoke call to avoid cross-agent pollution.
+            existing_stop = getattr(self.llm, "stop", []) or []
+            self._original_stop = list(existing_stop) if isinstance(existing_stop, list) else []
+            self._effective_stop = list(
                 set(
-                    existing_stop + self.stop
-                    if isinstance(existing_stop, list)
-                    else self.stop
+                    self._original_stop + self.stop
                 )
             )
 
@@ -208,6 +210,10 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         self.ask_for_human_input = bool(inputs.get("ask_for_human_input", False))
 
+        # Apply executor-specific stop words to the LLM for this run only,
+        # then restore the original value so shared LLM instances stay clean.
+        if self.llm and hasattr(self, "_effective_stop"):
+            self.llm.stop = self._effective_stop
         try:
             formatted_answer = self._invoke_loop()
         except AssertionError:
@@ -220,6 +226,9 @@ class CrewAgentExecutor(BaseAgentExecutor):
         except Exception as e:
             handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
             raise
+        finally:
+            if self.llm and hasattr(self, "_original_stop"):
+                self.llm.stop = self._original_stop
 
         if self.ask_for_human_input:
             formatted_answer = self._handle_human_feedback(formatted_answer)
@@ -1078,6 +1087,10 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         self.ask_for_human_input = bool(inputs.get("ask_for_human_input", False))
 
+        # Apply executor-specific stop words to the LLM for this run only,
+        # then restore the original value so shared LLM instances stay clean.
+        if self.llm and hasattr(self, "_effective_stop"):
+            self.llm.stop = self._effective_stop
         try:
             formatted_answer = await self._ainvoke_loop()
         except AssertionError:
@@ -1090,6 +1103,9 @@ class CrewAgentExecutor(BaseAgentExecutor):
         except Exception as e:
             handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
             raise
+        finally:
+            if self.llm and hasattr(self, "_original_stop"):
+                self.llm.stop = self._original_stop
 
         if self.ask_for_human_input:
             formatted_answer = await self._ahandle_human_feedback(formatted_answer)


### PR DESCRIPTION
## Summary

- Fixes the mutable shared state bug where `CrewAgentExecutor.__init__` permanently mutates `self.llm.stop`, causing stop words to accumulate across agents sharing the same LLM instance
- Computes effective stop words locally per-executor and only applies them to the LLM during `invoke`/`ainvoke`, restoring the original value in a `finally` block
- Prevents both sequential accumulation (Agent B inheriting Agent A's stop words) and reduces the race condition window in async execution

## Changes

Single file: `lib/crewai/src/crewai/agents/crew_agent_executor.py`

**`__init__`**: Instead of mutating `self.llm.stop` directly, we now store the original stop words (`self._original_stop`) and the merged per-executor stop words (`self._effective_stop`) without touching the shared LLM.

**`invoke` / `ainvoke`**: Set `self.llm.stop = self._effective_stop` before execution, then restore `self.llm.stop = self._original_stop` in a `finally` block.

## Test plan

- [ ] Verify that a shared LLM's `stop` attribute is not permanently modified after an executor runs
- [ ] Verify that multiple agents with different stop words do not pollute each other
- [ ] Verify that `llm.stop` is correctly restored even when execution raises an exception

Fixes #5141