### PR TITLE
fix: ensure output directory exists before writing in flow template

### DIFF
--- a/lib/crewai/src/crewai/cli/templates/flow/main.py
+++ b/lib/crewai/src/crewai/cli/templates/flow/main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from pydantic import BaseModel
 
 from crewai.flow import Flow, listen, start
@@ -42,7 +44,9 @@ class ContentFlow(Flow[ContentState]):
     @listen(generate_content)
     def save_content(self):
         print("Saving content")
-        with open("output/post.md", "w") as f:
+        output_dir = Path("output")
+        output_dir.mkdir(exist_ok=True)
+        with open(output_dir / "post.md", "w") as f:
             f.write(self.state.final_post)
         print("Post saved to output/post.md")
 


### PR DESCRIPTION
The `save_content` method wrote to `output/post.md` without ensuring the `output/` directory exists, causing a FileNotFoundError when the directory hasn't been created by another step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to file output in the flow template to avoid `FileNotFoundError` when `output/` is missing.
> 
> **Overview**
> Fixes the flow CLI template’s `save_content` step to **ensure `output/` exists before writing** `post.md`. The write path is updated to use `pathlib.Path` and `mkdir(exist_ok=True)` to prevent failures on first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b72aed7d62bbf3a4047a608f664d9648978cf6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->