### PR TITLE
ci: bump uv from 0.8.4 to 0.11.3

### DIFF
--- a/.github/workflows/build-uv-cache.yml
+++ b/.github/workflows/build-uv-cache.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: ${{ matrix.python-version }}
           enable-cache: false
 

--- a/.github/workflows/generate-tool-specs.yml
+++ b/.github/workflows/generate-tool-specs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: "3.12"
           enable-cache: true
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: "3.11"
           enable-cache: false
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: "3.12"
           enable-cache: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: "3.12"
           enable-cache: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: ${{ matrix.python-version }}
           enable-cache: false
 

--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: ${{ matrix.python-version }}
           enable-cache: false
 

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: ${{ matrix.python-version }}
           enable-cache: false
 

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: "0.11.3"
           python-version: "3.11"
           enable-cache: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         types: [python]
         exclude: ^(lib/crewai/src/crewai/cli/templates/|lib/crewai/tests/|lib/crewai-tools/tests/|lib/crewai-files/tests/)
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.9.3
+    rev: 0.11.3
     hooks:
       - id: uv-lock
   - repo: https://github.com/commitizen-tools/commitizen


### PR DESCRIPTION
## Summary
- Bump uv from 0.8.4 to 0.11.3 in all 9 CI workflows and the pre-commit hook
- Required to support `exclude-newer = "3 days"` in pyproject.toml (relative duration support added in uv 0.9.17)

## Test plan
- [x] CI workflows run successfully with the new version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates CI/pre-commit tool versions, though it could cause workflow failures if `uv` behavior or caching semantics changed between releases.
> 
> **Overview**
> Updates the `uv` version used across GitHub Actions workflows (tests, linting, type checks, publishing, cache building, tool-spec generation, and vulnerability scanning) from `0.8.4` to `0.11.3`.
> 
> Also bumps the `uv-pre-commit` hook revision to `0.11.3` to keep local developer tooling aligned with CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f955a4772198616e8aea73fedaaf2fef3744c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->