### PR TITLE
docs: add storage providers section, export JsonProvider

### DIFF
--- a/docs/ar/concepts/checkpointing.mdx
+++ b/docs/ar/concepts/checkpointing.mdx
@@ -144,6 +144,51 @@ agent = Agent(
 result = agent.kickoff(messages=[{"role": "user", "content": "Research AI trends"}])
 ```
 
+## مزودات التخزين
+
+يتضمن CrewAI مزودي تخزين لنقاط الحفظ.
+
+### JsonProvider (افتراضي)
+
+يكتب كل نقطة حفظ كملف JSON منفصل.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import JsonProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./my_checkpoints",
+        provider=JsonProvider(),
+        max_checkpoints=5,
+    ),
+)
+```
+
+### SqliteProvider
+
+يخزن جميع نقاط الحفظ في ملف قاعدة بيانات SQLite واحد.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import SqliteProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./.checkpoints.db",
+        provider=SqliteProvider(max_checkpoints=50),
+    ),
+)
+```
+
+<Note>
+عند استخدام `SqliteProvider`، حقل `directory` هو مسار ملف قاعدة البيانات، وليس مجلدا.
+</Note>
+
 ## انواع الاحداث
 
 يقبل حقل `on_events` اي مجموعة من سلاسل انواع الاحداث. الخيارات الشائعة:

--- a/docs/en/concepts/checkpointing.mdx
+++ b/docs/en/concepts/checkpointing.mdx
@@ -144,6 +144,55 @@ agent = Agent(
 result = agent.kickoff(messages=[{"role": "user", "content": "Research AI trends"}])
 ```
 
+## Storage Providers
+
+CrewAI ships with two checkpoint storage providers.
+
+### JsonProvider (default)
+
+Writes each checkpoint as a separate JSON file. Simple, human-readable, easy to inspect.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import JsonProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./my_checkpoints",
+        provider=JsonProvider(),       # this is the default
+        max_checkpoints=5,             # prunes oldest files
+    ),
+)
+```
+
+Files are named `<timestamp>_<uuid>.json` inside the directory.
+
+### SqliteProvider
+
+Stores all checkpoints in a single SQLite database file. Better for high-frequency checkpointing and avoids many small files.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import SqliteProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./.checkpoints.db",
+        provider=SqliteProvider(max_checkpoints=50),
+    ),
+)
+```
+
+`SqliteProvider` accepts its own `max_checkpoints` parameter that prunes old rows via SQL. WAL journal mode is enabled for concurrent read access.
+
+<Note>
+When using `SqliteProvider`, the `directory` field is the database file path, not a directory. The `max_checkpoints` on `CheckpointConfig` controls filesystem pruning (for `JsonProvider`), while `SqliteProvider.max_checkpoints` controls row pruning in the database.
+</Note>
+
 ## Event Types
 
 The `on_events` field accepts any combination of event type strings. Common choices:

--- a/docs/ko/concepts/checkpointing.mdx
+++ b/docs/ko/concepts/checkpointing.mdx
@@ -144,6 +144,51 @@ agent = Agent(
 result = agent.kickoff(messages=[{"role": "user", "content": "Research AI trends"}])
 ```
 
+## 스토리지 프로바이더
+
+CrewAI는 두 가지 체크포인트 스토리지 프로바이더를 제공합니다.
+
+### JsonProvider (기본값)
+
+각 체크포인트를 별도의 JSON 파일로 저장합니다.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import JsonProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./my_checkpoints",
+        provider=JsonProvider(),
+        max_checkpoints=5,
+    ),
+)
+```
+
+### SqliteProvider
+
+모든 체크포인트를 단일 SQLite 데이터베이스 파일에 저장합니다.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import SqliteProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./.checkpoints.db",
+        provider=SqliteProvider(max_checkpoints=50),
+    ),
+)
+```
+
+<Note>
+`SqliteProvider`를 사용할 때 `directory` 필드는 디렉토리가 아닌 데이터베이스 파일 경로입니다.
+</Note>
+
 ## 이벤트 타입
 
 `on_events` 필드는 이벤트 타입 문자열의 조합을 받습니다. 일반적인 선택:

--- a/docs/pt-BR/concepts/checkpointing.mdx
+++ b/docs/pt-BR/concepts/checkpointing.mdx
@@ -144,6 +144,51 @@ agent = Agent(
 result = agent.kickoff(messages=[{"role": "user", "content": "Research AI trends"}])
 ```
 
+## Provedores de Armazenamento
+
+O CrewAI inclui dois provedores de armazenamento para checkpoints.
+
+### JsonProvider (padrao)
+
+Grava cada checkpoint como um arquivo JSON separado.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import JsonProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./my_checkpoints",
+        provider=JsonProvider(),
+        max_checkpoints=5,
+    ),
+)
+```
+
+### SqliteProvider
+
+Armazena todos os checkpoints em um unico arquivo SQLite.
+
+```python
+from crewai import Crew, CheckpointConfig
+from crewai.state import SqliteProvider
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    checkpoint=CheckpointConfig(
+        directory="./.checkpoints.db",
+        provider=SqliteProvider(max_checkpoints=50),
+    ),
+)
+```
+
+<Note>
+Ao usar `SqliteProvider`, o campo `directory` e o caminho do arquivo de banco de dados, nao um diretorio.
+</Note>
+
 ## Tipos de Evento
 
 O campo `on_events` aceita qualquer combinacao de strings de tipo de evento. Escolhas comuns:

--- a/lib/crewai/src/crewai/state/__init__.py
+++ b/lib/crewai/src/crewai/state/__init__.py
@@ -1,5 +1,11 @@
 from crewai.state.checkpoint_config import CheckpointConfig, CheckpointEventType
+from crewai.state.provider.json_provider import JsonProvider
 from crewai.state.provider.sqlite_provider import SqliteProvider
 
 
-__all__ = ["CheckpointConfig", "CheckpointEventType", "SqliteProvider"]
+__all__ = [
+    "CheckpointConfig",
+    "CheckpointEventType",
+    "JsonProvider",
+    "SqliteProvider",
+]


### PR DESCRIPTION
## Summary
- Export `JsonProvider` from `crewai.state` alongside `SqliteProvider`
- Add Storage Providers section to checkpointing docs in all 4 languages (en, pt-BR, ko, ar)
- Document `JsonProvider` (default, file-per-checkpoint) and `SqliteProvider` (single SQLite db)

## Test plan
- [x] `from crewai.state import JsonProvider, SqliteProvider` works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation updates and a public-module export, with no runtime logic modifications beyond import surface.
> 
> **Overview**
> Adds a new **Storage Providers** section to checkpointing docs across `en`, `pt-BR`, `ko`, and `ar`, documenting `JsonProvider` (default file-per-checkpoint, pruning via `CheckpointConfig.max_checkpoints`) and `SqliteProvider` (single DB file, row pruning via `SqliteProvider.max_checkpoints`) plus a note clarifying `directory` semantics for SQLite.
> 
> Exports `JsonProvider` from `crewai.state` (via `__init__.py`) so users can `from crewai.state import JsonProvider, SqliteProvider`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b8c9a9bdc543913372931fbd9d215f92a4faa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->