### PR TITLE
perf: use JSONB for checkpoint data column

### DIFF
--- a/lib/crewai/src/crewai/state/provider/sqlite_provider.py
+++ b/lib/crewai/src/crewai/state/provider/sqlite_provider.py
@@ -16,12 +16,12 @@ _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS checkpoints (
     id TEXT PRIMARY KEY,
     created_at TEXT NOT NULL,
-    data TEXT NOT NULL
+    data JSONB NOT NULL
 )
 """
 
-_INSERT = "INSERT INTO checkpoints (id, created_at, data) VALUES (?, ?, ?)"
-_SELECT = "SELECT data FROM checkpoints WHERE id = ?"
+_INSERT = "INSERT INTO checkpoints (id, created_at, data) VALUES (?, ?, jsonb(?))"
+_SELECT = "SELECT json(data) FROM checkpoints WHERE id = ?"
 _PRUNE = """
 DELETE FROM checkpoints WHERE rowid NOT IN (
     SELECT rowid FROM checkpoints ORDER BY rowid DESC LIMIT ?


### PR DESCRIPTION
## Summary
- Change SqliteProvider checkpoint data column from `TEXT` to `JSONB`
- Insert via `jsonb(?)` for binary-compact storage
- Read via `json(data)` to return text for `model_validate_json`

Benefits: compact storage, JSON validation on write, enables future `json_extract` queries on checkpoint data.

Requires SQLite 3.45+ (ships with Python 3.12+, macOS 14+, Ubuntu 24.04+).

## Test plan
- [x] Sync round-trip verified
- [x] Async round-trip verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk SQLite schema and read/write SQL for checkpoints, which may break existing checkpoint DBs or require SQLite versions that support `JSONB`/`jsonb()`.
> 
> **Overview**
> Updates `SqliteProvider` to persist checkpoint `data` as **`JSONB`** instead of `TEXT`.
> 
> Writes now wrap payloads with `jsonb(?)`, and reads return `json(data)` so callers still receive a JSON string while benefiting from JSON validation/compact storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47264d0763894651160682d4439d29234f80c6ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->