### PR TITLE
refactor: make BaseProvider a BaseModel with discriminated union

### DIFF
--- a/lib/crewai/src/crewai/state/checkpoint_config.py
+++ b/lib/crewai/src/crewai/state/checkpoint_config.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from crewai.state.provider.core import BaseProvider
 from crewai.state.provider.json_provider import JsonProvider
+from crewai.state.provider.sqlite_provider import SqliteProvider
 
 
 CheckpointEventType = Literal[
@@ -189,7 +189,10 @@ class CheckpointConfig(BaseModel):
         description="Event types that trigger a checkpoint write. "
         'Use ["*"] to checkpoint on every event.',
     )
-    provider: BaseProvider = Field(
+    provider: Annotated[
+        JsonProvider | SqliteProvider,
+        Field(discriminator="provider_type"),
+    ] = Field(
         default_factory=JsonProvider,
         description="Storage backend. Defaults to JsonProvider.",
     )

--- a/lib/crewai/src/crewai/state/provider/core.py
+++ b/lib/crewai/src/crewai/state/provider/core.py
@@ -1,39 +1,22 @@
-"""Base protocol for state providers."""
+"""Base class for state providers."""
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from abc import ABC, abstractmethod
 
-from pydantic import GetCoreSchemaHandler
-from pydantic_core import CoreSchema, core_schema
+from pydantic import BaseModel
 
 
-@runtime_checkable
-class BaseProvider(Protocol):
-    """Interface for persisting and restoring runtime state checkpoints.
+class BaseProvider(BaseModel, ABC):
+    """Base class for persisting and restoring runtime state checkpoints.
 
     Implementations handle the storage backend — filesystem, cloud, database,
     etc. — while ``RuntimeState`` handles serialization.
     """
 
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
-    ) -> CoreSchema:
-        """Allow Pydantic to validate any ``BaseProvider`` instance."""
+    provider_type: str = "base"
 
-        def _validate(v: Any) -> BaseProvider:
-            if isinstance(v, BaseProvider):
-                return v
-            raise TypeError(f"Expected a BaseProvider instance, got {type(v)}")
-
-        return core_schema.no_info_plain_validator_function(
-            _validate,
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda v: type(v).__name__, info_arg=False
-            ),
-        )
-
+    @abstractmethod
     def checkpoint(self, data: str, location: str) -> str:
         """Persist a snapshot synchronously.
 
@@ -46,6 +29,7 @@ class BaseProvider(Protocol):
         """
         ...
 
+    @abstractmethod
     async def acheckpoint(self, data: str, location: str) -> str:
         """Persist a snapshot asynchronously.
 
@@ -58,6 +42,7 @@ class BaseProvider(Protocol):
         """
         ...
 
+    @abstractmethod
     def prune(self, location: str, max_keep: int) -> None:
         """Remove old checkpoints, keeping at most *max_keep*.
 
@@ -67,6 +52,7 @@ class BaseProvider(Protocol):
         """
         ...
 
+    @abstractmethod
     def from_checkpoint(self, location: str) -> str:
         """Read a snapshot synchronously.
 
@@ -78,6 +64,7 @@ class BaseProvider(Protocol):
         """
         ...
 
+    @abstractmethod
     async def afrom_checkpoint(self, location: str) -> str:
         """Read a snapshot asynchronously.
 

--- a/lib/crewai/src/crewai/state/provider/json_provider.py
+++ b/lib/crewai/src/crewai/state/provider/json_provider.py
@@ -7,6 +7,7 @@ import glob
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 import uuid
 
 import aiofiles
@@ -20,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 class JsonProvider(BaseProvider):
     """Persists runtime state checkpoints as JSON files on the local filesystem."""
+
+    provider_type: Literal["json"] = "json"
 
     def checkpoint(self, data: str, location: str) -> str:
         """Write a JSON checkpoint file.

--- a/lib/crewai/src/crewai/state/provider/sqlite_provider.py
+++ b/lib/crewai/src/crewai/state/provider/sqlite_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
+from typing import Literal
 import uuid
 
 import aiosqlite
@@ -46,6 +47,8 @@ class SqliteProvider(BaseProvider):
     The ``location`` argument to ``checkpoint`` / ``acheckpoint`` is
     used as the database file path.
     """
+
+    provider_type: Literal["sqlite"] = "sqlite"
 
     def checkpoint(self, data: str, location: str) -> str:
         """Write a checkpoint to the SQLite database.


### PR DESCRIPTION
## Summary
- Replace `BaseProvider` Protocol with BaseModel + ABC so providers serialize/deserialize natively via pydantic
- Add `provider_type` Literal field to JsonProvider and SqliteProvider
- Use discriminated union on `CheckpointConfig.provider` so the correct provider class is reconstructed from checkpoint JSON
- Fixes `TypeError: Expected a BaseProvider instance, got <class 'str'>` on checkpoint restore

## Test plan
- [ ] `CheckpointConfig(provider=SqliteProvider())` round-trips through `model_dump_json` / `model_validate_json`
- [ ] `Crew.from_checkpoint(path, provider=SqliteProvider())` works
- [ ] Existing checkpoint tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how checkpoint providers are typed/validated/serialized via Pydantic, which can affect checkpoint round-tripping and restore paths across existing stored snapshots.
> 
> **Overview**
> **Refactors checkpoint provider serialization** by replacing `BaseProvider` from a `Protocol` with an abstract `pydantic.BaseModel` carrying a `provider_type` discriminator.
> 
> `CheckpointConfig.provider` is now a discriminated union (`JsonProvider | SqliteProvider`) keyed by `provider_type`, and both providers add a `provider_type` `Literal` field so checkpoint configs can round-trip through JSON and reconstruct the correct provider implementation during restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e05e226e208d49fd2a1f74e5b721e0410b2db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->