### PR TITLE
fix: remove FilteredStream stdout/stderr wrapper

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -3,18 +3,14 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime
-import io
 import json
 import logging
 import os
-import sys
-import threading
 from typing import (
     TYPE_CHECKING,
     Any,
     Final,
     Literal,
-    TextIO,
     TypedDict,
     cast,
 )
@@ -100,72 +96,6 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 if LITELLM_AVAILABLE:
     litellm.suppress_debug_info = True
-
-
-class FilteredStream(io.TextIOBase):
-    _lock = None
-
-    def __init__(self, original_stream: TextIO):
-        self._original_stream = original_stream
-        self._lock = threading.Lock()
-
-    def write(self, s: str) -> int:
-        if not self._lock:
-            self._lock = threading.Lock()
-
-        with self._lock:
-            lower_s = s.lower()
-
-            # Skip common noisy LiteLLM banners and any other lines that contain "litellm"
-            if (
-                "litellm.info:" in lower_s
-                or "Consider using a smaller input or implementing a text splitting strategy"
-                in lower_s
-            ):
-                return 0
-
-            return self._original_stream.write(s)
-
-    def flush(self) -> None:
-        if self._lock:
-            with self._lock:
-                return self._original_stream.flush()
-        return None
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate attribute access to the wrapped original stream.
-
-        This ensures compatibility with libraries (e.g., Rich) that rely on
-        attributes such as `encoding`, `isatty`, `buffer`, etc., which may not
-        be explicitly defined on this proxy class.
-        """
-        return getattr(self._original_stream, name)
-
-    # Delegate common properties/methods explicitly so they aren't shadowed by
-    # the TextIOBase defaults (e.g., .encoding returns None by default, which
-    # confuses Rich). These explicit pass-throughs ensure the wrapped Console
-    # still sees a fully-featured stream.
-    @property
-    def encoding(self) -> str | Any:  # type: ignore[override]
-        return getattr(self._original_stream, "encoding", "utf-8")
-
-    def isatty(self) -> bool:
-        return self._original_stream.isatty()
-
-    def fileno(self) -> int:
-        return self._original_stream.fileno()
-
-    def writable(self) -> bool:
-        return True
-
-
-# Apply the filtered stream globally so that any subsequent writes containing the filtered
-# keywords (e.g., "litellm") are hidden from terminal output. We guard against double
-# wrapping to ensure idempotency in environments where this module might be reloaded.
-if not isinstance(sys.stdout, FilteredStream):
-    sys.stdout = FilteredStream(sys.stdout)
-if not isinstance(sys.stderr, FilteredStream):
-    sys.stderr = FilteredStream(sys.stderr)
 
 
 MIN_CONTEXT: Final[int] = 1024


### PR DESCRIPTION
## Summary
- Removes `FilteredStream` class that wrapped `sys.stdout` and `sys.stderr` at import time to suppress LiteLLM noise
- `litellm.suppress_debug_info = True` already handles this
- The wrapper added a `threading.Lock` + string comparison to every `print()` call in the process and was not fork-safe for Celery prefork workers

## Test plan
- [ ] Verify no LiteLLM banner noise appears in output
- [ ] Verify Rich console formatting still works correctly
- [ ] Run existing test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an import-time `sys.stdout`/`sys.stderr` wrapper, mainly affecting console/log output; primary potential regression is LiteLLM banner noise reappearing in some environments.
> 
> **Overview**
> Removes the `FilteredStream` proxy and the import-time wrapping of `sys.stdout`/`sys.stderr` that previously filtered LiteLLM-related banner output.
> 
> Cleans up related imports, relying solely on `litellm.suppress_debug_info = True` for noise suppression instead of intercepting all process output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e68975e46fb0d6a8addc46ec64d6c38573fd4861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->