### PR TITLE
fix: deflake MemoryRecord embedding serialization test

### DIFF
--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -51,14 +51,13 @@ def test_memory_record_embedding_excluded_from_serialization() -> None:
     dumped = r.model_dump()
     assert "embedding" not in dumped
     assert dumped["content"] == "hello"
-
-    # model_dump_json excludes embedding
     json_str = r.model_dump_json()
-    assert "0.1" not in json_str
     assert "embedding" not in json_str
+    rehydrated = MemoryRecord.model_validate_json(json_str)
+    assert rehydrated.embedding is None
 
     # repr excludes embedding
-    assert "0.1" not in repr(r)
+    assert "embedding=" not in repr(r)
 
     # Direct attribute access still works for storage layer
     assert r.embedding is not None


### PR DESCRIPTION
## Summary
- `test_memory_record_embedding_excluded_from_serialization` was flaky on GitHub Actions: it asserted `'0.1' not in json_str`, but serialized timestamps like `2026-04-10T13:00:50.140557` contain the substring `0.1` (e.g. inside `50.140`), so the test failed non-deterministically depending on wall-clock microseconds.
- Replaced the fragile substring checks with a structural round-trip: serialize via `model_dump_json`, rehydrate via `MemoryRecord.model_validate_json`, and assert `rehydrated.embedding is None`. This proves the exact property under test without depending on string representation.
- `repr` check switched from `'0.1' not in repr(r)` to `'embedding=' not in repr(r)` for the same reason.

This is a test-only change — the framework serialization behavior was already correct.

## Test plan
- [x] `uv run --project lib/crewai pytest lib/crewai/tests/memory/test_unified_memory.py::test_memory_record_embedding_excluded_from_serialization`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that replaces brittle substring checks with structural validation; low risk aside from potentially missing a regression if serialization semantics change.
> 
> **Overview**
> Fixes flakiness in `test_memory_record_embedding_excluded_from_serialization` by removing substring assertions on serialized JSON/`repr` and instead round-tripping `model_dump_json()` through `MemoryRecord.model_validate_json()` to assert `embedding` is omitted (rehydrates as `None`).
> 
> Also tightens the `repr` assertion to check for absence of `embedding=` rather than a specific float value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b35552b7f7683da90cb3f6c3e447c8ed123aaab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->