### PR TITLE
chore: re-record hierarchical verbose manager cassette

### DIFF
--- a/lib/crewai/tests/cassettes/test_hierarchical_verbose_false_manager_agent.yaml
+++ b/lib/crewai/tests/cassettes/test_hierarchical_verbose_false_manager_agent.yaml
@@ -55,7 +55,7 @@ interactions:
       x-stainless-os:
       - X-STAINLESS-OS-XXX
       x-stainless-package-version:
-      - 1.83.0
+      - 2.31.0
       x-stainless-read-timeout:
       - X-STAINLESS-READ-TIMEOUT-XXX
       x-stainless-retry-count:
@@ -63,50 +63,51 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.3
+      - 3.13.12
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-DIqxWpJbbFJoV8WlXhb9UYFbCmdPk\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1773385850,\n  \"model\": \"gpt-4o-2024-08-06\",\n
+      string: "{\n  \"id\": \"chatcmpl-DTApYQx2LepfeRL1XcDKPgrhMFnQr\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775845516,\n  \"model\": \"gpt-4o-2024-08-06\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
         \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_G2i9RJGNXKVfnd8ZTaBG8Fwi\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"ask_question_to_coworker\",\n
-        \             \"arguments\": \"{\\\"question\\\": \\\"What are some trending
-        topics or ideas in various fields that could be explored for an article?\\\",
-        \\\"context\\\": \\\"We need to generate a list of 5 interesting ideas to
-        explore for an article. These ideas should be engaging and relevant to current
-        trends or captivating subjects.\\\", \\\"coworker\\\": \\\"Researcher\\\"}\"\n
-        \           }\n          },\n          {\n            \"id\": \"call_j4KH2SGZvNeioql0HcRQ9NTp\",\n
+        \           \"id\": \"call_BCh6lXsBTdixRuRh6OTBPoIJ\",\n            \"type\":
+        \"function\",\n            \"function\": {\n              \"name\": \"delegate_work_to_coworker\",\n
+        \             \"arguments\": \"{\\\"task\\\": \\\"Come up with a list of 5
+        interesting ideas to explore for an article.\\\", \\\"context\\\": \\\"We
+        need five intriguing ideas worth exploring for an article. Each idea should
+        have potential for in-depth exploration and appeal to a broad audience, possibly
+        touching on current trends, historical insights, future possibilities, or
+        human interest stories.\\\", \\\"coworker\\\": \\\"Researcher\\\"}\"\n            }\n
+        \         },\n          {\n            \"id\": \"call_rAQFeCrS4ogsqvIWRGAYFHGI\",\n
         \           \"type\": \"function\",\n            \"function\": {\n              \"name\":
-        \"ask_question_to_coworker\",\n              \"arguments\": \"{\\\"question\\\":
-        \\\"What unique angles or perspectives could we explore to make articles more
-        compelling and engaging?\\\", \\\"context\\\": \\\"Our task involves coming
-        up with 5 ideas for articles, each with an exciting paragraph highlight that
-        illustrates the promise and intrigue of the topic. We want them to be more
-        than generic concepts, shining for readers with fresh insights or engaging
-        twists.\\\", \\\"coworker\\\": \\\"Senior Writer\\\"}\"\n            }\n          }\n
-        \       ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
-        \     \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n
-        \ ],\n  \"usage\": {\n    \"prompt_tokens\": 476,\n    \"completion_tokens\":
-        183,\n    \"total_tokens\": 659,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        \"delegate_work_to_coworker\",\n              \"arguments\": \"{\\\"task\\\":
+        \\\"Write one amazing paragraph highlight for each of 5 ideas that showcases
+        how good an article about this topic could be.\\\", \\\"context\\\": \\\"Upon
+        receiving five intriguing ideas from the Researcher, create a compelling paragraph
+        for each idea that highlights its potential as a fascinating article. These
+        paragraphs must capture the essence of the topic and explain why it would
+        captivate readers, incorporating possible themes and insights.\\\", \\\"coworker\\\":
+        \\\"Senior Writer\\\"}\"\n            }\n          }\n        ],\n        \"refusal\":
+        null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n
+        \     \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        476,\n    \"completion_tokens\": 201,\n    \"total_tokens\": 677,\n    \"prompt_tokens_details\":
+        {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_b7c8e3f100\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_2ca5b70601\"\n}\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9db9389a3f9e424c-EWR
+      - 9ea3cb06ba66b301-TPE
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Mar 2026 07:10:53 GMT
+      - Fri, 10 Apr 2026 18:25:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -122,7 +123,7 @@ interactions:
       openai-organization:
       - OPENAI-ORG-XXX
       openai-processing-ms:
-      - '2402'
+      - '1981'
       openai-project:
       - OPENAI-PROJECT-XXX
       openai-version:
@@ -154,13 +155,14 @@ interactions:
       You work as a freelancer and is now working on doing research and analysis for
       a new customer.\nYour personal goal is: Make the best research and analysis
       on content about AI and AI agents"},{"role":"user","content":"\nCurrent Task:
-      What are some trending topics or ideas in various fields that could be explored
-      for an article?\n\nThis is the expected criteria for your final answer: Your
-      best answer to your coworker asking you this, accounting for the context shared.\nyou
-      MUST return the actual complete content as the final answer, not a summary.\n\nThis
-      is the context you''re working with:\nWe need to generate a list of 5 interesting
-      ideas to explore for an article. These ideas should be engaging and relevant
-      to current trends or captivating subjects.\n\nProvide your complete response:"}],"model":"gpt-4.1-mini"}'
+      Come up with a list of 5 interesting ideas to explore for an article.\n\nThis
+      is the expected criteria for your final answer: Your best answer to your coworker
+      asking you this, accounting for the context shared.\nyou MUST return the actual
+      complete content as the final answer, not a summary.\n\nThis is the context
+      you''re working with:\nWe need five intriguing ideas worth exploring for an
+      article. Each idea should have potential for in-depth exploration and appeal
+      to a broad audience, possibly touching on current trends, historical insights,
+      future possibilities, or human interest stories.\n\nProvide your complete response:"}],"model":"gpt-4.1-mini"}'
     headers:
       User-Agent:
       - X-USER-AGENT-XXX
@@ -173,7 +175,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '978'
+      - '1046'
       content-type:
       - application/json
       host:
@@ -187,7 +189,7 @@ interactions:
       x-stainless-os:
       - X-STAINLESS-OS-XXX
       x-stainless-package-version:
-      - 1.83.0
+      - 2.31.0
       x-stainless-read-timeout:
       - X-STAINLESS-READ-TIMEOUT-XXX
       x-stainless-retry-count:
@@ -195,63 +197,69 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.3
+      - 3.13.12
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-DIqxak88AexErt9PGFGHnWPIJLwNV\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1773385854,\n  \"model\": \"gpt-4.1-mini-2025-04-14\",\n
+      string: "{\n  \"id\": \"chatcmpl-DTApalbfnYkqIc8slLS3DKwo9KXbc\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775845518,\n  \"model\": \"gpt-4.1-mini-2025-04-14\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"Here are five trending and engaging
-        topics across various fields that could be explored for an article:\\n\\n1.
-        **The Rise of Autonomous AI Agents and Their Impact on the Future of Work**
-        \ \\nExplore how autonomous AI agents\u2014systems capable of performing complex
-        tasks independently\u2014are transforming industries such as customer service,
-        software development, and logistics. Discuss implications for job automation,
-        human-AI collaboration, and ethical considerations surrounding decision-making
-        autonomy.\\n\\n2. **Generative AI Beyond Text: Innovations in Audio, Video,
-        and 3D Content Creation**  \\nDelve into advancements in generative AI models
-        that create not only text but also realistic audio, video content, virtual
-        environments, and 3D models. Highlight applications in gaming, entertainment,
-        education, and digital marketing, as well as challenges like misinformation
-        and deepfake detection.\\n\\n3. **AI-Driven Climate Modeling: Enhancing Predictive
-        Accuracy to Combat Climate Change**  \\nExamine how AI and machine learning
-        are improving climate models by analyzing vast datasets, uncovering patterns,
-        and simulating environmental scenarios. Discuss how these advances are aiding
-        policymakers in making informed decisions to address climate risks and sustainability
-        goals.\\n\\n4. **The Ethical Frontiers of AI in Healthcare: Balancing Innovation
-        with Patient Privacy**  \\nInvestigate ethical challenges posed by AI applications
-        in healthcare, including diagnosis, personalized treatment, and patient data
-        management. Focus on balancing rapid technological innovation with privacy,
-        bias mitigation, and regulatory frameworks to ensure equitable access and
-        trust.\\n\\n5. **Quantum Computing Meets AI: Exploring the Next Leap in Computational
-        Power**  \\nCover the intersection of quantum computing and artificial intelligence,
-        exploring how quantum algorithms could accelerate AI training processes and
-        solve problems beyond the reach of classical computers. Outline current research,
-        potential breakthroughs, and the timeline for real-world applications.\\n\\nEach
-        of these topics is timely, relevant, and has the potential to engage readers
-        interested in cutting-edge technology, societal impact, and future trends.
-        Let me know if you want me to help develop an outline or deeper research into
-        any of these areas!\",\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 178,\n    \"completion_tokens\":
-        402,\n    \"total_tokens\": 580,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        \"assistant\",\n        \"content\": \"Certainly! Here are five intriguing
+        article ideas that offer rich potential for deep exploration and broad audience
+        appeal, especially aligned with current trends and human interest in AI and
+        technology:\\n\\n1. **The Evolution of AI Agents: From Rule-Based Bots to
+        Autonomous Decision Makers**  \\n   Explore the historical development of
+        AI agents, tracing the journey from simple scripted chatbots to advanced autonomous
+        systems capable of complex decision-making and learning. Dive into key technological
+        milestones, breakthroughs in machine learning, and current state-of-the-art
+        AI agents. Discuss implications for industries such as customer service, healthcare,
+        and autonomous vehicles, highlighting both opportunities and ethical concerns.\\n\\n2.
+        **AI in Daily Life: How Intelligent Agents Are Reshaping Human Routines**
+        \ \\n   Investigate the integration of AI agents in everyday life\u2014from
+        virtual assistants like Siri and Alexa to personalized recommendation systems
+        and smart home devices. Analyze how these AI tools influence productivity,
+        privacy, and social behavior. Include human interest elements through stories
+        of individuals or communities who have embraced or resisted these technologies.\\n\\n3.
+        **The Future of Work: AI Agents as Collaborative Colleagues**  \\n   Examine
+        how AI agents are transforming workplaces by acting as collaborators rather
+        than just tools. Cover applications in creative fields, data analysis, and
+        decision support, while addressing potential challenges such as job displacement,
+        new skill requirements, and the evolving definition of teamwork. Use expert
+        opinions and case studies to paint a nuanced future outlook.\\n\\n4. **Ethics
+        and Accountability in AI Agent Development**  \\n   Delve into the ethical
+        dilemmas posed by increasingly autonomous AI agents\u2014topics like bias
+        in algorithms, data privacy, and accountability for AI-driven decisions. Explore
+        measures being taken globally to regulate AI, frameworks for responsible AI
+        development, and the role of public awareness. Include historical context
+        about technology ethics to provide depth.\\n\\n5. **Human-AI Symbiosis: Stories
+        of Innovative Partnerships Shaping Our World**  \\n   Tell compelling human
+        interest stories about individuals or organizations pioneering collaborative
+        projects with AI agents that lead to breakthroughs in science, art, or social
+        good. Highlight how these partnerships transcend traditional human-machine
+        interaction and open new creative and problem-solving possibilities, inspiring
+        readers about the potential of human-AI synergy.\\n\\nThese ideas are designed
+        to be both engaging and informative, offering multiple angles\u2014technical,
+        historical, ethical, and personal\u2014to keep readers captivated while providing
+        substantial content for in-depth analysis.\",\n        \"refusal\": null,\n
+        \       \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\":
+        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 189,\n    \"completion_tokens\":
+        472,\n    \"total_tokens\": 661,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
         0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_e76a310957\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_fbf43a1ff3\"\n}\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9db938b0493c4b9f-EWR
+      - 9ea3cb1b5c943323-TPE
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Mar 2026 07:10:59 GMT
+      - Fri, 10 Apr 2026 18:25:25 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -267,7 +275,7 @@ interactions:
       openai-organization:
       - OPENAI-ORG-XXX
       openai-processing-ms:
-      - '5699'
+      - '6990'
       openai-project:
       - OPENAI-PROJECT-XXX
       openai-version:
@@ -298,15 +306,16 @@ interactions:
       a senior writer, specialized in technology, software engineering, AI and startups.
       You work as a freelancer and are now working on writing content for a new customer.\nYour
       personal goal is: Write the best content about AI and AI agents."},{"role":"user","content":"\nCurrent
-      Task: What unique angles or perspectives could we explore to make articles more
-      compelling and engaging?\n\nThis is the expected criteria for your final answer:
-      Your best answer to your coworker asking you this, accounting for the context
-      shared.\nyou MUST return the actual complete content as the final answer, not
-      a summary.\n\nThis is the context you''re working with:\nOur task involves coming
-      up with 5 ideas for articles, each with an exciting paragraph highlight that
-      illustrates the promise and intrigue of the topic. We want them to be more than
-      generic concepts, shining for readers with fresh insights or engaging twists.\n\nProvide
-      your complete response:"}],"model":"gpt-4.1-mini"}'
+      Task: Write one amazing paragraph highlight for each of 5 ideas that showcases
+      how good an article about this topic could be.\n\nThis is the expected criteria
+      for your final answer: Your best answer to your coworker asking you this, accounting
+      for the context shared.\nyou MUST return the actual complete content as the
+      final answer, not a summary.\n\nThis is the context you''re working with:\nUpon
+      receiving five intriguing ideas from the Researcher, create a compelling paragraph
+      for each idea that highlights its potential as a fascinating article. These
+      paragraphs must capture the essence of the topic and explain why it would captivate
+      readers, incorporating possible themes and insights.\n\nProvide your complete
+      response:"}],"model":"gpt-4.1-mini"}'
     headers:
       User-Agent:
       - X-USER-AGENT-XXX
@@ -319,7 +328,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1041'
+      - '1103'
       content-type:
       - application/json
       host:
@@ -333,7 +342,7 @@ interactions:
       x-stainless-os:
       - X-STAINLESS-OS-XXX
       x-stainless-package-version:
-      - 1.83.0
+      - 2.31.0
       x-stainless-read-timeout:
       - X-STAINLESS-READ-TIMEOUT-XXX
       x-stainless-retry-count:
@@ -341,78 +350,83 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.3
+      - 3.13.12
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-DIqxZCl1kFIE7WXznIKow9QFNZ2QT\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1773385853,\n  \"model\": \"gpt-4.1-mini-2025-04-14\",\n
+      string: "{\n  \"id\": \"chatcmpl-DTApbrh9Z4yFAKPHIR48ubdB1R5xK\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775845519,\n  \"model\": \"gpt-4.1-mini-2025-04-14\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"Absolutely! To create compelling and
-        engaging AI articles that stand out, we need to go beyond surface-level discussions
-        and deliver fresh perspectives that challenge assumptions and spark curiosity.
-        Here are five unique angles with their highlight paragraphs that could really
-        captivate our readers:\\n\\n1. **The Hidden Psychology of AI Agents: How They
-        Learn Human Biases and What That Means for Our Future**  \\n*Highlight:* AI
-        agents don\u2019t just process data\u2014they absorb the subtle nuances and
-        biases embedded in human language, behavior, and culture. This article dives
-        deep into the psychological parallels between AI learning mechanisms and human
-        cognitive biases, revealing surprising ways AI can both mirror and amplify
-        our prejudices. Understanding these dynamics is crucial for building trustworthy
-        AI systems and reshaping the future relationship between humans and machines.\\n\\n2.
-        **From Assistants to Autonomous Creators: The Rise of AI Agents as Artists,
-        Writers, and Innovators**  \\n*Highlight:* What do we lose and gain when AI
-        agents start producing original art, literature, and innovations? This piece
-        explores groundbreaking examples where AI isn\u2019t just a tool but a creative
-        partner that challenges our definition of authorship and genius. We\u2019ll
-        examine ethical dilemmas, collaborative workflows, and the exciting frontier
-        where human intuition meets algorithmic originality.\\n\\n3. **AI Agents in
-        the Wild: How Decentralized Autonomous Organizations Could Redefine Economy
-        and Governance**  \\n*Highlight:* Imagine AI agents operating autonomously
-        in decentralized networks, making real-time decisions that affect finances,
-        resource management, and governance without human intervention. This article
-        uncovers how DAOs powered by AI agents might spontaneously evolve new forms
-        of organization\u2014transparent, efficient, and resistant to traditional
-        corruption. We\u2019ll investigate early case studies and speculate on how
-        this might disrupt centuries-old societal structures.\\n\\n4. **Beyond Chatbots:
-        The Next Generation of AI Agents as Empathetic Digital Companions**  \\n*Highlight:*
-        Moving past scripted conversations, emerging AI agents simulate empathy and
-        emotional intelligence in ways that can transform mental health care, education,
-        and companionship. This article provides an insider look at the complex algorithms
-        and biofeedback mechanisms enabling AI to recognize, respond to, and foster
-        human emotions\u2014potentially filling gaps in underserved populations while
-        raising profound questions about authenticity and connection.\\n\\n5. **The
-        Environmental Toll of AI Agents: Unmasking the Ecological Cost of Intelligent
-        Automation**  \\n*Highlight:* While AI promises efficiency and innovation,
-        the environmental footprint of training and deploying millions of AI agents
-        is rarely discussed. This eye-opening article quantifies the energy demands
-        of current models, challenges the narrative of AI as an unequivocal green
-        solution, and explores emerging approaches pathing toward sustainable intelligent
-        automation\u2014an urgent conversation for an increasingly eco-conscious tech
-        landscape.\\n\\nEach of these angles opens a door to rich storytelling that
-        blends technical depth, ethical inquiry, and visionary implications\u2014perfect
-        for readers hungry for insight that\u2019s both sophisticated and accessible.
-        Let me know which ones resonate most, or if you want me to refine any into
-        full article outlines!\",\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 188,\n    \"completion_tokens\":
-        595,\n    \"total_tokens\": 783,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        \"assistant\",\n        \"content\": \"1. **The Rise of Autonomous AI Agents:
+        Revolutionizing Everyday Tasks**  \\nImagine a world where AI agents autonomously
+        manage your daily schedule, optimize your work routines, and even handle complex
+        decision-making with minimal human intervention. An article exploring the
+        rise of autonomous AI agents would captivate readers by diving into how advancements
+        in machine learning and natural language processing have matured these agents
+        from simple chatbots to intelligent collaborators. Themes could include practical
+        applications in industries like healthcare, finance, and personal productivity,
+        the challenges of trust and transparency, and a glimpse into the ethical questions
+        surrounding AI autonomy. This topic not only showcases cutting-edge technology
+        but also invites readers to envision the near future of human-AI synergy.\\n\\n2.
+        **Building Ethical AI Agents: Balancing Innovation with Responsibility**  \\nAs
+        AI agents become more powerful and independent, the imperative to embed ethical
+        frameworks within their design comes sharply into focus. An insightful article
+        on this theme would engage readers by unpacking the complexities of programming
+        morality, fairness, and accountability into AI systems that influence critical
+        decisions\u2014whether in hiring processes, law enforcement, or digital content
+        moderation. Exploring real-world case studies alongside philosophical and
+        regulatory perspectives, the piece could illuminate the delicate balance between
+        technological innovation and societal values, offering a nuanced discussion
+        that appeals to technologists, ethicists, and everyday users alike.\\n\\n3.
+        **AI Agents in Startups: Accelerating Growth and Disrupting Markets**  \\nStartups
+        are uniquely positioned to leverage AI agents as game-changers that turbocharge
+        growth, optimize workflows, and unlock new business models. This article could
+        enthrall readers by detailing how nimble companies integrate AI-driven agents
+        for customer engagement, market analysis, and personalized product recommendations\u2014outpacing
+        larger incumbents. It would also examine hurdles such as data privacy, scaling
+        complexities, and the human-AI collaboration dynamic, providing actionable
+        insights for entrepreneurs and investors. The story of AI agents fueling startup
+        innovation not only inspires but also outlines the practical pathways and
+        pitfalls on the frontier of modern entrepreneurship.\\n\\n4. **The Future
+        of Work with AI Agents: Redefining Roles and Skills**  \\nAI agents are redefining
+        professional landscapes by automating routine tasks and augmenting human creativity
+        and decision-making. An article on this topic could engage readers by painting
+        a vivid picture of the evolving workplace, where collaboration between humans
+        and AI agents becomes the norm. Delving into emerging roles, necessary skill
+        sets, and how education and training must adapt, the piece would offer a forward-thinking
+        analysis that resonates deeply with employees, managers, and policymakers.
+        Exploring themes of workforce transformation, productivity gains, and potential
+        socioeconomic impacts, it provides a comprehensive outlook on an AI-integrated
+        work environment.\\n\\n5. **From Reactive to Proactive: How Next-Gen AI Agents
+        Anticipate Needs**  \\nThe leap from reactive AI assistants to truly proactive
+        AI agents signifies one of the most thrilling advances in artificial intelligence.
+        An article centered on this evolution would captivate readers by illustrating
+        how these agents utilize predictive analytics, contextual understanding, and
+        continuous learning to anticipate user needs before they are expressed. By
+        showcasing pioneering applications in personalized healthcare management,
+        smart homes, and adaptive learning platforms, the article would highlight
+        the profound shift toward intuitive, anticipatory technology. This theme not
+        only excites with futuristic promise but also probes the technical and privacy
+        challenges that come with increased agency and foresight.\",\n        \"refusal\":
+        null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n
+        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        197,\n    \"completion_tokens\": 666,\n    \"total_tokens\": 863,\n    \"prompt_tokens_details\":
+        {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_ae0f8c9a7b\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_d45f83c5fd\"\n}\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9db938b0489680d4-EWR
+      - 9ea3cb1cbfe2b312-TPE
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Mar 2026 07:11:02 GMT
+      - Fri, 10 Apr 2026 18:25:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -428,7 +442,7 @@ interactions:
       openai-organization:
       - OPENAI-ORG-XXX
       openai-processing-ms:
-      - '8310'
+      - '9479'
       openai-project:
       - OPENAI-PROJECT-XXX
       openai-version:
@@ -467,91 +481,105 @@ interactions:
       good an article about this topic could be. Return the list of ideas with their
       paragraph and your notes.\\n\\nThis is the expected criteria for your final
       answer: 5 bullet points with a paragraph for each idea.\\nyou MUST return the
-      actual complete content as the final answer, not a summary.\"},{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"call_G2i9RJGNXKVfnd8ZTaBG8Fwi\",\"type\":\"function\",\"function\":{\"name\":\"ask_question_to_coworker\",\"arguments\":\"{\\\"question\\\":
-      \\\"What are some trending topics or ideas in various fields that could be explored
-      for an article?\\\", \\\"context\\\": \\\"We need to generate a list of 5 interesting
-      ideas to explore for an article. These ideas should be engaging and relevant
-      to current trends or captivating subjects.\\\", \\\"coworker\\\": \\\"Researcher\\\"}\"}},{\"id\":\"call_j4KH2SGZvNeioql0HcRQ9NTp\",\"type\":\"function\",\"function\":{\"name\":\"ask_question_to_coworker\",\"arguments\":\"{\\\"question\\\":
-      \\\"What unique angles or perspectives could we explore to make articles more
-      compelling and engaging?\\\", \\\"context\\\": \\\"Our task involves coming
-      up with 5 ideas for articles, each with an exciting paragraph highlight that
-      illustrates the promise and intrigue of the topic. We want them to be more than
-      generic concepts, shining for readers with fresh insights or engaging twists.\\\",
-      \\\"coworker\\\": \\\"Senior Writer\\\"}\"}}]},{\"role\":\"tool\",\"tool_call_id\":\"call_G2i9RJGNXKVfnd8ZTaBG8Fwi\",\"name\":\"ask_question_to_coworker\",\"content\":\"Here
-      are five trending and engaging topics across various fields that could be explored
-      for an article:\\n\\n1. **The Rise of Autonomous AI Agents and Their Impact
-      on the Future of Work**  \\nExplore how autonomous AI agents\u2014systems capable
-      of performing complex tasks independently\u2014are transforming industries such
-      as customer service, software development, and logistics. Discuss implications
-      for job automation, human-AI collaboration, and ethical considerations surrounding
-      decision-making autonomy.\\n\\n2. **Generative AI Beyond Text: Innovations in
-      Audio, Video, and 3D Content Creation**  \\nDelve into advancements in generative
-      AI models that create not only text but also realistic audio, video content,
-      virtual environments, and 3D models. Highlight applications in gaming, entertainment,
-      education, and digital marketing, as well as challenges like misinformation
-      and deepfake detection.\\n\\n3. **AI-Driven Climate Modeling: Enhancing Predictive
-      Accuracy to Combat Climate Change**  \\nExamine how AI and machine learning
-      are improving climate models by analyzing vast datasets, uncovering patterns,
-      and simulating environmental scenarios. Discuss how these advances are aiding
-      policymakers in making informed decisions to address climate risks and sustainability
-      goals.\\n\\n4. **The Ethical Frontiers of AI in Healthcare: Balancing Innovation
-      with Patient Privacy**  \\nInvestigate ethical challenges posed by AI applications
-      in healthcare, including diagnosis, personalized treatment, and patient data
-      management. Focus on balancing rapid technological innovation with privacy,
-      bias mitigation, and regulatory frameworks to ensure equitable access and trust.\\n\\n5.
-      **Quantum Computing Meets AI: Exploring the Next Leap in Computational Power**
-      \ \\nCover the intersection of quantum computing and artificial intelligence,
-      exploring how quantum algorithms could accelerate AI training processes and
-      solve problems beyond the reach of classical computers. Outline current research,
-      potential breakthroughs, and the timeline for real-world applications.\\n\\nEach
-      of these topics is timely, relevant, and has the potential to engage readers
-      interested in cutting-edge technology, societal impact, and future trends. Let
-      me know if you want me to help develop an outline or deeper research into any
-      of these areas!\"},{\"role\":\"tool\",\"tool_call_id\":\"call_j4KH2SGZvNeioql0HcRQ9NTp\",\"name\":\"ask_question_to_coworker\",\"content\":\"Absolutely!
-      To create compelling and engaging AI articles that stand out, we need to go
-      beyond surface-level discussions and deliver fresh perspectives that challenge
-      assumptions and spark curiosity. Here are five unique angles with their highlight
-      paragraphs that could really captivate our readers:\\n\\n1. **The Hidden Psychology
-      of AI Agents: How They Learn Human Biases and What That Means for Our Future**
-      \ \\n*Highlight:* AI agents don\u2019t just process data\u2014they absorb the
-      subtle nuances and biases embedded in human language, behavior, and culture.
-      This article dives deep into the psychological parallels between AI learning
-      mechanisms and human cognitive biases, revealing surprising ways AI can both
-      mirror and amplify our prejudices. Understanding these dynamics is crucial for
-      building trustworthy AI systems and reshaping the future relationship between
-      humans and machines.\\n\\n2. **From Assistants to Autonomous Creators: The Rise
-      of AI Agents as Artists, Writers, and Innovators**  \\n*Highlight:* What do
-      we lose and gain when AI agents start producing original art, literature, and
-      innovations? This piece explores groundbreaking examples where AI isn\u2019t
-      just a tool but a creative partner that challenges our definition of authorship
-      and genius. We\u2019ll examine ethical dilemmas, collaborative workflows, and
-      the exciting frontier where human intuition meets algorithmic originality.\\n\\n3.
-      **AI Agents in the Wild: How Decentralized Autonomous Organizations Could Redefine
-      Economy and Governance**  \\n*Highlight:* Imagine AI agents operating autonomously
-      in decentralized networks, making real-time decisions that affect finances,
-      resource management, and governance without human intervention. This article
-      uncovers how DAOs powered by AI agents might spontaneously evolve new forms
-      of organization\u2014transparent, efficient, and resistant to traditional corruption.
-      We\u2019ll investigate early case studies and speculate on how this might disrupt
-      centuries-old societal structures.\\n\\n4. **Beyond Chatbots: The Next Generation
-      of AI Agents as Empathetic Digital Companions**  \\n*Highlight:* Moving past
-      scripted conversations, emerging AI agents simulate empathy and emotional intelligence
-      in ways that can transform mental health care, education, and companionship.
-      This article provides an insider look at the complex algorithms and biofeedback
-      mechanisms enabling AI to recognize, respond to, and foster human emotions\u2014potentially
-      filling gaps in underserved populations while raising profound questions about
-      authenticity and connection.\\n\\n5. **The Environmental Toll of AI Agents:
-      Unmasking the Ecological Cost of Intelligent Automation**  \\n*Highlight:* While
-      AI promises efficiency and innovation, the environmental footprint of training
-      and deploying millions of AI agents is rarely discussed. This eye-opening article
-      quantifies the energy demands of current models, challenges the narrative of
-      AI as an unequivocal green solution, and explores emerging approaches pathing
-      toward sustainable intelligent automation\u2014an urgent conversation for an
-      increasingly eco-conscious tech landscape.\\n\\nEach of these angles opens a
-      door to rich storytelling that blends technical depth, ethical inquiry, and
-      visionary implications\u2014perfect for readers hungry for insight that\u2019s
-      both sophisticated and accessible. Let me know which ones resonate most, or
-      if you want me to refine any into full article outlines!\"},{\"role\":\"user\",\"content\":\"Analyze
+      actual complete content as the final answer, not a summary.\"},{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"call_BCh6lXsBTdixRuRh6OTBPoIJ\",\"type\":\"function\",\"function\":{\"name\":\"delegate_work_to_coworker\",\"arguments\":\"{\\\"task\\\":
+      \\\"Come up with a list of 5 interesting ideas to explore for an article.\\\",
+      \\\"context\\\": \\\"We need five intriguing ideas worth exploring for an article.
+      Each idea should have potential for in-depth exploration and appeal to a broad
+      audience, possibly touching on current trends, historical insights, future possibilities,
+      or human interest stories.\\\", \\\"coworker\\\": \\\"Researcher\\\"}\"}},{\"id\":\"call_rAQFeCrS4ogsqvIWRGAYFHGI\",\"type\":\"function\",\"function\":{\"name\":\"delegate_work_to_coworker\",\"arguments\":\"{\\\"task\\\":
+      \\\"Write one amazing paragraph highlight for each of 5 ideas that showcases
+      how good an article about this topic could be.\\\", \\\"context\\\": \\\"Upon
+      receiving five intriguing ideas from the Researcher, create a compelling paragraph
+      for each idea that highlights its potential as a fascinating article. These
+      paragraphs must capture the essence of the topic and explain why it would captivate
+      readers, incorporating possible themes and insights.\\\", \\\"coworker\\\":
+      \\\"Senior Writer\\\"}\"}}]},{\"role\":\"tool\",\"tool_call_id\":\"call_BCh6lXsBTdixRuRh6OTBPoIJ\",\"name\":\"delegate_work_to_coworker\",\"content\":\"Certainly!
+      Here are five intriguing article ideas that offer rich potential for deep exploration
+      and broad audience appeal, especially aligned with current trends and human
+      interest in AI and technology:\\n\\n1. **The Evolution of AI Agents: From Rule-Based
+      Bots to Autonomous Decision Makers**  \\n   Explore the historical development
+      of AI agents, tracing the journey from simple scripted chatbots to advanced
+      autonomous systems capable of complex decision-making and learning. Dive into
+      key technological milestones, breakthroughs in machine learning, and current
+      state-of-the-art AI agents. Discuss implications for industries such as customer
+      service, healthcare, and autonomous vehicles, highlighting both opportunities
+      and ethical concerns.\\n\\n2. **AI in Daily Life: How Intelligent Agents Are
+      Reshaping Human Routines**  \\n   Investigate the integration of AI agents in
+      everyday life\u2014from virtual assistants like Siri and Alexa to personalized
+      recommendation systems and smart home devices. Analyze how these AI tools influence
+      productivity, privacy, and social behavior. Include human interest elements
+      through stories of individuals or communities who have embraced or resisted
+      these technologies.\\n\\n3. **The Future of Work: AI Agents as Collaborative
+      Colleagues**  \\n   Examine how AI agents are transforming workplaces by acting
+      as collaborators rather than just tools. Cover applications in creative fields,
+      data analysis, and decision support, while addressing potential challenges such
+      as job displacement, new skill requirements, and the evolving definition of
+      teamwork. Use expert opinions and case studies to paint a nuanced future outlook.\\n\\n4.
+      **Ethics and Accountability in AI Agent Development**  \\n   Delve into the
+      ethical dilemmas posed by increasingly autonomous AI agents\u2014topics like
+      bias in algorithms, data privacy, and accountability for AI-driven decisions.
+      Explore measures being taken globally to regulate AI, frameworks for responsible
+      AI development, and the role of public awareness. Include historical context
+      about technology ethics to provide depth.\\n\\n5. **Human-AI Symbiosis: Stories
+      of Innovative Partnerships Shaping Our World**  \\n   Tell compelling human
+      interest stories about individuals or organizations pioneering collaborative
+      projects with AI agents that lead to breakthroughs in science, art, or social
+      good. Highlight how these partnerships transcend traditional human-machine interaction
+      and open new creative and problem-solving possibilities, inspiring readers about
+      the potential of human-AI synergy.\\n\\nThese ideas are designed to be both
+      engaging and informative, offering multiple angles\u2014technical, historical,
+      ethical, and personal\u2014to keep readers captivated while providing substantial
+      content for in-depth analysis.\"},{\"role\":\"tool\",\"tool_call_id\":\"call_rAQFeCrS4ogsqvIWRGAYFHGI\",\"name\":\"delegate_work_to_coworker\",\"content\":\"1.
+      **The Rise of Autonomous AI Agents: Revolutionizing Everyday Tasks**  \\nImagine
+      a world where AI agents autonomously manage your daily schedule, optimize your
+      work routines, and even handle complex decision-making with minimal human intervention.
+      An article exploring the rise of autonomous AI agents would captivate readers
+      by diving into how advancements in machine learning and natural language processing
+      have matured these agents from simple chatbots to intelligent collaborators.
+      Themes could include practical applications in industries like healthcare, finance,
+      and personal productivity, the challenges of trust and transparency, and a glimpse
+      into the ethical questions surrounding AI autonomy. This topic not only showcases
+      cutting-edge technology but also invites readers to envision the near future
+      of human-AI synergy.\\n\\n2. **Building Ethical AI Agents: Balancing Innovation
+      with Responsibility**  \\nAs AI agents become more powerful and independent,
+      the imperative to embed ethical frameworks within their design comes sharply
+      into focus. An insightful article on this theme would engage readers by unpacking
+      the complexities of programming morality, fairness, and accountability into
+      AI systems that influence critical decisions\u2014whether in hiring processes,
+      law enforcement, or digital content moderation. Exploring real-world case studies
+      alongside philosophical and regulatory perspectives, the piece could illuminate
+      the delicate balance between technological innovation and societal values, offering
+      a nuanced discussion that appeals to technologists, ethicists, and everyday
+      users alike.\\n\\n3. **AI Agents in Startups: Accelerating Growth and Disrupting
+      Markets**  \\nStartups are uniquely positioned to leverage AI agents as game-changers
+      that turbocharge growth, optimize workflows, and unlock new business models.
+      This article could enthrall readers by detailing how nimble companies integrate
+      AI-driven agents for customer engagement, market analysis, and personalized
+      product recommendations\u2014outpacing larger incumbents. It would also examine
+      hurdles such as data privacy, scaling complexities, and the human-AI collaboration
+      dynamic, providing actionable insights for entrepreneurs and investors. The
+      story of AI agents fueling startup innovation not only inspires but also outlines
+      the practical pathways and pitfalls on the frontier of modern entrepreneurship.\\n\\n4.
+      **The Future of Work with AI Agents: Redefining Roles and Skills**  \\nAI agents
+      are redefining professional landscapes by automating routine tasks and augmenting
+      human creativity and decision-making. An article on this topic could engage
+      readers by painting a vivid picture of the evolving workplace, where collaboration
+      between humans and AI agents becomes the norm. Delving into emerging roles,
+      necessary skill sets, and how education and training must adapt, the piece would
+      offer a forward-thinking analysis that resonates deeply with employees, managers,
+      and policymakers. Exploring themes of workforce transformation, productivity
+      gains, and potential socioeconomic impacts, it provides a comprehensive outlook
+      on an AI-integrated work environment.\\n\\n5. **From Reactive to Proactive:
+      How Next-Gen AI Agents Anticipate Needs**  \\nThe leap from reactive AI assistants
+      to truly proactive AI agents signifies one of the most thrilling advances in
+      artificial intelligence. An article centered on this evolution would captivate
+      readers by illustrating how these agents utilize predictive analytics, contextual
+      understanding, and continuous learning to anticipate user needs before they
+      are expressed. By showcasing pioneering applications in personalized healthcare
+      management, smart homes, and adaptive learning platforms, the article would
+      highlight the profound shift toward intuitive, anticipatory technology. This
+      theme not only excites with futuristic promise but also probes the technical
+      and privacy challenges that come with increased agency and foresight.\"},{\"role\":\"user\",\"content\":\"Analyze
       the tool result. If requirements are met, provide the Final Answer. Otherwise,
       call the next tool. Deliver only the answer without meta-commentary.\"}],\"model\":\"gpt-4o\",\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"delegate_work_to_coworker\",\"description\":\"Delegate
       a specific task to one of the following coworkers: Researcher, Senior Writer\\nThe
@@ -582,7 +610,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '9923'
+      - '11056'
       content-type:
       - application/json
       cookie:
@@ -598,7 +626,7 @@ interactions:
       x-stainless-os:
       - X-STAINLESS-OS-XXX
       x-stainless-package-version:
-      - 1.83.0
+      - 2.31.0
       x-stainless-read-timeout:
       - X-STAINLESS-READ-TIMEOUT-XXX
       x-stainless-retry-count:
@@ -606,58 +634,64 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.3
+      - 3.13.12
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-DIqxidsfoqQl7qXSIVHfSCyETUwlU\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1773385862,\n  \"model\": \"gpt-4o-2024-08-06\",\n
+      string: "{\n  \"id\": \"chatcmpl-DTApljTaq8nDgNMS21B319i56seCn\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775845529,\n  \"model\": \"gpt-4o-2024-08-06\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"1. **The Rise of Autonomous AI Agents
-        and Their Impact on the Future of Work**  \\nExplore how autonomous AI agents\u2014systems
-        capable of performing complex tasks independently\u2014are transforming industries
-        such as customer service, software development, and logistics. Discuss implications
-        for job automation, human-AI collaboration, and ethical considerations surrounding
-        decision-making autonomy.\\n\\n2. **Generative AI Beyond Text: Innovations
-        in Audio, Video, and 3D Content Creation**  \\nDelve into advancements in
-        generative AI models that create not only text but also realistic audio, video
-        content, virtual environments, and 3D models. Highlight applications in gaming,
-        entertainment, education, and digital marketing, as well as challenges like
-        misinformation and deepfake detection.\\n\\n3. **AI-Driven Climate Modeling:
-        Enhancing Predictive Accuracy to Combat Climate Change**  \\nExamine how AI
-        and machine learning are improving climate models by analyzing vast datasets,
-        uncovering patterns, and simulating environmental scenarios. Discuss how these
-        advances are aiding policymakers in making informed decisions to address climate
-        risks and sustainability goals.\\n\\n4. **The Ethical Frontiers of AI in Healthcare:
-        Balancing Innovation with Patient Privacy**  \\nInvestigate ethical challenges
-        posed by AI applications in healthcare, including diagnosis, personalized
-        treatment, and patient data management. Focus on balancing rapid technological
-        innovation with privacy, bias mitigation, and regulatory frameworks to ensure
-        equitable access and trust.\\n\\n5. **Quantum Computing Meets AI: Exploring
-        the Next Leap in Computational Power**  \\nCover the intersection of quantum
-        computing and artificial intelligence, exploring how quantum algorithms could
-        accelerate AI training processes and solve problems beyond the reach of classical
-        computers. Outline current research, potential breakthroughs, and the timeline
-        for real-world applications.\",\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 1748,\n    \"completion_tokens\":
-        335,\n    \"total_tokens\": 2083,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        \"assistant\",\n        \"content\": \"- **The Evolution of AI Agents: From
+        Rule-Based Bots to Autonomous Decision Makers**  \\n   Explore the historical
+        development of AI agents, tracing the journey from simple scripted chatbots
+        to advanced autonomous systems capable of complex decision-making and learning.
+        Dive into key technological milestones, breakthroughs in machine learning,
+        and current state-of-the-art AI agents. Discuss implications for industries
+        such as customer service, healthcare, and autonomous vehicles, highlighting
+        both opportunities and ethical concerns.\\n\\n- **AI in Daily Life: How Intelligent
+        Agents Are Reshaping Human Routines**  \\n   Investigate the integration of
+        AI agents in everyday life\u2014from virtual assistants like Siri and Alexa
+        to personalized recommendation systems and smart home devices. Analyze how
+        these AI tools influence productivity, privacy, and social behavior. Include
+        human interest elements through stories of individuals or communities who
+        have embraced or resisted these technologies.\\n\\n- **The Future of Work:
+        AI Agents as Collaborative Colleagues**  \\n   Examine how AI agents are transforming
+        workplaces by acting as collaborators rather than just tools. Cover applications
+        in creative fields, data analysis, and decision support, while addressing
+        potential challenges such as job displacement, new skill requirements, and
+        the evolving definition of teamwork. Use expert opinions and case studies
+        to paint a nuanced future outlook.\\n\\n- **Ethics and Accountability in AI
+        Agent Development**  \\n   Delve into the ethical dilemmas posed by increasingly
+        autonomous AI agents\u2014topics like bias in algorithms, data privacy, and
+        accountability for AI-driven decisions. Explore measures being taken globally
+        to regulate AI, frameworks for responsible AI development, and the role of
+        public awareness. Include historical context about technology ethics to provide
+        depth.\\n\\n- **Human-AI Symbiosis: Stories of Innovative Partnerships Shaping
+        Our World**  \\n   Tell compelling human interest stories about individuals
+        or organizations pioneering collaborative projects with AI agents that lead
+        to breakthroughs in science, art, or social good. Highlight how these partnerships
+        transcend traditional human-machine interaction and open new creative and
+        problem-solving possibilities, inspiring readers about the potential of human-AI
+        synergy.\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
+        \     \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n
+        \ \"usage\": {\n    \"prompt_tokens\": 1903,\n    \"completion_tokens\": 399,\n
+        \   \"total_tokens\": 2302,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
         0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_b7c8e3f100\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_df40ab6c25\"\n}\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9db938e60d5bc5e7-EWR
+      - 9ea3cb5a6957b301-TPE
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Mar 2026 07:11:04 GMT
+      - Fri, 10 Apr 2026 18:25:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -673,7 +707,7 @@ interactions:
       openai-organization:
       - OPENAI-ORG-XXX
       openai-processing-ms:
-      - '2009'
+      - '2183'
       openai-project:
       - OPENAI-PROJECT-XXX
       openai-version:


### PR DESCRIPTION
## Summary
- Re-records `tests/cassettes/test_hierarchical_verbose_false_manager_agent.yaml` so `test_hierarchical_verbose_false_manager_agent` plays back cleanly under `--block-network`. The previous cassette no longer matched the current request body, causing VCR to fall through to a live OpenAI call and fail with a `ConnectionError`.

## Test plan
- [x] `uv run pytest tests/test_crew.py::test_hierarchical_verbose_false_manager_agent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change: updates recorded OpenAI/VCR interactions to match current request payloads so playback works under network blocking.
> 
> **Overview**
> Re-records `tests/cassettes/test_hierarchical_verbose_false_manager_agent.yaml` so `test_hierarchical_verbose_false_manager_agent` replays deterministically under VCR/`--block-network`.
> 
> The cassette now matches the current hierarchical manager behavior (uses `delegate_work_to_coworker` tool calls and updated request bodies/headers), preventing fallback to live OpenAI calls during tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04b26d5cb4cc01235fc6e2e515e464302484c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->