### PR TITLE
chore: bump pypdf to 6.10.0 for GHSA-3crg-w4f6-42mx

### DIFF
--- a/lib/crewai-files/pyproject.toml
+++ b/lib/crewai-files/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "Pillow~=12.1.1",
-    "pypdf~=6.9.1",
+    "pypdf~=6.10.0",
     "python-magic>=0.4.27",
     "aiocache~=0.12.3",
     "aiofiles~=24.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1420,7 +1420,7 @@ requires-dist = [
     { name = "aiofiles", specifier = "~=24.1.0" },
     { name = "av", specifier = "~=13.0.0" },
     { name = "pillow", specifier = "~=12.1.1" },
-    { name = "pypdf", specifier = "~=6.9.1" },
+    { name = "pypdf", specifier = "~=6.10.0" },
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "tinytag", specifier = "~=2.2.1" },
 ]
@@ -6724,14 +6724,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.9.2"
+version = "6.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/9f/ca96abf18683ca12602065e4ed2bec9050b672c87d317f1079abc7b6d993/pypdf-6.10.0.tar.gz", hash = "sha256:4c5a48ba258c37024ec2505f7e8fd858525f5502784a2e1c8d415604af29f6ef", size = 5314833, upload-time = "2026-04-10T09:34:57.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f2/7ebe366f633f30a6ad105f650f44f24f98cb1335c4157d21ae47138b3482/pypdf-6.10.0-py3-none-any.whl", hash = "sha256:90005e959e1596c6e6c84c8b0ad383285b3e17011751cedd17f2ce8fcdfc86de", size = 334459, upload-time = "2026-04-10T09:34:54.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `pypdf` from `~=6.9.1` to `~=6.10.0` in `lib/crewai-files/pyproject.toml` to resolve [GHSA-3crg-w4f6-42mx](https://github.com/advisories/GHSA-3crg-w4f6-42mx) / CVE-2026-40260, where manipulated XMP metadata entity declarations can exhaust RAM.
- Regenerates `uv.lock` (pypdf 6.9.2 → 6.10.0).

Unblocks the `pip-audit` vulnerability scan workflow, which was failing with:
```
Found vulnerabilities in 1 package(s)
  - pypdf==6.9.2: GHSA-3crg-w4f6-42mx
```

## Test plan
- [ ] `pip-audit` workflow passes on CI
- [ ] `uv lock --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change, but it may subtly affect PDF parsing/chunking behavior since `pypdf` is used in file processing utilities.
> 
> **Overview**
> Updates `lib/crewai-files` to require `pypdf~=6.10.0` (from `~=6.9.1`) to address **GHSA-3crg-w4f6-42mx**.
> 
> Regenerates `uv.lock`, moving the resolved `pypdf` version from `6.9.2` to `6.10.0` with corresponding artifact hashes/URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1a652105c9b406ef756870d7d999229736521f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->