### PR TITLE
fix: remove dead code before raise in _create_manager_agent

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1391,7 +1391,6 @@ class Crew(FlowTrackable, BaseModel):
                     "Manager agent should not have tools",
                     color="bold_yellow",
                 )
-                manager.tools = []
                 raise Exception("Manager agent should not have tools")
         else:
             self.manager_llm = create_llm(self.manager_llm)


### PR DESCRIPTION
## Summary
- Remove unreachable `manager.tools = []` assignment in `_create_manager_agent()` that is immediately followed by a `raise Exception`, making the assignment dead code.

## Details
In `crew.py`, the `_create_manager_agent` method had this code:

```python
manager.tools = []
raise Exception("Manager agent should not have tools")