### PR TITLE
fix: preserve Bedrock tool call arguments by removing truthy default

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -827,7 +827,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
             func_name = sanitize_tool_name(
                 func_info.get("name", "") or tool_call.get("name", "")
             )
-            func_args = func_info.get("arguments", "{}") or tool_call.get("input", {})
+            func_args = func_info.get("arguments") or tool_call.get("input", {})
             return call_id, func_name, func_args
         return None
 


### PR DESCRIPTION
## Summary

Fixes #5275

When using CrewAI with AWS Bedrock LLMs, tool arguments are silently discarded. The tool receives `{}` instead of the actual arguments.

## Root Cause

Bedrock's Converse API returns tool calls as:
```json
{"name": "get_travel_details", "toolUseId": "abc123", "input": {"city": "Paris"}}
```

In `_extract_tool_call_info`:
```python
func_info = tool_call.get('function', {})     # {} — no 'function' wrapper in Bedrock
func_args = func_info.get('arguments', '{}')  # '{}' — truthy default!
            or tool_call.get('input', {})      # never reached
```

`get('arguments', '{}')` returns `'{}'` (truthy string), so the `or` never falls through to `tool_call.get('input', ...)`.

## Fix

```python
# Before — '{}' default is truthy, blocks or-fallback
func_args = func_info.get('arguments', '{}') or tool_call.get('input', {})

# After — None default is falsy, allows or-fallback to Bedrock's 'input'
func_args = func_info.get('arguments') or tool_call.get('input', {})
```