### PR TITLE
chore: clean up redundant inline docs in a2a module

### DIFF
--- a/lib/crewai/src/crewai/a2a/errors.py
+++ b/lib/crewai/src/crewai/a2a/errors.py
@@ -98,7 +98,6 @@ class A2AErrorCode(IntEnum):
     """The specified artifact was not found."""
 
 
-# Error code to default message mapping
 ERROR_MESSAGES: dict[int, str] = {
     A2AErrorCode.JSON_PARSE_ERROR: "Parse error",
     A2AErrorCode.INVALID_REQUEST: "Invalid Request",

--- a/lib/crewai/src/crewai/a2a/extensions/base.py
+++ b/lib/crewai/src/crewai/a2a/extensions/base.py
@@ -63,25 +63,21 @@ class A2AExtension(Protocol):
     Example:
         class MyExtension:
             def inject_tools(self, agent: Agent) -> None:
-                # Add custom tools to the agent
                 pass
 
             def extract_state_from_history(
                 self, conversation_history: Sequence[Message]
             ) -> ConversationState | None:
-                # Extract state from conversation
                 return None
 
             def augment_prompt(
                 self, base_prompt: str, conversation_state: ConversationState | None
             ) -> str:
-                # Add custom instructions
                 return base_prompt
 
             def process_response(
                 self, agent_response: Any, conversation_state: ConversationState | None
             ) -> Any:
-                # Modify response if needed
                 return agent_response
     """
 

--- a/lib/crewai/src/crewai/a2a/utils/response_model.py
+++ b/lib/crewai/src/crewai/a2a/utils/response_model.py
@@ -77,7 +77,6 @@ def extract_a2a_agent_ids_from_config(
     else:
         configs = a2a_config
 
-    # Filter to only client configs (those with endpoint)
     client_configs: list[A2AClientConfigTypes] = [
         config for config in configs if isinstance(config, (A2AConfig, A2AClientConfig))
     ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this PR only removes redundant inline comments/doc examples without changing any runtime behavior or APIs.
> 
> **Overview**
> Cleans up redundant inline documentation in the A2A module by removing unnecessary comments from the `ERROR_MESSAGES` mapping, the `A2AExtension` protocol example, and `extract_a2a_agent_ids_from_config` config filtering logic.
> 
> No functional behavior changes; this is a readability-only documentation tidy-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb91d9a0c9f240d3ace18739d0407b5c9f1d48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->