### PR TITLE
chore: clean up redundant inline docs in agent module

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1485,8 +1485,6 @@ class Agent(BaseAgent):
         Note:
             For explicit async usage outside of Flow, use kickoff_async() directly.
         """
-        # Magic auto-async: if inside event loop (e.g., inside a Flow),
-        # return coroutine for Flow to await
         if is_inside_event_loop():
             return self.kickoff_async(messages, response_format, input_files)
 

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1341,7 +1341,6 @@ class Agent(BaseAgent):
 
         raw_tools: list[BaseTool] = self.tools or []
 
-        # Inject memory tools for standalone kickoff (crew path handles its own)
         agent_memory = getattr(self, "memory", None)
         if agent_memory is not None:
             from crewai.tools.memory_tools import create_memory_tools
@@ -1399,7 +1398,6 @@ class Agent(BaseAgent):
         if input_files:
             all_files.update(input_files)
 
-        # Inject memory context for standalone kickoff (recall before execution)
         if agent_memory is not None:
             try:
                 crewai_event_bus.emit(
@@ -1635,7 +1633,7 @@ class Agent(BaseAgent):
                 if isinstance(conversion_result, BaseModel):
                     formatted_result = conversion_result
             except ConverterError:
-                pass  # Keep raw output if conversion fails
+                pass
         else:
             raw_output = str(output) if not isinstance(output, str) else output
 
@@ -1717,7 +1715,6 @@ class Agent(BaseAgent):
         elif callable(self.guardrail):
             guardrail_callable = self.guardrail
         else:
-            # Should not happen if called from kickoff with guardrail check
             return output
 
         guardrail_result = process_guardrail(

--- a/lib/crewai/src/crewai/agent/planning_config.py
+++ b/lib/crewai/src/crewai/agent/planning_config.py
@@ -41,7 +41,6 @@ class PlanningConfig(BaseModel):
         from crewai import Agent
         from crewai.agent.planning_config import PlanningConfig
 
-        # Simple usage — fast, linear execution (default)
         agent = Agent(
             role="Researcher",
             goal="Research topics",
@@ -49,7 +48,6 @@ class PlanningConfig(BaseModel):
             planning_config=PlanningConfig(),
         )
 
-        # Balanced — replan only when steps fail
         agent = Agent(
             role="Researcher",
             goal="Research topics",
@@ -59,7 +57,6 @@ class PlanningConfig(BaseModel):
             ),
         )
 
-        # Full adaptive planning with refinement and replanning
         agent = Agent(
             role="Researcher",
             goal="Research topics",
@@ -69,7 +66,7 @@ class PlanningConfig(BaseModel):
                 max_attempts=3,
                 max_steps=10,
                 plan_prompt="Create a focused plan for: {description}",
-                llm="gpt-4o-mini",  # Use cheaper model for planning
+                llm="gpt-4o-mini",
             ),
         )
         ```

--- a/lib/crewai/src/crewai/agent/utils.py
+++ b/lib/crewai/src/crewai/agent/utils.py
@@ -39,7 +39,6 @@ def handle_reasoning(agent: Agent, task: Task) -> None:
         agent: The agent performing the task.
         task: The task to execute.
     """
-    # Check if planning is enabled using the planning_enabled property
     if not getattr(agent, "planning_enabled", False):
         return
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to removing/shortening comments and minor docstring tweaks without altering execution logic, APIs, or data handling.
> 
> **Overview**
> Cleans up redundant inline documentation across the agent module by removing several explanatory comments in `agent/core.py` (kickoff/memory/guardrail areas), `agent/utils.py` (planning gate), and the `PlanningConfig` doc examples.
> 
> No functional behavior is changed; this is a documentation/readability-only refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bacf9ed645e011d6e246a87d2ccf91964fd0f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->