### PR TITLE
feat(hooks): add provider-based pre-tool-call guardrails

### DIFF
--- a/docs/ar/learn/tool-hooks.mdx
+++ b/docs/ar/learn/tool-hooks.mdx
@@ -9,6 +9,7 @@ mode: "wide"
 ## نظرة عامة
 
 تُنفذ خطافات الأدوات في نقطتين حرجتين:
+
 - **قبل استدعاء الأداة**: تعديل المدخلات، التحقق من المعاملات، أو حظر التنفيذ
 - **بعد استدعاء الأداة**: تحويل النتائج، تنقية المخرجات، أو تسجيل تفاصيل التنفيذ
 
@@ -17,6 +18,7 @@ mode: "wide"
 ### خطافات ما قبل استدعاء الأداة
 
 تُنفذ قبل كل تنفيذ أداة، ويمكن لهذه الخطافات:
+
 - فحص وتعديل مدخلات الأداة
 - حظر تنفيذ الأداة بناءً على شروط
 - تنفيذ بوابات موافقة للعمليات الخطرة
@@ -24,6 +26,7 @@ mode: "wide"
 - تسجيل استدعاءات الأدوات
 
 **التوقيع:**
+
 ```python
 def before_hook(context: ToolCallHookContext) -> bool | None:
     # Return False to block execution
@@ -34,6 +37,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 ### خطافات ما بعد استدعاء الأداة
 
 تُنفذ بعد كل تنفيذ أداة، ويمكن لهذه الخطافات:
+
 - تعديل أو تنقية نتائج الأداة
 - إضافة بيانات وصفية أو تنسيق
 - تسجيل نتائج التنفيذ
@@ -41,6 +45,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 - تحويل تنسيقات المخرجات
 
 **التوقيع:**
+
 ```python
 def after_hook(context: ToolCallHookContext) -> str | None:
     # Return modified result string
@@ -147,6 +152,228 @@ class MyProjCrew:
             verbose=True
         )
 ```
+
+## حواجز الحماية المعتمدة على Provider
+
+إذا كنت تريد تفويضًا قابلاً لإعادة الاستخدام قبل استدعاء الأداة بدون كتابة
+دوال hook خام لكل crew، فإن CrewAI يوفّر أيضًا طبقة اختيارية من
+`GuardrailProvider` فوق `before_tool_call`.
+
+يتبع هذا النمط نفس الفكرة المستخدمة في أطر مثل Deerflow:
+
+- يعرّف CrewAI نقطة التوسعة الأساسية
+- يشحن CrewAI مزوّد allowlist مدمجًا وبسيطًا
+- يمكن للمزوّدات الخارجية أن تعمل عبر نفس العقد
+
+هذه الطبقة اختيارية وإضافية:
+
+- إذا لم تفعّل guardrail فسيبقى سلوك أدوات CrewAI كما هو
+- وإذا فعّلته، فسيعيد CrewAI استخدام تدفّق `before_tool_call` الحالي فقط
+
+العقد الأساسي صغير ومتزامن عمدًا اليوم:
+
+- يحصل المزوّد على `GuardrailRequest` موحّد
+- يعيد المزوّد `allow` أو `deny`
+- يربط CrewAI هذه النتيجة بتدفّق hook الحالي `before_tool_call`
+
+يدعم `before_tool_call` اليوم فقط دلالات السماح أو الحظر، لذلك لا يضيف CrewAI
+سلوك `delegate` أو `escalate` أو suspend/resume داخل هذا القلب.
+
+### واجهة GuardrailProvider
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailProvider, GuardrailRequest
+
+
+class MyProvider:
+    name = "my-provider"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.tool_name == "exec":
+            return GuardrailDecision(allow=False, reason="exec غير مسموح")
+        return GuardrailDecision(allow=True)
+```
+
+التسجيل:
+
+```python
+from crewai.hooks import enable_guardrail
+
+hook = enable_guardrail(MyProvider(), fail_closed=True)
+```
+
+يعني `fail_closed=True` أن أخطاء المزوّد ستحظر التنفيذ. وإذا أردت fail-open
+أثناء الإعداد الأولي أو التطوير:
+
+```python
+hook = enable_guardrail(MyProvider(), fail_closed=False)
+```
+
+وعندما لا تحتاج إليه:
+
+```python
+from crewai.hooks import disable_guardrail
+
+disable_guardrail(hook)
+```
+
+### AllowlistGuardrailProvider المدمج
+
+يشحن CrewAI مزوّدًا مدمجًا وبسيطًا للحالة الأكثر شيوعًا: السماح أو المنع حسب
+اسم الأداة.
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, enable_guardrail
+
+provider = AllowlistGuardrailProvider(
+    allowed_tools=["read_file", "web_search"],
+    denied_tools=["exec"],
+)
+
+enable_guardrail(provider, fail_closed=True)
+```
+
+هذا المزوّد صغير وخالٍ من الاعتماديات. ويعمل مع CrewAI وحده، من دون الحاجة
+إلى حزمة provider إضافية أو خدمة بعيدة.
+
+### مثال أساسي قابل للتشغيل
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, disable_guardrail, enable_guardrail
+
+guardrail = enable_guardrail(
+    AllowlistGuardrailProvider(
+        allowed_tools=["read_file", "web_search"],
+        denied_tools=["delete_file", "exec"],
+    ),
+    fail_closed=True,
+)
+
+# ... شغّل crew هنا ...
+
+disable_guardrail(guardrail)
+```
+
+### مثال على Provider مخصص
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailRequest, enable_guardrail
+
+
+class RoleAwareProvider:
+    name = "role-aware"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.agent_role == "Research Agent" and request.tool_name == "delete_file":
+            return GuardrailDecision(allow=False, reason="وكلاء البحث لا يمكنهم حذف الملفات")
+        return GuardrailDecision(allow=True)
+
+
+enable_guardrail(RoleAwareProvider(), fail_closed=True)
+```
+
+### مثال على OAP Provider خارجي
+
+يبقى CrewAI محايدًا هنا. فهو لا يضمّن Open Agent Passport (OAP) ولا أي محرك
+سياسات خاص بمورّد معين داخل القلب. بدلًا من ذلك يمكن للمزوّدات الخارجية تنفيذ
+نفس عقد `GuardrailProvider`.
+
+[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) هو
+مثال على هذا النمط. إذ يوفّر `OAPGuardrailProvider` خارجيًا يقيّم استدعاءات
+الأدوات مقابل نموذج سياسات
+[Open Agent Passport](https://github.com/aporthq/aport-spec).
+استخدم مزوّدًا خارجيًا كهذا عندما تحتاج إلى أكثر من قواعد allow/deny البسيطة
+المبنية على اسم الأداة فقط.
+
+ثبّته بشكل منفصل:
+
+```bash
+uvx --from aport-agent-guardrails aport setup --framework=crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+وإذا فضّلت bootstrap عبر Node:
+
+```bash
+npx -y @aporthq/aport-agent-guardrails crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+ولـ CI أو البيئات غير التفاعلية:
+
+```bash
+APORT_CREWAI_CONFIG_DIR=.aport/crewai \
+APORT_NONINTERACTIVE=1 \
+uvx --from aport-agent-guardrails aport setup \
+  --framework=crewai \
+  --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+يبقى تنفيذ CrewAI في وقت التشغيل داخل Python. ويُستخدم `npx` فقط للإعداد
+الأولي للـ passport/config.
+
+```python
+from crewai.hooks import enable_guardrail
+from aport_guardrails.providers import OAPGuardrailProvider
+
+provider = OAPGuardrailProvider(framework="crewai")
+enable_guardrail(provider, fail_closed=True)
+```
+
+وإذا كنت تستخدم مسار config مخصصًا:
+
+```python
+provider = OAPGuardrailProvider(
+    framework="crewai",
+    config_path=".aport/crewai/config.yaml",
+)
+enable_guardrail(provider, fail_closed=True)
+```
+
+### الوضع المستضاف
+
+إذا كان المزوّد الخارجي مهيأً للتقييم المستضاف، فلن تتغير شيفرة CrewAI.
+ويكفي ضبط المزوّد في ملف الإعداد الخاص به، مثلًا:
+
+```yaml
+mode: api
+agent_id: ap_xxx
+```
+
+يبقى CrewAI محايدًا تجاه ما إذا كان التقييم يتم محليًا أو عن بُعد.
+
+### سلوك وقت التشغيل
+
+عندما يعيد المزوّد نتيجة `allow`، يتابع CrewAI تنفيذ الأداة بشكل طبيعي.
+وعندما يعيد `deny`، يحظر CrewAI الاستدعاء عبر مسار hook الحالي
+`before_tool_call` ولا تُشغَّل الأداة نفسها.
+
+ويعرض CrewAI حاليًا رسالة الحظر القياسية من طبقة hook، وليس واجهة خاصة بكل
+مزوّد.
+
+في هذا الإعداد:
+
+- يوفّر CrewAI نقطة hook الأساسية
+- توفّر حزمة APort المزوّد الواعي بـ OAP
+- يبقى تنسيق passport وتقييم السياسة خارج قلب CrewAI
+
+### ما الذي يمكن لمزوّدات OAP الخارجية فرضه؟
+
+المزوّد المدمج من نوع allowlist يجيب فقط عن سؤال: "هل هذه الأداة مسموح بها
+بالاسم؟". أمّا مزوّد OAP الخارجي فيستطيع اتخاذ قرارات أغنى من استدعاء الأداة
+نفسه، عبر تقييم مدخلات الأداة مقابل القدرات ومتطلبات assurance والحدود
+المعرّفة في passport وpolicy pack.
+
+على سبيل المثال، يستطيع مزوّد خارجي الإجابة عن أسئلة مثل:
+
+- هل يمكن لهذا الوكيل إنشاء pull request أو دمجه في هذا المستودع وعلى هذا الفرع الأساسي ضمن حدود الحجم والمراجعات؟
+- هل يمكن لهذا الوكيل تحصيل `USD 100` الآن لهذا merchant ضمن الحد لكل معاملة والحد اليومي؟
+- هل يمكن لهذا الوكيل تصدير هذه البيانات فقط إذا بقي عدد الصفوف والوجهة ومعالجة PII ضمن حدود السياسة؟
+
+يبقى قلب CrewAI يتلقى نتيجة `allow` أو `deny` فقط. أمّا نموذج السياسة الأكثر
+غنى فيبقى داخل المزوّد. وهذا يحافظ على حياد CrewAI تجاه المورّدين، مع السماح
+للمزوّدات الخارجية بفرض ما هو أكثر من مجرد allowlist مبنية على أسماء الأدوات.
 
 ## حالات الاستخدام الشائعة
 
@@ -457,20 +684,24 @@ register_after_tool_call_hook(my_after_hook)
 ## استكشاف الأخطاء وإصلاحها
 
 ### الخطاف لا يُنفذ
+
 - تحقق من أن الخطاف مسجل قبل تنفيذ الطاقم
 - تحقق مما إذا كان خطاف سابق أرجع `False` (يحظر التنفيذ والخطافات اللاحقة)
 - تأكد من أن توقيع الخطاف يطابق النوع المتوقع
 
 ### تعديلات المدخلات لا تعمل
+
 - استخدم التعديلات في المكان: `context.tool_input['key'] = value`
 - لا تستبدل القاموس: `context.tool_input = {}`
 
 ### تعديلات النتائج لا تعمل
+
 - أرجع السلسلة النصية المعدلة من خطافات ما بعد
 - إرجاع `None` يحتفظ بالنتيجة الأصلية
 - تأكد من أن الأداة أرجعت نتيجة فعلاً
 
 ### أداة محظورة بشكل غير متوقع
+
 - تحقق من جميع خطافات ما قبل بحثاً عن شروط حظر
 - تحقق من ترتيب تنفيذ الخطافات
 - أضف تسجيل تصحيح لتحديد الخطاف الذي يحظر

--- a/docs/en/learn/tool-hooks.mdx
+++ b/docs/en/learn/tool-hooks.mdx
@@ -9,6 +9,7 @@ Tool Call Hooks provide fine-grained control over tool execution during agent op
 ## Overview
 
 Tool hooks are executed at two critical points:
+
 - **Before Tool Call**: Modify inputs, validate parameters, or block execution
 - **After Tool Call**: Transform results, sanitize outputs, or log execution details
 
@@ -17,6 +18,7 @@ Tool hooks are executed at two critical points:
 ### Before Tool Call Hooks
 
 Executed before every tool execution, these hooks can:
+
 - Inspect and modify tool inputs
 - Block tool execution based on conditions
 - Implement approval gates for dangerous operations
@@ -24,6 +26,7 @@ Executed before every tool execution, these hooks can:
 - Log tool invocations
 
 **Signature:**
+
 ```python
 def before_hook(context: ToolCallHookContext) -> bool | None:
     # Return False to block execution
@@ -34,6 +37,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 ### After Tool Call Hooks
 
 Executed after every tool execution, these hooks can:
+
 - Modify or sanitize tool results
 - Add metadata or formatting
 - Log execution results
@@ -41,6 +45,7 @@ Executed after every tool execution, these hooks can:
 - Transform output formats
 
 **Signature:**
+
 ```python
 def after_hook(context: ToolCallHookContext) -> str | None:
     # Return modified result string
@@ -145,8 +150,257 @@ class MyProjCrew:
             tasks=self.tasks,
             process=Process.sequential,
             verbose=True
-        )
+    )
 ```
+
+## Provider-Based Guardrails
+
+If you want reusable pre-tool-call authorization without writing raw hook
+functions for each crew, CrewAI also exposes an optional `GuardrailProvider`
+seam on top of `before_tool_call`.
+
+This follows the same pattern used by frameworks such as Deerflow:
+
+- CrewAI defines the core seam
+- CrewAI ships a minimal built-in allowlist provider
+- external providers plug into the same interface
+
+This layer is optional and additive:
+
+- if you do not enable a guardrail, CrewAI tool execution behaves exactly as before
+- if you do enable one, CrewAI reuses the existing `before_tool_call` hook flow
+
+The core contract is intentionally small and synchronous today:
+
+- providers receive a normalized `GuardrailRequest`
+- providers return `allow` or `deny`
+- CrewAI maps that result onto the existing `before_tool_call` hook flow
+
+`before_tool_call` currently supports allow-or-block semantics only, so CrewAI
+does not add native `delegate`, `escalate`, or suspend/resume behavior here.
+Those workflows should be layered on top by provider packages or future runtime
+APIs, not guessed inside core.
+
+### GuardrailProvider Interface
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailProvider, GuardrailRequest
+
+
+class MyProvider:
+    name = "my-provider"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.tool_name == "exec":
+            return GuardrailDecision(allow=False, reason="exec is not allowed")
+        return GuardrailDecision(allow=True)
+```
+
+Register it with:
+
+```python
+from crewai.hooks import enable_guardrail
+
+hook = enable_guardrail(MyProvider(), fail_closed=True)
+```
+
+`fail_closed=True` means provider errors block execution. If you prefer
+fail-open behavior during bootstrap or development:
+
+```python
+hook = enable_guardrail(MyProvider(), fail_closed=False)
+```
+
+When you no longer need it:
+
+```python
+from crewai.hooks import disable_guardrail
+
+disable_guardrail(hook)
+```
+
+### Built-In AllowlistGuardrailProvider
+
+CrewAI ships a minimal built-in provider for the most common case: allow or
+deny tools by name.
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, enable_guardrail
+
+provider = AllowlistGuardrailProvider(
+    allowed_tools=["read_file", "web_search"],
+    denied_tools=["exec"],
+)
+
+enable_guardrail(provider, fail_closed=True)
+```
+
+This provider is intentionally small and dependency-free. It is useful when you
+want a simple production safety boundary without bringing in an external policy
+engine. It works with CrewAI alone, with no additional provider package or
+remote service required.
+
+### Basic Runnable Example
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, disable_guardrail, enable_guardrail
+
+guardrail = enable_guardrail(
+    AllowlistGuardrailProvider(
+        allowed_tools=["read_file", "web_search"],
+        denied_tools=["delete_file", "exec"],
+    ),
+    fail_closed=True,
+)
+
+# ... run your crew here ...
+
+disable_guardrail(guardrail)
+```
+
+### Custom Provider Example
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailRequest, enable_guardrail
+
+
+class RoleAwareProvider:
+    name = "role-aware"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.agent_role == "Research Agent" and request.tool_name == "delete_file":
+            return GuardrailDecision(allow=False, reason="research agents cannot delete files")
+        return GuardrailDecision(allow=True)
+
+
+enable_guardrail(RoleAwareProvider(), fail_closed=True)
+```
+
+### External OAP Provider Example
+
+CrewAI stays neutral here. It does **not** bundle Open Agent Passport (OAP) or
+any vendor-specific policy runtime. Instead, external providers can implement
+the same `GuardrailProvider` contract.
+
+[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) is
+an example of that pattern. It ships an external
+`OAPGuardrailProvider` that evaluates tool calls against an
+[Open Agent Passport](https://github.com/aporthq/aport-spec) policy model.
+Use an external provider like this when you need more than simple tool-name
+allow/deny rules.
+
+Install it separately:
+
+```bash
+uvx --from aport-agent-guardrails aport setup --framework=crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+If you prefer the Node bootstrap, the equivalent one-time setup is:
+
+```bash
+npx -y @aporthq/aport-agent-guardrails crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+For CI or other non-interactive environments, the APort bootstrap command also
+supports explicit output and non-interactive mode:
+
+```bash
+APORT_CREWAI_CONFIG_DIR=.aport/crewai \
+APORT_NONINTERACTIVE=1 \
+uvx --from aport-agent-guardrails aport setup \
+  --framework=crewai \
+  --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+The equivalent Node bootstrap is:
+
+```bash
+APORT_CREWAI_CONFIG_DIR=.aport/crewai \
+npx -y @aporthq/aport-agent-guardrails crewai \
+  --integration-mode=native \
+  --output .aport/crewai/aport/passport.json \
+  --non-interactive
+uv add aport-agent-guardrails
+```
+
+CrewAI runtime enforcement stays in Python. The `npx` command is only used for
+one-time passport/config bootstrap.
+
+```python
+from crewai.hooks import enable_guardrail
+from aport_guardrails.providers import OAPGuardrailProvider
+
+provider = OAPGuardrailProvider(framework="crewai")
+enable_guardrail(provider, fail_closed=True)
+```
+
+If you bootstrap APort into a custom config directory instead of the default
+`~/.aport/crewai/config.yaml`, pass it explicitly:
+
+```python
+provider = OAPGuardrailProvider(
+    framework="crewai",
+    config_path=".aport/crewai/config.yaml",
+)
+enable_guardrail(provider, fail_closed=True)
+```
+
+### Hosted Mode
+
+If an external provider is configured for hosted evaluation, the CrewAI code
+does not change. Configure the provider in its own config, for example:
+
+```yaml
+mode: api
+agent_id: ap_xxx
+```
+
+CrewAI stays agnostic to whether the provider evaluates locally or remotely.
+
+### Runtime Behavior
+
+When a provider returns `allow`, CrewAI continues with normal tool execution.
+When a provider returns `deny`, CrewAI blocks the call through the existing
+`before_tool_call` hook path and the underlying tool does not run.
+
+CrewAI currently surfaces the standard blocked-tool message from the hook layer
+rather than a provider-specific UI.
+
+### What External OAP Providers Can Enforce
+
+The built-in allowlist provider only answers “is this tool allowed by name?”.
+An external OAP provider can make richer decisions from the same tool call by
+evaluating the tool input against capabilities, assurance requirements, and
+limits defined in a passport and policy pack.
+
+For example, an external provider can answer questions such as:
+
+- can this agent create or merge a pull request in this repository, on this base branch, within review and size limits?
+- can this agent charge `USD 100` right now for this merchant, within its per-transaction and daily caps?
+- can this agent export this dataset only if the row count, destination, and PII handling stay within policy?
+
+CrewAI core still only receives an `allow` or `deny` result. The richer policy
+model stays inside the provider. That keeps CrewAI vendor-neutral while letting
+external providers enforce more than simple tool-name allowlists.
+
+In that setup:
+
+- CrewAI provides the hook seam
+- the APort package provides the OAP-aware provider
+- the passport format and policy evaluation stay outside CrewAI core
+- APort setup writes the local config and passport under `~/.aport/crewai`
+
+This keeps CrewAI open to APort, internal policy engines, and other provider
+implementations without coupling the framework to a single governance system.
+
+Note: the current CrewAI hook pipeline returns a generic blocked-tool message to
+the agent when any `before_tool_call` hook denies execution. Provider-specific
+`reason` values are still useful for logs, audits, and provider-side policy
+debugging, but they are not surfaced to the agent automatically by this core
+seam yet.
 
 ## Common Use Cases
 
@@ -577,20 +831,24 @@ def log_to_external_system(context: ToolCallHookContext) -> None:
 ## Troubleshooting
 
 ### Hook Not Executing
+
 - Verify hook is registered before crew execution
 - Check if previous hook returned `False` (blocks execution and subsequent hooks)
 - Ensure hook signature matches expected type
 
 ### Input Modifications Not Working
+
 - Use in-place modifications: `context.tool_input['key'] = value`
 - Don't replace the dict: `context.tool_input = {}`
 
 ### Result Modifications Not Working
+
 - Return the modified string from after hooks
 - Returning `None` keeps the original result
 - Ensure the tool actually returned a result
 
 ### Tool Blocked Unexpectedly
+
 - Check all before hooks for blocking conditions
 - Verify hook execution order
 - Add debug logging to identify which hook is blocking

--- a/docs/ko/learn/tool-hooks.mdx
+++ b/docs/ko/learn/tool-hooks.mdx
@@ -9,6 +9,7 @@ mode: "wide"
 ## 개요
 
 도구 훅은 두 가지 중요한 시점에 실행됩니다:
+
 - **도구 호출 전**: 입력 수정, 매개변수 검증 또는 실행 차단
 - **도구 호출 후**: 결과 변환, 출력 정제 또는 실행 세부사항 로깅
 
@@ -17,6 +18,7 @@ mode: "wide"
 ### 도구 호출 전 훅
 
 모든 도구 실행 전에 실행되며, 다음을 수행할 수 있습니다:
+
 - 도구 입력 검사 및 수정
 - 조건에 따라 도구 실행 차단
 - 위험한 작업에 대한 승인 게이트 구현
@@ -24,6 +26,7 @@ mode: "wide"
 - 도구 호출 로깅
 
 **시그니처:**
+
 ```python
 def before_hook(context: ToolCallHookContext) -> bool | None:
     # 실행을 차단하려면 False 반환
@@ -34,6 +37,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 ### 도구 호출 후 훅
 
 모든 도구 실행 후에 실행되며, 다음을 수행할 수 있습니다:
+
 - 도구 결과 수정 또는 정제
 - 메타데이터 또는 서식 추가
 - 실행 결과 로깅
@@ -41,6 +45,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 - 출력 형식 변환
 
 **시그니처:**
+
 ```python
 def after_hook(context: ToolCallHookContext) -> str | None:
     # 수정된 결과 문자열 반환
@@ -122,13 +127,13 @@ class MyProjCrew:
                 print("❌ 잘못된 검색 쿼리")
                 return False
         return None
-    
+
     @after_tool_call_crew
     def log_tool_results(self, context):
         # 크루별 도구 로깅
         print(f"✅ {context.tool_name} 완료됨")
         return None
-    
+
     @crew
     def crew(self) -> Crew:
         return Crew(
@@ -138,6 +143,230 @@ class MyProjCrew:
             verbose=True
         )
 ```
+
+## Provider 기반 Guardrail
+
+각 크루마다 raw hook 함수를 직접 작성하지 않고 재사용 가능한 사전
+도구 호출 인가를 원한다면, CrewAI는 `before_tool_call` 위에 선택적인
+`GuardrailProvider` 레이어도 제공합니다.
+
+이 패턴은 Deerflow 같은 프레임워크와 동일합니다.
+
+- CrewAI가 핵심 확장 지점을 정의합니다
+- CrewAI가 최소한의 기본 allowlist provider를 제공합니다
+- 외부 provider는 같은 계약으로 연결됩니다
+
+이 레이어는 선택 사항이며 추가적입니다.
+
+- guardrail을 활성화하지 않으면 CrewAI 도구 실행 동작은 이전과 동일합니다
+- guardrail을 활성화해도 CrewAI는 기존 `before_tool_call` 흐름만 재사용합니다
+
+현재 핵심 계약은 의도적으로 작고 동기식입니다.
+
+- provider는 정규화된 `GuardrailRequest`를 받습니다
+- provider는 `allow` 또는 `deny`를 반환합니다
+- CrewAI는 그 결과를 기존 `before_tool_call` hook 흐름에 매핑합니다
+
+현재 `before_tool_call`은 허용 또는 차단 의미만 지원합니다. 따라서
+CrewAI는 이 코어 레이어에 `delegate`, `escalate`, suspend/resume 같은
+동작을 추가하지 않습니다.
+
+### GuardrailProvider 인터페이스
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailProvider, GuardrailRequest
+
+
+class MyProvider:
+    name = "my-provider"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.tool_name == "exec":
+            return GuardrailDecision(allow=False, reason="exec는 허용되지 않습니다")
+        return GuardrailDecision(allow=True)
+```
+
+등록:
+
+```python
+from crewai.hooks import enable_guardrail
+
+hook = enable_guardrail(MyProvider(), fail_closed=True)
+```
+
+`fail_closed=True`는 provider 오류 시 실행을 차단한다는 뜻입니다.
+부트스트랩이나 개발 중에는 fail-open을 선택할 수도 있습니다.
+
+```python
+hook = enable_guardrail(MyProvider(), fail_closed=False)
+```
+
+더 이상 필요 없으면:
+
+```python
+from crewai.hooks import disable_guardrail
+
+disable_guardrail(hook)
+```
+
+### 내장 AllowlistGuardrailProvider
+
+CrewAI는 가장 일반적인 경우를 위한 최소 내장 provider를 제공합니다.
+도구 이름 기준으로 허용 또는 차단합니다.
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, enable_guardrail
+
+provider = AllowlistGuardrailProvider(
+    allowed_tools=["read_file", "web_search"],
+    denied_tools=["exec"],
+)
+
+enable_guardrail(provider, fail_closed=True)
+```
+
+이 provider는 작고 의존성이 없습니다. 추가 provider 패키지나 원격
+서비스 없이 CrewAI만으로 바로 사용할 수 있습니다.
+
+### 실행 가능한 기본 예제
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, disable_guardrail, enable_guardrail
+
+guardrail = enable_guardrail(
+    AllowlistGuardrailProvider(
+        allowed_tools=["read_file", "web_search"],
+        denied_tools=["delete_file", "exec"],
+    ),
+    fail_closed=True,
+)
+
+# ... 여기서 crew를 실행합니다 ...
+
+disable_guardrail(guardrail)
+```
+
+### 사용자 정의 Provider 예제
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailRequest, enable_guardrail
+
+
+class RoleAwareProvider:
+    name = "role-aware"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.agent_role == "Research Agent" and request.tool_name == "delete_file":
+            return GuardrailDecision(allow=False, reason="리서치 에이전트는 파일을 삭제할 수 없습니다")
+        return GuardrailDecision(allow=True)
+
+
+enable_guardrail(RoleAwareProvider(), fail_closed=True)
+```
+
+### 외부 OAP Provider 예제
+
+CrewAI는 여기서 중립을 유지합니다. CrewAI 코어에 Open Agent Passport
+(OAP)나 특정 벤더의 정책 런타임을 번들하지 않습니다. 대신 외부
+provider가 동일한 `GuardrailProvider` 계약을 구현할 수 있습니다.
+
+[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails)는
+이 패턴의 예시입니다. 이 패키지는
+[Open Agent Passport](https://github.com/aporthq/aport-spec) 정책 모델에
+대해 도구 호출을 평가하는 외부 `OAPGuardrailProvider`를 제공합니다.
+이런 외부 provider는 단순한 도구 이름 allow/deny 규칙만으로는
+부족할 때 사용합니다.
+
+별도로 설치:
+
+```bash
+uvx --from aport-agent-guardrails aport setup --framework=crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+Node 부트스트랩을 선호한다면:
+
+```bash
+npx -y @aporthq/aport-agent-guardrails crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+CI 또는 비대화형 환경에서는:
+
+```bash
+APORT_CREWAI_CONFIG_DIR=.aport/crewai \
+APORT_NONINTERACTIVE=1 \
+uvx --from aport-agent-guardrails aport setup \
+  --framework=crewai \
+  --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+CrewAI 런타임 enforcement는 계속 Python에서 수행됩니다. `npx`는 일회성
+passport/config 부트스트랩에만 사용됩니다.
+
+```python
+from crewai.hooks import enable_guardrail
+from aport_guardrails.providers import OAPGuardrailProvider
+
+provider = OAPGuardrailProvider(framework="crewai")
+enable_guardrail(provider, fail_closed=True)
+```
+
+사용자 지정 config 디렉터리를 쓰는 경우:
+
+```python
+provider = OAPGuardrailProvider(
+    framework="crewai",
+    config_path=".aport/crewai/config.yaml",
+)
+enable_guardrail(provider, fail_closed=True)
+```
+
+### 호스티드 모드
+
+외부 provider가 호스티드 평가로 설정되어 있어도 CrewAI 코드는
+바뀌지 않습니다. 예를 들어 provider 자체 설정만 이렇게 바꾸면 됩니다.
+
+```yaml
+mode: api
+agent_id: ap_xxx
+```
+
+평가가 로컬인지 원격인지는 CrewAI가 아니라 provider가 결정합니다.
+
+### 런타임 동작
+
+provider가 `allow`를 반환하면 CrewAI는 평소처럼 도구 실행을 계속합니다.
+provider가 `deny`를 반환하면 CrewAI는 기존 `before_tool_call` hook
+경로에서 호출을 차단하고 실제 도구는 실행되지 않습니다.
+
+현재 CrewAI는 provider별 전용 UI 대신 hook 계층의 기본 차단 메시지를
+표시합니다.
+
+이 구성에서:
+
+- CrewAI는 hook 확장 지점을 제공합니다
+- APort 패키지는 OAP를 이해하는 provider를 제공합니다
+- passport 형식과 정책 평가는 CrewAI 코어 밖에 남습니다
+
+### 외부 OAP Provider가 적용할 수 있는 것
+
+내장 allowlist provider는 “이 도구 이름이 허용되는가?”만 판단합니다.
+외부 OAP provider는 같은 도구 호출이라도 passport와 policy pack에
+정의된 capability, assurance 요구사항, limit를 기준으로 더 풍부한
+판단을 내릴 수 있습니다.
+
+예를 들어 외부 provider는 다음과 같은 질문에 답할 수 있습니다.
+
+- 이 에이전트가 이 저장소에서, 이 base branch를 대상으로, 리뷰와 크기 제한 안에서 pull request를 만들거나 merge할 수 있는가?
+- 이 에이전트가 지금 이 merchant에 대해 `USD 100`을 건별 한도와 일일 한도 안에서 청구할 수 있는가?
+- 이 에이전트가 행 수, 목적지, PII 처리 조건이 정책 범위 안에 있을 때만 이 데이터를 내보낼 수 있는가?
+
+CrewAI 코어는 여전히 `allow` 또는 `deny` 결과만 받습니다. 더 풍부한
+정책 모델은 provider 내부에 남습니다. 그래서 CrewAI는 벤더 중립성을
+유지하면서도, 외부 provider는 단순한 도구 이름 allowlist보다 더 많은
+것을 강제할 수 있습니다.
 
 ## 일반적인 사용 사례
 
@@ -153,16 +382,16 @@ def safety_check(context: ToolCallHookContext) -> bool | None:
         'remove_user',
         'system_shutdown'
     ]
-    
+
     if context.tool_name in destructive_tools:
         print(f"🛑 파괴적인 도구 차단됨: {context.tool_name}")
         return False
-    
+
     # 민감한 작업에 대해 경고
     sensitive_tools = ['send_email', 'post_to_social_media', 'charge_payment']
     if context.tool_name in sensitive_tools:
         print(f"⚠️  민감한 도구 실행 중: {context.tool_name}")
-    
+
     return None
 ```
 
@@ -178,17 +407,17 @@ def require_approval_for_actions(context: ToolCallHookContext) -> bool | None:
         'delete_file',
         'post_message'
     ]
-    
+
     if context.tool_name in approval_required:
         response = context.request_human_input(
             prompt=f"{context.tool_name}을(를) 승인하시겠습니까?",
             default_message=f"입력: {context.tool_input}\n승인하려면 'yes'를 입력하세요:"
         )
-        
+
         if response.lower() != 'yes':
             print(f"❌ 도구 실행 거부됨: {context.tool_name}")
             return False
-    
+
     return None
 ```
 
@@ -204,17 +433,17 @@ def validate_and_sanitize_inputs(context: ToolCallHookContext) -> bool | None:
         if len(query) < 3:
             print("❌ 검색 쿼리가 너무 짧습니다")
             return False
-        
+
         # 쿼리 정제
         context.tool_input['query'] = query.strip().lower()
-    
+
     # 파일 경로 검증
     if context.tool_name == 'read_file':
         path = context.tool_input.get('path', '')
         if '..' in path or path.startswith('/'):
             print("❌ 잘못된 파일 경로")
             return False
-    
+
     return None
 ```
 
@@ -226,10 +455,10 @@ def sanitize_sensitive_data(context: ToolCallHookContext) -> str | None:
     """민감한 데이터를 정제합니다."""
     if not context.tool_result:
         return None
-    
+
     import re
     result = context.tool_result
-    
+
     # API 키 제거
     result = re.sub(
         r'(api[_-]?key|token)["\']?\s*[:=]\s*["\']?[\w-]+',
@@ -237,21 +466,21 @@ def sanitize_sensitive_data(context: ToolCallHookContext) -> str | None:
         result,
         flags=re.IGNORECASE
     )
-    
+
     # 이메일 주소 제거
     result = re.sub(
         r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
         '[이메일-수정됨]',
         result
     )
-    
+
     # 신용카드 번호 제거
     result = re.sub(
         r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b',
         '[카드-수정됨]',
         result
     )
-    
+
     return result
 ```
 
@@ -272,20 +501,20 @@ def start_timer(context: ToolCallHookContext) -> None:
 def track_tool_usage(context: ToolCallHookContext) -> None:
     start_time = context.tool_input.get('_start_time', time.time())
     duration = time.time() - start_time
-    
+
     tool_stats[context.tool_name]['count'] += 1
     tool_stats[context.tool_name]['total_time'] += duration
-    
+
     if not context.tool_result or 'error' in context.tool_result.lower():
         tool_stats[context.tool_name]['failures'] += 1
-    
+
     print(f"""
     📊 {context.tool_name} 도구 통계:
     - 실행 횟수: {tool_stats[context.tool_name]['count']}
     - 평균 시간: {tool_stats[context.tool_name]['total_time'] / tool_stats[context.tool_name]['count']:.2f}초
     - 실패: {tool_stats[context.tool_name]['failures']}
     """)
-    
+
     return None
 ```
 
@@ -302,18 +531,18 @@ def rate_limit_tools(context: ToolCallHookContext) -> bool | None:
     """도구 호출 속도를 제한합니다."""
     tool_name = context.tool_name
     now = datetime.now()
-    
+
     # 오래된 항목 정리 (1분 이상 된 것)
     tool_call_history[tool_name] = [
         call_time for call_time in tool_call_history[tool_name]
         if now - call_time < timedelta(minutes=1)
     ]
-    
+
     # 속도 제한 확인 (분당 최대 10회 호출)
     if len(tool_call_history[tool_name]) >= 10:
         print(f"🚫 {tool_name}에 대한 속도 제한 초과")
         return False
-    
+
     # 이 호출 기록
     tool_call_history[tool_name].append(now)
     return None
@@ -396,13 +625,13 @@ def conditional_blocking(context: ToolCallHookContext) -> bool | None:
         if context.tool_name in ['delete_file', 'send_email']:
             print(f"❌ 주니어 에이전트는 {context.tool_name}을(를) 사용할 수 없습니다")
             return False
-    
+
     # 특정 작업 중에만 차단
     if context.task and "민감한" in context.task.description.lower():
         if context.tool_name == 'web_search':
             print("❌ 민감한 작업에서는 웹 검색이 차단됩니다")
             return False
-    
+
     return None
 ```
 
@@ -417,12 +646,12 @@ def enhance_tool_inputs(context: ToolCallHookContext) -> None:
         if context.tool_name == 'web_search':
             # 연구원에 대한 도메인 제한 추가
             context.tool_input['domains'] = ['edu', 'gov', 'org']
-    
+
     # 작업에 따라 컨텍스트 추가
     if context.task and "긴급" in context.task.description.lower():
         if context.tool_name == 'send_email':
             context.tool_input['priority'] = 'high'
-    
+
     return None
 ```
 
@@ -474,20 +703,24 @@ register_after_tool_call_hook(my_after_hook)
 ## 문제 해결
 
 ### 훅이 실행되지 않음
+
 - 크루 실행 전에 훅이 등록되었는지 확인
 - 이전 훅이 `False`를 반환했는지 확인 (실행 및 후속 훅 차단)
 - 훅 시그니처가 예상 타입과 일치하는지 확인
 
 ### 입력 수정이 작동하지 않음
+
 - 제자리 수정 사용: `context.tool_input['key'] = value`
 - 딕셔너리를 교체하지 마세요: `context.tool_input = {}`
 
 ### 결과 수정이 작동하지 않음
+
 - 후 훅에서 수정된 문자열을 반환
 - `None`을 반환하면 원본 결과가 유지됩니다
 - 도구가 실제로 결과를 반환했는지 확인
 
 ### 도구가 예기치 않게 차단됨
+
 - 차단 조건에 대한 모든 전(before) 훅 확인
 - 훅 실행 순서 확인
 - 어떤 훅이 차단하는지 식별하기 위해 디버그 로깅 추가
@@ -495,4 +728,3 @@ register_after_tool_call_hook(my_after_hook)
 ## 결론
 
 도구 호출 훅은 CrewAI에서 도구 실행을 제어하고 모니터링하는 강력한 기능을 제공합니다. 이를 사용하여 안전 가드레일, 승인 게이트, 입력 검증, 결과 정제, 로깅 및 분석을 구현하세요. 적절한 오류 처리 및 타입 안전성과 결합하면, 훅을 통해 포괄적인 관찰성을 갖춘 안전하고 프로덕션 준비가 된 에이전트 시스템을 구축할 수 있습니다.
-

--- a/docs/pt-BR/learn/tool-hooks.mdx
+++ b/docs/pt-BR/learn/tool-hooks.mdx
@@ -9,6 +9,7 @@ Os Hooks de Chamada de Ferramenta fornecem controle fino sobre a execução de f
 ## Visão Geral
 
 Os hooks de ferramenta são executados em dois pontos críticos:
+
 - **Antes da Chamada de Ferramenta**: Modificar entradas, validar parâmetros ou bloquear execução
 - **Depois da Chamada de Ferramenta**: Transformar resultados, sanitizar saídas ou registrar detalhes de execução
 
@@ -17,6 +18,7 @@ Os hooks de ferramenta são executados em dois pontos críticos:
 ### Hooks Antes da Chamada de Ferramenta
 
 Executados antes de cada execução de ferramenta, esses hooks podem:
+
 - Inspecionar e modificar entradas de ferramenta
 - Bloquear execução de ferramenta com base em condições
 - Implementar gates de aprovação para operações perigosas
@@ -24,6 +26,7 @@ Executados antes de cada execução de ferramenta, esses hooks podem:
 - Registrar invocações de ferramenta
 
 **Assinatura:**
+
 ```python
 def before_hook(context: ToolCallHookContext) -> bool | None:
     # Retorne False para bloquear execução
@@ -34,6 +37,7 @@ def before_hook(context: ToolCallHookContext) -> bool | None:
 ### Hooks Depois da Chamada de Ferramenta
 
 Executados depois de cada execução de ferramenta, esses hooks podem:
+
 - Modificar ou sanitizar resultados de ferramenta
 - Adicionar metadados ou formatação
 - Registrar resultados de execução
@@ -41,6 +45,7 @@ Executados depois de cada execução de ferramenta, esses hooks podem:
 - Transformar formatos de saída
 
 **Assinatura:**
+
 ```python
 def after_hook(context: ToolCallHookContext) -> str | None:
     # Retorne string de resultado modificado
@@ -122,13 +127,13 @@ class MyProjCrew:
                 print("❌ Consulta de busca inválida")
                 return False
         return None
-    
+
     @after_tool_call_crew
     def log_tool_results(self, context):
         # Logging de ferramenta específico da crew
         print(f"✅ {context.tool_name} concluída")
         return None
-    
+
     @crew
     def crew(self) -> Crew:
         return Crew(
@@ -138,6 +143,234 @@ class MyProjCrew:
             verbose=True
         )
 ```
+
+## Guardrails Baseados em Provider
+
+Se você quiser autorização reutilizável antes da chamada de ferramenta sem
+escrever funções hook brutas para cada crew, o CrewAI também expõe uma camada
+opcional de `GuardrailProvider` sobre `before_tool_call`.
+
+Ela segue o mesmo padrão usado por frameworks como Deerflow:
+
+- o CrewAI define a extensão principal
+- o CrewAI envia um provider allowlist mínimo
+- providers externos se conectam pelo mesmo contrato
+
+Essa camada é opcional e aditiva:
+
+- se você não habilitar um guardrail, a execução de ferramentas do CrewAI continua igual
+- se você habilitar um, o CrewAI apenas reutiliza o fluxo existente de `before_tool_call`
+
+O contrato principal é intencionalmente pequeno e síncrono hoje:
+
+- providers recebem um `GuardrailRequest` normalizado
+- providers retornam `allow` ou `deny`
+- o CrewAI mapeia esse resultado para o fluxo existente de hook `before_tool_call`
+
+O `before_tool_call` atualmente suporta apenas semântica de permitir ou bloquear.
+Por isso, o CrewAI não adiciona `delegate`, `escalate` ou suspend/resume nativos
+nesta camada.
+
+### Interface GuardrailProvider
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailProvider, GuardrailRequest
+
+
+class MyProvider:
+    name = "my-provider"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.tool_name == "exec":
+            return GuardrailDecision(allow=False, reason="exec não é permitido")
+        return GuardrailDecision(allow=True)
+```
+
+Registre com:
+
+```python
+from crewai.hooks import enable_guardrail
+
+hook = enable_guardrail(MyProvider(), fail_closed=True)
+```
+
+`fail_closed=True` significa que falhas do provider bloqueiam a execução.
+Se você preferir fail-open durante bootstrap ou desenvolvimento:
+
+```python
+hook = enable_guardrail(MyProvider(), fail_closed=False)
+```
+
+Quando não precisar mais dele:
+
+```python
+from crewai.hooks import disable_guardrail
+
+disable_guardrail(hook)
+```
+
+### AllowlistGuardrailProvider Integrado
+
+O CrewAI envia um provider integrado mínimo para o caso mais comum: permitir ou
+negar ferramentas pelo nome.
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, enable_guardrail
+
+provider = AllowlistGuardrailProvider(
+    allowed_tools=["read_file", "web_search"],
+    denied_tools=["exec"],
+)
+
+enable_guardrail(provider, fail_closed=True)
+```
+
+Esse provider é pequeno e sem dependências. Ele funciona apenas com o CrewAI,
+sem exigir pacote de provider adicional nem serviço remoto.
+
+### Exemplo Básico Executável
+
+```python
+from crewai.hooks import AllowlistGuardrailProvider, disable_guardrail, enable_guardrail
+
+guardrail = enable_guardrail(
+    AllowlistGuardrailProvider(
+        allowed_tools=["read_file", "web_search"],
+        denied_tools=["delete_file", "exec"],
+    ),
+    fail_closed=True,
+)
+
+# ... execute sua crew aqui ...
+
+disable_guardrail(guardrail)
+```
+
+### Exemplo de Provider Customizado
+
+```python
+from crewai.hooks import GuardrailDecision, GuardrailRequest, enable_guardrail
+
+
+class RoleAwareProvider:
+    name = "role-aware"
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        if request.agent_role == "Research Agent" and request.tool_name == "delete_file":
+            return GuardrailDecision(allow=False, reason="agentes de pesquisa não podem excluir arquivos")
+        return GuardrailDecision(allow=True)
+
+
+enable_guardrail(RoleAwareProvider(), fail_closed=True)
+```
+
+### Exemplo de Provider OAP Externo
+
+O CrewAI permanece neutro aqui. Ele **não** embute Open Agent Passport (OAP)
+nem um runtime de política específico de fornecedor. Em vez disso, providers
+externos podem implementar o mesmo contrato `GuardrailProvider`.
+
+[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) é
+um exemplo desse padrão. Ele envia um `OAPGuardrailProvider` externo que avalia
+chamadas de ferramenta contra o modelo de política
+[Open Agent Passport](https://github.com/aporthq/aport-spec).
+Use um provider externo como esse quando precisar de mais do que regras simples
+de allow/deny por nome de ferramenta.
+
+Instale separadamente:
+
+```bash
+uvx --from aport-agent-guardrails aport setup --framework=crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+Se preferir o bootstrap via Node:
+
+```bash
+npx -y @aporthq/aport-agent-guardrails crewai --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+Para CI ou outros ambientes não interativos:
+
+```bash
+APORT_CREWAI_CONFIG_DIR=.aport/crewai \
+APORT_NONINTERACTIVE=1 \
+uvx --from aport-agent-guardrails aport setup \
+  --framework=crewai \
+  --integration-mode=native
+uv add aport-agent-guardrails
+```
+
+A execução em runtime do CrewAI continua em Python. O comando `npx` é usado
+apenas para bootstrap inicial de passport/config.
+
+```python
+from crewai.hooks import enable_guardrail
+from aport_guardrails.providers import OAPGuardrailProvider
+
+provider = OAPGuardrailProvider(framework="crewai")
+enable_guardrail(provider, fail_closed=True)
+```
+
+Se você usar um diretório de configuração customizado:
+
+```python
+provider = OAPGuardrailProvider(
+    framework="crewai",
+    config_path=".aport/crewai/config.yaml",
+)
+enable_guardrail(provider, fail_closed=True)
+```
+
+### Modo Hospedado
+
+Se um provider externo estiver configurado para avaliação hospedada, o código
+do CrewAI não muda. Basta configurar o provider no próprio arquivo dele, por
+exemplo:
+
+```yaml
+mode: api
+agent_id: ap_xxx
+```
+
+O CrewAI continua agnóstico quanto a a avaliação acontecer localmente ou de
+forma remota.
+
+### Comportamento em Runtime
+
+Quando um provider retorna `allow`, o CrewAI continua a execução da ferramenta
+normalmente. Quando um provider retorna `deny`, o CrewAI bloqueia a chamada
+pelo caminho existente de hook `before_tool_call` e a ferramenta não é
+executada.
+
+Hoje o CrewAI mostra a mensagem padrão de bloqueio da camada de hooks, em vez
+de uma UI específica do provider.
+
+Nessa configuração:
+
+- o CrewAI fornece a extensão do hook
+- o pacote APort fornece o provider compatível com OAP
+- o formato do passport e a avaliação de política ficam fora do core do CrewAI
+
+### O que Providers OAP Externos Podem Aplicar
+
+O provider allowlist integrado responde apenas “esta ferramenta é permitida pelo
+nome?”. Um provider OAP externo pode tomar decisões mais ricas a partir da
+mesma chamada de ferramenta, avaliando a entrada da ferramenta em relação a
+capacidades, requisitos de assurance e limites definidos em um passport e em um
+policy pack.
+
+Por exemplo, um provider externo pode responder perguntas como:
+
+- este agente pode criar ou fazer merge de um pull request neste repositório, nesta branch base, dentro dos limites de revisão e tamanho?
+- este agente pode cobrar `USD 100` agora para este merchant, dentro dos limites por transação e por dia?
+- este agente pode exportar este dataset apenas se a contagem de linhas, o destino e o tratamento de PII estiverem dentro da política?
+
+O core do CrewAI ainda recebe apenas um resultado `allow` ou `deny`. O modelo
+de política mais rico permanece dentro do provider. Isso mantém o CrewAI neutro
+em relação a vendors, ao mesmo tempo em que permite que providers externos
+apliquem mais do que simples allowlists por nome de ferramenta.
 
 ## Casos de Uso Comuns
 
@@ -153,16 +386,16 @@ def safety_check(context: ToolCallHookContext) -> bool | None:
         'remove_user',
         'system_shutdown'
     ]
-    
+
     if context.tool_name in destructive_tools:
         print(f"🛑 Ferramenta destrutiva bloqueada: {context.tool_name}")
         return False
-    
+
     # Avisar em operações sensíveis
     sensitive_tools = ['send_email', 'post_to_social_media', 'charge_payment']
     if context.tool_name in sensitive_tools:
         print(f"⚠️  Executando ferramenta sensível: {context.tool_name}")
-    
+
     return None
 ```
 
@@ -178,17 +411,17 @@ def require_approval_for_actions(context: ToolCallHookContext) -> bool | None:
         'delete_file',
         'post_message'
     ]
-    
+
     if context.tool_name in approval_required:
         response = context.request_human_input(
             prompt=f"Aprovar {context.tool_name}?",
             default_message=f"Entrada: {context.tool_input}\nDigite 'sim' para aprovar:"
         )
-        
+
         if response.lower() != 'sim':
             print(f"❌ Execução de ferramenta negada: {context.tool_name}")
             return False
-    
+
     return None
 ```
 
@@ -204,17 +437,17 @@ def validate_and_sanitize_inputs(context: ToolCallHookContext) -> bool | None:
         if len(query) < 3:
             print("❌ Consulta de busca muito curta")
             return False
-        
+
         # Sanitizar consulta
         context.tool_input['query'] = query.strip().lower()
-    
+
     # Validar caminhos de arquivo
     if context.tool_name == 'read_file':
         path = context.tool_input.get('path', '')
         if '..' in path or path.startswith('/'):
             print("❌ Caminho de arquivo inválido")
             return False
-    
+
     return None
 ```
 
@@ -226,10 +459,10 @@ def sanitize_sensitive_data(context: ToolCallHookContext) -> str | None:
     """Sanitiza dados sensíveis."""
     if not context.tool_result:
         return None
-    
+
     import re
     result = context.tool_result
-    
+
     # Remover chaves de API
     result = re.sub(
         r'(api[_-]?key|token)["\']?\s*[:=]\s*["\']?[\w-]+',
@@ -237,21 +470,21 @@ def sanitize_sensitive_data(context: ToolCallHookContext) -> str | None:
         result,
         flags=re.IGNORECASE
     )
-    
+
     # Remover endereços de email
     result = re.sub(
         r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
         '[EMAIL-CENSURADO]',
         result
     )
-    
+
     # Remover números de cartão de crédito
     result = re.sub(
         r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b',
         '[CARTÃO-CENSURADO]',
         result
     )
-    
+
     return result
 ```
 
@@ -272,20 +505,20 @@ def start_timer(context: ToolCallHookContext) -> None:
 def track_tool_usage(context: ToolCallHookContext) -> None:
     start_time = context.tool_input.get('_start_time', time.time())
     duration = time.time() - start_time
-    
+
     tool_stats[context.tool_name]['count'] += 1
     tool_stats[context.tool_name]['total_time'] += duration
-    
+
     if not context.tool_result or 'error' in context.tool_result.lower():
         tool_stats[context.tool_name]['failures'] += 1
-    
+
     print(f"""
     📊 Estatísticas da Ferramenta {context.tool_name}:
     - Execuções: {tool_stats[context.tool_name]['count']}
     - Tempo Médio: {tool_stats[context.tool_name]['total_time'] / tool_stats[context.tool_name]['count']:.2f}s
     - Falhas: {tool_stats[context.tool_name]['failures']}
     """)
-    
+
     return None
 ```
 
@@ -302,18 +535,18 @@ def rate_limit_tools(context: ToolCallHookContext) -> bool | None:
     """Limita taxa de chamadas de ferramenta."""
     tool_name = context.tool_name
     now = datetime.now()
-    
+
     # Limpar entradas antigas (mais antigas que 1 minuto)
     tool_call_history[tool_name] = [
         call_time for call_time in tool_call_history[tool_name]
         if now - call_time < timedelta(minutes=1)
     ]
-    
+
     # Verificar limite de taxa (máximo 10 chamadas por minuto)
     if len(tool_call_history[tool_name]) >= 10:
         print(f"🚫 Limite de taxa excedido para {tool_name}")
         return False
-    
+
     # Registrar esta chamada
     tool_call_history[tool_name].append(now)
     return None
@@ -396,13 +629,13 @@ def conditional_blocking(context: ToolCallHookContext) -> bool | None:
         if context.tool_name in ['delete_file', 'send_email']:
             print(f"❌ Agentes júnior não podem usar {context.tool_name}")
             return False
-    
+
     # Bloquear apenas durante tarefas específicas
     if context.task and "sensível" in context.task.description.lower():
         if context.tool_name == 'web_search':
             print("❌ Busca na web bloqueada para tarefas sensíveis")
             return False
-    
+
     return None
 ```
 
@@ -417,12 +650,12 @@ def enhance_tool_inputs(context: ToolCallHookContext) -> None:
         if context.tool_name == 'web_search':
             # Adicionar restrições de domínio para pesquisadores
             context.tool_input['domains'] = ['edu', 'gov', 'org']
-    
+
     # Adicionar contexto baseado na tarefa
     if context.task and "urgente" in context.task.description.lower():
         if context.tool_name == 'send_email':
             context.tool_input['priority'] = 'high'
-    
+
     return None
 ```
 
@@ -474,20 +707,24 @@ register_after_tool_call_hook(my_after_hook)
 ## Solução de Problemas
 
 ### Hook Não Está Executando
+
 - Verifique se hook está registrado antes da execução da crew
 - Verifique se hook anterior retornou `False` (bloqueia execução e hooks subsequentes)
 - Garanta que assinatura do hook corresponda ao tipo esperado
 
 ### Modificações de Entrada Não Funcionam
+
 - Use modificações in-place: `context.tool_input['key'] = value`
 - Não substitua o dict: `context.tool_input = {}`
 
 ### Modificações de Resultado Não Funcionam
+
 - Retorne a string modificada dos hooks posteriores
 - Retornar `None` mantém o resultado original
 - Garanta que a ferramenta realmente retornou um resultado
 
 ### Ferramenta Bloqueada Inesperadamente
+
 - Verifique todos os hooks antes por condições de bloqueio
 - Verifique ordem de execução do hook
 - Adicione logging de debug para identificar qual hook está bloqueando
@@ -495,4 +732,3 @@ register_after_tool_call_hook(my_after_hook)
 ## Conclusão
 
 Os Hooks de Chamada de Ferramenta fornecem capacidades poderosas para controlar e monitorar execução de ferramentas no CrewAI. Use-os para implementar guardrails de segurança, gates de aprovação, validação de entrada, sanitização de resultado, logging e análise. Combinados com tratamento adequado de erros e segurança de tipos, os hooks permitem sistemas de agentes seguros e prontos para produção com observabilidade abrangente.
-

--- a/lib/crewai/src/crewai/hooks/__init__.py
+++ b/lib/crewai/src/crewai/hooks/__init__.py
@@ -6,6 +6,15 @@ from crewai.hooks.decorators import (
     before_llm_call,
     before_tool_call,
 )
+from crewai.hooks.guardrails import (
+    AllowlistGuardrailProvider,
+    GuardrailDecision,
+    GuardrailProvider,
+    GuardrailRequest,
+    build_guardrail_request,
+    disable_guardrail,
+    enable_guardrail,
+)
 from crewai.hooks.llm_hooks import (
     LLMCallHookContext,
     clear_after_llm_call_hooks,
@@ -74,6 +83,11 @@ def clear_all_global_hooks() -> dict[str, tuple[int, int]]:
 
 
 __all__ = [
+    # Guardrails
+    "AllowlistGuardrailProvider",
+    "GuardrailDecision",
+    "GuardrailProvider",
+    "GuardrailRequest",
     # Context classes
     "LLMCallHookContext",
     "ToolCallHookContext",
@@ -82,6 +96,8 @@ __all__ = [
     "after_tool_call",
     "before_llm_call",
     "before_tool_call",
+    # Guardrail helpers
+    "build_guardrail_request",
     "clear_after_llm_call_hooks",
     "clear_after_tool_call_hooks",
     "clear_all_global_hooks",
@@ -90,6 +106,9 @@ __all__ = [
     # Clear hooks
     "clear_before_llm_call_hooks",
     "clear_before_tool_call_hooks",
+    # Guardrail helpers
+    "disable_guardrail",
+    "enable_guardrail",
     "get_after_llm_call_hooks",
     "get_after_tool_call_hooks",
     # Get hooks
@@ -101,6 +120,7 @@ __all__ = [
     "register_before_llm_call_hook",
     # Tool Hook registration
     "register_before_tool_call_hook",
+    # Unregister hooks
     "unregister_after_llm_call_hook",
     "unregister_after_tool_call_hook",
     "unregister_before_llm_call_hook",

--- a/lib/crewai/src/crewai/hooks/guardrails.py
+++ b/lib/crewai/src/crewai/hooks/guardrails.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    register_before_tool_call_hook,
+    unregister_before_tool_call_hook,
+)
+from crewai.hooks.types import BeforeToolCallHookCallable, BeforeToolCallHookType
+from crewai.utilities.string_utils import sanitize_tool_name
+
+
+@dataclass(frozen=True)
+class GuardrailRequest:
+    """Normalized context passed to a guardrail provider for each tool call."""
+
+    tool_name: str
+    tool_input: dict[str, Any]
+    agent_role: str | None = None
+    task_description: str | None = None
+    crew_id: str | None = None
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class GuardrailDecision:
+    """Provider verdict for a tool call."""
+
+    allow: bool
+    reason: str | None = None
+
+
+@runtime_checkable
+class GuardrailProvider(Protocol):
+    """Protocol for pluggable pre-tool-call authorization providers."""
+
+    name: str
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        """Evaluate whether a tool call should proceed."""
+        ...
+
+
+class AllowlistGuardrailProvider:
+    """Minimal built-in provider that allows or denies tools by name."""
+
+    name = "allowlist"
+
+    def __init__(
+        self,
+        *,
+        allowed_tools: Iterable[str] | None = None,
+        denied_tools: Iterable[str] | None = None,
+    ) -> None:
+        self._allowed = (
+            {sanitize_tool_name(tool_name) for tool_name in allowed_tools}
+            if allowed_tools is not None
+            else None
+        )
+        self._denied = {
+            sanitize_tool_name(tool_name) for tool_name in (denied_tools or [])
+        }
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        """Evaluate a tool call against allowlist and denylist rules."""
+        tool_name = request.tool_name
+
+        if tool_name in self._denied:
+            return GuardrailDecision(
+                allow=False,
+                reason=f"'{tool_name}' is in the denied tools list.",
+            )
+
+        if self._allowed is not None and tool_name not in self._allowed:
+            return GuardrailDecision(
+                allow=False,
+                reason=f"'{tool_name}' is not in the allowed tools list.",
+            )
+
+        return GuardrailDecision(allow=True)
+
+
+def build_guardrail_request(context: ToolCallHookContext) -> GuardrailRequest:
+    """Build a normalized, read-only request snapshot from a tool hook context."""
+    crew_id = getattr(context.crew, "id", None)
+    return GuardrailRequest(
+        tool_name=context.tool_name,
+        tool_input=dict(context.tool_input),
+        agent_role=getattr(context.agent, "role", None),
+        task_description=getattr(context.task, "description", None),
+        crew_id=str(crew_id) if crew_id is not None else None,
+    )
+
+
+def enable_guardrail(
+    provider: GuardrailProvider,
+    *,
+    fail_closed: bool = True,
+) -> BeforeToolCallHookType | BeforeToolCallHookCallable:
+    """Register a guardrail provider as a before_tool_call hook.
+
+    This is strictly additive. It reuses CrewAI's existing hook system and does
+    not alter the tool execution pipeline unless the caller explicitly enables
+    it. CrewAI before_tool_call hooks currently support allow or block semantics,
+    so escalation/delegation workflows should be handled by provider packages on
+    top of this seam rather than in core.
+
+    Args:
+        provider: Provider used to authorize tool calls.
+        fail_closed: When True, provider failures block execution. When False,
+            provider failures fall back to allow.
+
+    Returns:
+        The registered hook so callers can unregister it later.
+    """
+
+    def _hook(context: ToolCallHookContext) -> bool | None:
+        try:
+            decision = provider.evaluate(build_guardrail_request(context))
+        except Exception:
+            return False if fail_closed else None
+
+        if decision.allow:
+            return None
+        return False
+
+    register_before_tool_call_hook(_hook)
+    return _hook
+
+
+def disable_guardrail(
+    hook: BeforeToolCallHookType | BeforeToolCallHookCallable,
+) -> bool:
+    """Unregister a hook that was previously created by enable_guardrail()."""
+    return unregister_before_tool_call_hook(hook)

--- a/lib/crewai/tests/hooks/test_guardrails.py
+++ b/lib/crewai/tests/hooks/test_guardrails.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from crewai.hooks.guardrails import (
+    AllowlistGuardrailProvider,
+    GuardrailDecision,
+    GuardrailRequest,
+    build_guardrail_request,
+    disable_guardrail,
+    enable_guardrail,
+)
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    clear_after_tool_call_hooks,
+    clear_before_tool_call_hooks,
+    get_after_tool_call_hooks,
+    get_before_tool_call_hooks,
+    register_after_tool_call_hook,
+    register_before_tool_call_hook,
+)
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_hooks():
+    """Clear global hooks before and after each test."""
+    original_before = get_before_tool_call_hooks()
+    original_after = get_after_tool_call_hooks()
+
+    clear_before_tool_call_hooks()
+    clear_after_tool_call_hooks()
+
+    yield
+
+    clear_before_tool_call_hooks()
+    clear_after_tool_call_hooks()
+
+    for hook in original_before:
+        register_before_tool_call_hook(hook)
+    for hook in original_after:
+        register_after_tool_call_hook(hook)
+
+
+@pytest.fixture
+def mock_tool():
+    """Create a mock tool for testing."""
+    tool = Mock()
+    tool.name = "dangerous_tool"
+    return tool
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock agent for testing."""
+    agent = Mock()
+    agent.role = "Security Agent"
+    return agent
+
+
+@pytest.fixture
+def mock_task():
+    """Create a mock task for testing."""
+    task = Mock()
+    task.description = "Evaluate the tool call"
+    return task
+
+
+@pytest.fixture
+def mock_crew():
+    """Create a mock crew for testing."""
+    crew = Mock()
+    crew.id = "crew-123"
+    return crew
+
+
+def test_build_guardrail_request_uses_normalized_context_snapshot(
+    mock_tool, mock_agent, mock_task, mock_crew
+):
+    """Guardrail requests should expose a normalized snapshot of hook context."""
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+        agent=mock_agent,
+        task=mock_task,
+        crew=mock_crew,
+    )
+
+    request = build_guardrail_request(context)
+    request.tool_input["action"] = "read"
+
+    assert isinstance(request, GuardrailRequest)
+    assert request.tool_name == "dangerous_tool"
+    assert request.tool_input == {"action": "read"}
+    assert request.agent_role == "Security Agent"
+    assert request.task_description == "Evaluate the tool call"
+    assert request.crew_id == "crew-123"
+    assert context.tool_input == {"action": "delete"}
+    assert request.timestamp
+
+
+def test_enable_guardrail_registers_before_hook():
+    """Enabling guardrails should register exactly one before hook."""
+
+    class AllowProvider:
+        name = "allow-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            return GuardrailDecision(allow=True)
+
+    hook = enable_guardrail(AllowProvider())
+
+    hooks = get_before_tool_call_hooks()
+
+    assert len(hooks) == 1
+    assert hooks[0] == hook
+    disable_guardrail(hook)
+
+
+def test_disable_guardrail_unregisters_before_hook():
+    """Disabling guardrails should remove the registered hook."""
+
+    class AllowProvider:
+        name = "allow-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            return GuardrailDecision(allow=True)
+
+    hook = enable_guardrail(AllowProvider())
+
+    assert disable_guardrail(hook) is True
+    assert get_before_tool_call_hooks() == []
+
+
+def test_enable_guardrail_allows_execution(mock_tool):
+    """Allow decisions should not block tool execution."""
+
+    class AllowProvider:
+        name = "allow-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            assert request.tool_name == "dangerous_tool"
+            return GuardrailDecision(allow=True)
+
+    hook = enable_guardrail(AllowProvider())
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+    )
+
+    result = hook(context)
+
+    assert result is None
+    disable_guardrail(hook)
+
+
+def test_enable_guardrail_denies_execution(mock_tool):
+    """Deny decisions should block tool execution."""
+
+    class DenyProvider:
+        name = "deny-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            return GuardrailDecision(allow=False, reason="Shell access is not allowed.")
+
+    hook = enable_guardrail(DenyProvider())
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+    )
+
+    result = hook(context)
+
+    assert result is False
+    disable_guardrail(hook)
+
+
+def test_enable_guardrail_uses_request_snapshot(mock_tool):
+    """Providers should not be able to mutate live tool inputs by accident."""
+
+    class MutatingProvider:
+        name = "mutating-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            request.tool_input["action"] = "read"
+            return GuardrailDecision(allow=True)
+
+    hook = enable_guardrail(MutatingProvider())
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+    )
+
+    result = hook(context)
+
+    assert result is None
+    assert context.tool_input == {"action": "delete"}
+    disable_guardrail(hook)
+
+
+def test_enable_guardrail_fail_closed_blocks_on_provider_error(mock_tool):
+    """Provider errors should block execution when fail_closed is enabled."""
+
+    class FailingProvider:
+        name = "failing-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            raise RuntimeError("Provider unavailable")
+
+    hook = enable_guardrail(FailingProvider(), fail_closed=True)
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+    )
+
+    result = hook(context)
+
+    assert result is False
+    disable_guardrail(hook)
+
+
+def test_enable_guardrail_fail_open_allows_on_provider_error(mock_tool):
+    """Provider errors should allow execution when fail_closed is disabled."""
+
+    class FailingProvider:
+        name = "failing-provider"
+
+        def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+            raise RuntimeError("Provider unavailable")
+
+    hook = enable_guardrail(FailingProvider(), fail_closed=False)
+    context = ToolCallHookContext(
+        tool_name="dangerous_tool",
+        tool_input={"action": "delete"},
+        tool=mock_tool,
+    )
+
+    result = hook(context)
+
+    assert result is None
+    disable_guardrail(hook)
+
+
+def test_allowlist_guardrail_provider_blocks_denied_tools():
+    """The built-in allowlist provider should deny explicitly blocked tools."""
+    provider = AllowlistGuardrailProvider(denied_tools=["exec", "delete_file"])
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="exec",
+            tool_input={"command": "rm -rf /"},
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == "'exec' is in the denied tools list."
+
+
+def test_allowlist_guardrail_provider_allows_allowlisted_tools():
+    """The built-in allowlist provider should allow tools inside the allowlist."""
+    provider = AllowlistGuardrailProvider(
+        allowed_tools=["read_file", "web_search"],
+        denied_tools=["exec"],
+    )
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="read_file",
+            tool_input={"path": "README.md"},
+        )
+    )
+
+    assert decision.allow is True
+    assert decision.reason is None
+
+
+def test_allowlist_guardrail_provider_blocks_non_allowlisted_tools():
+    """The built-in allowlist provider should fail closed outside the allowlist."""
+    provider = AllowlistGuardrailProvider(allowed_tools=["read_file", "web_search"])
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="exec",
+            tool_input={"command": "ls"},
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == "'exec' is not in the allowed tools list."
+
+
+def test_allowlist_guardrail_provider_allows_tools_with_unsanitized_names():
+    """The built-in allowlist provider should allow tools present in the allowlist."""
+    provider = AllowlistGuardrailProvider(
+        allowed_tools=["Read File", "Web Search"],
+    )
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="read_file",
+            tool_input={"path": "notes.txt"},
+        )
+    )
+
+    assert decision.allow is True
+    assert decision.reason is None
+
+
+def test_allowlist_guardrail_provider_blocks_denied_tools_with_unsanitized_names():
+    """Configured deny entries should normalize the same way as tool hooks."""
+    provider = AllowlistGuardrailProvider(denied_tools=["Delete File"])
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="delete_file",
+            tool_input={"path": "notes.txt"},
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == "'delete_file' is in the denied tools list."
+
+
+def test_allowlist_guardrail_provider_prioritizes_denied_tools():
+    """Deny rules should win when a tool appears in both lists."""
+    provider = AllowlistGuardrailProvider(
+        allowed_tools=["exec", "read_file"],
+        denied_tools=["exec"],
+    )
+
+    decision = provider.evaluate(
+        GuardrailRequest(
+            tool_name="exec",
+            tool_input={"command": "ls"},
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == "'exec' is in the denied tools list."


### PR DESCRIPTION

### Summary

This PR adds an optional provider-based guardrail seam on top of CrewAI's existing `before_tool_call` hook flow.

It keeps the core design intentionally small:
- CrewAI defines a neutral `GuardrailProvider` contract
- CrewAI ships a minimal built-in `AllowlistGuardrailProvider`
- external providers can plug into the same interface
- tool execution is unchanged unless a guardrail is explicitly enabled

This closes crewAIInc/crewAI#4877 and follows the same architectural direction as the provider-based approach proposed in bytedance/deer-flow#1240, while staying consistent with CrewAI's current hook model and runtime behavior.

### What Changed

- add `GuardrailRequest`, `GuardrailDecision`, and `GuardrailProvider`
- add `enable_guardrail(...)` and `disable_guardrail(...)`
- add built-in `AllowlistGuardrailProvider`
- normalize tool-call input into a reusable request object for external providers
- support `fail_closed=True|False` behavior when provider evaluation errors
- document the new hook seam in English, Arabic, Korean, and Brazilian Portuguese
- include runnable examples for:
  - built-in allowlist guardrails
  - custom providers
  - external Open Agent Passport (OAP) providers such as APort

### Why This Shape

The issue thread correctly identified a missing production seam: CrewAI can run `before_tool_call` hooks, but it does not currently expose a reusable provider contract for pre-tool-call authorization.

This PR addresses that gap without overreaching:
- it does not bundle any vendor-specific policy engine
- it does not add async suspend/resume semantics to core
- it does not change normal CrewAI tool execution unless enabled
- it keeps the current core decision model at `allow` / `deny`

That makes the feature usable today while leaving room for richer future decisions such as `escalate` or signed receipts if CrewAI later adds first-class runtime support for them.

### External Provider Story

CrewAI stays vendor-neutral here.

The built-in allowlist provider covers the simplest production need, but external providers can enforce richer policy models through the same seam. The docs include an external OAP example with APort to show that the interface can support:
- repository and branch restrictions for code actions
- per-transaction and daily limits for payment actions
- export and PII limits for data actions

CrewAI core still only receives an `allow` or `deny` verdict. Capability logic, limits, assurance rules, and policy-pack evaluation remain outside the framework in the provider.

### Non-Goals

This PR does not add:
- async `suspend` / `resolve(decision_id, outcome)` flows
- native `allow | deny | escalate` tri-state decisions
- signed decision receipts in CrewAI core
- post-task or post-output verification
- bundled vendor integrations

Those are valid future extensions, but they do not fit cleanly into CrewAI's current boolean `before_tool_call` contract without broader runtime changes.

### Docs

Updated:
- `docs/en/learn/tool-hooks.mdx`
- `docs/ar/learn/tool-hooks.mdx`
- `docs/ko/learn/tool-hooks.mdx`
- `docs/pt-BR/learn/tool-hooks.mdx`

The docs keep the core examples minimal and runnable, while also showing that an external provider can enforce more than simple tool-name allowlists.

### Testing

Ran locally:

```bash
CREWAI_STORAGE_DIR=/tmp/crewai-test-storage \
PYTHONPATH=lib/crewai/src \
python3 -m pytest -o addopts= lib/crewai/tests/hooks/test_guardrails.py -q
```

Result:
- `12 passed`

Syntax check:

```bash
PYTHONPYCACHEPREFIX=/tmp/crewai-pyc \
python3 -m py_compile \
  lib/crewai/src/crewai/hooks/guardrails.py \
  lib/crewai/tests/hooks/test_guardrails.py
```

Docs flow validated with the published APort bootstrap/runtime path:
- native bootstrap works with `APORT_NONINTERACTIVE=1 uvx --from aport-agent-guardrails aport setup --framework=crewai --integration-mode=native`
- `OAPGuardrailProvider(framework="crewai")` registers through `enable_guardrail(...)`

Note:
- I did not run the full `uv run` repo lint/type suite on this machine because the existing workspace dependency resolution for `lancedb==0.30.0` is still failing on macOS x86_64 outside this diff.

### Linked Issue / Context

- Closes crewAIInc/crewAI#4877
- Aligns with the provider-based guardrail direction discussed in bytedance/deer-flow#1240

### Issue Thread Coverage

| Comment | Theme | Status | Notes |
|---|---|---:|---|
| [#1](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4065247310) | Pre-tool-call auth is a real gap; mentions anomaly scoring/approvals | Addressed | The missing pre-tool authorization seam is added; anomaly scoring and approval workflows remain provider concerns. |
| [#2](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4066372794) | Keep discussion provider-agnostic, not vendor-specific | Addressed | Core stays neutral; APort is documented as an external provider example only. |
| [#3](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4067923908) | Async authorization / wait for external approval | Deferred | CrewAI core stays synchronous because `before_tool_call` is currently boolean. |
| [#4](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4069547417) | `suspend + resolve(decision_id)` model | Deferred | Valid future direction, but not added in this PR. |
| [#5](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4069725208) | Downstream dependency handling during suspension | Deferred | Depends on suspend/resume semantics that CrewAI core does not expose today. |
| [#6](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4070199360) | Concern that pause/human approval may not fit CrewAI cleanly | Addressed | This PR intentionally keeps the core model to optional synchronous `allow` / `deny`. |
| [#7](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4090757026) | Include agent identity/boundaries, not just tool name | Partial | `GuardrailRequest` carries `agent_role`, `task_description`, and `crew_id`, but no explicit charter field yet. |
| [#8](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4092418435) | AuthGuardian vendor pitch | Marketing | Mostly product promotion; the core permission-gate idea is already covered by the seam. |
| [#9](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4156807661) | Healthcare, multilingual tool resolution, audit logging | Partial | Supported by custom providers, but not implemented in CrewAI core. |
| [#10](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4177908087) | Post-task output verification | Out of scope | This PR is pre-tool-call authorization only. |
| [#11](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4182584694) | VetoAPI human approval pitch | Marketing | Mostly vendor promotion; human approval remains outside current core scope. |
| [#12](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4183909660) | Layered pre-exec + post-exec verification | Out of scope | Good architecture, but broader than this seam. |
| [#13](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4186521316) | Stateless per-call provider, tri-state, structured denial | Partial | The seam is per-call and normalized; tri-state and structured denial are not in core yet. |
| [#14](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4186860127) | Compose policy + approval + verification | Out of scope | Broader systems layering, not the focus of this PR. |
| [#15](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4188091988) | Identity drift / behavioral inconsistency / escalate | Deferred | Needs richer request semantics and likely tri-state escalation support. |
| [#16](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4188646934) | Output correctness after tool success | Out of scope | Post-execution verification is separate from this feature. |
| [#17](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4193962088) | Signed decision receipts/evidence | Deferred | Not carried in `GuardrailDecision` yet. |
| [#18](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4195395214) | Default-deny, typed decisions, async callback, signed evidence | Partial | `fail_closed` behavior is present; typed tri-state/callback/evidence are deferred. |
| [#19](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4196073412) | SINT adapter shipped | Marketing | Useful ecosystem signal, but not a CrewAI core requirement. |
| [#20](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4196862246) | Conformance fixtures for providers | Deferred | Good follow-up, but not required for first seam landing. |
| [#21](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4198360254) | Fixtures for tri-state outputs | Deferred | Depends on tri-state support first. |
| [#22](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4207294138) | Delegation scope, budget, signed receipt | Partial | Possible through custom providers; not first-class in CrewAI core. |
| [#23](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4210820505) | VeroQ release update | Marketing | Product update, not a new framework requirement. |
| [#24](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4213649070) | Wallet-state provider before token transfers | Partial | A custom provider can do this today through the new seam. |
| [#25](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4223925304) | Multi-issuer wallet demo | Marketing | Demo/update rather than core feedback. |
| [#26](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4229250103) | SINT suspend/resolve adapter update | Deferred | Relevant if CrewAI later adds async suspension semantics. |
| [#27](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4229503900) | Compose delegation, policy, wallet, compliance into one verdict | Partial | The seam allows composed providers, but CrewAI does not ship one. |
| [#28](https://github.com/crewAIInc/crewAI/issues/4877#issuecomment-4229948266) | Add `escalation` field to decisions | Partial | Conceptually aligned, but intentionally omitted from current core API. |
