### PR TITLE
fix: override pypdf and uv for CVE-2026-40260 and GHSA-pjjw-68hj-v9mw

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ info = "Commits must follow Conventional Commits 1.0.0."
 
 
 [tool.uv]
-exclude-newer = "2026-04-10"  # pinned for CVE-2026-39892; restore to "3 days" after 2026-04-11
+exclude-newer = "3 days"
 
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.
@@ -170,6 +170,8 @@ exclude-newer = "2026-04-10"  # pinned for CVE-2026-39892; restore to "3 days" a
 # langchain-core <1.2.28 has GHSA-926x-3r5x-gfhw (incomplete f-string validation).
 # transformers 4.57.6 has CVE-2026-1839; force 5.4+ (docling 2.84 allows huggingface-hub>=1).
 # cryptography 46.0.6 has CVE-2026-39892; force 46.0.7+.
+# pypdf <6.10.0 has CVE-2026-40260; force 6.10.0+.
+# uv <0.11.6 has GHSA-pjjw-68hj-v9mw; force 0.11.6+.
 override-dependencies = [
     "rich>=13.7.1",
     "onnxruntime<1.24; python_version < '3.11'",
@@ -178,6 +180,8 @@ override-dependencies = [
     "urllib3>=2.6.3",
     "transformers>=5.4.0; python_version >= '3.10'",
     "cryptography>=46.0.7",
+    "pypdf>=6.10.0,<7",
+    "uv>=0.11.6,<1",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-10T16:00:00Z"
+exclude-newer = "2026-04-10T12:25:00.712108Z"
+exclude-newer-span = "P3D"
 
 [manifest]
 members = [
@@ -27,9 +28,11 @@ overrides = [
     { name = "langchain-core", specifier = ">=1.2.28,<2" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "pillow", specifier = ">=12.1.1" },
+    { name = "pypdf", specifier = ">=6.10.0,<7" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "transformers", marker = "python_full_version >= '3.10'", specifier = ">=5.4.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "uv", specifier = ">=0.11.6,<1" },
 ]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
## Summary
- Add `pypdf>=6.10.0,<7` and `uv>=0.11.6,<1` to `override-dependencies` to enforce patched floors across all resolution contexts
- Restore `exclude-newer` from a pinned date back to `"3 days"`
- Addresses pip-audit failures for `pypdf==6.9.2` (CVE-2026-40260) and `uv==0.9.30` (GHSA-pjjw-68hj-v9mw)

## Test plan
- [ ] CI pip-audit passes with no findings for pypdf or uv
- [ ] `uv lock` resolves without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-resolution change: it only adjusts `uv` pinning/overrides and the lockfile, but could affect reproducibility if downstream relies on older versions.
> 
> **Overview**
> Enforces security-driven dependency floors by adding `pypdf>=6.10.0,<7` and `uv>=0.11.6,<1` to `tool.uv.override-dependencies`, and updates `uv.lock` to reflect these overrides.
> 
> Restores `tool.uv.exclude-newer` from a fixed date pin back to `"3 days"` (with corresponding lockfile metadata changes), allowing newer releases to be considered again within that rolling window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f5af3bb93f6d53ab8862c5d9726286bbdc9f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->