### PR TITLE
docs: clean up enterprise A2A language

### DIFF
--- a/docs/en/enterprise/features/a2a.mdx
+++ b/docs/en/enterprise/features/a2a.mdx
@@ -1,6 +1,6 @@
 ---
 title: A2A on AMP
-description: Production-grade Agent-to-Agent communication with distributed state, multi-scheme authentication, and horizontal scaling
+description: Production-grade Agent-to-Agent communication with distributed state and multi-scheme authentication
 icon: "network-wired"
 mode: "wide"
 ---
@@ -66,7 +66,7 @@ A2A on AMP supports passing files and requesting structured output in both direc
 
 <CardGroup cols={2}>
   <Card title="Distributed State" icon="database">
-    Persistent task, context, and result storage that supports horizontal scaling
+    Persistent task, context, and result storage
   </Card>
   <Card title="Enterprise Authentication" icon="shield-halved">
     OIDC, OAuth2, mTLS, and Enterprise token validation beyond simple bearer tokens
@@ -89,7 +89,7 @@ A2A on AMP supports passing files and requesting structured output in both direc
 
 ## Distributed State Management
 
-In the open-source implementation, task and context state lives in memory on a single process. AMP replaces this with persistent, distributed stores that enable horizontal scaling.
+In the open-source implementation, task and context state lives in memory on a single process. AMP replaces this with persistent, distributed stores.
 
 ### Storage Layers
 


### PR DESCRIPTION
## Summary
- Remove horizontal scaling references from enterprise A2A doc

## Test plan
- [ ] Verify docs render correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording changes that remove/soften claims about horizontal scaling; no product code or APIs are affected.
> 
> **Overview**
> Updates the `A2A on AMP` enterprise doc to remove references to *horizontal scaling*, tightening wording around distributed state to describe persistent/distributed storage without scaling implications.
> 
> Adjusts the page frontmatter description and the "Distributed State"/"Distributed State Management" copy to match the revised messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f274ac353ae78ee92c394c19bf4ae4f61f4d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->