### PR TITLE
fix: bump openai lower bound to >=2.0.0

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     # Core Dependencies
     "pydantic~=2.11.9",
-    "openai>=1.83.0,<3",
+    "openai>=2.0.0,<3",
     "instructor>=1.3.3",
     # Text Processing
     "pdfplumber~=0.11.4",


### PR DESCRIPTION
## Summary
- Bumps openai dependency from `>=1.83.0,<3` to `>=2.0.0,<3`
- `ChatCompletionMessageFunctionToolCall` (imported in `completion.py`) was introduced in openai 2.0.0 and does not exist in 1.x, causing an `ImportError` at import time
- The 1.83.0 lower bound was historical — nothing in the codebase requires 1.x

## Test plan
- [ ] Verify clean install with `openai>=2.0.0`
- [ ] Confirm `from openai.types.chat import ChatCompletionMessageFunctionToolCall` resolves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a core runtime dependency and may break environments pinned to `openai` 1.x due to API/typing differences. Functional code changes are limited to packaging metadata.
> 
> **Overview**
> Updates `pyproject.toml` to require `openai>=2.0.0,<3` (from `>=1.83.0`) so installs match the OpenAI provider’s imports (e.g., `ChatCompletionMessageFunctionToolCall`) and avoid import-time failures with 1.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfab547fca2821b4f0fee3f67c8d5bca275ee6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->