### PR TITLE
fix: stop forwarding strict mode to Bedrock Converse API

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -17,10 +17,7 @@ from crewai.utilities.agent_utils import is_context_length_exceeded
 from crewai.utilities.exceptions.context_window_exceeding_exception import (
     LLMContextLengthExceededError,
 )
-from crewai.utilities.pydantic_schema_utils import (
-    generate_model_description,
-    sanitize_tool_params_for_bedrock_strict,
-)
+from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.types import LLMMessage
 
 
@@ -173,7 +170,6 @@ class ToolSpec(TypedDict, total=False):
     name: Required[str]
     description: Required[str]
     inputSchema: ToolInputSchema
-    strict: bool
 
 
 class ConverseToolTypeDef(TypedDict):
@@ -1988,20 +1984,9 @@ class BedrockCompletion(BaseLLM):
                     "description": description,
                 }
 
-                func_info = tool.get("function", {})
-                strict_enabled = bool(func_info.get("strict"))
-
                 if parameters and isinstance(parameters, dict):
-                    schema_params = (
-                        sanitize_tool_params_for_bedrock_strict(parameters)
-                        if strict_enabled
-                        else parameters
-                    )
-                    input_schema: ToolInputSchema = {"json": schema_params}
+                    input_schema: ToolInputSchema = {"json": parameters}
                     tool_spec["inputSchema"] = input_schema
-
-                if strict_enabled:
-                    tool_spec["strict"] = True
 
                 converse_tool: ConverseToolTypeDef = {"toolSpec": tool_spec}
 


### PR DESCRIPTION
## Summary
- Bedrock Converse requests hang until timeout when `strict` is forwarded on `toolSpec` or when tool schemas are sanitized for strict mode
- Drops `strict` forwarding and `sanitize_tool_params_for_bedrock_strict` usage from the Bedrock provider; tool parameters pass through unchanged
- Removes the now-unused `strict` field from the `ToolSpec` TypedDict

## Test plan
- [ ] Run existing Bedrock provider tests
- [ ] Verify a Converse API call with tools completes without timing out

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Bedrock tool payload shape by removing `toolSpec.strict` and no longer sanitizing schemas, which could affect tool-calling behavior if Bedrock expects the prior strict-formatting. Scope is limited to Bedrock Converse tool formatting.
> 
> **Overview**
> Prevents Bedrock Converse calls from including strict-mode tool metadata by **removing `toolSpec.strict` entirely** and dropping strict-mode schema sanitization.
> 
> Tool input schemas are now passed through to Bedrock unchanged (no `sanitize_tool_params_for_bedrock_strict`), reducing the chance of Converse requests hanging/timeing out when tools are enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b2e96554398323e5578cb63db5fe1a7379d185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->