### PR TITLE
fix: bump pypdf to 6.10.1 to patch GHSA-jj6c-8h6c-hppx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ info = "Commits must follow Conventional Commits 1.0.0."
 
 
 [tool.uv]
-exclude-newer = "3 days"
+exclude-newer = "1 day"
 
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.
@@ -170,7 +170,7 @@ exclude-newer = "3 days"
 # langchain-core <1.2.28 has GHSA-926x-3r5x-gfhw (incomplete f-string validation).
 # transformers 4.57.6 has CVE-2026-1839; force 5.4+ (docling 2.84 allows huggingface-hub>=1).
 # cryptography 46.0.6 has CVE-2026-39892; force 46.0.7+.
-# pypdf <6.10.0 has CVE-2026-40260; force 6.10.0+.
+# pypdf <6.10.1 has CVE-2026-40260 and GHSA-jj6c-8h6c-hppx; force 6.10.1+.
 # uv <0.11.6 has GHSA-pjjw-68hj-v9mw; force 0.11.6+.
 override-dependencies = [
     "rich>=13.7.1",
@@ -180,7 +180,7 @@ override-dependencies = [
     "urllib3>=2.6.3",
     "transformers>=5.4.0; python_version >= '3.10'",
     "cryptography>=46.0.7",
-    "pypdf>=6.10.0,<7",
+    "pypdf>=6.10.1,<7",
     "uv>=0.11.6,<1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-10T18:30:59.748668Z"
-exclude-newer-span = "P3D"
+exclude-newer = "2026-04-14T20:05:08.458275Z"
+exclude-newer-span = "P1D"
 
 [manifest]
 members = [
@@ -28,7 +28,7 @@ overrides = [
     { name = "langchain-core", specifier = ">=1.2.28,<2" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "pillow", specifier = ">=12.1.1" },
-    { name = "pypdf", specifier = ">=6.10.0,<7" },
+    { name = "pypdf", specifier = ">=6.10.1,<7" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "transformers", marker = "python_full_version >= '3.10'", specifier = ">=5.4.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
@@ -6727,14 +6727,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.10.0"
+version = "6.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/9f/ca96abf18683ca12602065e4ed2bec9050b672c87d317f1079abc7b6d993/pypdf-6.10.0.tar.gz", hash = "sha256:4c5a48ba258c37024ec2505f7e8fd858525f5502784a2e1c8d415604af29f6ef", size = 5314833, upload-time = "2026-04-10T09:34:57.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/79/f2730c42ec7891a75a2fcea2eb4f356872bcbc671b711418060424796612/pypdf-6.10.1.tar.gz", hash = "sha256:62e6ca7f65aaa28b3d192addb44f97296e4be1748f57ed0f4efb2d4915841880", size = 5315704, upload-time = "2026-04-14T12:55:20.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/f2/7ebe366f633f30a6ad105f650f44f24f98cb1335c4157d21ae47138b3482/pypdf-6.10.0-py3-none-any.whl", hash = "sha256:90005e959e1596c6e6c84c8b0ad383285b3e17011751cedd17f2ce8fcdfc86de", size = 334459, upload-time = "2026-04-10T09:34:54.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/04/e3aa7f1f14dbc53429cae34666261eb935d99bd61d24756ab94d7e0309da/pypdf-6.10.1-py3-none-any.whl", hash = "sha256:6331940d3bfe75b7e6601d35db7adabab5fc1d716efaeb384e3c0c3957d033de", size = 335606, upload-time = "2026-04-14T12:55:18.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes GHSA-jj6c-8h6c-hppx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/lockfile update; primary impact is updated `pypdf` artifacts and a tighter `uv` `exclude-newer` window that may slightly change future resolutions.
> 
> **Overview**
> Bumps the `pypdf` override from `6.10.0` to `6.10.1` and updates the associated security note to include `GHSA-jj6c-8h6c-hppx`.
> 
> Tightens `uv`'s `exclude-newer` setting from *3 days* to *1 day*, and refreshes `uv.lock` accordingly (new `exclude-newer` timestamp/span and `pypdf` package entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15faf271fa545a6a6663d540948093b4154ede92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->