### PR TITLE
feat: bump versions to 1.14.2rc1

### DIFF
--- a/lib/crewai-files/src/crewai_files/__init__.py
+++ b/lib/crewai-files/src/crewai_files/__init__.py
@@ -152,4 +152,4 @@ __all__ = [
     "wrap_file_source",
 ]
 
-__version__ = "1.14.2a5"
+__version__ = "1.14.2rc1"

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     "pytube~=15.0.0",
     "requests>=2.33.0,<3",
-    "crewai==1.14.2a5",
+    "crewai==1.14.2rc1",
     "tiktoken~=0.8.0",
     "beautifulsoup4~=4.13.4",
     "python-docx~=1.2.0",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -305,4 +305,4 @@ __all__ = [
     "ZapierActionTools",
 ]
 
-__version__ = "1.14.2a5"
+__version__ = "1.14.2rc1"

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -55,7 +55,7 @@ Repository = "https://github.com/crewAIInc/crewAI"
 
 [project.optional-dependencies]
 tools = [
-    "crewai-tools==1.14.2a5",
+    "crewai-tools==1.14.2rc1",
 ]
 embeddings = [
     "tiktoken~=0.8.0"

--- a/lib/crewai/src/crewai/__init__.py
+++ b/lib/crewai/src/crewai/__init__.py
@@ -46,7 +46,7 @@ def _suppress_pydantic_deprecation_warnings() -> None:
 
 _suppress_pydantic_deprecation_warnings()
 
-__version__ = "1.14.2a5"
+__version__ = "1.14.2rc1"
 _telemetry_submitted = False
 
 

--- a/lib/crewai/src/crewai/cli/templates/crew/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/crew/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.2a5"
+    "crewai[tools]==1.14.2rc1"
 ]
 
 [project.scripts]

--- a/lib/crewai/src/crewai/cli/templates/flow/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.2a5"
+    "crewai[tools]==1.14.2rc1"
 ]
 
 [project.scripts]

--- a/lib/crewai/src/crewai/cli/templates/tool/pyproject.toml
+++ b/lib/crewai/src/crewai/cli/templates/tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.2a5"
+    "crewai[tools]==1.14.2rc1"
 ]
 
 [tool.crewai]

--- a/lib/devtools/src/crewai_devtools/__init__.py
+++ b/lib/devtools/src/crewai_devtools/__init__.py
@@ -1,3 +1,3 @@
 """CrewAI development tools."""
 
-__version__ = "1.14.2a5"
+__version__ = "1.14.2rc1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-string and dependency-pin updates only; no runtime logic changes beyond what the new version implies.
> 
> **Overview**
> Bumps the release version across the monorepo from `1.14.2a5` to `1.14.2rc1`.
> 
> Updates package `__version__` constants (`crewai`, `crewai-tools`, `crewai-files`, `crewai_devtools`), aligns inter-package dependency pins (`crewai-tools` → `crewai`, `crewai[tools]` → `crewai-tools`), and refreshes CLI template `pyproject.toml` files to generate projects pinned to `crewai[tools]==1.14.2rc1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa633ea2bc61fb332c9485baaea59dfcb54e835d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->