### PR TITLE
docs: update changelog and version for v1.14.2rc1

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,27 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="16 أبريل 2026">
+  ## v1.14.2rc1
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.2rc1)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - إصلاح معالجة مخططات JSON الدائرية في أداة MCP
+  - إصلاح ثغرة أمنية من خلال تحديث python-multipart إلى 0.0.26
+  - إصلاح ثغرة أمنية من خلال تحديث pypdf إلى 6.10.1
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار لـ v1.14.2a5
+
+  ## المساهمون
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="15 أبريل 2026">
   ## v1.14.2a5
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,27 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Apr 16, 2026">
+  ## v1.14.2rc1
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.2rc1)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Fix handling of cyclic JSON schemas in MCP tool resolution
+  - Fix vulnerability by bumping python-multipart to 0.0.26
+  - Fix vulnerability by bumping pypdf to 6.10.1
+
+  ### Documentation
+  - Update changelog and version for v1.14.2a5
+
+  ## Contributors
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="Apr 15, 2026">
   ## v1.14.2a5
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,27 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 4월 16일">
+  ## v1.14.2rc1
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.2rc1)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - MCP 도구 해상도에서 순환 JSON 스키마 처리 수정
+  - python-multipart를 0.0.26으로 업데이트하여 취약점 수정
+  - pypdf를 6.10.1로 업데이트하여 취약점 수정
+
+  ### 문서
+  - v1.14.2a5에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="2026년 4월 15일">
   ## v1.14.2a5
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,27 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="16 abr 2026">
+  ## v1.14.2rc1
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.2rc1)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Corrigir o manuseio de esquemas JSON cíclicos na resolução da ferramenta MCP
+  - Corrigir vulnerabilidade atualizando python-multipart para 0.0.26
+  - Corrigir vulnerabilidade atualizando pypdf para 6.10.1
+
+  ### Documentação
+  - Atualizar o changelog e a versão para v1.14.2a5
+
+  ## Contribuidores
+
+  @greysonlalonde
+
+</Update>
+
 <Update label="15 abr 2026">
   ## v1.14.2a5
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes to changelog entries; no runtime code or dependency manifests are modified in this PR.
> 
> **Overview**
> Adds a new `v1.14.2rc1` entry to the changelog across locales (`docs/en`, `docs/ar`, `docs/ko`, `docs/pt-BR`), linking to the GitHub release and listing the headline bug fixes.
> 
> The new notes call out **MCP cyclic JSON schema handling** and **security-related dependency bumps** (`python-multipart` to `0.0.26`, `pypdf` to `6.10.1`), plus a small documentation/version note and contributor attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f17114c167d25a93ab5d840b3890f018aa2aa62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->