### PR TITLE
fix: validate JSON before Pydantic conversion to avoid false-positive matches on GraphQL schemas

### DIFF
--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -256,6 +256,21 @@ def handle_partial_json(
     """
     match = _JSON_PATTERN.search(result)
     if match:
+        # Guard against false-positive matches: verify the captured substring is
+        # valid JSON before attempting Pydantic validation. Curly-brace content
+        # like GraphQL schemas matches the pattern but is not JSON, and passing
+        # non-JSON to model_validate_json raises a ValidationError that would
+        # incorrectly surface as a conversion failure rather than a no-match.
+        try:
+            json.loads(match.group())
+        except json.JSONDecodeError:
+            return convert_with_instructions(
+                result=result,
+                model=model,
+                is_json_output=is_json_output,
+                agent=agent,
+                converter_cls=converter_cls,
+            )
         try:
             exported_result = model.model_validate_json(match.group())
             if is_json_output:

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -177,6 +177,27 @@ def test_handle_partial_json_with_invalid_partial(mock_agent: Mock) -> None:
         assert output == "Converted result"
 
 
+def test_handle_partial_json_with_graphql_schema_does_not_raise(mock_agent: Mock) -> None:
+    # GraphQL schemas contain curly braces that match _JSON_PATTERN but are not JSON.
+    # The function must not raise ValidationError; it should fall through to
+    # convert_with_instructions instead.
+    graphql_schema = """
+    type Query {
+        user(id: ID!): User
+    }
+    type User {
+        id: ID!
+        name: String
+        age: Int
+    }
+    """
+    with patch("crewai.utilities.converter.convert_with_instructions") as mock_convert:
+        mock_convert.return_value = "Converted result"
+        output = handle_partial_json(graphql_schema, SimpleModel, False, mock_agent)
+        assert output == "Converted result"
+        mock_convert.assert_called_once()
+
+
 # Tests for convert_with_instructions
 @patch("crewai.utilities.converter.create_converter")
 @patch("crewai.utilities.converter.get_conversion_instructions")


### PR DESCRIPTION
## Summary

Fixes #5460

`_JSON_PATTERN` matches any `{.*}` substring, including non-JSON content like GraphQL schemas. When such content is passed to `model_validate_json`, Pydantic raises a `ValidationError` that surfaces as a conversion failure rather than a graceful fallback.

**Root cause:** The regex matches curly-brace content but does not verify it is valid JSON before attempting Pydantic validation.

**Fix:** Call `json.loads()` on the regex match first. If it raises `JSONDecodeError`, the content is not JSON and we fall through to `convert_with_instructions` instead of attempting Pydantic validation.

## Changes

- `src/crewai/utilities/converter.py`: Added `json.loads()` guard before `model_validate_json` in `handle_partial_json`
- `tests/utilities/test_converter.py`: Added `test_handle_partial_json_with_graphql_schema_does_not_raise` to cover the false-positive case

## Test plan

- [ ] Existing converter tests pass
- [ ] New test `test_handle_partial_json_with_graphql_schema_does_not_raise` passes
- [ ] Task with `output_pydantic` and a GraphQL schema as agent output no longer raises `ValidationError`