### PR TITLE
fix(checkpoint): discover branch-based JSON checkpoints

### DIFF
--- a/lib/crewai/src/crewai/cli/checkpoint_cli.py
+++ b/lib/crewai/src/crewai/cli/checkpoint_cli.py
@@ -68,6 +68,19 @@ def _is_sqlite(path: str) -> bool:
         return False
 
 
+def _iter_json_checkpoint_paths(location: str) -> list[str]:
+    """Return JSON checkpoint files under *location*, including branch subdirs.
+
+    JSON checkpoints are stored directly under ``location`` for older layouts and
+    under ``location/<branch>/`` for fork-aware layouts. Returning both keeps the
+    CLI backward-compatible across providers and checkpoint versions.
+    """
+    pattern = os.path.join(location, "**", "*.json")
+    return sorted(
+        glob.glob(pattern, recursive=True), key=os.path.getmtime, reverse=True
+    )
+
+
 def _parse_checkpoint_json(raw: str, source: str) -> dict[str, Any]:
     """Parse checkpoint JSON into metadata dict."""
     data = json.loads(raw)
@@ -173,9 +186,8 @@ def _entity_summary(entities: list[dict[str, Any]]) -> str:
 
 
 def _list_json(location: str) -> list[dict[str, Any]]:
-    pattern = os.path.join(location, "*.json")
     results = []
-    for path in sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True):
+    for path in _iter_json_checkpoint_paths(location):
         name = os.path.basename(path)
         try:
             with open(path) as f:
@@ -192,8 +204,7 @@ def _list_json(location: str) -> list[dict[str, Any]]:
 
 
 def _info_json_latest(location: str) -> dict[str, Any] | None:
-    pattern = os.path.join(location, "*.json")
-    files = sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True)
+    files = _iter_json_checkpoint_paths(location)
     if not files:
         return None
     path = files[0]

--- a/lib/crewai/tests/cli/test_checkpoint_cli.py
+++ b/lib/crewai/tests/cli/test_checkpoint_cli.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from crewai.cli.checkpoint_cli import _info_json_latest, _list_json
+from crewai.state.provider.json_provider import JsonProvider
+
+
+def test_list_json_discovers_branch_subdirectories(tmp_path: Path) -> None:
+    provider = JsonProvider()
+    provider.checkpoint('{"entities": [], "event_record": {}}', str(tmp_path))
+    provider.checkpoint(
+        '{"entities": [], "event_record": {}}',
+        str(tmp_path),
+        branch="fork/exp1",
+    )
+
+    entries = _list_json(str(tmp_path))
+
+    assert len(entries) == 2
+    assert {Path(entry["path"]).parent.name for entry in entries} == {"main", "exp1"}
+
+
+def test_info_json_latest_reads_latest_checkpoint_from_branch_subdirectory(
+    tmp_path: Path,
+) -> None:
+    provider = JsonProvider()
+    provider.checkpoint('{"entities": [], "event_record": {}}', str(tmp_path))
+    latest_path = provider.checkpoint(
+        '{"entities": [], "event_record": {}}',
+        str(tmp_path),
+        branch="fork/exp1",
+    )
+
+    latest = _info_json_latest(str(tmp_path))
+
+    assert latest is not None
+    assert latest["path"] == latest_path


### PR DESCRIPTION
Fixes #5491

## Summary
- make JSON checkpoint discovery recursive so it finds both legacy flat files and newer branch-based files
- reuse the same recursive lookup for `_list_json()` and `_info_json_latest()`
- add focused CLI tests covering branch subdirectory discovery

## Why this scope

Recent merged PRs in this area (#5381, #5387) introduced branch-aware JSON checkpoint storage, but the JSON discovery path in `checkpoint_cli.py` still used `location/*.json` globs.

That made this a good candidate for a narrow regression fix:
- one subsystem (`checkpoint_cli.py`)
- one behavioral gap (discovery)
- backward-compatible behavior (flat layout still works)
- straightforward tests

## Test plan
- [x] `uv run pytest lib/crewai/tests/cli/test_checkpoint_cli.py -q`
- [x] `uv run ruff check lib/crewai/src/crewai/cli/checkpoint_cli.py lib/crewai/tests/cli/test_checkpoint_cli.py`
- [x] `uv run ruff format --check lib/crewai/src/crewai/cli/checkpoint_cli.py lib/crewai/tests/cli/test_checkpoint_cli.py`
- [ ] manual CLI/TUI verification against a real project checkpoint directory

---
This PR was drafted with AI assistance. I could not apply an `llm-generated` label from my account.
