### PR TITLE
fix(checkpoint): route Flow checkpoints through TUI restore/fork

### DIFF
--- a/lib/crewai/src/crewai/cli/checkpoint_tui.py
+++ b/lib/crewai/src/crewai/cli/checkpoint_tui.py
@@ -71,6 +71,37 @@ def _selected_runner_type(location: str) -> str:
     return "crew"
 
 
+def _resolve_flow_runner(location: str) -> type[Any]:
+    """Resolve the concrete Flow class for a selected checkpoint when possible."""
+    from crewai.flow.flow import Flow
+
+    entry = _load_selected_checkpoint_entry(location)
+    if entry is None:
+        return Flow
+
+    flow_names = [
+        str(entity.get("name", "")).strip()
+        for entity in entry.get("entities", [])
+        if str(entity.get("type", "")).lower() == "flow"
+    ]
+    if not flow_names:
+        return Flow
+
+    try:
+        from crewai.cli.utils import get_flows
+
+        for flow in get_flows():
+            flow_name = str(
+                getattr(flow, "name", "") or flow.__class__.__name__
+            ).strip()
+            if flow_name in flow_names or flow.__class__.__name__ in flow_names:
+                return flow.__class__
+    except Exception:
+        return Flow
+
+    return Flow
+
+
 def _short_id(name: str) -> str:
     """Shorten a checkpoint name for tree display."""
     if len(name) > 30:
@@ -584,14 +615,14 @@ async def _run_checkpoint_tui_async(location: str) -> None:
     runner_type = _selected_runner_type(selected)
 
     if runner_type == "flow":
-        from crewai.flow.flow import Flow
+        flow_runner = _resolve_flow_runner(selected)
 
         if action == "fork":
             click.echo(f"\nForking from: {selected}\n")
-            crew = Flow.fork(config)
+            crew = flow_runner.fork(config)
         else:
             click.echo(f"\nResuming from: {selected}\n")
-            crew = Flow.from_checkpoint(config)
+            crew = flow_runner.from_checkpoint(config)
     else:
         from crewai.crew import Crew
 

--- a/lib/crewai/src/crewai/cli/checkpoint_tui.py
+++ b/lib/crewai/src/crewai/cli/checkpoint_tui.py
@@ -66,7 +66,7 @@ def _selected_runner_type(location: str) -> str:
         for entity in entry.get("entities", [])
         if entity.get("type")
     }
-    if entity_types == {"flow"}:
+    if "flow" in entity_types:
         return "flow"
     return "crew"
 
@@ -79,11 +79,15 @@ def _resolve_flow_runner(location: str) -> type[Any]:
     if entry is None:
         return Flow
 
-    flow_names = [
-        str(entity.get("name", "")).strip()
-        for entity in entry.get("entities", [])
-        if str(entity.get("type", "")).lower() == "flow"
-    ]
+    flow_names = []
+    for entity in entry.get("entities", []):
+        if str(entity.get("type", "")).lower() != "flow":
+            continue
+        raw_name = entity.get("name")
+        if isinstance(raw_name, str):
+            cleaned_name = raw_name.strip()
+            if cleaned_name:
+                flow_names.append(cleaned_name)
     if not flow_names:
         return Flow
 

--- a/lib/crewai/src/crewai/cli/checkpoint_tui.py
+++ b/lib/crewai/src/crewai/cli/checkpoint_tui.py
@@ -20,6 +20,8 @@ from textual.widgets import (
 
 from crewai.cli.checkpoint_cli import (
     _format_size,
+    _info_json_file,
+    _info_sqlite_id,
     _is_sqlite,
     _list_json,
     _list_sqlite,
@@ -38,6 +40,35 @@ def _load_entries(location: str) -> list[dict[str, Any]]:
     if _is_sqlite(location):
         return _list_sqlite(location)
     return _list_json(location)
+
+
+def _load_selected_checkpoint_entry(location: str) -> dict[str, Any] | None:
+    """Load metadata for a selected checkpoint location string."""
+    if "#" in location:
+        db_path, checkpoint_id = location.split("#", 1)
+        if _is_sqlite(db_path):
+            return _info_sqlite_id(db_path, checkpoint_id)
+    if location.endswith(".json"):
+        try:
+            return _info_json_file(location)
+        except OSError:
+            return None
+    return None
+
+
+def _selected_runner_type(location: str) -> str:
+    """Infer which runtime entity should restore from a checkpoint selection."""
+    entry = _load_selected_checkpoint_entry(location)
+    if entry is None:
+        return "crew"
+    entity_types = {
+        str(entity.get("type", "")).lower()
+        for entity in entry.get("entities", [])
+        if entity.get("type")
+    }
+    if entity_types == {"flow"}:
+        return "flow"
+    return "crew"
 
 
 def _short_id(name: str) -> str:
@@ -547,17 +578,29 @@ async def _run_checkpoint_tui_async(location: str) -> None:
 
     selected, action, inputs, task_overrides = selection
 
-    from crewai.crew import Crew
     from crewai.state.checkpoint_config import CheckpointConfig
 
     config = CheckpointConfig(restore_from=selected)
+    runner_type = _selected_runner_type(selected)
 
-    if action == "fork":
-        click.echo(f"\nForking from: {selected}\n")
-        crew = Crew.fork(config)
+    if runner_type == "flow":
+        from crewai.flow.flow import Flow
+
+        if action == "fork":
+            click.echo(f"\nForking from: {selected}\n")
+            crew = Flow.fork(config)
+        else:
+            click.echo(f"\nResuming from: {selected}\n")
+            crew = Flow.from_checkpoint(config)
     else:
-        click.echo(f"\nResuming from: {selected}\n")
-        crew = Crew.from_checkpoint(config)
+        from crewai.crew import Crew
+
+        if action == "fork":
+            click.echo(f"\nForking from: {selected}\n")
+            crew = Crew.fork(config)
+        else:
+            click.echo(f"\nResuming from: {selected}\n")
+            crew = Crew.from_checkpoint(config)
 
     if task_overrides:
         click.echo("Modifications:")

--- a/lib/crewai/tests/cli/test_checkpoint_tui.py
+++ b/lib/crewai/tests/cli/test_checkpoint_tui.py
@@ -46,12 +46,18 @@ class _FakeFlow:
         raise RuntimeError(f"Flow.fork:{config.restore_from}")
 
 
+class _ConcreteFakeFlow(_FakeFlow):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def _reset_fake_calls() -> None:
     _FakeCrew.resume_calls = 0
     _FakeCrew.fork_calls = 0
     _FakeFlow.resume_calls = 0
     _FakeFlow.fork_calls = 0
+    _ConcreteFakeFlow.resume_calls = 0
+    _ConcreteFakeFlow.fork_calls = 0
 
 
 def _install_fake_runtime_modules(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -65,6 +71,10 @@ def _install_fake_runtime_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "crewai.crew", crew_mod)
     monkeypatch.setitem(sys.modules, "crewai.flow.flow", flow_mod)
     monkeypatch.setitem(sys.modules, "crewai.state.checkpoint_config", config_mod)
+
+    utils_mod = ModuleType("crewai.cli.utils")
+    utils_mod.get_flows = lambda: []
+    monkeypatch.setitem(sys.modules, "crewai.cli.utils", utils_mod)
 
 
 @pytest.mark.asyncio
@@ -80,13 +90,17 @@ async def test_run_checkpoint_tui_async_uses_flow_restore_path(
     monkeypatch.setattr(
         checkpoint_tui,
         "_load_selected_checkpoint_entry",
-        lambda location: {"entities": [{"type": "flow"}]},
+        lambda location: {"entities": [{"type": "flow", "name": "MyFlow"}]},
     )
+    monkeypatch.setattr(checkpoint_tui, "_resolve_flow_runner", lambda location: _ConcreteFakeFlow)
 
-    with pytest.raises(RuntimeError, match="Flow.from_checkpoint:/tmp/fake-flow.json"):
+    with pytest.raises(
+        RuntimeError,
+        match="Flow.from_checkpoint:/tmp/fake-flow.json",
+    ):
         await checkpoint_tui._run_checkpoint_tui_async("/tmp/unused")
 
-    assert _FakeFlow.resume_calls == 1
+    assert _ConcreteFakeFlow.resume_calls == 1
     assert _FakeCrew.resume_calls == 0
 
 
@@ -103,13 +117,14 @@ async def test_run_checkpoint_tui_async_uses_flow_fork_path(
     monkeypatch.setattr(
         checkpoint_tui,
         "_load_selected_checkpoint_entry",
-        lambda location: {"entities": [{"type": "flow"}]},
+        lambda location: {"entities": [{"type": "flow", "name": "MyFlow"}]},
     )
+    monkeypatch.setattr(checkpoint_tui, "_resolve_flow_runner", lambda location: _ConcreteFakeFlow)
 
     with pytest.raises(RuntimeError, match="Flow.fork:/tmp/fake-flow.json"):
         await checkpoint_tui._run_checkpoint_tui_async("/tmp/unused")
 
-    assert _FakeFlow.fork_calls == 1
+    assert _ConcreteFakeFlow.fork_calls == 1
     assert _FakeCrew.fork_calls == 0
 
 
@@ -127,3 +142,24 @@ def test_selected_runner_type_detects_flow_entry(
     )
 
     assert checkpoint_tui._selected_runner_type(str(Path("/tmp/fake-flow.json"))) == "flow"
+
+
+def test_resolve_flow_runner_prefers_matching_concrete_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utils_mod = ModuleType("crewai.cli.utils")
+
+    class MyFlow(_ConcreteFakeFlow):
+        name = "MyFlow"
+
+    utils_mod.get_flows = lambda: [MyFlow()]
+    monkeypatch.setitem(sys.modules, "crewai.cli.utils", utils_mod)
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {"entities": [{"type": "flow", "name": "MyFlow"}]},
+    )
+
+    runner = checkpoint_tui._resolve_flow_runner("/tmp/fake-flow.json")
+
+    assert runner is MyFlow

--- a/lib/crewai/tests/cli/test_checkpoint_tui.py
+++ b/lib/crewai/tests/cli/test_checkpoint_tui.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+from crewai.cli import checkpoint_tui
+
+
+class _FakeCheckpointConfig:
+    def __init__(self, restore_from: str) -> None:
+        self.restore_from = restore_from
+
+
+class _FakeCrew:
+    tasks: list[object] = []
+    resume_calls = 0
+    fork_calls = 0
+
+    @classmethod
+    def from_checkpoint(cls, config: _FakeCheckpointConfig) -> "_FakeCrew":
+        cls.resume_calls += 1
+        raise RuntimeError(f"Crew.from_checkpoint:{config.restore_from}")
+
+    @classmethod
+    def fork(cls, config: _FakeCheckpointConfig) -> "_FakeCrew":
+        cls.fork_calls += 1
+        raise RuntimeError(f"Crew.fork:{config.restore_from}")
+
+
+class _FakeFlow:
+    tasks: list[object] = []
+    resume_calls = 0
+    fork_calls = 0
+
+    @classmethod
+    def from_checkpoint(cls, config: _FakeCheckpointConfig) -> "_FakeFlow":
+        cls.resume_calls += 1
+        raise RuntimeError(f"Flow.from_checkpoint:{config.restore_from}")
+
+    @classmethod
+    def fork(cls, config: _FakeCheckpointConfig) -> "_FakeFlow":
+        cls.fork_calls += 1
+        raise RuntimeError(f"Flow.fork:{config.restore_from}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_calls() -> None:
+    _FakeCrew.resume_calls = 0
+    _FakeCrew.fork_calls = 0
+    _FakeFlow.resume_calls = 0
+    _FakeFlow.fork_calls = 0
+
+
+def _install_fake_runtime_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    crew_mod = ModuleType("crewai.crew")
+    crew_mod.Crew = _FakeCrew
+    flow_mod = ModuleType("crewai.flow.flow")
+    flow_mod.Flow = _FakeFlow
+    config_mod = ModuleType("crewai.state.checkpoint_config")
+    config_mod.CheckpointConfig = _FakeCheckpointConfig
+
+    monkeypatch.setitem(sys.modules, "crewai.crew", crew_mod)
+    monkeypatch.setitem(sys.modules, "crewai.flow.flow", flow_mod)
+    monkeypatch.setitem(sys.modules, "crewai.state.checkpoint_config", config_mod)
+
+
+@pytest.mark.asyncio
+async def test_run_checkpoint_tui_async_uses_flow_restore_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_runtime_modules(monkeypatch)
+
+    async def fake_run_async(self: checkpoint_tui.CheckpointTUI) -> tuple[str, str, None, None]:
+        return ("/tmp/fake-flow.json", "resume", None, None)
+
+    monkeypatch.setattr(checkpoint_tui.CheckpointTUI, "run_async", fake_run_async)
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {"entities": [{"type": "flow"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="Flow.from_checkpoint:/tmp/fake-flow.json"):
+        await checkpoint_tui._run_checkpoint_tui_async("/tmp/unused")
+
+    assert _FakeFlow.resume_calls == 1
+    assert _FakeCrew.resume_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_run_checkpoint_tui_async_uses_flow_fork_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_runtime_modules(monkeypatch)
+
+    async def fake_run_async(self: checkpoint_tui.CheckpointTUI) -> tuple[str, str, None, None]:
+        return ("/tmp/fake-flow.json", "fork", None, None)
+
+    monkeypatch.setattr(checkpoint_tui.CheckpointTUI, "run_async", fake_run_async)
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {"entities": [{"type": "flow"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="Flow.fork:/tmp/fake-flow.json"):
+        await checkpoint_tui._run_checkpoint_tui_async("/tmp/unused")
+
+    assert _FakeFlow.fork_calls == 1
+    assert _FakeCrew.fork_calls == 0
+
+
+def test_selected_runner_type_defaults_to_crew_for_unknown_entries() -> None:
+    assert checkpoint_tui._selected_runner_type("/tmp/unknown.json") == "crew"
+
+
+def test_selected_runner_type_detects_flow_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {"entities": [{"type": "flow"}]},
+    )
+
+    assert checkpoint_tui._selected_runner_type(str(Path("/tmp/fake-flow.json"))) == "flow"

--- a/lib/crewai/tests/cli/test_checkpoint_tui.py
+++ b/lib/crewai/tests/cli/test_checkpoint_tui.py
@@ -144,6 +144,23 @@ def test_selected_runner_type_detects_flow_entry(
     assert checkpoint_tui._selected_runner_type(str(Path("/tmp/fake-flow.json"))) == "flow"
 
 
+def test_selected_runner_type_prefers_flow_for_mixed_flow_and_crew_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {
+            "entities": [
+                {"type": "flow", "name": "MyFlow"},
+                {"type": "crew", "name": "NestedCrew"},
+            ]
+        },
+    )
+
+    assert checkpoint_tui._selected_runner_type(str(Path("/tmp/fake-flow.json"))) == "flow"
+
+
 def test_resolve_flow_runner_prefers_matching_concrete_flow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -158,6 +175,32 @@ def test_resolve_flow_runner_prefers_matching_concrete_flow(
         checkpoint_tui,
         "_load_selected_checkpoint_entry",
         lambda location: {"entities": [{"type": "flow", "name": "MyFlow"}]},
+    )
+
+    runner = checkpoint_tui._resolve_flow_runner("/tmp/fake-flow.json")
+
+    assert runner is MyFlow
+
+
+def test_resolve_flow_runner_ignores_null_flow_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utils_mod = ModuleType("crewai.cli.utils")
+
+    class MyFlow(_ConcreteFakeFlow):
+        pass
+
+    utils_mod.get_flows = lambda: [MyFlow()]
+    monkeypatch.setitem(sys.modules, "crewai.cli.utils", utils_mod)
+    monkeypatch.setattr(
+        checkpoint_tui,
+        "_load_selected_checkpoint_entry",
+        lambda location: {
+            "entities": [
+                {"type": "flow", "name": None},
+                {"type": "flow", "name": "MyFlow"},
+            ]
+        },
     )
 
     runner = checkpoint_tui._resolve_flow_runner("/tmp/fake-flow.json")


### PR DESCRIPTION
Fixes #5492

## Summary
- infer the selected checkpoint entity type before restore/fork in the TUI
- route Flow checkpoints through `Flow.from_checkpoint()` / `Flow.fork()`
- keep the existing Crew path unchanged for Crew checkpoints and unknown entries
- add focused async tests covering Flow dispatch

## Why this scope

Based on recent merged PR patterns in this repo, the safest path seemed to be a narrow checkpoint/TUI-only fix rather than combining this with unrelated checkpoint behavior.

This PR stays small on purpose:
- no storage changes
- no restore semantics changes outside the TUI entry point
- explicit metadata-based dispatch using existing checkpoint entity metadata
- focused tests for the dispatch behavior only

## Test plan
- [x] `uv run pytest lib/crewai/tests/cli/test_checkpoint_tui.py -q`
- [x] `uv run ruff check lib/crewai/src/crewai/cli/checkpoint_tui.py lib/crewai/tests/cli/test_checkpoint_tui.py`
- [x] `uv run ruff format --check lib/crewai/src/crewai/cli/checkpoint_tui.py lib/crewai/tests/cli/test_checkpoint_tui.py`
- [ ] manual Textual TUI verification against a real Flow checkpoint

---
This PR was drafted with AI assistance. I could not apply an `llm-generated` label from my account.
