### PR TITLE
fix: JSON checkpoint discovery ignores branch subdirectories

### DIFF
--- a/lib/crewai/src/crewai/cli/checkpoint_cli.py
+++ b/lib/crewai/src/crewai/cli/checkpoint_cli.py
@@ -173,9 +173,11 @@ def _entity_summary(entities: list[dict[str, Any]]) -> str:
 
 
 def _list_json(location: str) -> list[dict[str, Any]]:
-    pattern = os.path.join(location, "*.json")
+    pattern = os.path.join(location, "**", "*.json")
     results = []
-    for path in sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True):
+    for path in sorted(
+        glob.glob(pattern, recursive=True), key=os.path.getmtime, reverse=True
+    ):
         name = os.path.basename(path)
         try:
             with open(path) as f:
@@ -192,8 +194,10 @@ def _list_json(location: str) -> list[dict[str, Any]]:
 
 
 def _info_json_latest(location: str) -> dict[str, Any] | None:
-    pattern = os.path.join(location, "*.json")
-    files = sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True)
+    pattern = os.path.join(location, "**", "*.json")
+    files = sorted(
+        glob.glob(pattern, recursive=True), key=os.path.getmtime, reverse=True
+    )
     if not files:
         return None
     path = files[0]


### PR DESCRIPTION
## Summary
- Use recursive glob (`**/*.json`) in `_list_json()` and `_info_json_latest()` so JSON checkpoints stored under branch subdirectories (e.g. `main/`, `fork/exp1/`) are discovered correctly
- Maintains backward compatibility with the legacy flat layout

Closes #5491

## Test plan
- [ ] Verify `_list_json()` discovers checkpoints in branch subdirectories
- [ ] Verify `_info_json_latest()` returns the most recent checkpoint across all branches
- [ ] Verify legacy flat-layout checkpoints are still discovered

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to filesystem globbing in the CLI; main risk is slight performance impact or unintended inclusion of extra `.json` files under the checkpoint directory.
> 
> **Overview**
> Checkpoint CLI JSON discovery now searches recursively (via `**/*.json`) when listing checkpoints and when computing the latest checkpoint, so checkpoints stored under branch/subdirectories are picked up alongside the legacy flat layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de4ef9d1206aa819be84170fa0255c0258b32a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->