### PR TITLE
fix: bump langsmith to 0.7.31 to patch GHSA-rr7j-v2q5-chgv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ exclude-newer = "1 day"
 # pypdf <6.10.1 has CVE-2026-40260 and GHSA-jj6c-8h6c-hppx; force 6.10.1+.
 # uv <0.11.6 has GHSA-pjjw-68hj-v9mw; force 0.11.6+.
 # python-multipart <0.0.26 has GHSA-mj87-hwqh-73pj; force 0.0.26+.
+# langsmith <0.7.31 has GHSA-rr7j-v2q5-chgv (streaming token redaction bypass); force 0.7.31+.
 override-dependencies = [
     "rich>=13.7.1",
     "onnxruntime<1.24; python_version < '3.11'",
@@ -184,6 +185,7 @@ override-dependencies = [
     "pypdf>=6.10.1,<7",
     "uv>=0.11.6,<1",
     "python-multipart>=0.0.26,<1",
+    "langsmith>=0.7.31,<0.8",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T20:20:18.36862Z"
+exclude-newer = "2026-04-15T15:14:38.695171Z"
 exclude-newer-span = "P1D"
 
 [manifest]
@@ -26,6 +26,7 @@ members = [
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "langchain-core", specifier = ">=1.2.28,<2" },
+    { name = "langsmith", specifier = ">=0.7.31,<0.8" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pypdf", specifier = ">=6.10.1,<7" },
@@ -3596,7 +3597,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langsmith"
-version = "0.7.30"
+version = "0.7.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3609,9 +3610,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/e7/d27d952ce9824d684a3bb500a06541a2d55734bc4d849cdfcca2dfd4d93a/langsmith-0.7.30.tar.gz", hash = "sha256:d9df7ba5e42f818b63bda78776c8f2fc853388be3ae77b117e5d183a149321a2", size = 1106040, upload-time = "2026-04-09T21:12:01.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/11/696019490992db5c87774dc20515529ef42a01e1d770fb754ed6d9b12fb0/langsmith-0.7.31.tar.gz", hash = "sha256:331ee4f7c26bb5be4022b9859b7d7b122cbf8c9d01d9f530114c1914b0349ffb", size = 1178480, upload-time = "2026-04-14T17:55:41.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/19/96250cf58070c5563446651b03bb76c2eb5afbf08e754840ab639532d8c6/langsmith-0.7.30-py3-none-any.whl", hash = "sha256:43dd9f8d290e4d406606d6cc0bd62f5d1050963f05fe0ab6ffe50acf41f2f55a", size = 372682, upload-time = "2026-04-09T21:12:00.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a1/a013cf458c301cda86a213dd153ce0a01c93f1ab5833f951e6a44c9763ce/langsmith-0.7.31-py3-none-any.whl", hash = "sha256:0291d49203f6e80dda011af1afda61eb0595a4d697adb684590a8805e1d61fb6", size = 373276, upload-time = "2026-04-14T17:55:39.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `langsmith>=0.7.31,<0.8` to `override-dependencies` to patch GHSA-rr7j-v2q5-chgv
- langsmith <0.7.31 bypasses output redaction for streaming token events, leaking sensitive LLM outputs into LangSmith storage despite redaction being enabled

## Test plan
- [ ] `pip-audit` CI step passes without langsmith vulnerability
- [ ] Existing tests pass with updated lockfile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin/lockfile update only; no application logic changes, with limited risk beyond potential upstream behavior changes in `langsmith`.
> 
> **Overview**
> Pins `langsmith` to `>=0.7.31,<0.8` via `tool.uv.override-dependencies` to remediate GHSA-rr7j-v2q5-chgv (streaming token redaction bypass).
> 
> Regenerates `uv.lock` to apply the override (including bumping `langsmith` from `0.7.30` to `0.7.31` and updating the lockfile timestamp).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cfa67cbd8052afd3b78152c85b4f28b4427148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->