### PR TITLE
fix: scope streaming handlers to prevent cross-run chunk contamination

### DIFF
--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -7,6 +7,7 @@ import logging
 import queue
 import threading
 from typing import Any, NamedTuple
+import uuid
 
 from typing_extensions import TypedDict
 
@@ -24,6 +25,10 @@ from crewai.utilities.string_utils import sanitize_tool_name
 
 
 logger = logging.getLogger(__name__)
+
+_current_stream_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_stream_id", default=None
+)
 
 
 class TaskInfo(TypedDict):
@@ -106,6 +111,7 @@ def _create_stream_handler(
     sync_queue: queue.Queue[StreamChunk | None | Exception],
     async_queue: asyncio.Queue[StreamChunk | None | Exception] | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
+    stream_id: str | None = None,
 ) -> Callable[[Any, BaseEvent], None]:
     """Create a stream handler function.
 
@@ -114,19 +120,17 @@ def _create_stream_handler(
         sync_queue: Synchronous queue for chunks.
         async_queue: Optional async queue for chunks.
         loop: Optional event loop for async operations.
+        stream_id: Stream scope ID for concurrent isolation.
 
     Returns:
         Handler function that can be registered with the event bus.
     """
 
     def stream_handler(_: Any, event: BaseEvent) -> None:
-        """Handle LLM stream chunk events and enqueue them.
-
-        Args:
-            _: Event source (unused).
-            event: The event to process.
-        """
         if not isinstance(event, LLMStreamChunkEvent):
+            return
+
+        if stream_id is not None and _current_stream_id.get() != stream_id:
             return
 
         chunk = _create_stream_chunk(event, current_task_info)
@@ -203,7 +207,12 @@ def create_streaming_state(
         async_queue = asyncio.Queue()
         loop = asyncio.get_event_loop()
 
-    handler = _create_stream_handler(current_task_info, sync_queue, async_queue, loop)
+    stream_id = str(uuid.uuid4())
+    _current_stream_id.set(stream_id)
+
+    handler = _create_stream_handler(
+        current_task_info, sync_queue, async_queue, loop, stream_id=stream_id
+    )
     crewai_event_bus.register_handler(LLMStreamChunkEvent, handler)
 
     return StreamingState(

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -26,8 +26,8 @@ from crewai.utilities.string_utils import sanitize_tool_name
 
 logger = logging.getLogger(__name__)
 
-_current_stream_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_current_stream_id", default=None
+_current_stream_ids: contextvars.ContextVar[tuple[str, ...]] = contextvars.ContextVar(
+    "_current_stream_ids", default=()
 )
 
 
@@ -130,7 +130,7 @@ def _create_stream_handler(
         if not isinstance(event, LLMStreamChunkEvent):
             return
 
-        if stream_id is not None and _current_stream_id.get() != stream_id:
+        if stream_id is not None and stream_id not in _current_stream_ids.get():
             return
 
         chunk = _create_stream_chunk(event, current_task_info)
@@ -208,7 +208,7 @@ def create_streaming_state(
         loop = asyncio.get_event_loop()
 
     stream_id = str(uuid.uuid4())
-    _current_stream_id.set(stream_id)
+    _current_stream_ids.set((*_current_stream_ids.get(), stream_id))
 
     handler = _create_stream_handler(
         current_task_info, sync_queue, async_queue, loop, stream_id=stream_id

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -50,6 +50,7 @@ class StreamingState(NamedTuple):
     async_queue: asyncio.Queue[StreamChunk | None | Exception] | None
     loop: asyncio.AbstractEventLoop | None
     handler: Callable[[Any, BaseEvent], None]
+    stream_id: str | None = None
 
 
 def _extract_tool_call_info(
@@ -208,7 +209,6 @@ def create_streaming_state(
         loop = asyncio.get_event_loop()
 
     stream_id = str(uuid.uuid4())
-    _current_stream_ids.set((*_current_stream_ids.get(), stream_id))
 
     handler = _create_stream_handler(
         current_task_info, sync_queue, async_queue, loop, stream_id=stream_id
@@ -222,6 +222,7 @@ def create_streaming_state(
         async_queue=async_queue,
         loop=loop,
         handler=handler,
+        stream_id=stream_id,
     )
 
 
@@ -269,7 +270,12 @@ def create_chunk_generator(
     Yields:
         StreamChunk objects as they arrive.
     """
-    ctx = contextvars.copy_context()
+    if state.stream_id is not None:
+        token = _current_stream_ids.set((*_current_stream_ids.get(), state.stream_id))
+        ctx = contextvars.copy_context()
+        _current_stream_ids.reset(token)
+    else:
+        ctx = contextvars.copy_context()
     thread = threading.Thread(target=ctx.run, args=(run_func,), daemon=True)
     thread.start()
 
@@ -309,7 +315,12 @@ async def create_async_chunk_generator(
             "Async queue not initialized. Use create_streaming_state(use_async=True)."
         )
 
-    task = asyncio.create_task(run_coro())
+    if state.stream_id is not None:
+        token = _current_stream_ids.set((*_current_stream_ids.get(), state.stream_id))
+        task = asyncio.create_task(run_coro())
+        _current_stream_ids.reset(token)
+    else:
+        task = asyncio.create_task(run_coro())
 
     try:
         while True:

--- a/lib/crewai/tests/test_streaming.py
+++ b/lib/crewai/tests/test_streaming.py
@@ -879,3 +879,103 @@ class TestStreamingImports:
         assert StreamChunk is not None
         assert StreamChunkType is not None
         assert ToolCallChunk is not None
+
+
+class TestConcurrentStreamIsolation:
+    """Regression tests for concurrent streaming isolation (issue #5376)."""
+
+    def test_concurrent_streams_do_not_cross_contaminate(self) -> None:
+        """Two concurrent streaming runs must each receive only their own chunks."""
+        import contextvars
+        import queue
+        import threading
+
+        from crewai.utilities.streaming import (
+            TaskInfo,
+            _current_stream_id,
+            create_streaming_state,
+        )
+
+        task_info_a: TaskInfo = {
+            "index": 0,
+            "name": "task_a",
+            "id": "a",
+            "agent_role": "A",
+            "agent_id": "a",
+        }
+        task_info_b: TaskInfo = {
+            "index": 1,
+            "name": "task_b",
+            "id": "b",
+            "agent_role": "B",
+            "agent_id": "b",
+        }
+
+        ctx_a = contextvars.copy_context()
+        ctx_b = contextvars.copy_context()
+
+        state_holder_a: list[Any] = []
+        state_holder_b: list[Any] = []
+
+        def setup_a() -> None:
+            s = create_streaming_state(task_info_a, [])
+            state_holder_a.append(s)
+
+        def setup_b() -> None:
+            s = create_streaming_state(task_info_b, [])
+            state_holder_b.append(s)
+
+        ctx_a.run(setup_a)
+        ctx_b.run(setup_b)
+
+        state_a = state_holder_a[0]
+        state_b = state_holder_b[0]
+
+        def emit_chunks_a() -> None:
+            for text in ["A1", "A2", "A3"]:
+                crewai_event_bus.emit(
+                    None,
+                    event=LLMStreamChunkEvent(
+                        chunk=text, call_id="call-a", response_id="r-a"
+                    ),
+                )
+
+        def emit_chunks_b() -> None:
+            for text in ["B1", "B2", "B3"]:
+                crewai_event_bus.emit(
+                    None,
+                    event=LLMStreamChunkEvent(
+                        chunk=text, call_id="call-b", response_id="r-b"
+                    ),
+                )
+
+        t_a = threading.Thread(target=ctx_a.run, args=(emit_chunks_a,))
+        t_b = threading.Thread(target=ctx_b.run, args=(emit_chunks_b,))
+        t_a.start()
+        t_b.start()
+        t_a.join()
+        t_b.join()
+
+        chunks_a: list[str] = []
+        while not state_a.sync_queue.empty():
+            item = state_a.sync_queue.get_nowait()
+            if isinstance(item, StreamChunk):
+                chunks_a.append(item.content)
+
+        chunks_b: list[str] = []
+        while not state_b.sync_queue.empty():
+            item = state_b.sync_queue.get_nowait()
+            if isinstance(item, StreamChunk):
+                chunks_b.append(item.content)
+
+        assert set(chunks_a) == {"A1", "A2", "A3"}, (
+            f"Stream A received unexpected chunks: {chunks_a}"
+        )
+        assert set(chunks_b) == {"B1", "B2", "B3"}, (
+            f"Stream B received unexpected chunks: {chunks_b}"
+        )
+
+        from crewai.utilities.streaming import _unregister_handler
+
+        _unregister_handler(state_a.handler)
+        _unregister_handler(state_b.handler)

--- a/lib/crewai/tests/test_streaming.py
+++ b/lib/crewai/tests/test_streaming.py
@@ -892,7 +892,6 @@ class TestConcurrentStreamIsolation:
 
         from crewai.utilities.streaming import (
             TaskInfo,
-            _current_stream_id,
             create_streaming_state,
         )
 

--- a/lib/crewai/tests/test_streaming.py
+++ b/lib/crewai/tests/test_streaming.py
@@ -885,13 +885,19 @@ class TestConcurrentStreamIsolation:
     """Regression tests for concurrent streaming isolation (issue #5376)."""
 
     def test_concurrent_streams_do_not_cross_contaminate(self) -> None:
-        """Two concurrent streaming runs must each receive only their own chunks."""
+        """Two concurrent streaming runs must each receive only their own chunks.
+
+        Mirrors the real production path: create_streaming_state in the caller,
+        then temporarily push the stream_id into the ContextVar, copy_context,
+        and reset — exactly as create_chunk_generator does.
+        """
         import contextvars
-        import queue
         import threading
 
         from crewai.utilities.streaming import (
             TaskInfo,
+            _current_stream_ids,
+            _unregister_handler,
             create_streaming_state,
         )
 
@@ -910,46 +916,31 @@ class TestConcurrentStreamIsolation:
             "agent_id": "b",
         }
 
-        ctx_a = contextvars.copy_context()
-        ctx_b = contextvars.copy_context()
+        state_a = create_streaming_state(task_info_a, [])
+        state_b = create_streaming_state(task_info_b, [])
 
-        state_holder_a: list[Any] = []
-        state_holder_b: list[Any] = []
+        def make_emitter_ctx(state: Any) -> contextvars.Context:
+            token = _current_stream_ids.set(
+                (*_current_stream_ids.get(), state.stream_id)
+            )
+            ctx = contextvars.copy_context()
+            _current_stream_ids.reset(token)
+            return ctx
 
-        def setup_a() -> None:
-            s = create_streaming_state(task_info_a, [])
-            state_holder_a.append(s)
+        ctx_a = make_emitter_ctx(state_a)
+        ctx_b = make_emitter_ctx(state_b)
 
-        def setup_b() -> None:
-            s = create_streaming_state(task_info_b, [])
-            state_holder_b.append(s)
-
-        ctx_a.run(setup_a)
-        ctx_b.run(setup_b)
-
-        state_a = state_holder_a[0]
-        state_b = state_holder_b[0]
-
-        def emit_chunks_a() -> None:
-            for text in ["A1", "A2", "A3"]:
+        def emit_chunks(prefix: str, call_id: str) -> None:
+            for text in [f"{prefix}1", f"{prefix}2", f"{prefix}3"]:
                 crewai_event_bus.emit(
                     None,
                     event=LLMStreamChunkEvent(
-                        chunk=text, call_id="call-a", response_id="r-a"
+                        chunk=text, call_id=call_id, response_id="r"
                     ),
                 )
 
-        def emit_chunks_b() -> None:
-            for text in ["B1", "B2", "B3"]:
-                crewai_event_bus.emit(
-                    None,
-                    event=LLMStreamChunkEvent(
-                        chunk=text, call_id="call-b", response_id="r-b"
-                    ),
-                )
-
-        t_a = threading.Thread(target=ctx_a.run, args=(emit_chunks_a,))
-        t_b = threading.Thread(target=ctx_b.run, args=(emit_chunks_b,))
+        t_a = threading.Thread(target=ctx_a.run, args=(lambda: emit_chunks("A", "ca"),))
+        t_b = threading.Thread(target=ctx_b.run, args=(lambda: emit_chunks("B", "cb"),))
         t_a.start()
         t_b.start()
         t_a.join()
@@ -973,8 +964,6 @@ class TestConcurrentStreamIsolation:
         assert set(chunks_b) == {"B1", "B2", "B3"}, (
             f"Stream B received unexpected chunks: {chunks_b}"
         )
-
-        from crewai.utilities.streaming import _unregister_handler
 
         _unregister_handler(state_a.handler)
         _unregister_handler(state_b.handler)


### PR DESCRIPTION
## Summary
- Streaming handlers on the singleton `crewai_event_bus` received ALL `LLMStreamChunkEvent` emissions, causing cross-run chunk fan-out when multiple streaming runs executed concurrently
- Adds a `ContextVar`-based stream scope ID (`_current_stream_id`) so each handler only accepts events emitted within its own execution context
- `LLMStreamChunkEvent` handlers run synchronously in the emitter's thread, so the context var naturally reflects the correct stream scope

Closes #5376

## Test plan
- [ ] Added `TestConcurrentStreamIsolation` regression test: sets up two streams in separate contexts, emits chunks concurrently, asserts zero cross-contamination
- [ ] All 35 existing streaming tests pass unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming/event-bus integration and relies on `ContextVar` propagation across threads/tasks; mistakes could lead to missing chunks or continued fan-out under concurrency.
> 
> **Overview**
> Prevents concurrent streaming runs from cross-contaminating by scoping each registered `LLMStreamChunkEvent` handler to a per-run `stream_id` propagated via a `ContextVar`.
> 
> `create_streaming_state` now generates and stores a UUID `stream_id`, handlers drop events outside their context, and both sync/async chunk generators temporarily push the `stream_id` into the copied execution context so only in-scope emitters are observed. Adds a regression test that runs two concurrent streams and asserts each receives only its own chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7359c5c1f67216198cab566586797f5e4c1cfbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->