### PR TITLE
fix: mock Repository.__init__ in test_publish_when_not_in_sync

### DIFF
--- a/lib/crewai/tests/cli/tools/test_main.py
+++ b/lib/crewai/tests/cli/tools/test_main.py
@@ -161,7 +161,8 @@ def test_install_api_error(mock_get, capsys, tool_command):
 
 
 @patch("crewai.cli.tools.main.git.Repository.is_synced", return_value=False)
-def test_publish_when_not_in_sync(mock_is_synced, capsys, tool_command):
+@patch("crewai.cli.tools.main.git.Repository.__init__", return_value=None)
+def test_publish_when_not_in_sync(mock_init, mock_is_synced, capsys, tool_command):
     with raises(SystemExit):
         tool_command.publish(is_public=True)
 


### PR DESCRIPTION
## Summary
- `test_publish_when_not_in_sync` only mocked `Repository.is_synced` but not `Repository.__init__`, which calls `is_git_repo()` and `fetch()` — fails in CI where the working directory is not a git repo
- Added `@patch("...git.Repository.__init__", return_value=None)` to skip real git initialization

## Test plan
- [x] `test_publish_when_not_in_sync` passes locally
- [x] All 13 tests in `test_main.py` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts mocks to avoid git side effects in CI; no production code paths are modified.
> 
> **Overview**
> Makes `test_publish_when_not_in_sync` robust in non-git environments by mocking `git.Repository.__init__` in addition to `Repository.is_synced`, preventing real git initialization (`is_git_repo()`/`fetch()`) during the publish preflight check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07949b276ed95778cffcdca920067930934fbf7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->