### PR TITLE
test: add mock for git.Repository.fetch in publish test

### DIFF
--- a/lib/crewai/tests/cli/tools/test_main.py
+++ b/lib/crewai/tests/cli/tools/test_main.py
@@ -160,8 +160,9 @@ def test_install_api_error(mock_get, capsys, tool_command):
     mock_get.assert_called_once_with("error-tool")
 
 
+@patch("crewai.cli.tools.main.git.Repository.fetch")
 @patch("crewai.cli.tools.main.git.Repository.is_synced", return_value=False)
-def test_publish_when_not_in_sync(mock_is_synced, capsys, tool_command):
+def test_publish_when_not_in_sync(mock_is_synced, mock_fetch, capsys, tool_command):
     with raises(SystemExit):
         tool_command.publish(is_public=True)
 
@@ -180,6 +181,7 @@ def test_publish_when_not_in_sync(mock_is_synced, capsys, tool_command):
     read_data=b"sample tarball content",
 )
 @patch("crewai.cli.plus_api.PlusAPI.publish_tool")
+@patch("crewai.cli.tools.main.git.Repository.fetch")
 @patch("crewai.cli.tools.main.git.Repository.is_synced", return_value=False)
 @patch(
     "crewai.cli.tools.main.extract_available_exports",
@@ -195,6 +197,7 @@ def test_publish_when_not_in_sync_and_force(
     mock_tools_metadata,
     mock_available_exports,
     mock_is_synced,
+    mock_fetch,
     mock_publish,
     mock_open,
     mock_listdir,


### PR DESCRIPTION
- Updated the test_publish_when_not_in_sync function to include a mock for git.Repository.fetch.
- This change ensures that the test accurately simulates the behavior of the repository during the publish process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add an extra mock; no production logic is modified.
> 
> **Overview**
> Updates CLI tool publishing tests to also patch `git.Repository.fetch` when exercising the “repo not synced” publish paths.
> 
> This adjusts the patch decorators and test function signatures so the publish flow can call `fetch()` without hitting real git/network behavior, keeping the tests deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365c6493b9b856f91c49d2f0f1ea8e1b91eacbc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->