### PR TITLE
fix: remove erroneous dollar-sign from BrightDataSearchTool search URLs and expose results_count in schema

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
@@ -32,6 +32,7 @@ class BrightDataSearchToolSchema(BaseModel):
         search_type (Optional[str]): Type of search, such as "isch" (images), "nws" (news), "jobs", etc.
         device_type (Optional[str]): Device type to simulate ("desktop", "mobile", "ios", "android"). Default is "desktop".
         parse_results (Optional[bool]): If True, results will be returned in structured JSON. If False, raw HTML. Default is True.
+        results_count (Optional[int]): Number of search results to fetch. Default is 10.
     """
 
     query: str = Field(..., description="Search query to perform")
@@ -58,6 +59,10 @@ class BrightDataSearchToolSchema(BaseModel):
     parse_results: bool | None = Field(
         default=True,
         description="Whether to parse and return JSON (True) or raw HTML/text (False)",
+    )
+    results_count: int | None = Field(
+        default=10,
+        description="Number of search results to fetch (default: 10)",
     )
 
 
@@ -131,10 +136,10 @@ class BrightDataSearchTool(BaseTool):
 
     def get_search_url(self, engine: str, query: str) -> str:
         if engine == "yandex":
-            return f"https://yandex.com/search/?text=${query}"
+            return f"https://yandex.com/search/?text={query}"
         if engine == "bing":
-            return f"https://www.bing.com/search?q=${query}"
-        return f"https://www.google.com/search?q=${query}"
+            return f"https://www.bing.com/search?q={query}"
+        return f"https://www.google.com/search?q={query}"
 
     def _run(
         self,
@@ -145,6 +150,7 @@ class BrightDataSearchTool(BaseTool):
         search_type: str | None = None,
         device_type: str | None = None,
         parse_results: bool | None = None,
+        results_count: int | None = None,
         **kwargs: Any,
     ) -> Any:
         """Executes a search query using Bright Data SERP API and returns results.
@@ -157,7 +163,7 @@ class BrightDataSearchTool(BaseTool):
             search_type (str): Optional type of search such as "nws", "isch", "jobs".
             device_type (str): Optional device type to simulate (e.g., "mobile", "ios", "desktop").
             parse_results (bool): If True, returns structured data; else raw page (default: True).
-            results_count (str or int): Number of search results to fetch (default: "10").
+            results_count (int): Number of search results to fetch (default: 10).
 
         Returns:
             dict or str: Parsed JSON data from Bright Data if available, otherwise error message.
@@ -171,7 +177,7 @@ class BrightDataSearchTool(BaseTool):
         parse_results = (
             parse_results if parse_results is not None else self.parse_results
         )
-        results_count = kwargs.get("results_count", "10")
+        effective_results_count = results_count if results_count is not None else 10
 
         # Validate required parameters
         if not query:
@@ -190,8 +196,7 @@ class BrightDataSearchTool(BaseTool):
         if language:
             params.append(f"hl={language}")
 
-        if results_count:
-            params.append(f"num={results_count}")
+        params.append(f"num={effective_results_count}")
 
         if parse_results:
             params.append("brd_json=1")

--- a/lib/crewai-tools/tests/tools/brightdata_serp_tool_test.py
+++ b/lib/crewai-tools/tests/tools/brightdata_serp_tool_test.py
@@ -12,6 +12,29 @@ class TestBrightDataSearchTool(unittest.TestCase):
     def setUp(self):
         self.tool = BrightDataSearchTool()
 
+    def test_get_search_url_google(self):
+        url = self.tool.get_search_url("google", "hello+world")
+        self.assertIn("google.com/search", url)
+        self.assertIn("q=hello+world", url)
+        self.assertNotIn("$", url)
+
+    def test_get_search_url_bing(self):
+        url = self.tool.get_search_url("bing", "hello+world")
+        self.assertIn("bing.com/search", url)
+        self.assertIn("q=hello+world", url)
+        self.assertNotIn("$", url)
+
+    def test_get_search_url_yandex(self):
+        url = self.tool.get_search_url("yandex", "hello+world")
+        self.assertIn("yandex.com/search", url)
+        self.assertIn("text=hello+world", url)
+        self.assertNotIn("$", url)
+
+    def test_get_search_url_default_is_google(self):
+        url = self.tool.get_search_url("unknown_engine", "query")
+        self.assertIn("google.com", url)
+        self.assertNotIn("$", url)
+
     @patch("requests.post")
     def test_run_successful_search(self, mock_post):
         # Sample mock JSON response
@@ -29,14 +52,47 @@ class TestBrightDataSearchTool(unittest.TestCase):
             "search_type": "nws",
             "device_type": "desktop",
             "parse_results": True,
-            "save_file": False,
         }
 
         result = self.tool._run(**input_data)
 
         # Assertions
-        self.assertIsInstance(result, str)  # Your tool returns response.text (string)
+        self.assertIsInstance(result, str)
         mock_post.assert_called_once()
+
+        # Verify the request URL does not contain '$'
+        call_args = mock_post.call_args
+        request_params = call_args[1]["json"] if call_args[1] else call_args[0][1]
+        url_in_request = request_params.get("url", "")
+        self.assertNotIn("$", url_in_request)
+
+    @patch("requests.post")
+    def test_run_with_custom_results_count(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "mock response text"
+        mock_post.return_value = mock_response
+
+        self.tool._run(query="AI news", results_count=5)
+
+        call_args = mock_post.call_args
+        request_params = call_args[1]["json"] if call_args[1] else call_args[0][1]
+        url_in_request = request_params.get("url", "")
+        self.assertIn("num=5", url_in_request)
+
+    @patch("requests.post")
+    def test_run_default_results_count_is_10(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "mock response text"
+        mock_post.return_value = mock_response
+
+        self.tool._run(query="AI news")
+
+        call_args = mock_post.call_args
+        request_params = call_args[1]["json"] if call_args[1] else call_args[0][1]
+        url_in_request = request_params.get("url", "")
+        self.assertIn("num=10", url_in_request)
 
     @patch("requests.post")
     def test_run_with_request_exception(self, mock_post):


### PR DESCRIPTION
Fixes #5269

## Problem

`BrightDataSearchTool.get_search_url` used JavaScript template-literal syntax inside Python f-strings. Python treats `$` as a literal character, so every constructed URL contained a stray dollar sign:

- Google: `https://www.google.com/search?q=$hello%20world`
- Bing: `https://www.bing.com/search?q=$some+query`
- Yandex: `https://yandex.com/search/?text=$query`

This caused all SERP searches to fail because the search engine received `$<query>` instead of the actual query string.

Additionally, `results_count` was read from `**kwargs` with a hard-coded default of `"10"`, making it completely invisible to the Pydantic schema. Agents had no way to control the number of results returned.

## Solution

1. Removed the `$` prefix from all three f-string URL templates in `get_search_url`.
2. Added `results_count` to `BrightDataSearchToolSchema` as a typed `int | None` field with `default=10`, so agents can explicitly pass the desired number of results.
3. Added `results_count` as an explicit parameter to `_run`, replacing the hidden `kwargs.get("results_count", "10")` pattern.
4. Added tests verifying correct URL construction and results_count handling.

## Testing

New unit tests added to `brightdata_serp_tool_test.py`:
- `test_get_search_url_google` — verifies no `$` in Google URL
- `test_get_search_url_bing` — verifies no `$` in Bing URL
- `test_get_search_url_yandex` — verifies no `$` in Yandex URL
- `test_run_default_results_count_is_10` — verifies default `num=10`
- `test_run_with_custom_results_count` — verifies custom count is forwarded

> Note: This PR was created with AI assistance. Per the CONTRIBUTING.md guidelines, the `llm-generated` label should be applied (label does not yet exist in the repo).