### PR TITLE
docs: add Doubleword as an LLM provider

### DIFF
--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -1189,6 +1189,42 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Doubleword">
+    [Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API.
+
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    DOUBLEWORD_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    import os
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        base_url="https://api.doubleword.ai/v1",
+        api_key=os.environ["DOUBLEWORD_API_KEY"],
+    )
+    ```
+
+    <Info>
+      Doubleword features:
+      - OpenAI-compatible API for any supported model
+      - Unified routing across multiple inference providers
+      - Per-model rate limiting and access control
+      - Request logging and analytics
+
+      See the [Doubleword docs](https://docs.doubleword.ai) for available models and configuration.
+    </Info>
+
+    **Note:** This provider uses LiteLLM with the `openai/` prefix. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses


### PR DESCRIPTION
## Summary
- Add Doubleword to the provider configuration examples in `docs/en/concepts/llms.mdx`
- Doubleword is an AI model gateway that exposes an OpenAI-compatible API, so it works with CrewAI via LiteLLM using the `openai/` model prefix
- Includes environment variable setup, Python code example, and feature highlights

## Details
[Doubleword](https://doubleword.ai) provides unified routing, management, and security for inference across multiple model providers. Configuration follows the same pattern as other LiteLLM-based providers (Open Router, Nebius, etc.) in the docs.