### PR TITLE
fix: devtools release dry-run order and stale checked-out branch

### DIFF
--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -247,6 +247,14 @@ def create_or_reset_branch(branch: str, cwd: Path | None = None) -> None:
             remote_exists = False
 
         if local_exists:
+            current = run_command(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd
+            ).strip()
+            if current == branch:
+                console.print(
+                    f"[yellow]![/yellow] Currently on {branch}, switching to main before delete"
+                )
+                run_command(["git", "checkout", "main"], cwd=cwd)
             console.print(f"[yellow]![/yellow] Deleting local branch {branch}")
             run_command(["git", "branch", "-D", branch], cwd=cwd)
 
@@ -2019,9 +2027,8 @@ def release(
             create_or_reset_branch(branch_name)
             console.print("[green]✓[/green] Branch created")
 
-        _update_all_versions(cwd, lib_dir, version, packages, dry_run)
+            _update_all_versions(cwd, lib_dir, version, packages, dry_run)
 
-        if not dry_run:
             console.print("\nCommitting changes...")
             run_command(["git", "add", "."])
             run_command(["git", "commit", "-m", f"feat: bump versions to {version}"])
@@ -2051,6 +2058,7 @@ def release(
             _poll_pr_until_merged(branch_name, "bump PR")
         else:
             console.print(f"[dim][DRY RUN][/dim] Would create branch: {branch_name}")
+            _update_all_versions(cwd, lib_dir, version, packages, dry_run)
             console.print(
                 f"[dim][DRY RUN][/dim] Would commit: feat: bump versions to {version}"
             )


### PR DESCRIPTION
## Summary
- Fix dry-run output in `devtools release` Phase 1 so "Would create branch" prints before "Would update…", matching actual execution order (previously `_update_all_versions` ran unconditionally, so dry-run was misleading)
- Fix `create_or_reset_branch` so it checks out `main` before `git branch -D` when HEAD is on the stale branch; previously the delete failed, breaking the recovery path the prior stale-branch PR was designed to enable

## Test plan
- [ ] Run `devtools release <version> --dry-run` from main, confirm order: "Would create branch" → "Would update…" → "Would commit…"
- [ ] Check out a stale `feat/bump-version-<v>` branch, run `devtools bump <v>`, accept the reset prompt, confirm the local delete succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI control-flow tweaks around git branch deletion and dry-run output, but could affect release automation if edge cases weren’t covered.
> 
> **Overview**
> Adjusts `devtools release` Phase 1 so `_update_all_versions` runs in the same order as the printed steps, and only in the appropriate dry-run/non-dry-run paths (avoiding misleading dry-run output).
> 
> Hardens `create_or_reset_branch` by detecting when the stale branch is currently checked out and switching to `main` before deleting it, preventing `git branch -D` failures during branch reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609d611404ff3eccfe23ccf7080436c3759d97af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->