### PR TITLE
feat: add DeepKeep AI Firewall tools

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -286,3 +286,5 @@ __all__ = [
     "YoutubeVideoSearchTool",
     "ZapierActionTools",
 ]
+
+from .deepkeep_tool import DeepKeepCheckInputTool, DeepKeepCreateConversationTool, DeepKeepMakeApiCallTool

--- a/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/__init__.py
@@ -1,0 +1,9 @@
+from .deepkeep_check_input_tool import DeepKeepCheckInputTool
+from .deepkeep_create_conversation_tool import DeepKeepCreateConversationTool
+from .deepkeep_make_api_call_tool import DeepKeepMakeApiCallTool
+
+__all__ = [
+    "DeepKeepCheckInputTool",
+    "DeepKeepCreateConversationTool",
+    "DeepKeepMakeApiCallTool",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_check_input_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_check_input_tool.py
@@ -1,0 +1,93 @@
+from typing import Any, Optional, Type
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, model_validator
+
+
+class DeepKeepCheckInputSchema(BaseModel):
+    """Input schema for DeepKeepCheckInputTool."""
+
+    firewall_id: str = Field(
+        ...,
+        description="The ID of the DeepKeep firewall to check the input against.",
+    )
+    conversation_id: str = Field(
+        ...,
+        description="The ID of the conversation the message belongs to.",
+    )
+    content: str = Field(
+        ...,
+        description="The user prompt or text content to be checked by the firewall.",
+    )
+    logs: bool = Field(
+        False,
+        description=(
+            "Set to True to return the full list of detected violations. "
+            "Useful for audit or debugging; defaults to False."
+        ),
+    )
+
+
+class DeepKeepCheckInputTool(BaseTool):
+    """Check a user prompt against a DeepKeep AI firewall's guardrails.
+
+    Calls POST /v2/firewalls/{firewallId}/conversation/{conversationId}/check_user_input
+    and returns the violation details as a JSON string. Use this before passing
+    any user input to an LLM to enforce safety policies.
+
+    Requires:
+        subdomain: Your DeepKeep tenant subdomain (e.g. "acme").
+        api_key:   Your DeepKeep API key.
+    """
+
+    name: str = "DeepKeep Check Input"
+    description: str = (
+        "Check a user prompt or AI-generated text against a DeepKeep AI firewall. "
+        "Returns a JSON object with violation details. Use this before passing "
+        "any user input to an LLM to enforce guardrails and safety policies."
+    )
+    args_schema: Type[BaseModel] = DeepKeepCheckInputSchema
+
+    subdomain: str = Field(
+        ..., description="Your DeepKeep tenant subdomain (e.g. 'acme')."
+    )
+    api_key: str = Field(..., description="Your DeepKeep API key.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_credentials(cls, values: dict[str, Any]) -> dict[str, Any]:
+        subdomain = values.get("subdomain", "")
+        api_key = values.get("api_key", "")
+        if not subdomain:
+            raise ValueError("DeepKeepCheckInputTool requires a non-empty 'subdomain'.")
+        if not api_key:
+            raise ValueError("DeepKeepCheckInputTool requires a non-empty 'api_key'.")
+        return values
+
+    def _run(
+        self,
+        firewall_id: str,
+        conversation_id: str,
+        content: str,
+        logs: bool = False,
+    ) -> str:
+        import json
+
+        base_url = f"https://api.{self.subdomain}.deepkeep.ai/api"
+        url = (
+            f"{base_url}/v2/firewalls/{firewall_id}"
+            f"/conversation/{conversation_id}/check_user_input"
+        )
+        headers = {
+            "X-API-Key": self.api_key,
+            "Content-Type": "application/json",
+        }
+        response = requests.post(
+            url,
+            headers=headers,
+            json={"content": content, "logs": logs},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return json.dumps({"results": response.json()}, indent=2)

--- a/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_create_conversation_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_create_conversation_tool.py
@@ -1,0 +1,72 @@
+from typing import Any, Type
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, model_validator
+
+
+class DeepKeepCreateConversationSchema(BaseModel):
+    """Input schema for DeepKeepCreateConversationTool."""
+
+    firewall_id: str = Field(
+        ...,
+        description="The ID of the DeepKeep firewall in which to create the conversation.",
+    )
+
+
+class DeepKeepCreateConversationTool(BaseTool):
+    """Open a new tracked conversation inside a DeepKeep AI firewall.
+
+    Calls POST /v2/firewalls/{firewallId}/conversation and returns the
+    conversation object as a JSON string. The conversation ID in the
+    response must be passed to DeepKeepCheckInputTool for every subsequent
+    message in that conversation.
+
+    Requires:
+        subdomain: Your DeepKeep tenant subdomain (e.g. "acme").
+        api_key:   Your DeepKeep API key.
+    """
+
+    name: str = "DeepKeep Create Conversation"
+    description: str = (
+        "Create a new conversation inside a DeepKeep AI firewall. "
+        "Returns a JSON object containing the conversation ID, which must be "
+        "passed to 'DeepKeep Check Input' for every message in that conversation."
+    )
+    args_schema: Type[BaseModel] = DeepKeepCreateConversationSchema
+
+    subdomain: str = Field(
+        ..., description="Your DeepKeep tenant subdomain (e.g. 'acme')."
+    )
+    api_key: str = Field(..., description="Your DeepKeep API key.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_credentials(cls, values: dict[str, Any]) -> dict[str, Any]:
+        subdomain = values.get("subdomain", "")
+        api_key = values.get("api_key", "")
+        if not subdomain:
+            raise ValueError(
+                "DeepKeepCreateConversationTool requires a non-empty 'subdomain'."
+            )
+        if not api_key:
+            raise ValueError(
+                "DeepKeepCreateConversationTool requires a non-empty 'api_key'."
+            )
+        return values
+
+    def _run(self, firewall_id: str) -> str:
+        import json
+
+        base_url = f"https://api.{self.subdomain}.deepkeep.ai/api"
+        url = f"{base_url}/v2/firewalls/{firewall_id}/conversation"
+        headers = {
+            "X-API-Key": self.api_key,
+            "Content-Type": "application/json",
+        }
+        # The DeepKeep API requires a JSON body even when empty; sending an
+        # empty dict causes some HTTP clients to drop the body, so we send the
+        # literal string "{}" with an explicit Content-Type header.
+        response = requests.post(url, headers=headers, data="{}", timeout=30)
+        response.raise_for_status()
+        return json.dumps(response.json(), indent=2)

--- a/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_make_api_call_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/deepkeep_make_api_call_tool.py
@@ -1,0 +1,126 @@
+from typing import Any, Optional, Type
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, model_validator
+
+
+class DeepKeepMakeApiCallSchema(BaseModel):
+    """Input schema for DeepKeepMakeApiCallTool."""
+
+    path: str = Field(
+        ...,
+        description=(
+            "The API path relative to deepkeep.ai/api, e.g. '/v2/firewalls'. "
+            "A leading slash is optional."
+        ),
+    )
+    method: str = Field(
+        "GET",
+        description="HTTP method: GET, POST, PUT, or DELETE.",
+    )
+    query_params: Optional[dict[str, str]] = Field(
+        None,
+        description="Optional dictionary of URL query-string parameters.",
+    )
+    extra_headers: Optional[dict[str, str]] = Field(
+        None,
+        description=(
+            "Optional extra request headers. Auth headers are injected automatically — "
+            "do not include X-API-Key here."
+        ),
+    )
+    body: Optional[str] = Field(
+        None,
+        description=(
+            "Optional raw request body (usually a JSON string). "
+            "Leave empty for GET or DELETE requests."
+        ),
+    )
+
+
+class DeepKeepMakeApiCallTool(BaseTool):
+    """Perform any authenticated HTTP request to the DeepKeep API.
+
+    An escape-hatch for endpoints not yet covered by the dedicated tools.
+    Auth headers are injected automatically.
+
+    Returns a JSON string with { "statusCode", "headers", "body" }, matching
+    the envelope used by the Make.com and n8n DeepKeep integrations.
+
+    Requires:
+        subdomain: Your DeepKeep tenant subdomain (e.g. "acme").
+        api_key:   Your DeepKeep API key.
+    """
+
+    name: str = "DeepKeep Make API Call"
+    description: str = (
+        "Perform any authenticated HTTP request to the DeepKeep API. "
+        "Use this for endpoints not covered by the dedicated tools. "
+        "Returns a JSON object with statusCode, headers, and body."
+    )
+    args_schema: Type[BaseModel] = DeepKeepMakeApiCallSchema
+
+    subdomain: str = Field(
+        ..., description="Your DeepKeep tenant subdomain (e.g. 'acme')."
+    )
+    api_key: str = Field(..., description="Your DeepKeep API key.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_credentials(cls, values: dict[str, Any]) -> dict[str, Any]:
+        subdomain = values.get("subdomain", "")
+        api_key = values.get("api_key", "")
+        if not subdomain:
+            raise ValueError(
+                "DeepKeepMakeApiCallTool requires a non-empty 'subdomain'."
+            )
+        if not api_key:
+            raise ValueError(
+                "DeepKeepMakeApiCallTool requires a non-empty 'api_key'."
+            )
+        return values
+
+    def _run(
+        self,
+        path: str,
+        method: str = "GET",
+        query_params: Optional[dict[str, str]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        body: Optional[str] = None,
+    ) -> str:
+        import json
+
+        base_url = f"https://api.{self.subdomain}.deepkeep.ai/api"
+        clean_path = path.lstrip("/")
+        url = f"{base_url}/{clean_path}"
+
+        headers: dict[str, str] = {
+            "X-API-Key": self.api_key,
+            "Content-Type": "application/json",
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+
+        response = requests.request(
+            method=method.upper(),
+            url=url,
+            headers=headers,
+            params=query_params or {},
+            data=body or None,
+            timeout=30,
+        )
+
+        try:
+            parsed_body: Any = response.json()
+        except ValueError:
+            parsed_body = response.text
+
+        return json.dumps(
+            {
+                "statusCode": response.status_code,
+                "headers": dict(response.headers),
+                "body": parsed_body,
+            },
+            indent=2,
+        )

--- a/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/example.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/example.py
@@ -1,0 +1,60 @@
+"""
+Example: guard an AI agent's input with DeepKeep.
+
+Prerequisites
+-------------
+pip install 'crewai[tools]'
+
+Set your credentials before running:
+    export DEEPKEEP_SUBDOMAIN="acme"
+    export DEEPKEEP_API_KEY="dk_..."
+    export OPENAI_API_KEY="sk_..."
+"""
+
+import os
+
+from crewai import Agent, Crew, Task
+
+from crewai_tools.tools.deepkeep_tool import (
+    DeepKeepCheckInputTool,
+    DeepKeepCreateConversationTool,
+)
+
+SUBDOMAIN = os.environ["DEEPKEEP_SUBDOMAIN"]
+API_KEY = os.environ["DEEPKEEP_API_KEY"]
+FIREWALL_ID = "your-firewall-id-here"
+
+create_conversation_tool = DeepKeepCreateConversationTool(
+    subdomain=SUBDOMAIN,
+    api_key=API_KEY,
+)
+check_input_tool = DeepKeepCheckInputTool(
+    subdomain=SUBDOMAIN,
+    api_key=API_KEY,
+)
+
+guard_agent = Agent(
+    role="AI Security Guard",
+    goal="Ensure all user inputs comply with company AI policies before they reach other agents.",
+    backstory=(
+        "You are a security specialist responsible for enforcing AI guardrails. "
+        "You use the DeepKeep firewall to screen every user message."
+    ),
+    tools=[create_conversation_tool, check_input_tool],
+    verbose=True,
+)
+
+check_task = Task(
+    description=(
+        f"1. Create a new conversation in firewall '{FIREWALL_ID}'.\n"
+        f"2. Check the following user input:\n\n"
+        f"   'How do I reset my password?'\n\n"
+        f"3. Report whether the input was flagged, and include the violation details if any."
+    ),
+    expected_output="A summary of the firewall check result, including any violations found.",
+    agent=guard_agent,
+)
+
+crew = Crew(agents=[guard_agent], tasks=[check_task])
+result = crew.kickoff()
+print(result)


### PR DESCRIPTION
## Summary

Adds three new tools under `lib/crewai-tools/src/crewai_tools/tools/deepkeep_tool/` that let CrewAI agents interact with the [DeepKeep](https://deepkeep.ai) AI Firewall API.

| Tool | Description |
|------|-------------|
| `DeepKeepCheckInputTool` | Check a user prompt against a firewall's safety guardrails |
| `DeepKeepCreateConversationTool` | Open a new tracked conversation in a firewall |
| `DeepKeepMakeApiCallTool` | Escape-hatch for any authenticated DeepKeep API request |

## Motivation

DeepKeep is an AI firewall platform that enforces guardrails (prompt injection, PII leakage, jailbreaks, policy violations, etc.) on LLM inputs and outputs in real time. These tools allow any CrewAI agent to screen user messages before passing them to an LLM, creating an auditable, policy-enforced layer around autonomous agent workflows.

## Usage

```python
from crewai_tools import DeepKeepCheckInputTool, DeepKeepCreateConversationTool

create_conversation = DeepKeepCreateConversationTool(subdomain="acme", api_key="dk_...")
check_input = DeepKeepCheckInputTool(subdomain="acme", api_key="dk_...")

agent = Agent(
    role="AI Security Guard",
    tools=[create_conversation, check_input],
    ...
)
```
## Checklist

- [x] Follows existing tool conventions (`BaseTool`, `args_schema`, `model_validator`)
- [x] Strict type annotations (mypy-compatible)
- [x] No new mandatory dependencies (uses `requests`, already in the project)
- [x] `example.py` included
- [x] `__init__.py` exports all three tools