### PR TITLE
docs(observability): add AgentSeal integration guide

### DIFF
--- a/docs/ar/observability/agentseal.mdx
+++ b/docs/ar/observability/agentseal.mdx
@@ -1,0 +1,106 @@
+---
+title: AgentSeal Integration
+description: Verifiable audit trails for your CrewAI agents
+icon: shield-check
+mode: "wide"
+---
+
+# Introduction
+
+AgentSeal is a logging and audit trail API for AI agents. Every action is recorded with a verifiable history that can't be silently modified. Built for compliance and production use.
+
+It captures task completions and agent steps, recording what happened, why, and who authorized it.
+
+## Why use AgentSeal?
+
+CrewAI agents make decisions, use tools, and complete tasks autonomously. When something goes wrong or a client asks what happened, you need a clear record.
+
+AgentSeal lets you:
+
+- Record every task completion and agent step
+- Verify that no records have been modified after the fact
+- Query your audit trail by agent, action type, or time range
+- Meet compliance requirements (EU AI Act, SOC 2)
+
+## Quick Setup with CrewAI
+
+<Steps>
+  <Step title="Sign Up & Get API Key">
+    Visit [agentseal.io](https://agentseal.io), create an account, and copy your API key.
+  </Step>
+  <Step title="Install the SDK">
+    ```bash
+    pip install agentseal-sdk
+    ```
+  </Step>
+  <Step title="Add AgentSeal to Your Crew">
+    ```python
+    from crewai import Agent, Task, Crew
+    from agentseal import Seal
+    from agentseal.integrations.crewai import AgentSealCrewHook
+
+    # Initialize AgentSeal
+    seal = Seal(api_key="your-agentseal-api-key")
+    hook = AgentSealCrewHook(seal=seal, agent="my-crew")
+
+    # Create your agents and tasks as usual
+    researcher = Agent(
+        role="Researcher",
+        goal="Find relevant information",
+        backstory="You are a research assistant.",
+    )
+
+    task = Task(
+        description="Research the latest AI regulations",
+        expected_output="A summary of current AI regulations",
+        agent=researcher,
+    )
+
+    # Pass AgentSeal callbacks to the Crew
+    crew = Crew(
+        agents=[researcher],
+        tasks=[task],
+        **hook.callbacks(),
+    )
+
+    result = crew.kickoff()
+    ```
+
+    Every task completion and agent step is now recorded automatically.
+  </Step>
+</Steps>
+
+## What Gets Recorded
+
+| Event | Action Type | Details |
+|-------|------------|---------|
+| Task completion | `task:complete` | Task description, output |
+| Agent step (tool use) | `step:<tool_name>` | Tool name, output |
+| Agent step (reasoning) | `step:thought` | Reasoning output |
+
+## Verifying Your Audit Trail
+
+You can verify that no records have been modified at any time:
+
+```python
+result = seal.verify()
+# {"valid": True, "entries_verified": 42}
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seal` | `Seal` | required | AgentSeal client instance |
+| `agent` | `str` | `"crewai"` | Agent identifier for grouping entries |
+
+## Error Handling
+
+AgentSeal never interrupts your crew's execution. If the AgentSeal API is unreachable or returns an error, a warning is printed to stderr and the crew continues normally.
+
+## Links
+
+- [Website](https://agentseal.io)
+- [Documentation](https://agentseal.io/docs)
+- [GitHub (SDK)](https://github.com/JoeyBrar/agentseal-sdk)
+- [PyPI](https://pypi.org/project/agentseal-sdk/)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -318,6 +318,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -1266,6 +1267,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -1740,6 +1742,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -2214,6 +2217,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -2687,6 +2691,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -3159,6 +3164,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -3631,6 +3637,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -4103,6 +4110,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -4577,6 +4585,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -5050,6 +5059,7 @@
                     "pages": [
                       "en/observability/tracing",
                       "en/observability/overview",
+                      "en/observability/agentseal",
                       "en/observability/arize-phoenix",
                       "en/observability/braintrust",
                       "en/observability/datadog",
@@ -5543,6 +5553,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -6459,6 +6470,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -6917,6 +6929,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -7375,6 +7388,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -7832,6 +7846,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -8289,6 +8304,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -8746,6 +8762,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -9202,6 +9219,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -9658,6 +9676,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -10115,6 +10134,7 @@
                     "pages": [
                       "pt-BR/observability/tracing",
                       "pt-BR/observability/overview",
+                      "pt-BR/observability/agentseal",
                       "pt-BR/observability/arize-phoenix",
                       "pt-BR/observability/braintrust",
                       "pt-BR/observability/datadog",
@@ -10615,6 +10635,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -11555,6 +11576,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -12025,6 +12047,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -12495,6 +12518,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -12964,6 +12988,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -13433,6 +13458,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -13902,6 +13928,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -14370,6 +14397,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -14838,6 +14866,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -15307,6 +15336,7 @@
                     "pages": [
                       "ko/observability/tracing",
                       "ko/observability/overview",
+                      "ko/observability/agentseal",
                       "ko/observability/arize-phoenix",
                       "ko/observability/braintrust",
                       "ko/observability/datadog",
@@ -15807,6 +15837,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -16747,6 +16778,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -17217,6 +17249,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -17687,6 +17720,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -18156,6 +18190,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -18625,6 +18660,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -19094,6 +19130,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -19562,6 +19599,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -20030,6 +20068,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",
@@ -20499,6 +20538,7 @@
                     "pages": [
                       "ar/observability/tracing",
                       "ar/observability/overview",
+                      "ar/observability/agentseal",
                       "ar/observability/arize-phoenix",
                       "ar/observability/braintrust",
                       "ar/observability/datadog",

--- a/docs/en/observability/agentseal.mdx
+++ b/docs/en/observability/agentseal.mdx
@@ -1,0 +1,106 @@
+---
+title: AgentSeal Integration
+description: Verifiable audit trails for your CrewAI agents
+icon: shield-check
+mode: "wide"
+---
+
+# Introduction
+
+AgentSeal is a logging and audit trail API for AI agents. Every action is recorded with a verifiable history that can't be silently modified. Built for compliance and production use.
+
+It captures task completions and agent steps, recording what happened, why, and who authorized it.
+
+## Why use AgentSeal?
+
+CrewAI agents make decisions, use tools, and complete tasks autonomously. When something goes wrong or a client asks what happened, you need a clear record.
+
+AgentSeal lets you:
+
+- Record every task completion and agent step
+- Verify that no records have been modified after the fact
+- Query your audit trail by agent, action type, or time range
+- Meet compliance requirements (EU AI Act, SOC 2)
+
+## Quick Setup with CrewAI
+
+<Steps>
+  <Step title="Sign Up & Get API Key">
+    Visit [agentseal.io](https://agentseal.io), create an account, and copy your API key.
+  </Step>
+  <Step title="Install the SDK">
+    ```bash
+    pip install agentseal-sdk
+    ```
+  </Step>
+  <Step title="Add AgentSeal to Your Crew">
+    ```python
+    from crewai import Agent, Task, Crew
+    from agentseal import Seal
+    from agentseal.integrations.crewai import AgentSealCrewHook
+
+    # Initialize AgentSeal
+    seal = Seal(api_key="your-agentseal-api-key")
+    hook = AgentSealCrewHook(seal=seal, agent="my-crew")
+
+    # Create your agents and tasks as usual
+    researcher = Agent(
+        role="Researcher",
+        goal="Find relevant information",
+        backstory="You are a research assistant.",
+    )
+
+    task = Task(
+        description="Research the latest AI regulations",
+        expected_output="A summary of current AI regulations",
+        agent=researcher,
+    )
+
+    # Pass AgentSeal callbacks to the Crew
+    crew = Crew(
+        agents=[researcher],
+        tasks=[task],
+        **hook.callbacks(),
+    )
+
+    result = crew.kickoff()
+    ```
+
+    Every task completion and agent step is now recorded automatically.
+  </Step>
+</Steps>
+
+## What Gets Recorded
+
+| Event | Action Type | Details |
+|-------|------------|---------|
+| Task completion | `task:complete` | Task description, output |
+| Agent step (tool use) | `step:<tool_name>` | Tool name, output |
+| Agent step (reasoning) | `step:thought` | Reasoning output |
+
+## Verifying Your Audit Trail
+
+You can verify that no records have been modified at any time:
+
+```python
+result = seal.verify()
+# {"valid": True, "entries_verified": 42}
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seal` | `Seal` | required | AgentSeal client instance |
+| `agent` | `str` | `"crewai"` | Agent identifier for grouping entries |
+
+## Error Handling
+
+AgentSeal never interrupts your crew's execution. If the AgentSeal API is unreachable or returns an error, a warning is printed to stderr and the crew continues normally.
+
+## Links
+
+- [Website](https://agentseal.io)
+- [Documentation](https://agentseal.io/docs)
+- [GitHub (SDK)](https://github.com/JoeyBrar/agentseal-sdk)
+- [PyPI](https://pypi.org/project/agentseal-sdk/)

--- a/docs/en/observability/overview.mdx
+++ b/docs/en/observability/overview.mdx
@@ -43,6 +43,10 @@ Observability is crucial for understanding how your CrewAI agents perform, ident
     Open-source observability for LLMs and agent frameworks.
   </Card>
 
+  <Card title="AgentSeal" icon="shield-check" href="/en/observability/agentseal">
+    Verifiable audit trails with cryptographic integrity verification.
+  </Card>
+
   <Card title="Arize Phoenix" icon="meteor" href="/en/observability/arize-phoenix">
     AI observability platform for monitoring and troubleshooting.
   </Card>

--- a/docs/ko/observability/agentseal.mdx
+++ b/docs/ko/observability/agentseal.mdx
@@ -1,0 +1,106 @@
+---
+title: AgentSeal Integration
+description: Verifiable audit trails for your CrewAI agents
+icon: shield-check
+mode: "wide"
+---
+
+# Introduction
+
+AgentSeal is a logging and audit trail API for AI agents. Every action is recorded with a verifiable history that can't be silently modified. Built for compliance and production use.
+
+It captures task completions and agent steps, recording what happened, why, and who authorized it.
+
+## Why use AgentSeal?
+
+CrewAI agents make decisions, use tools, and complete tasks autonomously. When something goes wrong or a client asks what happened, you need a clear record.
+
+AgentSeal lets you:
+
+- Record every task completion and agent step
+- Verify that no records have been modified after the fact
+- Query your audit trail by agent, action type, or time range
+- Meet compliance requirements (EU AI Act, SOC 2)
+
+## Quick Setup with CrewAI
+
+<Steps>
+  <Step title="Sign Up & Get API Key">
+    Visit [agentseal.io](https://agentseal.io), create an account, and copy your API key.
+  </Step>
+  <Step title="Install the SDK">
+    ```bash
+    pip install agentseal-sdk
+    ```
+  </Step>
+  <Step title="Add AgentSeal to Your Crew">
+    ```python
+    from crewai import Agent, Task, Crew
+    from agentseal import Seal
+    from agentseal.integrations.crewai import AgentSealCrewHook
+
+    # Initialize AgentSeal
+    seal = Seal(api_key="your-agentseal-api-key")
+    hook = AgentSealCrewHook(seal=seal, agent="my-crew")
+
+    # Create your agents and tasks as usual
+    researcher = Agent(
+        role="Researcher",
+        goal="Find relevant information",
+        backstory="You are a research assistant.",
+    )
+
+    task = Task(
+        description="Research the latest AI regulations",
+        expected_output="A summary of current AI regulations",
+        agent=researcher,
+    )
+
+    # Pass AgentSeal callbacks to the Crew
+    crew = Crew(
+        agents=[researcher],
+        tasks=[task],
+        **hook.callbacks(),
+    )
+
+    result = crew.kickoff()
+    ```
+
+    Every task completion and agent step is now recorded automatically.
+  </Step>
+</Steps>
+
+## What Gets Recorded
+
+| Event | Action Type | Details |
+|-------|------------|---------|
+| Task completion | `task:complete` | Task description, output |
+| Agent step (tool use) | `step:<tool_name>` | Tool name, output |
+| Agent step (reasoning) | `step:thought` | Reasoning output |
+
+## Verifying Your Audit Trail
+
+You can verify that no records have been modified at any time:
+
+```python
+result = seal.verify()
+# {"valid": True, "entries_verified": 42}
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seal` | `Seal` | required | AgentSeal client instance |
+| `agent` | `str` | `"crewai"` | Agent identifier for grouping entries |
+
+## Error Handling
+
+AgentSeal never interrupts your crew's execution. If the AgentSeal API is unreachable or returns an error, a warning is printed to stderr and the crew continues normally.
+
+## Links
+
+- [Website](https://agentseal.io)
+- [Documentation](https://agentseal.io/docs)
+- [GitHub (SDK)](https://github.com/JoeyBrar/agentseal-sdk)
+- [PyPI](https://pypi.org/project/agentseal-sdk/)

--- a/docs/pt-BR/observability/agentseal.mdx
+++ b/docs/pt-BR/observability/agentseal.mdx
@@ -1,0 +1,106 @@
+---
+title: AgentSeal Integration
+description: Verifiable audit trails for your CrewAI agents
+icon: shield-check
+mode: "wide"
+---
+
+# Introduction
+
+AgentSeal is a logging and audit trail API for AI agents. Every action is recorded with a verifiable history that can't be silently modified. Built for compliance and production use.
+
+It captures task completions and agent steps, recording what happened, why, and who authorized it.
+
+## Why use AgentSeal?
+
+CrewAI agents make decisions, use tools, and complete tasks autonomously. When something goes wrong or a client asks what happened, you need a clear record.
+
+AgentSeal lets you:
+
+- Record every task completion and agent step
+- Verify that no records have been modified after the fact
+- Query your audit trail by agent, action type, or time range
+- Meet compliance requirements (EU AI Act, SOC 2)
+
+## Quick Setup with CrewAI
+
+<Steps>
+  <Step title="Sign Up & Get API Key">
+    Visit [agentseal.io](https://agentseal.io), create an account, and copy your API key.
+  </Step>
+  <Step title="Install the SDK">
+    ```bash
+    pip install agentseal-sdk
+    ```
+  </Step>
+  <Step title="Add AgentSeal to Your Crew">
+    ```python
+    from crewai import Agent, Task, Crew
+    from agentseal import Seal
+    from agentseal.integrations.crewai import AgentSealCrewHook
+
+    # Initialize AgentSeal
+    seal = Seal(api_key="your-agentseal-api-key")
+    hook = AgentSealCrewHook(seal=seal, agent="my-crew")
+
+    # Create your agents and tasks as usual
+    researcher = Agent(
+        role="Researcher",
+        goal="Find relevant information",
+        backstory="You are a research assistant.",
+    )
+
+    task = Task(
+        description="Research the latest AI regulations",
+        expected_output="A summary of current AI regulations",
+        agent=researcher,
+    )
+
+    # Pass AgentSeal callbacks to the Crew
+    crew = Crew(
+        agents=[researcher],
+        tasks=[task],
+        **hook.callbacks(),
+    )
+
+    result = crew.kickoff()
+    ```
+
+    Every task completion and agent step is now recorded automatically.
+  </Step>
+</Steps>
+
+## What Gets Recorded
+
+| Event | Action Type | Details |
+|-------|------------|---------|
+| Task completion | `task:complete` | Task description, output |
+| Agent step (tool use) | `step:<tool_name>` | Tool name, output |
+| Agent step (reasoning) | `step:thought` | Reasoning output |
+
+## Verifying Your Audit Trail
+
+You can verify that no records have been modified at any time:
+
+```python
+result = seal.verify()
+# {"valid": True, "entries_verified": 42}
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seal` | `Seal` | required | AgentSeal client instance |
+| `agent` | `str` | `"crewai"` | Agent identifier for grouping entries |
+
+## Error Handling
+
+AgentSeal never interrupts your crew's execution. If the AgentSeal API is unreachable or returns an error, a warning is printed to stderr and the crew continues normally.
+
+## Links
+
+- [Website](https://agentseal.io)
+- [Documentation](https://agentseal.io/docs)
+- [GitHub (SDK)](https://github.com/JoeyBrar/agentseal-sdk)
+- [PyPI](https://pypi.org/project/agentseal-sdk/)


### PR DESCRIPTION
Adds AgentSeal as an observability integration. AgentSeal is a logging and audit trail API for AI agents. Includes doc page, translation copies (ar/ko/pt-BR), navigation entries, and overview card.