### PR TITLE
fix(mcp): initialize tools_list and warn when no tools discovered in _resolve_native

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -353,6 +353,7 @@ class MCPToolResolver:
                     f"Error during setup client and list tools: {e}"
                 ) from e
 
+        tools_list: list[dict[str, Any]] = []
         try:
             try:
                 asyncio.get_running_loop()
@@ -400,6 +401,13 @@ class MCPToolResolver:
                     else:
                         filtered_tools.append(tool)
                 tools_list = filtered_tools
+
+            if not tools_list:
+                self._logger.log(
+                    "warning",
+                    f"No tools discovered from MCP server: {server_name}. "
+                    "Verify the server is running and tool_filter is not too restrictive.",
+                )
 
             def _client_factory() -> MCPClient:
                 transport, _ = self._create_transport(mcp_config)


### PR DESCRIPTION
## Summary

Fixes #5116

Two related issues in `MCPToolResolver._resolve_native()`:

1. **UnboundLocalError** — `tools_list` was only assigned inside conditional branches of the try/except block. If neither the `ThreadPoolExecutor` path nor `asyncio.run()` path executed (e.g. a swallowed exception), `tools_list` was unbound at the `for tool_def in tools_list:` loop, raising `UnboundLocalError`.

2. **Silent empty tool list** — When the MCP server returns no tools, or `tool_filter` removes all tools, no warning was logged. This made it very hard to diagnose why an agent had zero tools. `_resolve_external()` already logs a clear warning in this case — this PR adds the same behavior to `_resolve_native()`.

## Changes

- Initialize `tools_list: list[dict[str, Any]] = []` before the try block (prevents `UnboundLocalError`)
- Add `logger.warning` after filtering when `tools_list` is empty (matches `_resolve_external()` behavior)

## Test plan

- [ ] Configure an MCP agent with a server that returns no tools → confirm warning appears in logs
- [ ] Configure an MCP agent with a `tool_filter` that removes all tools → confirm warning appears in logs
- [ ] Normal MCP agent with tools → confirm no regression