### PR TITLE
fix: use future dates in checkpoint prune tests to prevent time-dependent failures

### DIFF
--- a/lib/crewai/tests/test_checkpoint_cli.py
+++ b/lib/crewai/tests/test_checkpoint_cli.py
@@ -292,7 +292,7 @@ class TestPruneJson:
                 d, name="20250101T000000_old01111_p-none.json"
             )
             os.utime(old_path, (0, 0))
-            _write_json_checkpoint(d, name="20260417T000000_new01111_p-none.json")
+            _write_json_checkpoint(d, name="20990101T000000_new01111_p-none.json")
             deleted = _prune_json(d, keep=None, older_than=timedelta(days=1))
             assert deleted == 1
 
@@ -330,7 +330,7 @@ class TestPruneSqlite:
         with tempfile.TemporaryDirectory() as d:
             db_path = os.path.join(d, "test.db")
             _create_sqlite_checkpoint(db_path, "20200101T000000_old01111")
-            _create_sqlite_checkpoint(db_path, "20260417T000000_new01111")
+            _create_sqlite_checkpoint(db_path, "20990101T000000_new01111")
             deleted = _prune_sqlite(db_path, keep=None, older_than=timedelta(days=1))
             assert deleted >= 1
             with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Problem

`TestPruneSqlite::test_older_than` and `TestPruneJson::test_older_than` use hardcoded `20260417T000000` timestamps for the 'new' checkpoint. Once April 17 passes, that checkpoint is older than 1 day and gets pruned along with the 'old' one, causing `assert count >= 1` to fail (count=0).

This is currently breaking CI on every PR branch.

## Fix

Use `20990101T000000` for the 'new' checkpoint so the tests remain stable regardless of when they run.

## Testing

The fix is a 2-line change in test fixtures. No production code changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only test fixtures to avoid date-dependent failures; no production logic changes.
> 
> **Overview**
> Fixes flaky `checkpoint prune` tests by changing the “new” checkpoint timestamps in `test_checkpoint_cli.py` to a far-future date so `older_than=1 day` pruning always leaves at least one checkpoint remaining regardless of when CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f614d17a89d0927949176930144dde2843bb0e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->