### PR TITLE
fix: preserve thought_signature in Gemini streaming tool calls

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -976,6 +976,7 @@ class GeminiCompletion(BaseLLM):
                             "id": call_id,
                             "name": part.function_call.name,
                             "args": args_dict,
+                            "raw_part": part,
                         }
 
                         self._emit_stream_chunk_event(
@@ -1060,29 +1061,20 @@ class GeminiCompletion(BaseLLM):
             if call_data.get("name") != STRUCTURED_OUTPUT_TOOL_NAME
         }
 
-        # If there are function calls but no available_functions,
-        # return them for the executor to handle
         if non_structured_output_calls and not available_functions:
-            formatted_function_calls = [
-                {
-                    "id": call_data["id"],
-                    "function": {
-                        "name": call_data["name"],
-                        "arguments": json.dumps(call_data["args"]),
-                    },
-                    "type": "function",
-                }
+            raw_parts = [
+                call_data["raw_part"]
                 for call_data in non_structured_output_calls.values()
             ]
             self._emit_call_completed_event(
-                response=formatted_function_calls,
+                response=raw_parts,
                 call_type=LLMCallType.TOOL_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
                 messages=self._convert_contents_to_dict(contents),
                 usage=usage_data,
             )
-            return formatted_function_calls
+            return raw_parts
 
         # Handle completed function calls (excluding structured_output)
         if non_structured_output_calls and available_functions:


### PR DESCRIPTION
## Summary
- Gemini thinking models (2.5+, 3.x) return a `thought_signature` on `functionCall` parts that must be passed back in conversation history
- The streaming path was extracting only name/args into plain dicts, stripping the signature and causing `400 INVALID_ARGUMENT` on subsequent turns
- Now returns raw `Part` objects from streaming (matching the non-streaming path), so the executor preserves them via `raw_tool_call_parts`

## Test plan
- [x] Existing Gemini test suite passes (97 passed)
- [x] Streaming tests pass (93 passed)
- [ ] Manual verification: Gemini 3.x model + streaming + tool calls completes multi-turn without 400 error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the streaming Gemini tool-call return type from normalized dicts to raw `types.Part` objects, which may affect downstream consumers expecting OpenAI-style tool_call dicts. Scope is limited to the Gemini streaming path when `available_functions` is not provided.
> 
> **Overview**
> Preserves Gemini thinking-model metadata (e.g. `thought_signature`) during streaming tool calls by storing each raw `types.Part` (`raw_part`) alongside extracted name/args.
> 
> When streaming returns tool calls *without* `available_functions`, the completion now emits and returns the collected raw `Part` objects instead of converting them into simplified `{"id","function":...}` dicts, aligning streaming behavior with the non-streaming path and preventing loss of provider-specific fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f83d3d1e53cf24f27d62f607e1a6ef63861248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->