### PR TITLE
fix: handle BaseModel result in guardrail retry loop

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -1241,12 +1241,26 @@ Follow these guidelines:
                 tools=tools,
             )
 
-            pydantic_output, json_output = self._export_output(result)
+            if isinstance(result, BaseModel):
+                raw = result.model_dump_json()
+                if self.output_pydantic:
+                    pydantic_output = result
+                    json_output = None
+                elif self.output_json:
+                    pydantic_output = None
+                    json_output = result.model_dump()
+                else:
+                    pydantic_output = None
+                    json_output = None
+            else:
+                raw = result
+                pydantic_output, json_output = self._export_output(result)
+
             task_output = TaskOutput(
                 name=self.name or self.description,
                 description=self.description,
                 expected_output=self.expected_output,
-                raw=result,
+                raw=raw,
                 pydantic=pydantic_output,
                 json_dict=json_output,
                 agent=agent.role,
@@ -1337,12 +1351,26 @@ Follow these guidelines:
                 tools=tools,
             )
 
-            pydantic_output, json_output = self._export_output(result)
+            if isinstance(result, BaseModel):
+                raw = result.model_dump_json()
+                if self.output_pydantic:
+                    pydantic_output = result
+                    json_output = None
+                elif self.output_json:
+                    pydantic_output = None
+                    json_output = result.model_dump()
+                else:
+                    pydantic_output = None
+                    json_output = None
+            else:
+                raw = result
+                pydantic_output, json_output = self._export_output(result)
+
             task_output = TaskOutput(
                 name=self.name or self.description,
                 description=self.description,
                 expected_output=self.expected_output,
-                raw=result,
+                raw=raw,
                 pydantic=pydantic_output,
                 json_dict=json_output,
                 agent=agent.role,


### PR DESCRIPTION
## Summary
- Fixes guardrail retry failing with `ValidationError` when a task uses `output_pydantic` and a guardrail returns `(False, feedback)`
- The retry path was passing a Pydantic object directly to `TaskOutput.raw` (expects `str`), now mirrors the `isinstance(result, BaseModel)` check from the initial execution path
- Applied to both sync and async retry loops

Closes #5544 (part 1 — guardrail retry issue)

## Test plan
- [ ] Task with `output_pydantic` + guardrail that fails once should retry and succeed
- [ ] Existing guardrail tests continue to pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to guardrail retry paths; main risk is subtle behavioral change in what `TaskOutput.raw` contains when an agent returns a Pydantic model during retries.
> 
> **Overview**
> Fixes guardrail retry loops (sync and async) to correctly handle agent results that are Pydantic `BaseModel`s.
> 
> During retries, `TaskOutput.raw` is now always a string (using `model_dump_json()` for `BaseModel` results), while `TaskOutput.pydantic`/`json_dict` are populated consistently based on `output_pydantic`/`output_json`, preventing validation errors when regenerating outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e239416ded68bed36b1307f7cdfec5318dbb91ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->