### PR TITLE
feat: add TwoCaptchaSolverTool for automated captcha solving

### DIFF
--- a/libs/crewai_tools/src/crewai_tools/__init__.py
+++ b/libs/crewai_tools/src/crewai_tools/__init__.py
@@ -1,0 +1,8 @@
+
+from .tools.twocaptcha_solver.twocaptcha_solver import TwoCaptchaSolverTool
+
+if "__all__" not in globals():
+    __all__ = []
+
+if "TwoCaptchaSolverTool" not in __all__:
+    __all__.append("TwoCaptchaSolverTool")

--- a/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/__init__.py
+++ b/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/__init__.py
@@ -1,0 +1,1 @@
+from .twocaptcha_solver import TwoCaptchaSolverTool

--- a/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/twocaptcha_solver.py
+++ b/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/twocaptcha_solver.py
@@ -1,0 +1,80 @@
+import os
+import time
+import requests
+from typing import Type, Any, Optional
+from pydantic import BaseModel, Field
+from crewai.tools import BaseTool
+
+class TwoCaptchaSolverSchema(BaseModel):
+    """Input for TwoCaptchaSolverTool."""
+    website_url: str = Field(..., description="The full URL of the website where the captcha is located.")
+    sitekey: str = Field(..., description="The 'data-sitekey' value found in the website's HTML.")
+    captcha_type: str = Field(
+        default="RecaptchaV2TaskProxyless", 
+        description="Type of captcha to solve (e.g., RecaptchaV2TaskProxyless, hCaptchaTaskProxyless, TurnstileTaskProxyless)."
+    )
+
+class TwoCaptchaSolverTool(BaseTool):
+    name: str = "twocaptcha_solver"
+    description: str = (
+        "Automated tool for solving various captchas (reCAPTCHA, hCaptcha, Cloudflare Turnstile) "
+        "via the 2Captcha service. Requires the TWOCAPTCHA_API_KEY environment variable."
+    )
+    args_schema: Type[BaseModel] = TwoCaptchaSolverSchema
+    api_key: Optional[str] = Field(default=None)
+
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.api_key = api_key or os.getenv("TWOCAPTCHA_API_KEY")
+
+    def _run(
+        self, 
+        website_url: str, 
+        sitekey: str, 
+        captcha_type: str = "RecaptchaV2TaskProxyless", 
+        **kwargs: Any
+    ) -> str:
+        if not self.api_key:
+            return "Error: 2Captcha API key not found. Please set the TWOCAPTCHA_API_KEY environment variable."
+
+        create_task_url = "https://api.2captcha.com/createTask"
+        get_result_url = "https://api.2captcha.com/getTaskResult"
+
+        payload = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": captcha_type,
+                "websiteURL": website_url,
+                "websiteKey": sitekey
+            }
+        }
+
+        try:
+            response = requests.post(create_task_url, json=payload, timeout=20)
+            response.raise_for_status()
+            data = response.json()
+
+            if data.get("errorId") != 0:
+                return f"2Captcha API Error: {data.get('errorDescription')}"
+
+            task_id = data.get("taskId")
+            
+            # Polling for the result (max 2 minutes)
+            for _ in range(24):
+                time.sleep(5)
+                result_payload = {"clientKey": self.api_key, "taskId": task_id}
+                result_resp = requests.post(get_result_url, json=result_payload, timeout=20)
+                result_resp.raise_for_status()
+                result_data = result_resp.json()
+
+                if result_data.get("status") == "ready":
+                    solution = result_data.get("solution", {})
+                    # Return gRecaptchaResponse for reCAPTCHA or token for other types
+                    return solution.get("gRecaptchaResponse") or solution.get("token") or "Error: No token in response."
+            
+            return "Error: Timed out waiting for captcha solution."
+
+        except requests.exceptions.RequestException as e:
+            return f"Network error connecting to 2Captcha: {str(e)}"
+        except Exception as e:
+            return f"Unexpected error: {str(e)}"

--- a/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/twocaptcha_solver_tool.py
+++ b/libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/twocaptcha_solver_tool.py
@@ -1,0 +1,36 @@
+
+import os
+import time
+import requests
+from typing import Type, Any
+from pydantic import BaseModel, Field
+from crewai.tools import BaseTool
+
+class TwoCaptchaSolverSchema(BaseModel):
+    website_url: str = Field(..., description="URL ???????? ? ??????.")
+    sitekey: str = Field(..., description="???? sitekey ?? HTML ???? ????????.")
+    captcha_type: str = Field(default="RecaptchaV2TaskProxyless", description="??? ?????.")
+
+class TwoCaptchaSolverTool(BaseTool):
+    name: str = "twocaptcha_solver"
+    description: str = "?????? ????? (reCAPTCHA, hCaptcha, Turnstile) ????? ?????? 2Captcha."
+    args_schema: Type[BaseModel] = TwoCaptchaSolverSchema
+    api_key: str = Field(default_factory=lambda: os.getenv("TWOCAPTCHA_API_KEY", ""))
+
+    def _run(self, website_url: str, sitekey: str, captcha_type: str = "RecaptchaV2TaskProxyless", **kwargs: Any) -> str:
+        api_key = self.api_key or os.getenv("TWOCAPTCHA_API_KEY")
+        if not api_key: return "??????: API ???? 2Captcha ?? ??????."
+        payload = {"clientKey": api_key, "task": {"type": captcha_type, "websiteURL": website_url, "websiteKey": sitekey}}
+        try:
+            res = requests.post("https://api.2captcha.com/createTask", json=payload).json()
+            if res.get("errorId") != 0: return f"?????? API: {res.get('errorDescription')}"
+            task_id = res.get("taskId")
+            for _ in range(20):
+                time.sleep(5)
+                result = requests.post("https://api.2captcha.com/getTaskResult", json={"clientKey": api_key, "taskId": task_id}).json()
+                if result.get("status") == "ready":
+                    sol = result.get("solution", {})
+                    return f"??????! ?????: {sol.get('gRecaptchaResponse') or sol.get('token')}"
+            return "??????? ??????? ?????."
+        except Exception as e: return f"??????: {str(e)}"
+

--- a/libs/crewai_tools/tests/test_twocaptcha_solver.py
+++ b/libs/crewai_tools/tests/test_twocaptcha_solver.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from crewai_tools.tools.twocaptcha_solver.twocaptcha_solver import TwoCaptchaSolverTool
+
+def test_tool_initialization():
+    """Test tool initialization with API key."""
+    tool = TwoCaptchaSolverTool(api_key="test_api_key")
+    assert tool.name == "twocaptcha_solver"
+    assert tool.api_key == "test_api_key"
+
+@patch("requests.post")
+def test_tool_execution_success(mock_post):
+    """Test successful captcha solving workflow."""
+    # Mock for createTask
+    mock_create = MagicMock()
+    mock_create.json.return_value = {"errorId": 0, "taskId": 999}
+    mock_create.status_code = 200
+    
+    # Mock for getTaskResult
+    mock_result = MagicMock()
+    mock_result.json.return_value = {
+        "status": "ready", 
+        "solution": {"token": "solved_token_xyz"}
+    }
+    mock_result.status_code = 200
+    
+    mock_post.side_effect = [mock_create, mock_result]
+    
+    tool = TwoCaptchaSolverTool(api_key="test_key")
+    result = tool._run(website_url="http://site.com", sitekey="abc-123")
+    
+    assert result == "solved_token_xyz"
+
+def test_tool_missing_api_key():
+    """Test error message when API key is missing."""
+    # We use patch.dict to temporarily clear environment variables
+    with patch.dict(os.environ, {}, clear=True):
+        tool = TwoCaptchaSolverTool()
+        result = tool._run(website_url="http://site.com", sitekey="abc-123")
+        assert "API key not found" in result


### PR DESCRIPTION
This PR introduces the `TwoCaptchaSolverTool`, enabling CrewAI agents to solve common web captchas (reCAPTCHA v2, hCaptcha, Cloudflare Turnstile) via the 2Captcha API.

## Why this is needed
Web scraping and automation agents often encounter bot protection (CAPTCHAs). This tool provides a seamless way for agents to autonomously solve these challenges, retrieve solution tokens, and proceed with their tasks without human intervention.

## Changes
- **New Tool**: Created `TwoCaptchaSolverTool` in `libs/crewai_tools/src/crewai_tools/tools/twocaptcha_solver/`.
- **Functionality**: Added support for polling and handling various captcha types (reCAPTCHA, hCaptcha, Turnstile).
- **Tests**: Added comprehensive unit tests with mock API responses in `libs/crewai_tools/tests/test_twocaptcha_solver.py`.
- **Registration**: Registered the new tool in the `crewai_tools` main `__init__.py` for easy access.

## How to test
1. **Unit Tests**: Run `pytest libs/crewai_tools/tests/test_twocaptcha_solver.py`.
2. **Manual Test**: 
   - Set the environment variable `TWOCAPTCHA_API_KEY`.
   - Initialize the tool: `tool = TwoCaptchaSolverTool()`.
   - Run: `tool._run(website_url="...", sitekey="...")`.

## Checklist
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes