### PR TITLE
fix: propagate implicit @CrewBase names to crew events

### DIFF
--- a/lib/crewai/src/crewai/project/annotations.py
+++ b/lib/crewai/src/crewai/project/annotations.py
@@ -237,6 +237,8 @@ def crew(
         self.tasks = instantiated_tasks
 
         crew_instance: Crew = _call_method(meth, self, *args, **kwargs)
+        if "name" not in crew_instance.model_fields_set:
+            crew_instance.name = getattr(self, "_crew_name", None) or crew_instance.name
 
         def callback_wrapper(
             hook: Callable[Concatenate[CrewInstance, P2], R2], instance: CrewInstance

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -8,7 +8,7 @@ from concurrent.futures import Future
 from hashlib import md5
 import re
 import sys
-from typing import Any
+from typing import Any, cast
 from unittest.mock import ANY, MagicMock, call, patch
 
 from crewai.agent import Agent
@@ -4792,7 +4792,8 @@ def test_crew_kickoff_started_emits_display_name(
         def _capture(_source: Any, event: CrewKickoffStartedEvent) -> None:
             captured.append(event.crew_name)
 
-        prepare_kickoff(ResearchAutomation().crew(), inputs=None)
+        automation_cls = cast(type[Any], ResearchAutomation)
+        prepare_kickoff(cast(Any, automation_cls()).crew(), inputs=None)
 
     assert captured == [expected]
 

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -8,6 +8,7 @@ from concurrent.futures import Future
 from hashlib import md5
 import re
 import sys
+from typing import Any
 from unittest.mock import ANY, MagicMock, call, patch
 
 from crewai.agent import Agent
@@ -17,6 +18,7 @@ from crewai.crew import Crew
 from crewai.crews.crew_output import CrewOutput
 from crewai.events.event_bus import crewai_event_bus
 from crewai.events.types.crew_events import (
+    CrewKickoffStartedEvent,
     CrewTestCompletedEvent,
     CrewTestStartedEvent,
     CrewTrainCompletedEvent,
@@ -4739,6 +4741,60 @@ def test_default_crew_name(researcher, writer):
         ],
     )
     assert crew.name == "crew"
+
+
+@pytest.mark.parametrize(
+    "explicit_name,expected",
+    [
+        (None, "ResearchAutomation"),
+        ("My Research Automation", "My Research Automation"),
+    ],
+    ids=["class_name_from_decorator", "explicit_name_preserved"],
+)
+def test_crew_kickoff_started_emits_display_name(
+    researcher, writer, explicit_name, expected
+):
+    """Kickoff events should use the decorator-provided display name when implicit."""
+    from crewai.crews.utils import prepare_kickoff
+    from crewai.project import CrewBase, agent, crew, task
+
+    @CrewBase
+    class ResearchAutomation:
+        agents_config = None
+        tasks_config = None
+
+        @agent
+        def researcher(self):
+            return researcher
+
+        @task
+        def first_task(self):
+            return Task(
+                description="Task 1",
+                expected_output="output",
+                agent=self.researcher(),
+            )
+
+        @crew
+        def crew(self):
+            crew_kwargs: dict[str, Any] = {
+                "agents": self.agents,
+                "tasks": self.tasks,
+            }
+            if explicit_name is not None:
+                crew_kwargs["name"] = explicit_name
+            return Crew(**crew_kwargs)
+
+    captured: list[str | None] = []
+    with crewai_event_bus.scoped_handlers():
+
+        @crewai_event_bus.on(CrewKickoffStartedEvent)
+        def _capture(_source: Any, event: CrewKickoffStartedEvent) -> None:
+            captured.append(event.crew_name)
+
+        prepare_kickoff(ResearchAutomation().crew(), inputs=None)
+
+    assert captured == [expected]
 
 
 @pytest.mark.vcr()

--- a/lib/crewai/tests/test_project.py
+++ b/lib/crewai/tests/test_project.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from unittest.mock import Mock, create_autospec, patch
 
 import pytest
@@ -259,6 +259,55 @@ def test_multiple_before_after_kickoff():
 def test_crew_name():
     crew = InternalCrew()
     assert crew._crew_name == "InternalCrew"
+
+
+def test_crew_decorator_propagates_class_name_to_instance():
+    """@crew-decorated factory method should set Crew.name to the decorated class name."""
+    sample_agent = Agent(role="r", goal="g", backstory="b")
+    sample_task = Task(description="d", expected_output="o", agent=sample_agent)
+
+    @CrewBase
+    class ImplicitNameCrewFactory:
+        agents_config = None
+        tasks_config = None
+        agents: list[BaseAgent] = [sample_agent]
+        tasks: list[Task] = [sample_task]
+
+        @crew
+        def crew(self):
+            return Crew(
+                agents=[sample_agent],
+                tasks=[sample_task],
+            )
+
+    factory_cls = cast(type[Any], ImplicitNameCrewFactory)
+    crew_instance: Crew = cast(Any, factory_cls()).crew()
+    assert crew_instance.name == "ImplicitNameCrewFactory"
+
+
+def test_crew_decorator_preserves_explicit_name():
+    """Explicit Crew(name=...) inside @crew should win over the @CrewBase class name."""
+    sample_agent = Agent(role="r", goal="g", backstory="b")
+    sample_task = Task(description="d", expected_output="o", agent=sample_agent)
+
+    @CrewBase
+    class NamedCrewFactory:
+        agents_config = None
+        tasks_config = None
+        agents: list[BaseAgent] = [sample_agent]
+        tasks: list[Task] = [sample_task]
+
+        @crew
+        def crew(self):
+            return Crew(
+                name="My Explicit Name",
+                agents=[sample_agent],
+                tasks=[sample_task],
+            )
+
+    factory_cls = cast(type[Any], NamedCrewFactory)
+    crew_instance: Crew = cast(Any, factory_cls()).crew()
+    assert crew_instance.name == "My Explicit Name"
 
 
 @tool


### PR DESCRIPTION
## Summary

Fixes the case where OpenTelemetry logs and traces report the crew or automation name as `"crew"` instead of the actual `@CrewBase` automation name.

- propagate the `@CrewBase` class name onto the returned `Crew` instance only when `name` was not explicitly provided
- preserve explicit `Crew(name=...)` values
- avoid changing global `Crew.name` semantics or adding new `Crew` state just for tracing

## Root Cause

For `@CrewBase` projects, the `@crew` factory could return a `Crew` instance that still had the default name `"crew"`. That value was then emitted through kickoff events and consumed downstream by tracing/logging, causing OTel metadata to show the wrong automation name.

## Changes

- update the `@crew` decorator to apply the `@CrewBase` class name only when `name` was implicit
- leave explicit `Crew(name=...)` untouched
- add focused tests covering:
  - implicit class-name propagation
  - explicit-name preservation
  - kickoff events emitting the correct display name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes `@crew` decorator behavior to set `Crew.name` only when the name was implicit, and adds tests to prevent regressions in event/tracing display names.
> 
> **Overview**
> Fixes incorrect crew display names (e.g., defaulting to `"crew"`) for `@CrewBase` projects by having the `@crew` decorator copy the `@CrewBase` class name onto the returned `Crew` instance **only when `name` was not explicitly set** (checked via `Crew.model_fields_set`).
> 
> Adds focused tests ensuring implicit class-name propagation, explicit `Crew(name=...)` preservation, and that `CrewKickoffStartedEvent` emits the expected display name for tracing/logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1c7921ed871695a356ccb0454860902f92c558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->