### PR TITLE
fix: handle ValidationError from JSON pattern false positives in converter

### DIFF
--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from crewai.llm import LLM
     from crewai.llms.base_llm import BaseLLM
 
-_JSON_PATTERN: Final[re.Pattern[str]] = re.compile(r"({.*})", re.DOTALL)
+_JSON_PATTERN: Final[re.Pattern[str]] = re.compile(r"(\{.*?\})", re.DOTALL)
 _I18N = I18N_DEFAULT
 
 
@@ -264,7 +264,11 @@ def handle_partial_json(
         except json.JSONDecodeError:
             pass
         except ValidationError:
-            raise
+            # The regex match may be a false positive (e.g. GraphQL schemas,
+            # template strings) that happens to contain curly braces.
+            # Fall through to convert_with_instructions so the LLM can
+            # reformat the output correctly instead of crashing.
+            pass
         except Exception as e:
             if agent and getattr(agent, "verbose", True):
                 PRINTER.print(


### PR DESCRIPTION
Fixes #5460.

**Bug**

`_JSON_PATTERN` uses a greedy `{.*}` regex with `re.DOTALL`, which can match any content that contains curly braces - including GraphQL schemas, template strings, and similar non-JSON text. When such a false-positive match happens to survive `json.JSONDecodeError` (because the outer structure looks valid) but then fails Pydantic model validation, the `ValidationError` was re-raised directly, crashing the task.

**Changes**

1. **Regex: greedy to non-greedy** - `{.*}` becomes `{.*?}` to prefer the shortest match, reducing the chance of gobbling up large non-JSON blocks.

2. **`ValidationError`: `raise` to `pass`** - if `model_validate_json` fails schema validation on a regex match, the match was likely a false positive. Falling through to `convert_with_instructions` lets the LLM reformat the output correctly instead of crashing.

**Why this is safe**

`convert_with_instructions` is the right fallback for any output the regex misidentifies - it re-prompts the LLM to produce the correct schema. This is already the path taken for `json.JSONDecodeError`, so treating `ValidationError` the same way is consistent.
