### PR TITLE
feat(azure): fall back to DefaultAzureCredential when no API key

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -94,6 +94,7 @@ google-genai = [
 ]
 azure-ai-inference = [
     "azure-ai-inference~=1.0.0b9",
+    "azure-identity>=1.17.0,<2",
 ]
 anthropic = [
     "anthropic~=0.73.0",

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -183,11 +183,6 @@ class AzureCompletion(BaseLLM):
                     AzureCompletion._is_azure_openai_endpoint(self.endpoint)
                 )
 
-        if not self.api_key:
-            raise ValueError(
-                "Azure API key is required. Set AZURE_API_KEY environment "
-                "variable or pass api_key parameter."
-            )
         if not self.endpoint:
             raise ValueError(
                 "Azure endpoint is required. Set AZURE_ENDPOINT environment "
@@ -195,11 +190,38 @@ class AzureCompletion(BaseLLM):
             )
         client_kwargs: dict[str, Any] = {
             "endpoint": self.endpoint,
-            "credential": AzureKeyCredential(self.api_key),
+            "credential": self._resolve_credential(),
         }
         if self.api_version:
             client_kwargs["api_version"] = self.api_version
         return client_kwargs
+
+    def _resolve_credential(self) -> Any:
+        """Return an Azure credential, preferring the API key when set.
+
+        Without an API key, fall back to ``DefaultAzureCredential`` from
+        ``azure-identity``. That chain auto-detects the standard keyless
+        paths the customer's environment may provide — OIDC Workload
+        Identity Federation (``AZURE_FEDERATED_TOKEN_FILE`` +
+        ``AZURE_TENANT_ID`` + ``AZURE_CLIENT_ID``), Managed Identity on
+        AKS/Azure VMs, environment-configured service principals, and
+        developer tools like the Azure CLI. Installing ``azure-identity``
+        is what enables these paths; without it we raise the existing
+        API-key error.
+        """
+        if self.api_key:
+            return AzureKeyCredential(self.api_key)
+
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            raise ValueError(
+                "Azure API key is required when azure-identity is not "
+                "installed. Set AZURE_API_KEY, or install azure-identity "
+                'for keyless auth: uv add "crewai[azure-ai-inference]"'
+            ) from None
+
+        return DefaultAzureCredential()
 
     def _get_sync_client(self) -> Any:
         if self._client is None:

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -389,17 +389,41 @@ def test_azure_raises_error_when_endpoint_missing():
             llm._get_sync_client()
 
 
-def test_azure_raises_error_when_api_key_missing():
-    """Credentials are validated lazily: construction succeeds, first
+def test_azure_raises_error_when_api_key_missing_without_azure_identity():
+    """Without an API key AND without ``azure-identity`` installed,
     client build raises the descriptive error."""
     from crewai.llms.providers.azure.completion import AzureCompletion
 
     with patch.dict(os.environ, {}, clear=True):
-        llm = AzureCompletion(
-            model="gpt-4", endpoint="https://test.openai.azure.com"
-        )
-        with pytest.raises(ValueError, match="Azure API key is required"):
-            llm._get_sync_client()
+        with patch.dict("sys.modules", {"azure.identity": None}):
+            llm = AzureCompletion(
+                model="gpt-4", endpoint="https://test.openai.azure.com"
+            )
+            with pytest.raises(ValueError, match="Azure API key is required"):
+                llm._get_sync_client()
+
+
+def test_azure_uses_default_credential_when_api_key_missing():
+    """With ``azure-identity`` installed, a missing API key falls back to
+    ``DefaultAzureCredential`` instead of raising. This is the path that
+    enables keyless auth (OIDC WIF on EKS/AKS, Managed Identity, Azure
+    CLI) without any crewAI-specific config."""
+    from unittest.mock import MagicMock
+
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    sentinel = MagicMock(name="DefaultAzureCredential()")
+    with patch.dict(os.environ, {}, clear=True):
+        with patch(
+            "azure.identity.DefaultAzureCredential", return_value=sentinel
+        ) as mock_cls:
+            llm = AzureCompletion(
+                model="gpt-4",
+                endpoint="https://test-ai.services.example.com",
+            )
+            kwargs = llm._make_client_kwargs()
+            assert kwargs["credential"] is sentinel
+            mock_cls.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `AzureCompletion` falls back to `DefaultAzureCredential` from `azure-identity` when no `api_key` is set. The existing API-key path is unchanged.
- Adds `azure-identity>=1.17.0,<2` to the `azure-ai-inference` optional dependency.
- Updates the \"missing api_key\" test to reflect the new behaviour and adds a test asserting the `DefaultAzureCredential` fallback.

## Why

Some deployment environments — hosted Kubernetes clusters with OIDC federation, Azure VMs / AKS with Managed Identity, developer machines authenticated via Azure CLI — can produce Entra-valid tokens natively, without any application-level secret. Today `AzureCompletion` refuses to build a client in those cases because it hard-requires `AZURE_API_KEY`.

With `DefaultAzureCredential` as the fallback, keyless Azure auth works out of the box whenever the standard `azure-identity` env vars (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_FEDERATED_TOKEN_FILE`) are present on the host, and the user doesn't need to configure anything crewAI-specific. The API-key path is preserved as the primary behaviour when a key is provided.

## Scope

Intentionally narrow. No new model fields, no per-instance tenant/client configuration, no explicit `WorkloadIdentityCredential` or `ClientSecretCredential` wiring — `DefaultAzureCredential` already chains through all of those paths internally, so the smallest change is to let it run.

## Test plan

- `uv run --extra azure-ai-inference pytest tests/llms/azure/ -q` — 62 passed locally.
- `uv.lock` not included; my local `uv` drops the project's `exclude-newer` stanza on regen. Please regenerate with a matching uv version before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure client authentication by allowing keyless `DefaultAzureCredential` fallback when `AZURE_API_KEY` is absent, which could alter behavior in environments relying on implicit Azure identity configuration. Risk is moderated by keeping the API-key path as the preferred credential and adding targeted tests.
> 
> **Overview**
> `AzureCompletion` no longer hard-requires an API key: when `api_key`/`AZURE_API_KEY` is missing it now attempts to use `azure-identity`’s `DefaultAzureCredential`, while still preferring `AzureKeyCredential` when a key is provided.
> 
> The `crewai[azure-ai-inference]` optional extra now includes `azure-identity`, and Azure tests are updated to cover both the *no-key + no `azure-identity`* error case and the successful `DefaultAzureCredential` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07cc3718c84e0fe8b668966f09c3528164a98b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->