### PR TITLE
fix: forward base_url to instructor client for Anthropic, Azure, and OpenAI-compatible endpoints

### DIFF
--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -73,8 +73,32 @@ class InternalInstructor(Generic[T]):
             else:
                 self._client = self._create_instructor_client()
 
+    def _get_llm_client_kwargs(self) -> dict[str, Any]:
+        """Extract base_url and api_key from the LLM so they can be forwarded
+        to the instructor client.
+
+        Returns:
+            Dict with ``base_url`` and/or ``api_key`` when present on the LLM.
+        """
+        kwargs: dict[str, Any] = {}
+        if isinstance(self.llm, str):
+            return kwargs
+        for attr in ("base_url", "api_base", "api_key"):
+            value = getattr(self.llm, attr, None)
+            if value is not None:
+                # Normalize api_base → base_url for the OpenAI client.
+                # First writer wins: base_url takes precedence over api_base.
+                key = "base_url" if attr == "api_base" else attr
+                if key not in kwargs:
+                    kwargs[key] = value
+        return kwargs
+
     def _create_instructor_client(self) -> Any:
-        """Create instructor client using the modern from_provider pattern.
+        """Create instructor client configured for the LLM provider.
+
+        When the LLM carries a custom ``base_url`` (e.g. self-hosted vLLM,
+        Ollama, or any OpenAI-compatible endpoint), we construct an explicit
+        provider client so the URL is not silently discarded.
 
         Returns:
             Instructor client configured for the LLM provider
@@ -96,9 +120,78 @@ class InternalInstructor(Generic[T]):
         elif self.llm is not None and hasattr(self.llm, "provider"):
             provider = self.llm.provider
         else:
-            provider = "openai"  # Default fallback
+            provider = "openai"
+
+        extra_kwargs = self._get_llm_client_kwargs()
+
+        # If the LLM has a custom base_url we must construct the provider
+        # client explicitly — instructor.from_provider() does not forward
+        # base_url to the underlying SDK client constructor.
+        if "base_url" in extra_kwargs:
+            return self._create_instructor_client_with_base_url(
+                provider, model_string, extra_kwargs
+            )
 
         return instructor.from_provider(f"{provider}/{model_string}")
+
+    def _create_instructor_client_with_base_url(
+        self, provider: str, model_string: str, kwargs: dict[str, Any]
+    ) -> Any:
+        """Create an instructor client using an explicit SDK client so that
+        ``base_url`` is forwarded correctly.
+
+        Args:
+            provider: The provider name (e.g. ``"openai"``, ``"anthropic"``).
+            model_string: The model identifier.
+            kwargs: Dict containing ``base_url`` and optionally ``api_key``.
+
+        Returns:
+            An Instructor client wrapping a provider-specific SDK client.
+        """
+        import instructor
+
+        base_url = kwargs.get("base_url")
+        api_key = kwargs.get("api_key")
+
+        if provider in ("azure", "azure_openai"):
+            from openai import AzureOpenAI
+
+            client_kwargs: dict[str, Any] = {}
+            if base_url is not None:
+                client_kwargs["azure_endpoint"] = base_url
+            if api_key is not None:
+                client_kwargs["api_key"] = api_key
+            api_version = getattr(self.llm, "api_version", None)
+            if api_version is not None:
+                client_kwargs["api_version"] = api_version
+            return instructor.from_openai(AzureOpenAI(**client_kwargs))
+
+        if provider == "openai":
+            from openai import OpenAI
+
+            client_kwargs = {}
+            if base_url is not None:
+                client_kwargs["base_url"] = base_url
+            if api_key is not None:
+                client_kwargs["api_key"] = api_key
+            return instructor.from_openai(OpenAI(**client_kwargs))
+
+        if provider == "anthropic":
+            from anthropic import Anthropic
+
+            client_kwargs = {}
+            if base_url is not None:
+                client_kwargs["base_url"] = base_url
+            if api_key is not None:
+                client_kwargs["api_key"] = api_key
+            return instructor.from_anthropic(Anthropic(**client_kwargs))
+
+        # For other providers, fall back to from_provider. base_url may not
+        # be supported, but we forward api_key if available.
+        fp_kwargs: dict[str, Any] = {}
+        if api_key is not None:
+            fp_kwargs["api_key"] = api_key
+        return instructor.from_provider(f"{provider}/{model_string}", **fp_kwargs)
 
     def _extract_provider(self) -> str:
         """Extract provider from LLM model name.

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -111,22 +111,19 @@ class InternalInstructor(Generic[T]):
         """
         import instructor
 
+        # Resolve model_string and provider in a single dispatch to avoid
+        # redundant isinstance checks.  model_string strips any provider prefix
+        # (e.g. "anthropic/claude-3-5-sonnet" → "claude-3-5-sonnet") so that
+        # direct SDK clients receive a bare model id while from_provider can
+        # reconstruct the full routing string.
         if isinstance(self.llm, str):
-            # Strip provider prefix so "anthropic/claude-3-5-sonnet" → "claude-3-5-sonnet"
             model_string = self.llm.partition("/")[2] or self.llm
+            provider = self._extract_provider()
         elif self.llm is not None and hasattr(self.llm, "model"):
-            # Strip provider prefix to avoid double-prefix in from_provider()
-            # and to send bare model ids to direct Anthropic/OpenAI SDK clients.
             model_string = self.llm.model.partition("/")[2] or self.llm.model
+            provider = getattr(self.llm, "provider", None) or "openai"
         else:
             raise ValueError("LLM must be a string or have a model attribute")
-
-        if isinstance(self.llm, str):
-            provider = self._extract_provider()
-        elif self.llm is not None and hasattr(self.llm, "provider"):
-            provider = self.llm.provider
-        else:
-            provider = "openai"
 
         # Normalise api_base → base_url; base_url takes precedence when both are set.
         # Empty strings are treated the same as absent (normalised to None).

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -117,8 +117,12 @@ class InternalInstructor(Generic[T]):
             base_url = getattr(self.llm, "api_base", None)
         api_key: str | None = getattr(self.llm, "api_key", None)
 
+        # Casefold for case-insensitive matching (e.g. "Anthropic" == "anthropic").
+        # from_provider still receives the original casing preserved by the LLM.
+        provider_lower = provider.casefold() if provider else "openai"
+
         if base_url:
-            if provider == "anthropic":
+            if provider_lower == "anthropic":
                 from anthropic import Anthropic
 
                 client_kwargs: dict[str, Any] = {"base_url": base_url}
@@ -126,7 +130,7 @@ class InternalInstructor(Generic[T]):
                     client_kwargs["api_key"] = api_key
                 return instructor.from_anthropic(Anthropic(**client_kwargs))
 
-            if provider in ("azure", "azure_openai"):
+            if provider_lower in ("azure", "azure_openai"):
                 from openai import AzureOpenAI
 
                 client_kwargs = {"azure_endpoint": base_url}

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -78,9 +78,7 @@ class InternalInstructor(Generic[T]):
                 if _base:
                     self._litellm_api_base = str(_base)
                 # Litellm uses the provider-prefixed model string for routing.
-                if isinstance(self.llm, str):
-                    self._instructor_model_name = self.llm
-                elif hasattr(self.llm, "model"):
+                if hasattr(self.llm, "model"):
                     self._instructor_model_name = str(self.llm.model)
             else:
                 self._client = self._create_instructor_client()
@@ -119,9 +117,6 @@ class InternalInstructor(Generic[T]):
         else:
             raise ValueError("LLM must be a string or have a model attribute")
 
-        # Cache for to_pydantic so the bare model id reaches direct SDK clients.
-        self._instructor_model_name = model_string
-
         if isinstance(self.llm, str):
             provider = self._extract_provider()
         elif self.llm is not None and hasattr(self.llm, "provider"):
@@ -150,6 +145,7 @@ class InternalInstructor(Generic[T]):
                         "Install it with: pip install anthropic"
                     ) from exc
 
+                self._instructor_model_name = model_string
                 client_kwargs: dict[str, Any] = {"base_url": base_url}
                 if api_key is not None:
                     client_kwargs["api_key"] = api_key
@@ -158,13 +154,14 @@ class InternalInstructor(Generic[T]):
             if provider_lower in ("azure", "azure_openai"):
                 from openai import AzureOpenAI
 
+                self._instructor_model_name = model_string
                 client_kwargs = {"azure_endpoint": base_url}
                 if api_key is not None:
                     client_kwargs["api_key"] = api_key
-                api_version: str | None = getattr(self.llm, "api_version", None)
+                api_version: str | None = getattr(self.llm, "api_version", None) or None
                 if api_version is not None:
                     client_kwargs["api_version"] = api_version
-                azure_deployment: str | None = getattr(self.llm, "azure_deployment", None)
+                azure_deployment: str | None = getattr(self.llm, "azure_deployment", None) or None
                 if azure_deployment is not None:
                     client_kwargs["azure_deployment"] = azure_deployment
                 return instructor.from_openai(AzureOpenAI(**client_kwargs))
@@ -172,11 +169,14 @@ class InternalInstructor(Generic[T]):
             # OpenAI and all other OpenAI-compatible providers (vLLM, Ollama, Groq, …)
             from openai import OpenAI
 
+            self._instructor_model_name = model_string
             client_kwargs = {"base_url": base_url}
             if api_key is not None:
                 client_kwargs["api_key"] = api_key
             return instructor.from_openai(OpenAI(**client_kwargs))
 
+        # from_provider requires the full "provider/model" routing string.
+        self._instructor_model_name = f"{provider}/{model_string}"
         return instructor.from_provider(f"{provider}/{model_string}")
 
     def _extract_provider(self) -> str:

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -58,6 +58,7 @@ class InternalInstructor(Generic[T]):
         self.agent = agent
         self.model = model
         self.llm = llm or (agent.function_calling_llm or agent.llm if agent else None)
+        self._litellm_api_base: str | None = None
 
         with suppress_warnings():
             import instructor  # type: ignore[import-untyped]
@@ -70,6 +71,11 @@ class InternalInstructor(Generic[T]):
                 from litellm import completion
 
                 self._client = instructor.from_litellm(completion)
+                _base = getattr(self.llm, "base_url", None) or getattr(
+                    self.llm, "api_base", None
+                )
+                if _base:
+                    self._litellm_api_base = str(_base)
             else:
                 self._client = self._create_instructor_client()
 
@@ -100,7 +106,8 @@ class InternalInstructor(Generic[T]):
             # Strip provider prefix so "anthropic/claude-3-5-sonnet" → "claude-3-5-sonnet"
             model_string = self.llm.partition("/")[2] or self.llm
         elif self.llm is not None and hasattr(self.llm, "model"):
-            model_string = self.llm.model
+            # Strip provider prefix to avoid double-prefix in from_provider()
+            model_string = self.llm.model.partition("/")[2] or self.llm.model
         else:
             raise ValueError("LLM must be a string or have a model attribute")
 
@@ -112,9 +119,10 @@ class InternalInstructor(Generic[T]):
             provider = "openai"
 
         # Normalise api_base → base_url; base_url takes precedence when both are set.
-        base_url: str | None = getattr(self.llm, "base_url", None)
+        # Empty strings are treated the same as absent (normalised to None).
+        base_url: str | None = getattr(self.llm, "base_url", None) or None
         if base_url is None:
-            base_url = getattr(self.llm, "api_base", None)
+            base_url = getattr(self.llm, "api_base", None) or None
         api_key: str | None = getattr(self.llm, "api_key", None)
 
         # Casefold for case-insensitive matching (e.g. "Anthropic" == "anthropic").
@@ -123,7 +131,13 @@ class InternalInstructor(Generic[T]):
 
         if base_url:
             if provider_lower == "anthropic":
-                from anthropic import Anthropic
+                try:
+                    from anthropic import Anthropic
+                except ImportError as exc:
+                    raise ImportError(
+                        "The 'anthropic' package is required for Anthropic provider support. "
+                        "Install it with: pip install anthropic"
+                    ) from exc
 
                 client_kwargs: dict[str, Any] = {"base_url": base_url}
                 if api_key is not None:
@@ -139,6 +153,9 @@ class InternalInstructor(Generic[T]):
                 api_version: str | None = getattr(self.llm, "api_version", None)
                 if api_version is not None:
                     client_kwargs["api_version"] = api_version
+                azure_deployment: str | None = getattr(self.llm, "azure_deployment", None)
+                if azure_deployment is not None:
+                    client_kwargs["azure_deployment"] = azure_deployment
                 return instructor.from_openai(AzureOpenAI(**client_kwargs))
 
             # OpenAI and all other OpenAI-compatible providers (vLLM, Ollama, Groq, …)
@@ -196,6 +213,10 @@ class InternalInstructor(Generic[T]):
         else:
             model_name = self.llm.model
 
+        extra: dict[str, Any] = {}
+        if self._litellm_api_base:
+            extra["api_base"] = self._litellm_api_base
+
         return self._client.chat.completions.create(  # type: ignore[no-any-return]
-            model=model_name, response_model=self.model, messages=messages
+            model=model_name, response_model=self.model, messages=messages, **extra
         )

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -59,6 +59,7 @@ class InternalInstructor(Generic[T]):
         self.model = model
         self.llm = llm or (agent.function_calling_llm or agent.llm if agent else None)
         self._litellm_api_base: str | None = None
+        self._instructor_model_name: str = ""
 
         with suppress_warnings():
             import instructor  # type: ignore[import-untyped]
@@ -76,8 +77,14 @@ class InternalInstructor(Generic[T]):
                 )
                 if _base:
                     self._litellm_api_base = str(_base)
+                # Litellm uses the provider-prefixed model string for routing.
+                if isinstance(self.llm, str):
+                    self._instructor_model_name = self.llm
+                elif hasattr(self.llm, "model"):
+                    self._instructor_model_name = str(self.llm.model)
             else:
                 self._client = self._create_instructor_client()
+                # _instructor_model_name is set inside _create_instructor_client()
 
     def _create_instructor_client(self) -> Any:
         """Create instructor client configured for the LLM provider.
@@ -107,9 +114,13 @@ class InternalInstructor(Generic[T]):
             model_string = self.llm.partition("/")[2] or self.llm
         elif self.llm is not None and hasattr(self.llm, "model"):
             # Strip provider prefix to avoid double-prefix in from_provider()
+            # and to send bare model ids to direct Anthropic/OpenAI SDK clients.
             model_string = self.llm.model.partition("/")[2] or self.llm.model
         else:
             raise ValueError("LLM must be a string or have a model attribute")
+
+        # Cache for to_pydantic so the bare model id reaches direct SDK clients.
+        self._instructor_model_name = model_string
 
         if isinstance(self.llm, str):
             provider = self._extract_provider()
@@ -123,7 +134,7 @@ class InternalInstructor(Generic[T]):
         base_url: str | None = getattr(self.llm, "base_url", None) or None
         if base_url is None:
             base_url = getattr(self.llm, "api_base", None) or None
-        api_key: str | None = getattr(self.llm, "api_key", None)
+        api_key: str | None = getattr(self.llm, "api_key", None) or None
 
         # Casefold for case-insensitive matching (e.g. "Anthropic" == "anthropic").
         # from_provider still receives the original casing preserved by the LLM.
@@ -208,15 +219,13 @@ class InternalInstructor(Generic[T]):
                 "LLM must be provided and have a model attribute or be a string"
             )
 
-        if isinstance(self.llm, str):
-            model_name = self.llm
-        else:
-            model_name = self.llm.model
-
         extra: dict[str, Any] = {}
         if self._litellm_api_base:
             extra["api_base"] = self._litellm_api_base
 
         return self._client.chat.completions.create(  # type: ignore[no-any-return]
-            model=model_name, response_model=self.model, messages=messages, **extra
+            model=self._instructor_model_name,
+            response_model=self.model,
+            messages=messages,
+            **extra,
         )

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -73,43 +73,32 @@ class InternalInstructor(Generic[T]):
             else:
                 self._client = self._create_instructor_client()
 
-    def _get_llm_client_kwargs(self) -> dict[str, Any]:
-        """Extract base_url and api_key from the LLM so they can be forwarded
-        to the instructor client.
-
-        Returns:
-            Dict with ``base_url`` and/or ``api_key`` when present on the LLM.
-        """
-        kwargs: dict[str, Any] = {}
-        if isinstance(self.llm, str):
-            return kwargs
-        for attr in ("base_url", "api_base", "api_key"):
-            value = getattr(self.llm, attr, None)
-            if value is not None:
-                # Normalize api_base → base_url for the OpenAI client.
-                # First writer wins: base_url takes precedence over api_base.
-                key = "base_url" if attr == "api_base" else attr
-                if key not in kwargs:
-                    kwargs[key] = value
-        return kwargs
-
     def _create_instructor_client(self) -> Any:
         """Create instructor client configured for the LLM provider.
 
         When the LLM carries a custom ``base_url`` (e.g. self-hosted vLLM,
-        Ollama, or any OpenAI-compatible endpoint), we construct an explicit
-        provider client so the URL is not silently discarded.
+        Ollama, Anthropic proxy, or Azure OpenAI), constructs an explicit
+        provider-specific SDK client so the URL is not silently discarded by
+        ``instructor.from_provider()``.
+
+        Provider routing when ``base_url`` is set:
+        - ``anthropic``                → ``Anthropic(base_url=...)`` via ``instructor.from_anthropic()``
+        - ``azure`` / ``azure_openai`` → ``AzureOpenAI(azure_endpoint=...)`` via ``instructor.from_openai()``
+        - everything else              → ``OpenAI(base_url=...)`` via ``instructor.from_openai()``
+
+        ``base_url`` takes precedence over ``api_base`` when both are present.
 
         Returns:
             Instructor client configured for the LLM provider
 
         Raises:
-            ValueError: If the provider is not supported
+            ValueError: If the LLM is not valid
         """
         import instructor
 
         if isinstance(self.llm, str):
-            model_string = self.llm
+            # Strip provider prefix so "anthropic/claude-3-5-sonnet" → "claude-3-5-sonnet"
+            model_string = self.llm.partition("/")[2] or self.llm
         elif self.llm is not None and hasattr(self.llm, "model"):
             model_string = self.llm.model
         else:
@@ -122,76 +111,41 @@ class InternalInstructor(Generic[T]):
         else:
             provider = "openai"
 
-        extra_kwargs = self._get_llm_client_kwargs()
+        # Normalise api_base → base_url; base_url takes precedence when both are set.
+        base_url: str | None = getattr(self.llm, "base_url", None)
+        if base_url is None:
+            base_url = getattr(self.llm, "api_base", None)
+        api_key: str | None = getattr(self.llm, "api_key", None)
 
-        # If the LLM has a custom base_url we must construct the provider
-        # client explicitly — instructor.from_provider() does not forward
-        # base_url to the underlying SDK client constructor.
-        if "base_url" in extra_kwargs:
-            return self._create_instructor_client_with_base_url(
-                provider, model_string, extra_kwargs
-            )
+        if base_url:
+            if provider == "anthropic":
+                from anthropic import Anthropic
 
-        return instructor.from_provider(f"{provider}/{model_string}")
+                client_kwargs: dict[str, Any] = {"base_url": base_url}
+                if api_key is not None:
+                    client_kwargs["api_key"] = api_key
+                return instructor.from_anthropic(Anthropic(**client_kwargs))
 
-    def _create_instructor_client_with_base_url(
-        self, provider: str, model_string: str, kwargs: dict[str, Any]
-    ) -> Any:
-        """Create an instructor client using an explicit SDK client so that
-        ``base_url`` is forwarded correctly.
+            if provider in ("azure", "azure_openai"):
+                from openai import AzureOpenAI
 
-        Args:
-            provider: The provider name (e.g. ``"openai"``, ``"anthropic"``).
-            model_string: The model identifier.
-            kwargs: Dict containing ``base_url`` and optionally ``api_key``.
+                client_kwargs = {"azure_endpoint": base_url}
+                if api_key is not None:
+                    client_kwargs["api_key"] = api_key
+                api_version: str | None = getattr(self.llm, "api_version", None)
+                if api_version is not None:
+                    client_kwargs["api_version"] = api_version
+                return instructor.from_openai(AzureOpenAI(**client_kwargs))
 
-        Returns:
-            An Instructor client wrapping a provider-specific SDK client.
-        """
-        import instructor
-
-        base_url = kwargs.get("base_url")
-        api_key = kwargs.get("api_key")
-
-        if provider in ("azure", "azure_openai"):
-            from openai import AzureOpenAI
-
-            client_kwargs: dict[str, Any] = {}
-            if base_url is not None:
-                client_kwargs["azure_endpoint"] = base_url
-            if api_key is not None:
-                client_kwargs["api_key"] = api_key
-            api_version = getattr(self.llm, "api_version", None)
-            if api_version is not None:
-                client_kwargs["api_version"] = api_version
-            return instructor.from_openai(AzureOpenAI(**client_kwargs))
-
-        if provider == "openai":
+            # OpenAI and all other OpenAI-compatible providers (vLLM, Ollama, Groq, …)
             from openai import OpenAI
 
-            client_kwargs = {}
-            if base_url is not None:
-                client_kwargs["base_url"] = base_url
+            client_kwargs = {"base_url": base_url}
             if api_key is not None:
                 client_kwargs["api_key"] = api_key
             return instructor.from_openai(OpenAI(**client_kwargs))
 
-        if provider == "anthropic":
-            from anthropic import Anthropic
-
-            client_kwargs = {}
-            if base_url is not None:
-                client_kwargs["base_url"] = base_url
-            if api_key is not None:
-                client_kwargs["api_key"] = api_key
-            return instructor.from_anthropic(Anthropic(**client_kwargs))
-
-        # For other providers, fall back to from_provider. base_url may not
-        # be supported, but we forward api_key if available.
-        fp_kwargs: dict[str, Any] = {}
-        if api_key is not None:
-            fp_kwargs["api_key"] = api_key
-        return instructor.from_provider(f"{provider}/{model_string}", **fp_kwargs)
+        return instructor.from_provider(f"{provider}/{model_string}")
 
     def _extract_provider(self) -> str:
         """Extract provider from LLM model name.

--- a/lib/crewai/src/crewai/utilities/internal_instructor.py
+++ b/lib/crewai/src/crewai/utilities/internal_instructor.py
@@ -80,6 +80,10 @@ class InternalInstructor(Generic[T]):
                 # Litellm uses the provider-prefixed model string for routing.
                 if hasattr(self.llm, "model"):
                     self._instructor_model_name = str(self.llm.model)
+                else:
+                    raise ValueError(
+                        "LLM must have a model attribute when used with litellm"
+                    )
             else:
                 self._client = self._create_instructor_client()
                 # _instructor_model_name is set inside _create_instructor_client()
@@ -167,12 +171,12 @@ class InternalInstructor(Generic[T]):
                 return instructor.from_openai(AzureOpenAI(**client_kwargs))
 
             # OpenAI and all other OpenAI-compatible providers (vLLM, Ollama, Groq, …)
+            # Keyless local servers (Ollama, vLLM) still require a non-empty api_key
+            # for the openai SDK constructor; use a placeholder when none is provided.
             from openai import OpenAI
 
             self._instructor_model_name = model_string
-            client_kwargs = {"base_url": base_url}
-            if api_key is not None:
-                client_kwargs["api_key"] = api_key
+            client_kwargs = {"base_url": base_url, "api_key": api_key or "not-needed"}
             return instructor.from_openai(OpenAI(**client_kwargs))
 
         # from_provider requires the full "provider/model" routing string.

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -940,6 +940,9 @@ def test_internal_instructor_real_unsupported_provider() -> None:
     mock_llm.is_litellm = False
     mock_llm.model = "unsupported-model"
     mock_llm.provider = "unsupported"
+    mock_llm.base_url = None
+    mock_llm.api_base = None
+    mock_llm.api_key = None
 
     # This should raise a ConfigurationError from the real instructor library
     with pytest.raises(Exception) as exc_info:
@@ -952,3 +955,228 @@ def test_internal_instructor_real_unsupported_provider() -> None:
 
     # Verify it's a configuration error about unsupported provider
     assert "Unsupported provider" in str(exc_info.value) or "unsupported" in str(exc_info.value).lower()
+
+
+# =========================================================================
+# base_url forwarding tests (issue #5204)
+# =========================================================================
+
+
+def test_internal_instructor_forwards_base_url_to_openai_client() -> None:
+    """When LLM has a custom base_url, _create_instructor_client_with_base_url is called."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "my-model"
+    mock_llm.provider = "openai"
+    mock_llm.base_url = "http://localhost:8000/v1"
+    mock_llm.api_key = "test-key"
+    mock_llm.api_base = None
+
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
+
+    with patch.object(
+        InternalInstructor, '_create_instructor_client_with_base_url',
+        return_value=mock_client,
+    ) as mock_with_base_url:
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+        # Verify _create_instructor_client_with_base_url was called
+        mock_with_base_url.assert_called_once()
+        call_args = mock_with_base_url.call_args
+        assert call_args[0][0] == "openai"  # provider
+        assert call_args[0][1] == "my-model"  # model_string
+        assert call_args[0][2]["base_url"] == "http://localhost:8000/v1"
+        assert call_args[0][2]["api_key"] == "test-key"
+
+        result = inst.to_pydantic()
+        assert isinstance(result, SimpleModel)
+
+
+def test_internal_instructor_no_base_url_uses_from_provider() -> None:
+    """When LLM has no custom base_url, use instructor.from_provider normally."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "gpt-4o"
+    mock_llm.provider = "openai"
+    mock_llm.base_url = None
+    mock_llm.api_base = None
+    mock_llm.api_key = None
+
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
+
+    with patch.object(InternalInstructor, '_create_instructor_client') as mock_create:
+        mock_create.return_value = mock_client
+
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+        result = inst.to_pydantic()
+        assert isinstance(result, SimpleModel)
+        mock_create.assert_called_once()
+
+
+def test_get_llm_client_kwargs_extracts_base_url() -> None:
+    """_get_llm_client_kwargs should extract base_url and api_key from LLM."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "my-model"
+    mock_llm.provider = "openai"
+    mock_llm.base_url = "http://localhost:8000/v1"
+    mock_llm.api_key = "sk-test"
+    mock_llm.api_base = None
+
+    mock_client = Mock()
+    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+    kwargs = inst._get_llm_client_kwargs()
+    assert kwargs["base_url"] == "http://localhost:8000/v1"
+    assert kwargs["api_key"] == "sk-test"
+
+
+def test_get_llm_client_kwargs_normalizes_api_base() -> None:
+    """api_base should be normalized to base_url."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "my-model"
+    mock_llm.provider = "openai"
+    mock_llm.base_url = None
+    mock_llm.api_base = "http://ollama:11434/v1"
+    mock_llm.api_key = None
+
+    mock_client = Mock()
+    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+    kwargs = inst._get_llm_client_kwargs()
+    assert kwargs["base_url"] == "http://ollama:11434/v1"
+    assert "api_base" not in kwargs
+
+
+def test_get_llm_client_kwargs_string_llm_returns_empty() -> None:
+    """String LLMs have no base_url — should return empty dict."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_client = Mock()
+    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm="openai/gpt-4o",
+        )
+
+    kwargs = inst._get_llm_client_kwargs()
+    assert kwargs == {}
+
+
+def test_get_llm_client_kwargs_base_url_wins_over_api_base() -> None:
+    """When both base_url and api_base are set, base_url takes precedence."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "my-model"
+    mock_llm.provider = "openai"
+    mock_llm.base_url = "http://primary:8000/v1"
+    mock_llm.api_base = "http://secondary:8000/v1"
+    mock_llm.api_key = None
+
+    mock_client = Mock()
+    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+    kwargs = inst._get_llm_client_kwargs()
+    assert kwargs["base_url"] == "http://primary:8000/v1"
+
+
+def test_internal_instructor_anthropic_base_url_forwarded() -> None:
+    """Anthropic provider with base_url should use instructor.from_anthropic."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "claude-3-5-sonnet"
+    mock_llm.provider = "anthropic"
+    mock_llm.base_url = "http://my-proxy:9000"
+    mock_llm.api_base = None
+    mock_llm.api_key = "sk-ant-test"
+
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
+
+    with patch.object(
+        InternalInstructor, '_create_instructor_client_with_base_url',
+        return_value=mock_client,
+    ) as mock_with_base_url:
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+        mock_with_base_url.assert_called_once()
+        call_args = mock_with_base_url.call_args[0]
+        assert call_args[0] == "anthropic"
+        assert call_args[2]["base_url"] == "http://my-proxy:9000"
+        assert call_args[2]["api_key"] == "sk-ant-test"
+
+
+def test_internal_instructor_azure_base_url_forwarded() -> None:
+    """Azure provider with base_url should use AzureOpenAI, not OpenAI."""
+    from crewai.utilities.internal_instructor import InternalInstructor
+
+    mock_llm = Mock()
+    mock_llm.is_litellm = False
+    mock_llm.model = "gpt-4o"
+    mock_llm.provider = "azure"
+    mock_llm.base_url = "https://my-resource.openai.azure.com"
+    mock_llm.api_base = None
+    mock_llm.api_key = "azure-key"
+    mock_llm.api_version = "2024-02-15-preview"
+
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
+
+    with patch.object(
+        InternalInstructor, '_create_instructor_client_with_base_url',
+        return_value=mock_client,
+    ) as mock_with_base_url:
+        inst = InternalInstructor(
+            content="Test",
+            model=SimpleModel,
+            llm=mock_llm,
+        )
+
+        mock_with_base_url.assert_called_once()
+        call_args = mock_with_base_url.call_args[0]
+        assert call_args[0] == "azure"
+        assert call_args[2]["base_url"] == "https://my-resource.openai.azure.com"

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -787,6 +787,30 @@ class TestInternalInstructorBaseUrl:
         assert call_kwargs["model"] == "claude-3-5-sonnet-20241022"
         assert "anthropic/" not in call_kwargs["model"]
 
+    @patch("instructor.from_provider")
+    def test_from_provider_path_sets_full_prefixed_model_name(
+        self, mock_from_provider: Mock
+    ) -> None:
+        """_instructor_model_name must include provider prefix for the from_provider path.
+
+        Regression guard: an early assignment of the stripped model_string was
+        incorrectly shared by both the direct-SDK and from_provider paths, causing
+        to_pydantic to send a bare 'gpt-4o' to a from_provider client that routes
+        on 'openai/gpt-4o'.
+        """
+        llm = _make_llm("openai", model="gpt-4o")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._litellm_api_base = None
+        inst._instructor_model_name = ""
+
+        inst._create_instructor_client()
+
+        assert inst._instructor_model_name == "openai/gpt-4o"
+
 
 # Tests for error handling
 def test_converter_error_handling() -> None:

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -493,13 +493,16 @@ class TestInternalInstructorBaseUrl:
         inst.agent = None
 
         fake_anthropic = MagicMock()
+        mock_from_anthropic = Mock()
         with patch.dict("sys.modules", {"anthropic": fake_anthropic}), \
-             patch("instructor.from_anthropic", Mock(), create=True):
-            inst._create_instructor_client()
+             patch("instructor.from_anthropic", mock_from_anthropic, create=True):
+            client = inst._create_instructor_client()
 
         fake_anthropic.Anthropic.assert_called_once_with(
             base_url="https://my-anthropic-proxy.example.com", api_key="sk-ant-test"
         )
+        mock_from_anthropic.assert_called_once_with(fake_anthropic.Anthropic.return_value)
+        assert client is mock_from_anthropic.return_value
 
     def test_anthropic_api_base_normalised_to_base_url(self) -> None:
         """api_base should be used as base_url when base_url is absent."""
@@ -566,13 +569,15 @@ class TestInternalInstructorBaseUrl:
         inst.content = "test"
         inst.model = SimpleModel
         inst.agent = None
-        inst._create_instructor_client()
+        client = inst._create_instructor_client()
 
         mock_azure_cls.assert_called_once_with(
             azure_endpoint="https://my-resource.openai.azure.com",
             api_key="azure-key",
             api_version="2024-02-01",
         )
+        mock_from_openai.assert_called_once_with(mock_azure_cls.return_value)
+        assert client is mock_from_openai.return_value
 
     @patch("instructor.from_provider")
     def test_azure_without_base_url_uses_from_provider(
@@ -621,6 +626,58 @@ class TestInternalInstructorBaseUrl:
         inst._create_instructor_client()
 
         mock_from_provider.assert_called_once_with("openai/gpt-4o")
+
+    @patch("openai.OpenAI")
+    @patch("instructor.from_openai")
+    def test_base_url_wins_over_api_base(
+        self, mock_from_openai: Mock, mock_openai_cls: Mock
+    ) -> None:
+        """When both base_url and api_base are set, base_url takes precedence."""
+        llm = _make_llm(
+            "openai",
+            model="gpt-4o",
+            base_url="http://primary:8000/v1",
+            api_base="http://secondary:8000/v1",
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_openai_cls.assert_called_once_with(base_url="http://primary:8000/v1")
+
+    @patch("instructor.from_provider")
+    def test_string_llm_strips_provider_prefix(
+        self, mock_from_provider: Mock
+    ) -> None:
+        """String LLMs like 'anthropic/claude-3-5-sonnet' should not produce a double prefix."""
+        inst = object.__new__(InternalInstructor)
+        inst.llm = "anthropic/claude-3-5-sonnet"
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with("anthropic/claude-3-5-sonnet")
+
+    def test_provider_routing_is_case_insensitive(self) -> None:
+        """Provider names with non-standard casing should still route correctly."""
+        llm = _make_llm("Anthropic", base_url="https://proxy.example.com")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+
+        fake_anthropic = MagicMock()
+        mock_from_anthropic = Mock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}), \
+             patch("instructor.from_anthropic", mock_from_anthropic, create=True):
+            inst._create_instructor_client()
+
+        fake_anthropic.Anthropic.assert_called_once_with(base_url="https://proxy.example.com")
 
 
 # Tests for error handling

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -649,7 +649,30 @@ class TestInternalInstructorBaseUrl:
         inst.agent = None
         inst._create_instructor_client()
 
-        mock_openai_cls.assert_called_once_with(base_url="http://primary:8000/v1")
+        mock_openai_cls.assert_called_once_with(base_url="http://primary:8000/v1", api_key="not-needed")
+
+    @patch("openai.OpenAI")
+    @patch("instructor.from_openai")
+    def test_keyless_openai_compatible_endpoint(
+        self, mock_from_openai: Mock, mock_openai_cls: Mock
+    ) -> None:
+        """Ollama/vLLM with base_url but no api_key must use 'not-needed' sentinel.
+
+        The openai SDK raises OpenAIError when api_key is None and OPENAI_API_KEY
+        is not set. A placeholder key allows keyless local servers to work.
+        """
+        llm = _make_llm("openai", model="llama3", base_url="http://localhost:11434/v1")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_openai_cls.assert_called_once_with(
+            base_url="http://localhost:11434/v1", api_key="not-needed"
+        )
+        mock_from_openai.assert_called_once_with(mock_openai_cls.return_value)
 
     @patch("instructor.from_provider")
     def test_string_llm_strips_provider_prefix(

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -760,6 +760,7 @@ class TestInternalInstructorBaseUrl:
         inst.model = SimpleModel
         inst.agent = None
         inst._litellm_api_base = "http://custom:8080/v1"
+        inst._instructor_model_name = "gpt-4o"
         mock_client = MagicMock()
         inst._client = mock_client
 
@@ -767,6 +768,24 @@ class TestInternalInstructorBaseUrl:
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs.get("api_base") == "http://custom:8080/v1"
+
+    def test_to_pydantic_sends_stripped_model_name(self) -> None:
+        """to_pydantic must send the bare model id, not a provider-prefixed string."""
+        inst = object.__new__(InternalInstructor)
+        inst.llm = _make_llm("anthropic", model="anthropic/claude-3-5-sonnet-20241022")
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._litellm_api_base = None
+        inst._instructor_model_name = "claude-3-5-sonnet-20241022"  # stripped by _create_instructor_client
+        mock_client = MagicMock()
+        inst._client = mock_client
+
+        inst.to_pydantic()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "claude-3-5-sonnet-20241022"
+        assert "anthropic/" not in call_kwargs["model"]
 
 
 # Tests for error handling

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -431,6 +431,7 @@ def test_converter_with_nested_model() -> None:
 # ---------------------------------------------------------------------------
 
 from crewai.utilities.internal_instructor import InternalInstructor  # noqa: E402
+import instructor  # noqa: E402 — ensure cached before sys.modules patches in tests below
 
 
 def _make_llm(
@@ -440,6 +441,7 @@ def _make_llm(
     api_base: str | None = None,
     api_key: str | None = None,
     api_version: str | None = None,
+    azure_deployment: str | None = None,
     is_litellm: bool = False,
 ) -> Mock:
     llm = Mock()
@@ -449,6 +451,7 @@ def _make_llm(
     llm.api_base = api_base
     llm.api_key = api_key
     llm.api_version = api_version
+    llm.azure_deployment = azure_deployment
     llm.is_litellm = is_litellm
     return llm
 
@@ -678,6 +681,92 @@ class TestInternalInstructorBaseUrl:
             inst._create_instructor_client()
 
         fake_anthropic.Anthropic.assert_called_once_with(base_url="https://proxy.example.com")
+
+    def test_anthropic_import_error_has_friendly_message(self) -> None:
+        """Missing anthropic package raises ImportError with pip install hint."""
+        llm = _make_llm("anthropic", base_url="https://proxy.example.com")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+
+        with patch.dict("sys.modules", {"anthropic": None}):
+            with pytest.raises(ImportError, match="pip install anthropic"):
+                inst._create_instructor_client()
+
+    @patch("openai.AzureOpenAI")
+    @patch("instructor.from_openai")
+    def test_azure_with_deployment(
+        self, mock_from_openai: Mock, mock_azure_cls: Mock
+    ) -> None:
+        """azure_deployment is forwarded to AzureOpenAI when set on the LLM."""
+        llm = _make_llm(
+            "azure",
+            model="gpt-4o",
+            base_url="https://my-resource.openai.azure.com",
+            azure_deployment="my-gpt4o-deployment",
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_azure_cls.assert_called_once_with(
+            azure_endpoint="https://my-resource.openai.azure.com",
+            azure_deployment="my-gpt4o-deployment",
+        )
+        mock_from_openai.assert_called_once_with(mock_azure_cls.return_value)
+
+    @patch("instructor.from_provider")
+    def test_object_llm_strips_model_prefix(
+        self, mock_from_provider: Mock
+    ) -> None:
+        """An LLM object whose .model contains 'provider/model' must not double-prefix."""
+        llm = _make_llm("anthropic", model="anthropic/claude-3-5-sonnet-20241022")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with(
+            "anthropic/claude-3-5-sonnet-20241022"
+        )
+
+    @patch("instructor.from_provider")
+    def test_empty_string_base_url_treated_as_absent(
+        self, mock_from_provider: Mock
+    ) -> None:
+        """Empty string base_url must not trigger the custom-client path."""
+        llm = _make_llm("openai", model="gpt-4o", base_url="")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with("openai/gpt-4o")
+
+    def test_litellm_api_base_forwarded_in_to_pydantic(self) -> None:
+        """When _litellm_api_base is set, to_pydantic passes it as api_base kwarg."""
+        inst = object.__new__(InternalInstructor)
+        inst.llm = _make_llm("openai", model="gpt-4o")
+        inst.content = "test content"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._litellm_api_base = "http://custom:8080/v1"
+        mock_client = MagicMock()
+        inst._client = mock_client
+
+        inst.to_pydantic()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs.get("api_base") == "http://custom:8080/v1"
 
 
 # Tests for error handling

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -426,6 +426,203 @@ def test_converter_with_nested_model() -> None:
     assert output.address.zip_code == "12345"
 
 
+# ---------------------------------------------------------------------------
+# InternalInstructor — base_url forwarding (Anthropic + Azure + regression)
+# ---------------------------------------------------------------------------
+
+from crewai.utilities.internal_instructor import InternalInstructor  # noqa: E402
+
+
+def _make_llm(
+    provider: str,
+    model: str = "test-model",
+    base_url: str | None = None,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    api_version: str | None = None,
+    is_litellm: bool = False,
+) -> Mock:
+    llm = Mock()
+    llm.provider = provider
+    llm.model = model
+    llm.base_url = base_url
+    llm.api_base = api_base
+    llm.api_key = api_key
+    llm.api_version = api_version
+    llm.is_litellm = is_litellm
+    return llm
+
+
+class TestInternalInstructorBaseUrl:
+    """Verify _create_instructor_client routes to the correct SDK client.
+
+    Note: anthropic is an optional dependency that may not be installed in the
+    test environment. Tests that exercise the Anthropic path inject a fake
+    anthropic module via sys.modules and use create=True on instructor.from_anthropic
+    since that attribute is conditionally exported only when anthropic is installed.
+    """
+
+    def test_anthropic_with_base_url(self) -> None:
+        llm = _make_llm("anthropic", base_url="https://my-anthropic-proxy.example.com")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+
+        fake_anthropic = MagicMock()
+        mock_from_anthropic = Mock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}), \
+             patch("instructor.from_anthropic", mock_from_anthropic, create=True):
+            client = inst._create_instructor_client()
+
+        fake_anthropic.Anthropic.assert_called_once_with(base_url="https://my-anthropic-proxy.example.com")
+        mock_from_anthropic.assert_called_once_with(fake_anthropic.Anthropic.return_value)
+        assert client is mock_from_anthropic.return_value
+
+    def test_anthropic_with_base_url_and_api_key(self) -> None:
+        llm = _make_llm(
+            "anthropic",
+            base_url="https://my-anthropic-proxy.example.com",
+            api_key="sk-ant-test",
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+
+        fake_anthropic = MagicMock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}), \
+             patch("instructor.from_anthropic", Mock(), create=True):
+            inst._create_instructor_client()
+
+        fake_anthropic.Anthropic.assert_called_once_with(
+            base_url="https://my-anthropic-proxy.example.com", api_key="sk-ant-test"
+        )
+
+    def test_anthropic_api_base_normalised_to_base_url(self) -> None:
+        """api_base should be used as base_url when base_url is absent."""
+        llm = _make_llm("anthropic", base_url=None, api_base="https://proxy.example.com")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+
+        fake_anthropic = MagicMock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}), \
+             patch("instructor.from_anthropic", Mock(), create=True):
+            inst._create_instructor_client()
+
+        fake_anthropic.Anthropic.assert_called_once_with(base_url="https://proxy.example.com")
+
+    @patch("instructor.from_provider")
+    def test_anthropic_without_base_url_uses_from_provider(
+        self, mock_from_provider: Mock
+    ) -> None:
+        llm = _make_llm("anthropic", model="claude-3-5-sonnet")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with("anthropic/claude-3-5-sonnet")
+
+    @patch("openai.AzureOpenAI")
+    @patch("instructor.from_openai")
+    def test_azure_with_base_url(
+        self, mock_from_openai: Mock, mock_azure_cls: Mock
+    ) -> None:
+        llm = _make_llm(
+            "azure", model="gpt-4o", base_url="https://my-resource.openai.azure.com"
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_azure_cls.assert_called_once_with(azure_endpoint="https://my-resource.openai.azure.com")
+        mock_from_openai.assert_called_once_with(mock_azure_cls.return_value)
+
+    @patch("openai.AzureOpenAI")
+    @patch("instructor.from_openai")
+    def test_azure_openai_alias_with_api_version(
+        self, mock_from_openai: Mock, mock_azure_cls: Mock
+    ) -> None:
+        llm = _make_llm(
+            "azure_openai",
+            model="gpt-4o",
+            base_url="https://my-resource.openai.azure.com",
+            api_key="azure-key",
+            api_version="2024-02-01",
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_azure_cls.assert_called_once_with(
+            azure_endpoint="https://my-resource.openai.azure.com",
+            api_key="azure-key",
+            api_version="2024-02-01",
+        )
+
+    @patch("instructor.from_provider")
+    def test_azure_without_base_url_uses_from_provider(
+        self, mock_from_provider: Mock
+    ) -> None:
+        llm = _make_llm("azure", model="gpt-4o")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with("azure/gpt-4o")
+
+    @patch("openai.OpenAI")
+    @patch("instructor.from_openai")
+    def test_openai_compatible_with_base_url(
+        self, mock_from_openai: Mock, mock_openai_cls: Mock
+    ) -> None:
+        """Any OpenAI-compatible provider (vLLM, Ollama, Groq…) with base_url."""
+        llm = _make_llm(
+            "openai", model="llama3", base_url="http://localhost:8000/v1", api_key="x"
+        )
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_openai_cls.assert_called_once_with(base_url="http://localhost:8000/v1", api_key="x")
+        mock_from_openai.assert_called_once_with(mock_openai_cls.return_value)
+
+    @patch("instructor.from_provider")
+    def test_no_base_url_regression(
+        self, mock_from_provider: Mock
+    ) -> None:
+        """Existing from_provider() path must be unchanged when no base_url is set."""
+        llm = _make_llm("openai", model="gpt-4o")
+        inst = object.__new__(InternalInstructor)
+        inst.llm = llm
+        inst.content = "test"
+        inst.model = SimpleModel
+        inst.agent = None
+        inst._create_instructor_client()
+
+        mock_from_provider.assert_called_once_with("openai/gpt-4o")
+
+
 # Tests for error handling
 def test_converter_error_handling() -> None:
     llm = Mock(spec=LLM)
@@ -962,43 +1159,6 @@ def test_internal_instructor_real_unsupported_provider() -> None:
 # =========================================================================
 
 
-def test_internal_instructor_forwards_base_url_to_openai_client() -> None:
-    """When LLM has a custom base_url, _create_instructor_client_with_base_url is called."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "my-model"
-    mock_llm.provider = "openai"
-    mock_llm.base_url = "http://localhost:8000/v1"
-    mock_llm.api_key = "test-key"
-    mock_llm.api_base = None
-
-    mock_client = Mock()
-    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
-
-    with patch.object(
-        InternalInstructor, '_create_instructor_client_with_base_url',
-        return_value=mock_client,
-    ) as mock_with_base_url:
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-        # Verify _create_instructor_client_with_base_url was called
-        mock_with_base_url.assert_called_once()
-        call_args = mock_with_base_url.call_args
-        assert call_args[0][0] == "openai"  # provider
-        assert call_args[0][1] == "my-model"  # model_string
-        assert call_args[0][2]["base_url"] == "http://localhost:8000/v1"
-        assert call_args[0][2]["api_key"] == "test-key"
-
-        result = inst.to_pydantic()
-        assert isinstance(result, SimpleModel)
-
-
 def test_internal_instructor_no_base_url_uses_from_provider() -> None:
     """When LLM has no custom base_url, use instructor.from_provider normally."""
     from crewai.utilities.internal_instructor import InternalInstructor
@@ -1028,155 +1188,3 @@ def test_internal_instructor_no_base_url_uses_from_provider() -> None:
         mock_create.assert_called_once()
 
 
-def test_get_llm_client_kwargs_extracts_base_url() -> None:
-    """_get_llm_client_kwargs should extract base_url and api_key from LLM."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "my-model"
-    mock_llm.provider = "openai"
-    mock_llm.base_url = "http://localhost:8000/v1"
-    mock_llm.api_key = "sk-test"
-    mock_llm.api_base = None
-
-    mock_client = Mock()
-    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-    kwargs = inst._get_llm_client_kwargs()
-    assert kwargs["base_url"] == "http://localhost:8000/v1"
-    assert kwargs["api_key"] == "sk-test"
-
-
-def test_get_llm_client_kwargs_normalizes_api_base() -> None:
-    """api_base should be normalized to base_url."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "my-model"
-    mock_llm.provider = "openai"
-    mock_llm.base_url = None
-    mock_llm.api_base = "http://ollama:11434/v1"
-    mock_llm.api_key = None
-
-    mock_client = Mock()
-    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-    kwargs = inst._get_llm_client_kwargs()
-    assert kwargs["base_url"] == "http://ollama:11434/v1"
-    assert "api_base" not in kwargs
-
-
-def test_get_llm_client_kwargs_string_llm_returns_empty() -> None:
-    """String LLMs have no base_url — should return empty dict."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_client = Mock()
-    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm="openai/gpt-4o",
-        )
-
-    kwargs = inst._get_llm_client_kwargs()
-    assert kwargs == {}
-
-
-def test_get_llm_client_kwargs_base_url_wins_over_api_base() -> None:
-    """When both base_url and api_base are set, base_url takes precedence."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "my-model"
-    mock_llm.provider = "openai"
-    mock_llm.base_url = "http://primary:8000/v1"
-    mock_llm.api_base = "http://secondary:8000/v1"
-    mock_llm.api_key = None
-
-    mock_client = Mock()
-    with patch.object(InternalInstructor, '_create_instructor_client', return_value=mock_client):
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-    kwargs = inst._get_llm_client_kwargs()
-    assert kwargs["base_url"] == "http://primary:8000/v1"
-
-
-def test_internal_instructor_anthropic_base_url_forwarded() -> None:
-    """Anthropic provider with base_url should use instructor.from_anthropic."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "claude-3-5-sonnet"
-    mock_llm.provider = "anthropic"
-    mock_llm.base_url = "http://my-proxy:9000"
-    mock_llm.api_base = None
-    mock_llm.api_key = "sk-ant-test"
-
-    mock_client = Mock()
-    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
-
-    with patch.object(
-        InternalInstructor, '_create_instructor_client_with_base_url',
-        return_value=mock_client,
-    ) as mock_with_base_url:
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-        mock_with_base_url.assert_called_once()
-        call_args = mock_with_base_url.call_args[0]
-        assert call_args[0] == "anthropic"
-        assert call_args[2]["base_url"] == "http://my-proxy:9000"
-        assert call_args[2]["api_key"] == "sk-ant-test"
-
-
-def test_internal_instructor_azure_base_url_forwarded() -> None:
-    """Azure provider with base_url should use AzureOpenAI, not OpenAI."""
-    from crewai.utilities.internal_instructor import InternalInstructor
-
-    mock_llm = Mock()
-    mock_llm.is_litellm = False
-    mock_llm.model = "gpt-4o"
-    mock_llm.provider = "azure"
-    mock_llm.base_url = "https://my-resource.openai.azure.com"
-    mock_llm.api_base = None
-    mock_llm.api_key = "azure-key"
-    mock_llm.api_version = "2024-02-15-preview"
-
-    mock_client = Mock()
-    mock_client.chat.completions.create.return_value = SimpleModel(name="Test", age=25)
-
-    with patch.object(
-        InternalInstructor, '_create_instructor_client_with_base_url',
-        return_value=mock_client,
-    ) as mock_with_base_url:
-        inst = InternalInstructor(
-            content="Test",
-            model=SimpleModel,
-            llm=mock_llm,
-        )
-
-        mock_with_base_url.assert_called_once()
-        call_args = mock_with_base_url.call_args[0]
-        assert call_args[0] == "azure"
-        assert call_args[2]["base_url"] == "https://my-resource.openai.azure.com"


### PR DESCRIPTION
## Summary

- Fixes `InternalInstructor` silently dropping `base_url` / `api_base` when constructing an `instructor` client via `from_provider()` — the library discards custom endpoints at that call site
- Extends the fix beyond #5218 (OpenAI-only) to cover all three provider families:
  - **Anthropic** (`provider="anthropic"`) → `Anthropic(base_url=...)` + `instructor.from_anthropic()`
  - **Azure OpenAI** (`provider="azure"` / `"azure_openai"`) → `AzureOpenAI(azure_endpoint=..., api_version=..., azure_deployment=...)` + `instructor.from_openai()`
  - **OpenAI-compatible** (vLLM, Ollama, Groq, self-hosted proxies) → `OpenAI(base_url=..., api_key=api_key or "not-needed")` + `instructor.from_openai()`; the `"not-needed"` sentinel covers keyless local servers that the SDK would otherwise reject
- `base_url` takes precedence over `api_base`; empty strings are normalised to `None` for all five endpoint-related fields
- `_instructor_model_name` is now set inside each branch with the exact string that branch's client expects: bare model id for direct SDK clients, `"provider/model"` for `from_provider()`, provider-prefixed for litellm
- LiteLLM path raises `ValueError` eagerly if the LLM object lacks a `.model` attribute instead of silently sending `model=""` downstream

## What's different from #5218

PR #5218 only handles the OpenAI-compatible case. This PR adds the Anthropic proxy path and the Azure OpenAI path, including `api_version` and `azure_deployment` forwarding.

Closes #5204 (original issue).

## Test plan

- [ ] 20 new unit tests in `TestInternalInstructorBaseUrl` covering all provider paths, `_instructor_model_name` correctness per branch, empty-string normalisation, provider prefix stripping, keyless Ollama sentinel, and a regression guard for the `from_provider` model-name routing string
- [ ] All tests pass: `uv run pytest tests/utilities/test_converter.py::TestInternalInstructorBaseUrl -q`
- [ ] Existing converter test suite unaffected