### PR TITLE
fix: allow A2A delegation by skill ID as well as endpoint URL

### DIFF
--- a/lib/crewai/src/crewai/a2a/utils/response_model.py
+++ b/lib/crewai/src/crewai/a2a/utils/response_model.py
@@ -32,11 +32,11 @@ def create_agent_response_model(agent_ids: tuple[str, ...]) -> type[BaseModel] |
     return create_model(
         "AgentResponse",
         a2a_ids=(
-            tuple[DynamicLiteral, ...],  # type: ignore[valid-type]
+            tuple[str, ...],
             Field(
                 default_factory=tuple,
                 max_length=len(agent_ids),
-                description="A2A agent IDs to delegate to.",
+                description="A2A agent IDs to delegate to. Use the agent endpoint URL or skill ID.",
             ),
         ),
         message=(

--- a/lib/crewai/src/crewai/a2a/wrapper.py
+++ b/lib/crewai/src/crewai/a2a/wrapper.py
@@ -1012,11 +1012,52 @@ def _get_turn_context(
     return agent_branch, accepted_output_modes
 
 
+def _resolve_agent_id(
+    agent_id: str,
+    a2a_agents: list[A2AConfig | A2AClientConfig],
+    agent_cards: dict[str, Any] | None,
+) -> str:
+    """Resolve an A2A agent ID (endpoint URL or skill ID) to an endpoint URL.
+
+    Args:
+        agent_id: The ID provided by the LLM (endpoint URL or skill ID).
+        a2a_agents: List of configured A2A agents.
+        agent_cards: Dictionary mapping endpoints to fetched agent cards.
+
+    Returns:
+        The resolved endpoint URL.
+    """
+    # Direct endpoint match
+    for config in a2a_agents:
+        if config.endpoint == agent_id:
+            return agent_id
+
+    # Skill ID match via agent cards
+    if agent_cards:
+        for endpoint, card in agent_cards.items():
+            if isinstance(card, dict):
+                skills = card.get("skills", [])
+                for skill in skills:
+                    skill_id = skill.get("id") if isinstance(skill, dict) else getattr(skill, "id", None)
+                    if skill_id == agent_id:
+                        return endpoint
+            else:
+                skills = getattr(card, "skills", None)
+                if skills:
+                    for skill in skills:
+                        skill_id = skill.id if hasattr(skill, "id") else skill.get("id") if isinstance(skill, dict) else None
+                        if skill_id == agent_id:
+                            return endpoint
+
+    return agent_id
+
+
 def _prepare_delegation_context(
     self: Agent,
     agent_response: AgentResponseProtocol,
     task: Task,
     original_task_description: str | None,
+    agent_cards: dict[str, Any] | None = None,
 ) -> DelegationContext:
     """Prepare delegation context from agent response and task.
 
@@ -1033,7 +1074,8 @@ def _prepare_delegation_context(
         raise ValueError("No A2A agents configured for delegation")
 
     if isinstance(agent_response, AgentResponseProtocol) and agent_response.a2a_ids:
-        agent_id = agent_response.a2a_ids[0]
+        raw_agent_id = agent_response.a2a_ids[0]
+        agent_id = _resolve_agent_id(raw_agent_id, a2a_agents, agent_cards)
     else:
         agent_id = agent_ids[0]
 
@@ -1260,7 +1302,7 @@ def _delegate_to_a2a(
         ImportError: If a2a-sdk is not installed
     """
     ctx = _prepare_delegation_context(
-        self, agent_response, task, original_task_description
+        self, agent_response, task, original_task_description, agent_cards
     )
     state = _init_delegation_state(ctx, agent_cards)
     current_request = state.current_request
@@ -1615,7 +1657,7 @@ async def _adelegate_to_a2a(
 ) -> str:
     """Async version of _delegate_to_a2a."""
     ctx = _prepare_delegation_context(
-        self, agent_response, task, original_task_description
+        self, agent_response, task, original_task_description, agent_cards
     )
     state = _init_delegation_state(ctx, agent_cards)
     current_request = state.current_request

--- a/tests/a2a/test_a2a_skill_id_resolution.py
+++ b/tests/a2a/test_a2a_skill_id_resolution.py
@@ -1,0 +1,138 @@
+"""Test A2A skill ID resolution in delegation context."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from crewai.a2a.config import A2AClientConfig, A2AConfig
+
+
+def _create_mock_agent_card_dict(endpoint: str = "http://test-endpoint.com/", skill_id: str = "Research") -> dict:
+    """Create a mock agent card as a dict with skills."""
+    return {
+        "name": "Test Agent",
+        "url": endpoint,
+        "skills": [
+            {
+                "id": skill_id,
+                "name": skill_id,
+                "description": "Test skill",
+            }
+        ],
+    }
+
+
+def _create_mock_agent_card_object(endpoint: str = "http://test-endpoint.com/", skill_id: str = "Research"):
+    """Create a mock agent card object with skills."""
+    mock_skill = MagicMock()
+    mock_skill.id = skill_id
+
+    mock_card = MagicMock()
+    mock_card.name = "Test Agent"
+    mock_card.url = endpoint
+    mock_card.skills = [mock_skill]
+    return mock_card
+
+
+class TestResolveAgentId:
+    """Tests for _resolve_agent_id function."""
+
+    def test_direct_endpoint_match(self):
+        """Should return the agent_id when it matches an endpoint directly."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [
+            A2AConfig(endpoint="http://agent1.com"),
+            A2AConfig(endpoint="http://agent2.com"),
+        ]
+
+        result = _resolve_agent_id("http://agent2.com", agents, None)
+        assert result == "http://agent2.com"
+
+    def test_resolve_skill_id_dict_card(self):
+        """Should resolve skill ID to endpoint when agent_cards is a dict."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [A2AConfig(endpoint="http://test-endpoint.com/")]
+        agent_cards = {"http://test-endpoint.com/": _create_mock_agent_card_dict("http://test-endpoint.com/", "Research")}
+
+        result = _resolve_agent_id("Research", agents, agent_cards)
+        assert result == "http://test-endpoint.com/"
+
+    def test_resolve_skill_id_object_card(self):
+        """Should resolve skill ID to endpoint when agent_cards is an object."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [A2AConfig(endpoint="http://test-endpoint.com/")]
+        agent_cards = {"http://test-endpoint.com/": _create_mock_agent_card_object("http://test-endpoint.com/", "Research")}
+
+        result = _resolve_agent_id("Research", agents, agent_cards)
+        assert result == "http://test-endpoint.com/"
+
+    def test_no_match_returns_original(self):
+        """Should return original agent_id when no match is found."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [A2AConfig(endpoint="http://test-endpoint.com/")]
+        agent_cards = {"http://test-endpoint.com/": _create_mock_agent_card_dict("http://test-endpoint.com/", "Research")}
+
+        result = _resolve_agent_id("UnknownSkill", agents, agent_cards)
+        assert result == "UnknownSkill"
+
+    def test_no_agent_cards_returns_original(self):
+        """Should return original agent_id when agent_cards is None."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [A2AConfig(endpoint="http://test-endpoint.com/")]
+
+        result = _resolve_agent_id("Research", agents, None)
+        assert result == "Research"
+
+    def test_multiple_agents_resolves_correct_one(self):
+        """Should resolve skill ID to the correct endpoint among multiple agents."""
+        from crewai.a2a.wrapper import _resolve_agent_id
+
+        agents = [
+            A2AConfig(endpoint="http://agent1.com"),
+            A2AConfig(endpoint="http://agent2.com"),
+        ]
+        agent_cards = {
+            "http://agent1.com": _create_mock_agent_card_dict("http://agent1.com", "Analysis"),
+            "http://agent2.com": _create_mock_agent_card_dict("http://agent2.com", "Research"),
+        }
+
+        result = _resolve_agent_id("Research", agents, agent_cards)
+        assert result == "http://agent2.com"
+
+
+class TestPrepareDelegationContext:
+    """Tests for _prepare_delegation_context with skill IDs."""
+
+    def test_prepare_delegation_context_with_skill_id(self):
+        """Should resolve skill ID in agent_response to endpoint URL."""
+        from crewai.a2a.wrapper import _prepare_delegation_context
+        from crewai.a2a.types import AgentResponseProtocol
+        from crewai import Agent, Task
+
+        a2a_config = A2AConfig(endpoint="http://test-endpoint.com/")
+        agent = Agent(
+            role="test manager",
+            goal="coordinate",
+            backstory="test",
+            a2a=a2a_config,
+        )
+        task = Task(description="test", expected_output="test", agent=agent)
+
+        class MockResponse:
+            is_a2a = True
+            message = "Please help"
+            a2a_ids = ("Research",)
+
+        agent_cards = {
+            "http://test-endpoint.com/": _create_mock_agent_card_dict("http://test-endpoint.com/", "Research")
+        }
+
+        ctx = _prepare_delegation_context(agent, MockResponse(), task, "test", agent_cards)
+
+        assert ctx.agent_id == "http://test-endpoint.com/"
+        assert ctx.agent_config.endpoint == "http://test-endpoint.com/"


### PR DESCRIPTION
Fixes #3897

When using A2A delegation, the LLM was returning skill IDs (e.g. 'Research')
instead of endpoint URLs because the agent card prompt includes skill IDs.
The dynamic AgentResponse model used Literal types constrained to endpoint
URLs, causing a pydantic validation error when the LLM returned a skill ID.

### Changes
- Change a2a_ids field from Literal-based to plain tuple[str, ...]
- Add _resolve_agent_id() to map skill IDs back to endpoint URLs via
  fetched agent cards
- Update _prepare_delegation_context to accept agent_cards and resolve IDs
- Update sync/async delegation callers to pass agent_cards

### Testing
All 7 new tests pass locally:
```
pytest tests/a2a/test_a2a_skill_id_resolution.py -v
```
