### PR TITLE
docs(mcp/streamable-http): add a copy-pasteable worked example with a live remote server

### DIFF
--- a/docs/en/mcp/streamable-http.mdx
+++ b/docs/en/mcp/streamable-http.mdx
@@ -134,3 +134,41 @@ When using Streamable HTTP transport, general web security best practices are pa
 - **Input Validation**: Ensure your MCP server validates all incoming requests and parameters.
 
 For a comprehensive guide on securing your MCP integrations, please refer to our [Security Considerations](./security.mdx) page and the official [MCP Transport Security documentation](https://modelcontextprotocol.io/docs/concepts/transports#security-considerations).
+## Worked example: connecting to a live remote server
+
+If you want a working server URL to plug into the snippets above without running anything locally, you can use **OpenRegistry** — a free hosted MCP server that proxies 27 national company registries (UK Companies House, Germany Handelsregister, France Sirene+RNE, Italy InfoCamere via EU BRIS, Spain BORME, Korea OPENDART, plus 21 more). Anonymous tier — no signup, no API key.
+
+```python
+from crewai import Agent, Task, Crew, Process
+from crewai_tools import MCPServerAdapter
+
+server_params = {
+    "url": "https://openregistry.sophymarine.com/mcp",
+    "transport": "streamable-http",
+}
+
+with MCPServerAdapter(server_params) as tools:
+    print(f"Tools: {[t.name for t in tools]}")
+
+    analyst = Agent(
+        role="Cross-border KYC Analyst",
+        goal="Verify the statutory record of a counterparty across jurisdictions.",
+        backstory="An AI analyst with live access to national company registries.",
+        tools=tools,
+        verbose=True,
+    )
+
+    task = Task(
+        description=(
+            "Find Tesco PLC on UK Companies House (jurisdiction='gb'), pull "
+            "the list of current directors, then summarise."
+        ),
+        expected_output="A short paragraph quoting the registry's own field names.",
+        agent=analyst,
+    )
+
+    Crew(agents=[analyst], tasks=[task], process=Process.sequential, verbose=True).kickoff()
+```
+
+Docs and the full 27-registry capability matrix: <https://openregistry.sophymarine.com/docs/integrations/crewai>.
+


### PR DESCRIPTION
## Summary

Adds a "Worked example" section at the end of `docs/en/mcp/streamable-http.mdx` so readers have a real, hosted Streamable-HTTP MCP URL they can copy/paste into the existing snippets without running anything locally.

The example uses **OpenRegistry** — a free hosted MCP server that proxies **27 national company registries** (UK Companies House, Germany Handelsregister, France Sirene+RNE, Italy InfoCamere via EU BRIS, Spain BORME, Korea OPENDART, plus 21 more). Anonymous tier, no signup, no API key.

## Why

The current `streamable-http.mdx` page has placeholder `http://localhost:8001/mcp` URLs. Most readers landing here are evaluating whether MCP works with CrewAI for their use case — having a real public server they can point at first proves the wiring before they go build their own.

## Files changed

- `docs/en/mcp/streamable-http.mdx` — appended one "Worked example" section. No other content touched, no formatting changes elsewhere.

## Notes

- Cross-border KYC / UBO walking is OpenRegistry's flagship use case and pairs well with the multi-agent CrewAI flow.
- Repo: https://github.com/sophymarine/openregistry · CC-BY-4.0 docs.

Happy to trim wording or move the section if a different placement fits better.
