### PR TITLE
feat(printer): respect NO_COLOR environment variable for log output

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/printer.py
+++ b/lib/crewai-tools/src/crewai_tools/printer.py
@@ -1,8 +1,12 @@
+import os
+
 """Utility for colored console output."""
 
+NO_COLOR = os.environ.get("CREWAI_NO_COLOR", "false") == "true"
 
 class Printer:
     """Handles colored console output formatting."""
+    
 
     @staticmethod
     def print(content: str, color: str | None = None) -> None:
@@ -15,7 +19,7 @@ class Printer:
                 If not provided or if the color is not supported, prints without
                 formatting.
         """
-        if hasattr(Printer, f"_print_{color}"):
+        if not NO_COLOR and hasattr(Printer, f"_print_{color}"):
             getattr(Printer, f"_print_{color}")(content)
         else:
             print(content)  # noqa: T201

--- a/lib/crewai-tools/src/crewai_tools/printer.py
+++ b/lib/crewai-tools/src/crewai_tools/printer.py
@@ -2,7 +2,7 @@ import os
 
 """Utility for colored console output."""
 
-NO_COLOR = os.environ.get("CREWAI_NO_COLOR", "false") == "true"
+NO_COLOR = os.environ.get("NO_COLOR", "false") == "true"
 
 class Printer:
     """Handles colored console output formatting."""


### PR DESCRIPTION
## Description
This PR adds support for the industry-standard `NO_COLOR` environment variable (https://no-color.org/) to the `printer.py` utility. 

## Motivation
When integrating CrewAI into automated pipelines, CI/CD, or monitoring systems, ANSI color codes can clutter plain text logs. More importantly, if these logs are ingested and processed by LLMs or monitoring systems, the ANSI characters inflate the payload size. By supporting `NO_COLOR`, this change:
* Reduces the amount of consumed tokens for systems watching the logs.
* Lowers ingestion sizes, directly reducing costs.
* Improves overall log readability in non-interactive environments.

## Changes Made
* Added a check for the `NO_COLOR` environment variable in `printer.py`.
* Strips or bypasses color formatting when this flag is present.
* **Backward-compatible:** The current default behavior remains entirely unchanged for users who do not set this variable.