### PR TITLE
fix: add JSON serializer for guardrail callable fields to fix checkpoint crash

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -285,7 +285,14 @@ class Agent(BaseAgent):
         default=None,
         description="The Agent's role to be used from your repository.",
     )
-    guardrail: GuardrailType | None = Field(
+    guardrail: Annotated[
+        GuardrailType | None,
+        PlainSerializer(
+            lambda v: v if isinstance(v, str) else None,
+            return_type=str | None,
+            when_used="json",
+        ),
+    ] = Field(
         default=None,
         description="Function or string description of a guardrail to validate agent output",
     )

--- a/lib/crewai/src/crewai/lite_agent.py
+++ b/lib/crewai/src/crewai/lite_agent.py
@@ -9,6 +9,7 @@ import time
 from types import MethodType
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Literal,
     cast,
@@ -25,6 +26,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from pydantic.functional_serializers import PlainSerializer
 from typing_extensions import Self, deprecated
 
 
@@ -235,7 +237,14 @@ class LiteAgent(FlowTrackable, BaseModel):
     verbose: bool = Field(
         default=False, description="Whether to print execution details"
     )
-    guardrail: GuardrailType | None = Field(
+    guardrail: Annotated[
+        GuardrailType | None,
+        PlainSerializer(
+            lambda v: v if isinstance(v, str) else None,
+            return_type=str | None,
+            when_used="json",
+        ),
+    ] = Field(
         default=None,
         description="Function or string description of a guardrail to validate agent output",
     )

--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -87,6 +87,20 @@ from crewai.utilities.printer import PRINTER
 from crewai.utilities.string_utils import interpolate_only
 
 
+def _serialize_guardrail(v: Any) -> str | None:
+    """Serialize a guardrail for JSON checkpointing: keep strings, drop callables."""
+    if isinstance(v, str):
+        return v
+    return None
+
+
+def _serialize_guardrails(v: Any) -> list[str | None] | str | None:
+    """Serialize a guardrails list/value for JSON checkpointing."""
+    if isinstance(v, (list, tuple)):
+        return [_serialize_guardrail(g) for g in v]
+    return _serialize_guardrail(v)
+
+
 def _serialize_model_class(v: type[BaseModel] | None) -> dict[str, Any] | None:
     """Serialize a Pydantic model class reference to its JSON schema."""
     return v.model_json_schema() if v else None
@@ -235,11 +249,21 @@ class Task(BaseModel):
         default=None,
     )
     processed_by_agents: set[str] = Field(default_factory=set)
-    guardrail: GuardrailType | None = Field(
+    guardrail: Annotated[
+        GuardrailType | None,
+        PlainSerializer(
+            _serialize_guardrail, return_type=str | None, when_used="json"
+        ),
+    ] = Field(
         default=None,
         description="Function or string description of a guardrail to validate task output before proceeding to next task",
     )
-    guardrails: GuardrailsType | None = Field(
+    guardrails: Annotated[
+        GuardrailsType | None,
+        PlainSerializer(
+            _serialize_guardrails, return_type=list | str | None, when_used="json"
+        ),
+    ] = Field(
         default=None,
         description="List of guardrails to validate task output before proceeding to next task. Also supports a single guardrail function or string description of a guardrail to validate task output before proceeding to next task",
     )


### PR DESCRIPTION
Fixes #5620

### Root Cause

`Task.guardrail`, `Task.guardrails`, `Agent.guardrail`, and `LiteAgent.guardrail` fields accept `GuardrailType` (which is `Callable | str`). When a user passes a Python function as a guardrail and checkpointing calls `model_dump(mode="json")`, Pydantic cannot serialize the callable, raising:

```
TypeError: Unable to serialize unknown type: <class 'function'>
```

PR #5559 fixed the same class of issue for `output_pydantic`, `output_json`, `converter_cls` etc., but missed the guardrail fields.

### Fix

Add `PlainSerializer` annotations to all guardrail fields across `Task`, `Agent`, and `LiteAgent`:
- String guardrail descriptions are preserved as-is
- Callable references are serialized as `None` (they cannot be round-tripped through JSON)

This follows the same pattern used for `output_pydantic` and `converter_cls` in #5559.

### Files Changed
- `lib/crewai/src/crewai/task.py` — `guardrail` and `guardrails` fields
- `lib/crewai/src/crewai/agent/core.py` — `guardrail` field
- `lib/crewai/src/crewai/lite_agent.py` — `guardrail` field