### PR TITLE
fix(crew): bind task-only agents to crew so multimodal input_files reach the LLM

### DIFF
--- a/lib/crewai/src/crewai/crews/utils.py
+++ b/lib/crewai/src/crewai/crews/utils.py
@@ -357,10 +357,9 @@ def prepare_kickoff(
     agents_to_setup: list[BaseAgent] = list(crew.agents)
     seen_agent_ids: set[int] = {id(agent) for agent in agents_to_setup}
     for task in crew.tasks:
-        task_agent = getattr(task, "agent", None)
-        if task_agent is not None and id(task_agent) not in seen_agent_ids:
-            agents_to_setup.append(task_agent)
-            seen_agent_ids.add(id(task_agent))
+        if task.agent is not None and id(task.agent) not in seen_agent_ids:
+            agents_to_setup.append(task.agent)
+            seen_agent_ids.add(id(task.agent))
 
     setup_agents(
         crew,

--- a/lib/crewai/src/crewai/crews/utils.py
+++ b/lib/crewai/src/crewai/crews/utils.py
@@ -354,9 +354,17 @@ def prepare_kickoff(
     crew._set_tasks_callbacks()
     crew._set_allow_crewai_trigger_context_for_first_task()
 
+    agents_to_setup: list[BaseAgent] = list(crew.agents)
+    seen_agent_ids: set[int] = {id(agent) for agent in agents_to_setup}
+    for task in crew.tasks:
+        task_agent = getattr(task, "agent", None)
+        if task_agent is not None and id(task_agent) not in seen_agent_ids:
+            agents_to_setup.append(task_agent)
+            seen_agent_ids.add(id(task_agent))
+
     setup_agents(
         crew,
-        crew.agents,
+        agents_to_setup,
         crew.embedder,
         crew.function_calling_llm,
         crew.step_callback,

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -4798,6 +4798,37 @@ def test_crew_kickoff_started_emits_display_name(
     assert captured == [expected]
 
 
+def test_prepare_kickoff_binds_task_only_agent_to_crew():
+    """Agents referenced only via task.agent must get .crew set during prepare_kickoff.
+
+    Regression for crewAIInc/crewAI#5534: when Crew is built without
+    agents=[...], multimodal input_files were silently dropped because the
+    agent's .crew attribute was never assigned, gating file lookup off in
+    Task and CrewAgentExecutor.
+    """
+    from crewai.crews.utils import prepare_kickoff
+
+    task_only_agent = Agent(
+        role="Solo",
+        goal="Describe inputs",
+        backstory="Solo agent assigned only via task.agent",
+        allow_delegation=False,
+    )
+    task = Task(
+        description="Describe the input.",
+        expected_output="A description.",
+        agent=task_only_agent,
+    )
+    crew = Crew(tasks=[task])
+
+    assert task_only_agent.crew is None
+    assert crew.agents == []
+
+    prepare_kickoff(crew, inputs=None)
+
+    assert task_only_agent.crew is crew
+
+
 @pytest.mark.vcr()
 def test_memory_remember_receives_task_content():
     """With memory=True, extract_memories receives raw content with task, agent, expected output, and result."""


### PR DESCRIPTION
Closes #5534.

`prepare_kickoff` only ran `setup_agents` over `crew.agents`, so an agent referenced solely via `task.agent` never got `agent.crew` assigned — silently disabling the multimodal file lookup at `task.py:907` and `crew_agent_executor.py:242`. Task agents are now merged into the setup list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `prepare_kickoff` agent initialization, which affects how executors are created and how multimodal `input_files` are resolved at runtime; regression risk is limited but in a core execution path.
> 
> **Overview**
> Fixes a kickoff regression where agents assigned only via `Task.agent` were not passed through `setup_agents`, leaving `agent.crew` unset and preventing multimodal `input_files` from being found/used.
> 
> `prepare_kickoff` now builds a de-duplicated `agents_to_setup` list that merges `crew.agents` with any per-task agents, and a new test covers the scenario where `Crew(agents=[])` still binds the task-only agent to the crew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51cd622310719071870acafc9f17c7d653d3068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->