### PR TITLE
docs: add Daytona sandbox tools documentation

### DIFF
--- a/docs/ar/tools/ai-ml/daytona.mdx
+++ b/docs/ar/tools/ai-ml/daytona.mdx
@@ -1,0 +1,180 @@
+---
+title: Daytona Sandbox Tools
+description: Run shell commands, execute Python, and manage files inside isolated [Daytona](https://www.daytona.io/) sandboxes.
+icon: box
+mode: "wide"
+---
+
+# Daytona Sandbox Tools
+
+## Description
+
+The Daytona sandbox tools give CrewAI agents access to isolated, ephemeral compute environments powered by [Daytona](https://www.daytona.io/). Three tools are available so you can give an agent exactly the capabilities it needs:
+
+- **`DaytonaExecTool`** — run any shell command inside a sandbox.
+- **`DaytonaPythonTool`** — execute a block of Python source code inside a sandbox.
+- **`DaytonaFileTool`** — read, write, append, list, delete, and inspect files inside a sandbox.
+
+All three tools share the same sandbox lifecycle controls, so you can mix and match them while keeping state in a single persistent sandbox.
+
+## Installation
+
+```shell
+uv add "crewai-tools[daytona]"
+# or
+pip install "crewai-tools[daytona]"
+```
+
+Set your API key:
+
+```shell
+export DAYTONA_API_KEY="your-api-key"
+```
+
+`DAYTONA_API_URL` and `DAYTONA_TARGET` are also respected if set.
+
+## Sandbox Lifecycle
+
+All three tools inherit lifecycle controls from `DaytonaBaseTool`:
+
+| Mode | How to enable | Sandbox created | Sandbox deleted |
+|------|--------------|-----------------|-----------------|
+| **Ephemeral** (default) | `persistent=False` (default) | On every `_run` call | At the end of that same call |
+| **Persistent** | `persistent=True` | Lazily on first use | At process exit (via `atexit`), or manually via `tool.close()` |
+| **Attach** | `sandbox_id="<id>"` | Never — attaches to an existing sandbox | Never — the tool will not delete a sandbox it did not create |
+
+Ephemeral mode is the safe default: nothing leaks if the agent forgets to clean up. Use persistent mode when you want filesystem state or installed packages to carry across multiple tool calls — this is typical when pairing `DaytonaFileTool` with `DaytonaExecTool`.
+
+## Examples
+
+### One-shot Python execution (ephemeral)
+
+```python Code
+from crewai_tools import DaytonaPythonTool
+
+tool = DaytonaPythonTool()
+result = tool.run(code="print(sum(range(10)))")
+print(result)
+# {"exit_code": 0, "result": "45\n", "artifacts": None}
+```
+
+### Multi-step shell session (persistent)
+
+```python Code
+from crewai_tools import DaytonaExecTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+# Install a package, then write and run a script — all in the same sandbox
+exec_tool.run(command="pip install httpx -q")
+file_tool.run(action="write", path="/workspace/fetch.py", content="import httpx; print(httpx.get('https://httpbin.org/get').status_code)")
+exec_tool.run(command="python /workspace/fetch.py")
+```
+
+<Note>
+Each tool instance maintains its own persistent sandbox. To share **one** sandbox across two tools, create the first tool, grab its sandbox id via `tool._persistent_sandbox.id`, and pass it to the second tool via `sandbox_id=...`.
+</Note>
+
+### Attach to an existing sandbox
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(sandbox_id="my-long-lived-sandbox")
+result = tool.run(command="ls /workspace")
+```
+
+### Custom sandbox parameters
+
+Pass Daytona's `CreateSandboxFromSnapshotParams` kwargs via `create_params`:
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(
+    persistent=True,
+    create_params={
+        "language": "python",
+        "env_vars": {"MY_FLAG": "1"},
+        "labels": {"owner": "crewai-agent"},
+    },
+)
+```
+
+### Agent integration
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools import DaytonaExecTool, DaytonaPythonTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+python_tool = DaytonaPythonTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+coder = Agent(
+    role="Sandbox Engineer",
+    goal="Write and run code in an isolated environment",
+    backstory="An engineer who uses Daytona sandboxes to safely execute code and manage files.",
+    tools=[exec_tool, python_tool, file_tool],
+    verbose=True,
+)
+
+task = Task(
+    description="Write a Python script that prints the first 10 Fibonacci numbers, save it to /workspace/fib.py, and run it.",
+    expected_output="The first 10 Fibonacci numbers printed to stdout.",
+    agent=coder,
+)
+
+crew = Crew(agents=[coder], tasks=[task])
+result = crew.kickoff()
+```
+
+## Parameters
+
+### Shared (`DaytonaBaseTool`)
+
+All three tools accept these parameters at initialization:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | `$DAYTONA_API_KEY` | Daytona API key. Falls back to the `DAYTONA_API_KEY` env var. |
+| `api_url` | `str \| None` | `$DAYTONA_API_URL` | Daytona API URL override. |
+| `target` | `str \| None` | `$DAYTONA_TARGET` | Daytona target region. |
+| `persistent` | `bool` | `False` | Reuse one sandbox across all calls and delete it at process exit. |
+| `sandbox_id` | `str \| None` | `None` | Attach to an existing sandbox by id or name. |
+| `create_params` | `dict \| None` | `None` | Extra kwargs forwarded to `CreateSandboxFromSnapshotParams` (e.g. `language`, `env_vars`, `labels`). |
+| `sandbox_timeout` | `float` | `60.0` | Timeout in seconds for sandbox create/delete operations. |
+
+### `DaytonaExecTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | `str` | ✓ | Shell command to execute. |
+| `cwd` | `str \| None` | | Working directory inside the sandbox. |
+| `env` | `dict[str, str] \| None` | | Extra environment variables for this command. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for the command. |
+
+### `DaytonaPythonTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `str` | ✓ | Python source code to execute. |
+| `argv` | `list[str] \| None` | | Argument vector forwarded via `CodeRunParams`. |
+| `env` | `dict[str, str] \| None` | | Environment variables forwarded via `CodeRunParams`. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for execution. |
+
+### `DaytonaFileTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `str` | ✓ | One of: `read`, `write`, `append`, `list`, `delete`, `mkdir`, `info`. |
+| `path` | `str` | ✓ | Absolute path inside the sandbox. |
+| `content` | `str \| None` | | Content to write or append. Required for `append`. |
+| `binary` | `bool` | | If `True`, `content` is base64 on write; returns base64 on read. |
+| `recursive` | `bool` | | For `delete`: remove directories recursively. |
+| `mode` | `str` | | For `mkdir`: octal permission string (default `"0755"`). |
+
+<Tip>
+For files larger than a few KB, create the file first with `action="write"` and empty content, then send the body via multiple `action="append"` calls of ~4 KB each to stay within tool-call payload limits.
+</Tip>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -279,7 +279,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -755,7 +756,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -1231,7 +1233,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -1707,7 +1710,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -2183,7 +2187,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -2658,7 +2663,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -3132,7 +3138,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -3606,7 +3613,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -4080,7 +4088,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -4556,7 +4565,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -5031,7 +5041,8 @@
                           "en/tools/ai-ml/llamaindextool",
                           "en/tools/ai-ml/langchaintool",
                           "en/tools/ai-ml/ragtool",
-                          "en/tools/ai-ml/codeinterpretertool"
+                          "en/tools/ai-ml/codeinterpretertool",
+                          "en/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -5527,7 +5538,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -5986,7 +5998,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -6445,7 +6458,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -6904,7 +6918,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -7363,7 +7378,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -7821,7 +7837,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -8279,7 +8296,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -8737,7 +8755,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -9194,7 +9213,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -9651,7 +9671,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -10109,7 +10130,8 @@
                           "pt-BR/tools/ai-ml/llamaindextool",
                           "pt-BR/tools/ai-ml/langchaintool",
                           "pt-BR/tools/ai-ml/ragtool",
-                          "pt-BR/tools/ai-ml/codeinterpretertool"
+                          "pt-BR/tools/ai-ml/codeinterpretertool",
+                          "pt-BR/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -10609,7 +10631,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -11080,7 +11103,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -11551,7 +11575,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -12022,7 +12047,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -12493,7 +12519,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -12963,7 +12990,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -13433,7 +13461,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -13903,7 +13932,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -14372,7 +14402,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -14841,7 +14872,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -15311,7 +15343,8 @@
                           "ko/tools/ai-ml/llamaindextool",
                           "ko/tools/ai-ml/langchaintool",
                           "ko/tools/ai-ml/ragtool",
-                          "ko/tools/ai-ml/codeinterpretertool"
+                          "ko/tools/ai-ml/codeinterpretertool",
+                          "ko/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -15812,7 +15845,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -16283,7 +16317,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -16754,7 +16789,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -17225,7 +17261,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -17696,7 +17733,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -18166,7 +18204,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -18636,7 +18675,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -19106,7 +19146,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -19575,7 +19616,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -20044,7 +20086,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {
@@ -20514,7 +20557,8 @@
                           "ar/tools/ai-ml/llamaindextool",
                           "ar/tools/ai-ml/langchaintool",
                           "ar/tools/ai-ml/ragtool",
-                          "ar/tools/ai-ml/codeinterpretertool"
+                          "ar/tools/ai-ml/codeinterpretertool",
+                          "ar/tools/ai-ml/daytona"
                         ]
                       },
                       {

--- a/docs/en/tools/ai-ml/daytona.mdx
+++ b/docs/en/tools/ai-ml/daytona.mdx
@@ -1,0 +1,180 @@
+---
+title: Daytona Sandbox Tools
+description: Run shell commands, execute Python, and manage files inside isolated [Daytona](https://www.daytona.io/) sandboxes.
+icon: box
+mode: "wide"
+---
+
+# Daytona Sandbox Tools
+
+## Description
+
+The Daytona sandbox tools give CrewAI agents access to isolated, ephemeral compute environments powered by [Daytona](https://www.daytona.io/). Three tools are available so you can give an agent exactly the capabilities it needs:
+
+- **`DaytonaExecTool`** — run any shell command inside a sandbox.
+- **`DaytonaPythonTool`** — execute a block of Python source code inside a sandbox.
+- **`DaytonaFileTool`** — read, write, append, list, delete, and inspect files inside a sandbox.
+
+All three tools share the same sandbox lifecycle controls, so you can mix and match them while keeping state in a single persistent sandbox.
+
+## Installation
+
+```shell
+uv add "crewai-tools[daytona]"
+# or
+pip install "crewai-tools[daytona]"
+```
+
+Set your API key:
+
+```shell
+export DAYTONA_API_KEY="your-api-key"
+```
+
+`DAYTONA_API_URL` and `DAYTONA_TARGET` are also respected if set.
+
+## Sandbox Lifecycle
+
+All three tools inherit lifecycle controls from `DaytonaBaseTool`:
+
+| Mode | How to enable | Sandbox created | Sandbox deleted |
+|------|--------------|-----------------|-----------------|
+| **Ephemeral** (default) | `persistent=False` (default) | On every `_run` call | At the end of that same call |
+| **Persistent** | `persistent=True` | Lazily on first use | At process exit (via `atexit`), or manually via `tool.close()` |
+| **Attach** | `sandbox_id="<id>"` | Never — attaches to an existing sandbox | Never — the tool will not delete a sandbox it did not create |
+
+Ephemeral mode is the safe default: nothing leaks if the agent forgets to clean up. Use persistent mode when you want filesystem state or installed packages to carry across multiple tool calls — this is typical when pairing `DaytonaFileTool` with `DaytonaExecTool`.
+
+## Examples
+
+### One-shot Python execution (ephemeral)
+
+```python Code
+from crewai_tools import DaytonaPythonTool
+
+tool = DaytonaPythonTool()
+result = tool.run(code="print(sum(range(10)))")
+print(result)
+# {"exit_code": 0, "result": "45\n", "artifacts": None}
+```
+
+### Multi-step shell session (persistent)
+
+```python Code
+from crewai_tools import DaytonaExecTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+# Install a package, then write and run a script — all in the same sandbox
+exec_tool.run(command="pip install httpx -q")
+file_tool.run(action="write", path="/workspace/fetch.py", content="import httpx; print(httpx.get('https://httpbin.org/get').status_code)")
+exec_tool.run(command="python /workspace/fetch.py")
+```
+
+<Note>
+Each tool instance maintains its own persistent sandbox. To share **one** sandbox across two tools, create the first tool, grab its sandbox id via `tool._persistent_sandbox.id`, and pass it to the second tool via `sandbox_id=...`.
+</Note>
+
+### Attach to an existing sandbox
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(sandbox_id="my-long-lived-sandbox")
+result = tool.run(command="ls /workspace")
+```
+
+### Custom sandbox parameters
+
+Pass Daytona's `CreateSandboxFromSnapshotParams` kwargs via `create_params`:
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(
+    persistent=True,
+    create_params={
+        "language": "python",
+        "env_vars": {"MY_FLAG": "1"},
+        "labels": {"owner": "crewai-agent"},
+    },
+)
+```
+
+### Agent integration
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools import DaytonaExecTool, DaytonaPythonTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+python_tool = DaytonaPythonTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+coder = Agent(
+    role="Sandbox Engineer",
+    goal="Write and run code in an isolated environment",
+    backstory="An engineer who uses Daytona sandboxes to safely execute code and manage files.",
+    tools=[exec_tool, python_tool, file_tool],
+    verbose=True,
+)
+
+task = Task(
+    description="Write a Python script that prints the first 10 Fibonacci numbers, save it to /workspace/fib.py, and run it.",
+    expected_output="The first 10 Fibonacci numbers printed to stdout.",
+    agent=coder,
+)
+
+crew = Crew(agents=[coder], tasks=[task])
+result = crew.kickoff()
+```
+
+## Parameters
+
+### Shared (`DaytonaBaseTool`)
+
+All three tools accept these parameters at initialization:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | `$DAYTONA_API_KEY` | Daytona API key. Falls back to the `DAYTONA_API_KEY` env var. |
+| `api_url` | `str \| None` | `$DAYTONA_API_URL` | Daytona API URL override. |
+| `target` | `str \| None` | `$DAYTONA_TARGET` | Daytona target region. |
+| `persistent` | `bool` | `False` | Reuse one sandbox across all calls and delete it at process exit. |
+| `sandbox_id` | `str \| None` | `None` | Attach to an existing sandbox by id or name. |
+| `create_params` | `dict \| None` | `None` | Extra kwargs forwarded to `CreateSandboxFromSnapshotParams` (e.g. `language`, `env_vars`, `labels`). |
+| `sandbox_timeout` | `float` | `60.0` | Timeout in seconds for sandbox create/delete operations. |
+
+### `DaytonaExecTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | `str` | ✓ | Shell command to execute. |
+| `cwd` | `str \| None` | | Working directory inside the sandbox. |
+| `env` | `dict[str, str] \| None` | | Extra environment variables for this command. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for the command. |
+
+### `DaytonaPythonTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `str` | ✓ | Python source code to execute. |
+| `argv` | `list[str] \| None` | | Argument vector forwarded via `CodeRunParams`. |
+| `env` | `dict[str, str] \| None` | | Environment variables forwarded via `CodeRunParams`. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for execution. |
+
+### `DaytonaFileTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `str` | ✓ | One of: `read`, `write`, `append`, `list`, `delete`, `mkdir`, `info`. |
+| `path` | `str` | ✓ | Absolute path inside the sandbox. |
+| `content` | `str \| None` | | Content to write or append. Required for `append`. |
+| `binary` | `bool` | | If `True`, `content` is base64 on write; returns base64 on read. |
+| `recursive` | `bool` | | For `delete`: remove directories recursively. |
+| `mode` | `str` | | For `mkdir`: octal permission string (default `"0755"`). |
+
+<Tip>
+For files larger than a few KB, create the file first with `action="write"` and empty content, then send the body via multiple `action="append"` calls of ~4 KB each to stay within tool-call payload limits.
+</Tip>

--- a/docs/ko/tools/ai-ml/daytona.mdx
+++ b/docs/ko/tools/ai-ml/daytona.mdx
@@ -1,0 +1,180 @@
+---
+title: Daytona Sandbox Tools
+description: Run shell commands, execute Python, and manage files inside isolated [Daytona](https://www.daytona.io/) sandboxes.
+icon: box
+mode: "wide"
+---
+
+# Daytona Sandbox Tools
+
+## Description
+
+The Daytona sandbox tools give CrewAI agents access to isolated, ephemeral compute environments powered by [Daytona](https://www.daytona.io/). Three tools are available so you can give an agent exactly the capabilities it needs:
+
+- **`DaytonaExecTool`** — run any shell command inside a sandbox.
+- **`DaytonaPythonTool`** — execute a block of Python source code inside a sandbox.
+- **`DaytonaFileTool`** — read, write, append, list, delete, and inspect files inside a sandbox.
+
+All three tools share the same sandbox lifecycle controls, so you can mix and match them while keeping state in a single persistent sandbox.
+
+## Installation
+
+```shell
+uv add "crewai-tools[daytona]"
+# or
+pip install "crewai-tools[daytona]"
+```
+
+Set your API key:
+
+```shell
+export DAYTONA_API_KEY="your-api-key"
+```
+
+`DAYTONA_API_URL` and `DAYTONA_TARGET` are also respected if set.
+
+## Sandbox Lifecycle
+
+All three tools inherit lifecycle controls from `DaytonaBaseTool`:
+
+| Mode | How to enable | Sandbox created | Sandbox deleted |
+|------|--------------|-----------------|-----------------|
+| **Ephemeral** (default) | `persistent=False` (default) | On every `_run` call | At the end of that same call |
+| **Persistent** | `persistent=True` | Lazily on first use | At process exit (via `atexit`), or manually via `tool.close()` |
+| **Attach** | `sandbox_id="<id>"` | Never — attaches to an existing sandbox | Never — the tool will not delete a sandbox it did not create |
+
+Ephemeral mode is the safe default: nothing leaks if the agent forgets to clean up. Use persistent mode when you want filesystem state or installed packages to carry across multiple tool calls — this is typical when pairing `DaytonaFileTool` with `DaytonaExecTool`.
+
+## Examples
+
+### One-shot Python execution (ephemeral)
+
+```python Code
+from crewai_tools import DaytonaPythonTool
+
+tool = DaytonaPythonTool()
+result = tool.run(code="print(sum(range(10)))")
+print(result)
+# {"exit_code": 0, "result": "45\n", "artifacts": None}
+```
+
+### Multi-step shell session (persistent)
+
+```python Code
+from crewai_tools import DaytonaExecTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+# Install a package, then write and run a script — all in the same sandbox
+exec_tool.run(command="pip install httpx -q")
+file_tool.run(action="write", path="/workspace/fetch.py", content="import httpx; print(httpx.get('https://httpbin.org/get').status_code)")
+exec_tool.run(command="python /workspace/fetch.py")
+```
+
+<Note>
+Each tool instance maintains its own persistent sandbox. To share **one** sandbox across two tools, create the first tool, grab its sandbox id via `tool._persistent_sandbox.id`, and pass it to the second tool via `sandbox_id=...`.
+</Note>
+
+### Attach to an existing sandbox
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(sandbox_id="my-long-lived-sandbox")
+result = tool.run(command="ls /workspace")
+```
+
+### Custom sandbox parameters
+
+Pass Daytona's `CreateSandboxFromSnapshotParams` kwargs via `create_params`:
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(
+    persistent=True,
+    create_params={
+        "language": "python",
+        "env_vars": {"MY_FLAG": "1"},
+        "labels": {"owner": "crewai-agent"},
+    },
+)
+```
+
+### Agent integration
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools import DaytonaExecTool, DaytonaPythonTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+python_tool = DaytonaPythonTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+coder = Agent(
+    role="Sandbox Engineer",
+    goal="Write and run code in an isolated environment",
+    backstory="An engineer who uses Daytona sandboxes to safely execute code and manage files.",
+    tools=[exec_tool, python_tool, file_tool],
+    verbose=True,
+)
+
+task = Task(
+    description="Write a Python script that prints the first 10 Fibonacci numbers, save it to /workspace/fib.py, and run it.",
+    expected_output="The first 10 Fibonacci numbers printed to stdout.",
+    agent=coder,
+)
+
+crew = Crew(agents=[coder], tasks=[task])
+result = crew.kickoff()
+```
+
+## Parameters
+
+### Shared (`DaytonaBaseTool`)
+
+All three tools accept these parameters at initialization:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | `$DAYTONA_API_KEY` | Daytona API key. Falls back to the `DAYTONA_API_KEY` env var. |
+| `api_url` | `str \| None` | `$DAYTONA_API_URL` | Daytona API URL override. |
+| `target` | `str \| None` | `$DAYTONA_TARGET` | Daytona target region. |
+| `persistent` | `bool` | `False` | Reuse one sandbox across all calls and delete it at process exit. |
+| `sandbox_id` | `str \| None` | `None` | Attach to an existing sandbox by id or name. |
+| `create_params` | `dict \| None` | `None` | Extra kwargs forwarded to `CreateSandboxFromSnapshotParams` (e.g. `language`, `env_vars`, `labels`). |
+| `sandbox_timeout` | `float` | `60.0` | Timeout in seconds for sandbox create/delete operations. |
+
+### `DaytonaExecTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | `str` | ✓ | Shell command to execute. |
+| `cwd` | `str \| None` | | Working directory inside the sandbox. |
+| `env` | `dict[str, str] \| None` | | Extra environment variables for this command. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for the command. |
+
+### `DaytonaPythonTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `str` | ✓ | Python source code to execute. |
+| `argv` | `list[str] \| None` | | Argument vector forwarded via `CodeRunParams`. |
+| `env` | `dict[str, str] \| None` | | Environment variables forwarded via `CodeRunParams`. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for execution. |
+
+### `DaytonaFileTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `str` | ✓ | One of: `read`, `write`, `append`, `list`, `delete`, `mkdir`, `info`. |
+| `path` | `str` | ✓ | Absolute path inside the sandbox. |
+| `content` | `str \| None` | | Content to write or append. Required for `append`. |
+| `binary` | `bool` | | If `True`, `content` is base64 on write; returns base64 on read. |
+| `recursive` | `bool` | | For `delete`: remove directories recursively. |
+| `mode` | `str` | | For `mkdir`: octal permission string (default `"0755"`). |
+
+<Tip>
+For files larger than a few KB, create the file first with `action="write"` and empty content, then send the body via multiple `action="append"` calls of ~4 KB each to stay within tool-call payload limits.
+</Tip>

--- a/docs/pt-BR/tools/ai-ml/daytona.mdx
+++ b/docs/pt-BR/tools/ai-ml/daytona.mdx
@@ -1,0 +1,180 @@
+---
+title: Daytona Sandbox Tools
+description: Run shell commands, execute Python, and manage files inside isolated [Daytona](https://www.daytona.io/) sandboxes.
+icon: box
+mode: "wide"
+---
+
+# Daytona Sandbox Tools
+
+## Description
+
+The Daytona sandbox tools give CrewAI agents access to isolated, ephemeral compute environments powered by [Daytona](https://www.daytona.io/). Three tools are available so you can give an agent exactly the capabilities it needs:
+
+- **`DaytonaExecTool`** — run any shell command inside a sandbox.
+- **`DaytonaPythonTool`** — execute a block of Python source code inside a sandbox.
+- **`DaytonaFileTool`** — read, write, append, list, delete, and inspect files inside a sandbox.
+
+All three tools share the same sandbox lifecycle controls, so you can mix and match them while keeping state in a single persistent sandbox.
+
+## Installation
+
+```shell
+uv add "crewai-tools[daytona]"
+# or
+pip install "crewai-tools[daytona]"
+```
+
+Set your API key:
+
+```shell
+export DAYTONA_API_KEY="your-api-key"
+```
+
+`DAYTONA_API_URL` and `DAYTONA_TARGET` are also respected if set.
+
+## Sandbox Lifecycle
+
+All three tools inherit lifecycle controls from `DaytonaBaseTool`:
+
+| Mode | How to enable | Sandbox created | Sandbox deleted |
+|------|--------------|-----------------|-----------------|
+| **Ephemeral** (default) | `persistent=False` (default) | On every `_run` call | At the end of that same call |
+| **Persistent** | `persistent=True` | Lazily on first use | At process exit (via `atexit`), or manually via `tool.close()` |
+| **Attach** | `sandbox_id="<id>"` | Never — attaches to an existing sandbox | Never — the tool will not delete a sandbox it did not create |
+
+Ephemeral mode is the safe default: nothing leaks if the agent forgets to clean up. Use persistent mode when you want filesystem state or installed packages to carry across multiple tool calls — this is typical when pairing `DaytonaFileTool` with `DaytonaExecTool`.
+
+## Examples
+
+### One-shot Python execution (ephemeral)
+
+```python Code
+from crewai_tools import DaytonaPythonTool
+
+tool = DaytonaPythonTool()
+result = tool.run(code="print(sum(range(10)))")
+print(result)
+# {"exit_code": 0, "result": "45\n", "artifacts": None}
+```
+
+### Multi-step shell session (persistent)
+
+```python Code
+from crewai_tools import DaytonaExecTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+# Install a package, then write and run a script — all in the same sandbox
+exec_tool.run(command="pip install httpx -q")
+file_tool.run(action="write", path="/workspace/fetch.py", content="import httpx; print(httpx.get('https://httpbin.org/get').status_code)")
+exec_tool.run(command="python /workspace/fetch.py")
+```
+
+<Note>
+Each tool instance maintains its own persistent sandbox. To share **one** sandbox across two tools, create the first tool, grab its sandbox id via `tool._persistent_sandbox.id`, and pass it to the second tool via `sandbox_id=...`.
+</Note>
+
+### Attach to an existing sandbox
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(sandbox_id="my-long-lived-sandbox")
+result = tool.run(command="ls /workspace")
+```
+
+### Custom sandbox parameters
+
+Pass Daytona's `CreateSandboxFromSnapshotParams` kwargs via `create_params`:
+
+```python Code
+from crewai_tools import DaytonaExecTool
+
+tool = DaytonaExecTool(
+    persistent=True,
+    create_params={
+        "language": "python",
+        "env_vars": {"MY_FLAG": "1"},
+        "labels": {"owner": "crewai-agent"},
+    },
+)
+```
+
+### Agent integration
+
+```python Code
+from crewai import Agent, Task, Crew
+from crewai_tools import DaytonaExecTool, DaytonaPythonTool, DaytonaFileTool
+
+exec_tool = DaytonaExecTool(persistent=True)
+python_tool = DaytonaPythonTool(persistent=True)
+file_tool = DaytonaFileTool(persistent=True)
+
+coder = Agent(
+    role="Sandbox Engineer",
+    goal="Write and run code in an isolated environment",
+    backstory="An engineer who uses Daytona sandboxes to safely execute code and manage files.",
+    tools=[exec_tool, python_tool, file_tool],
+    verbose=True,
+)
+
+task = Task(
+    description="Write a Python script that prints the first 10 Fibonacci numbers, save it to /workspace/fib.py, and run it.",
+    expected_output="The first 10 Fibonacci numbers printed to stdout.",
+    agent=coder,
+)
+
+crew = Crew(agents=[coder], tasks=[task])
+result = crew.kickoff()
+```
+
+## Parameters
+
+### Shared (`DaytonaBaseTool`)
+
+All three tools accept these parameters at initialization:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | `$DAYTONA_API_KEY` | Daytona API key. Falls back to the `DAYTONA_API_KEY` env var. |
+| `api_url` | `str \| None` | `$DAYTONA_API_URL` | Daytona API URL override. |
+| `target` | `str \| None` | `$DAYTONA_TARGET` | Daytona target region. |
+| `persistent` | `bool` | `False` | Reuse one sandbox across all calls and delete it at process exit. |
+| `sandbox_id` | `str \| None` | `None` | Attach to an existing sandbox by id or name. |
+| `create_params` | `dict \| None` | `None` | Extra kwargs forwarded to `CreateSandboxFromSnapshotParams` (e.g. `language`, `env_vars`, `labels`). |
+| `sandbox_timeout` | `float` | `60.0` | Timeout in seconds for sandbox create/delete operations. |
+
+### `DaytonaExecTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | `str` | ✓ | Shell command to execute. |
+| `cwd` | `str \| None` | | Working directory inside the sandbox. |
+| `env` | `dict[str, str] \| None` | | Extra environment variables for this command. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for the command. |
+
+### `DaytonaPythonTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `str` | ✓ | Python source code to execute. |
+| `argv` | `list[str] \| None` | | Argument vector forwarded via `CodeRunParams`. |
+| `env` | `dict[str, str] \| None` | | Environment variables forwarded via `CodeRunParams`. |
+| `timeout` | `int \| None` | | Maximum seconds to wait for execution. |
+
+### `DaytonaFileTool`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `str` | ✓ | One of: `read`, `write`, `append`, `list`, `delete`, `mkdir`, `info`. |
+| `path` | `str` | ✓ | Absolute path inside the sandbox. |
+| `content` | `str \| None` | | Content to write or append. Required for `append`. |
+| `binary` | `bool` | | If `True`, `content` is base64 on write; returns base64 on read. |
+| `recursive` | `bool` | | For `delete`: remove directories recursively. |
+| `mode` | `str` | | For `mkdir`: octal permission string (default `"0755"`). |
+
+<Tip>
+For files larger than a few KB, create the file first with `action="write"` and empty content, then send the body via multiple `action="append"` calls of ~4 KB each to stay within tool-call payload limits.
+</Tip>


### PR DESCRIPTION
## Summary

Adds full documentation for the Daytona sandbox tools introduced in #5530.

### What's included
- `docs/en/tools/ai-ml/daytona.mdx` — complete English doc covering:
  - Installation (`crewai-tools[daytona]`)
  - Tool lifecycle table (ephemeral / persistent / attach)
  - Examples: one-shot Python, multi-step persistent session, attach mode, custom `create_params`, full agent integration
  - Parameter reference tables for all three tools + shared base params
- Stub translations in `pt-BR/`, `ko/`, `ar/` (ready for native translation)
- `docs.json` nav updated across all 4 languages

### Related
Documents #5530

cc @lorenze

---
> Requested by: Joao Moura <joao@crewai.com>