### PR TITLE
security: fix critical arbitrary code execution vectors

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1536,14 +1536,15 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         agent_training_data = training_data.get(agent_id, {})
 
+        iteration_key = str(train_iteration)
         if human_feedback is not None:
-            agent_training_data[train_iteration] = {
+            agent_training_data[iteration_key] = {
                 "initial_output": result.output,
                 "human_feedback": human_feedback,
             }
         else:
-            if train_iteration in agent_training_data:
-                agent_training_data[train_iteration]["improved_output"] = result.output
+            if iteration_key in agent_training_data:
+                agent_training_data[iteration_key]["improved_output"] = result.output
             else:
                 if self.agent.verbose:
                     PRINTER.print(

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -37,7 +37,7 @@ from crewai.tools.structured_tool import (
     _serialize_schema,
     build_schema_hint,
 )
-from crewai.types.callback import SerializableCallable, _resolve_dotted_path
+from crewai.types.callback import SerializableCallable, _resolve_dotted_path, string_to_callable
 from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.string_utils import sanitize_tool_name
 
@@ -70,7 +70,7 @@ def _resolve_tool_dict(value: dict[str, Any]) -> Any:
         val = data.get(key)
         if isinstance(val, str):
             try:
-                data[key] = _resolve_dotted_path(val)
+                data[key] = string_to_callable(val)
             except (ValueError, ImportError):
                 data.pop(key)
 

--- a/lib/crewai/src/crewai/utilities/file_handler.py
+++ b/lib/crewai/src/crewai/utilities/file_handler.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import json
 import os
-import pickle
 from typing import Any, TypedDict
 
 from typing_extensions import Unpack
@@ -128,10 +127,10 @@ class FileHandler:
 
 
 class PickleHandler:
-    """Handler for saving and loading data using pickle.
+    """Handler for saving and loading data using JSON.
 
     Attributes:
-        file_path: The path to the pickle file.
+        file_path: The path to the data file.
     """
 
     def __init__(self, file_name: str) -> None:
@@ -153,17 +152,17 @@ class PickleHandler:
 
     def save(self, data: Any) -> None:
         """
-        Save the data to the specified file using pickle.
+        Save the data to the specified file using JSON.
 
         Args:
           data: The data to be saved to the file.
         """
         with store_lock(f"file:{os.path.realpath(self.file_path)}"):
-            with open(self.file_path, "wb") as f:
-                pickle.dump(obj=data, file=f)
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
 
     def load(self) -> Any:
-        """Load the data from the specified file using pickle.
+        """Load the data from the specified file using JSON.
 
         Returns:
             The data loaded from the file.
@@ -175,10 +174,8 @@ class PickleHandler:
             ):
                 return {}
 
-            with open(self.file_path, "rb") as file:
+            with open(self.file_path, "r", encoding="utf-8") as file:
                 try:
-                    return pickle.load(file)  # noqa: S301
-                except EOFError:
-                    return {}
+                    return json.load(file)
                 except Exception:
                     raise

--- a/lib/crewai/src/crewai/utilities/training_handler.py
+++ b/lib/crewai/src/crewai/utilities/training_handler.py
@@ -27,7 +27,7 @@ class CrewTrainingHandler(PickleHandler):
         data = self.load()
         if agent_id not in data:
             data[agent_id] = {}
-        data[agent_id][train_iteration] = new_data
+        data[agent_id][str(train_iteration)] = new_data
         self.save(data)
 
     def clear(self) -> None:

--- a/lib/crewai/tests/utilities/test_file_handler.py
+++ b/lib/crewai/tests/utilities/test_file_handler.py
@@ -45,5 +45,4 @@ class TestPickleHandler(unittest.TestCase):
         with pytest.raises(Exception) as exc:
             self.handler.load()
 
-        assert str(exc.value) == "pickle data was truncated"
-        assert "<class '_pickle.UnpicklingError'>" == str(exc.type)
+        assert "<class 'json.decoder.JSONDecodeError'>" == str(exc.type)

--- a/lib/crewai/tests/utilities/test_training_handler.py
+++ b/lib/crewai/tests/utilities/test_training_handler.py
@@ -39,10 +39,10 @@ class InternalCrewTrainingHandler(unittest.TestCase):
         # Assert that the new data is appended correctly to the existing agent
         data = self.handler.load()
         assert agent_id in data
-        assert initial_iteration in data[agent_id]
-        assert train_iteration in data[agent_id]
-        assert data[agent_id][initial_iteration] == initial_data
-        assert data[agent_id][train_iteration] == new_data
+        assert str(initial_iteration) in data[agent_id]
+        assert str(train_iteration) in data[agent_id]
+        assert data[agent_id][str(initial_iteration)] == initial_data
+        assert data[agent_id][str(train_iteration)] == new_data
 
     def test_append_new_agent(self):
         train_iteration = 1
@@ -52,4 +52,4 @@ class InternalCrewTrainingHandler(unittest.TestCase):
 
         # Assert that the new agent and data are appended correctly
         data = self.handler.load()
-        assert data[agent_id][train_iteration] == new_data
+        assert data[agent_id][str(train_iteration)] == new_data


### PR DESCRIPTION
## Summary

Fixes two [Critical] security findings from the 2026-04-28 AI Tooling Security Audit:

1. **Arbitrary code execution via pickle deserialization** (`lib/crewai/src/crewai/utilities/file_handler.py:180`)
   - Replaced `pickle.load()` / `pickle.dump()` with `json.load()` / `json.dump()` in `PickleHandler`.
   - Training data iteration keys are normalized to strings for JSON compatibility.
   - Removes the RCE surface entirely — JSON cannot execute arbitrary code during deserialization.

2. **Arbitrary code execution via tool `cache_function` dotted-path resolution** (`lib/crewai/src/crewai/tools/base_tool.py:69-73`)
   - Changed `_resolve_tool_dict` to use `string_to_callable()` instead of calling `_resolve_dotted_path()` directly.
   - This enforces the existing `CREWAI_DESERIALIZE_CALLBACKS` environment-variable guard, which was previously bypassed during tool dict deserialization.

## Files changed

- `lib/crewai/src/crewai/utilities/file_handler.py`
- `lib/crewai/src/crewai/utilities/training_handler.py`
- `lib/crewai/src/crewai/tools/base_tool.py`
- `lib/crewai/src/crewai/agents/crew_agent_executor.py`
- `lib/crewai/tests/utilities/test_file_handler.py`
- `lib/crewai/tests/utilities/test_training_handler.py`

## Test results

All 73 tests in the affected test suites pass:
- `lib/crewai/tests/utilities/test_file_handler.py`
- `lib/crewai/tests/utilities/test_training_handler.py`
- `lib/crewai/tests/tools/test_base_tool.py`
- `lib/crewai/tests/test_callback.py`