### PR TITLE
fix(llm): use validated messages variable in non-streaming handlers

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1160,7 +1160,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
                 usage=None,
             )
             return structured_response
@@ -1316,7 +1316,7 @@ class LLM(BaseLLM):
                 call_type=LLMCallType.LLM_CALL,
                 from_task=from_task,
                 from_agent=from_agent,
-                messages=params["messages"],
+                messages=messages,
                 usage=None,
             )
             return structured_response


### PR DESCRIPTION
## Summary
- In `_handle_non_streaming_response` and `_ahandle_non_streaming_response`, the `response_model` + litellm path validates `messages` via `params.get("messages", [])` and raises a clear `ValueError` if missing, but then re-indexes `params["messages"]` a few lines later when calling `_handle_emit_call_events` — which would raise a confusing `KeyError` instead.
- Use the already-validated local `messages` variable in both call sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to event payload wiring in the non-streaming `response_model` path; no changes to completion behavior or data processing.
> 
> **Overview**
> Fixes event emission in `_handle_non_streaming_response` and `_ahandle_non_streaming_response` when `response_model` is used with the LiteLLM path.
> 
> Instead of re-indexing `params["messages"]` (which could raise a `KeyError` despite earlier validation), the code now passes the already-validated local `messages` variable into `_handle_emit_call_events`, preserving the intended `ValueError` for missing messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d029bca162c311fd6e9a92ff8ccaeb5fd3a5c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->