### PR TITLE
feat(tools): Add PerplexitySearchTool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -140,6 +140,9 @@ from crewai_tools.tools.patronus_eval_tool.patronus_predefined_criteria_eval_too
     PatronusPredefinedCriteriaEvalTool,
 )
 from crewai_tools.tools.pdf_search_tool.pdf_search_tool import PDFSearchTool
+from crewai_tools.tools.perplexity_tools.perplexity_search_tool import (
+    PerplexitySearchTool,
+)
 from crewai_tools.tools.qdrant_vector_search_tool.qdrant_search_tool import (
     QdrantVectorSearchTool,
 )
@@ -290,6 +293,7 @@ __all__ = [
     "PatronusEvalTool",
     "PatronusLocalEvaluatorTool",
     "PatronusPredefinedCriteriaEvalTool",
+    "PerplexitySearchTool",
     "QdrantVectorSearchTool",
     "RagTool",
     "S3ReaderTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -128,6 +128,7 @@ from crewai_tools.tools.patronus_eval_tool import (
     PatronusPredefinedCriteriaEvalTool,
 )
 from crewai_tools.tools.pdf_search_tool.pdf_search_tool import PDFSearchTool
+from crewai_tools.tools.perplexity_tools import PerplexitySearchTool
 from crewai_tools.tools.qdrant_vector_search_tool.qdrant_search_tool import (
     QdrantVectorSearchTool,
 )
@@ -274,6 +275,7 @@ __all__ = [
     "PatronusEvalTool",
     "PatronusLocalEvaluatorTool",
     "PatronusPredefinedCriteriaEvalTool",
+    "PerplexitySearchTool",
     "QdrantVectorSearchTool",
     "RagTool",
     "ScrapeElementFromWebsiteTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/README.md
@@ -1,0 +1,106 @@
+# PerplexitySearchTool
+
+Search the web with Perplexity's Search API. Returns a ranked list of web
+results (title, URL, snippet, date) for a given query, suitable for grounding
+LLM answers.
+
+- **Quickstart**: [Search API Quickstart](https://docs.perplexity.ai/docs/search/quickstart)
+- **API reference**: [Search API reference](https://docs.perplexity.ai/api-reference/search-post)
+- **Domain filters**: [Domain filter docs](https://docs.perplexity.ai/docs/search/filters/domain-filter)
+- **Recency filters**: [Date/time filter docs](https://docs.perplexity.ai/docs/search/filters/date-time-filters)
+
+## Why this tool
+
+- **Ranked web results**: A direct line to Perplexity's web index, returning
+  ranked results with titles, URLs, snippets, and dates.
+- **Filterable**: Restrict results by domain (allow OR deny) and by recency
+  window.
+- **No model coupling**: This is the Search API, not chat — useful as a search
+  primitive for any agent or RAG pipeline.
+
+## Environment
+
+- `PERPLEXITY_API_KEY` (required) — also accepts `PPLX_API_KEY`. Get a key at
+  https://www.perplexity.ai/account/api/keys.
+
+## Parameters
+
+- `query` (str, required): The search query.
+- `max_results` (int, default `5`): Maximum number of results to return.
+- `search_domain_filter` (list[str], optional): Allow- or deny-list of domains.
+  Prefix with `-` to exclude (e.g. `"-pinterest.com"`). Do not mix allow and
+  deny entries in the same list.
+- `search_recency_filter` (str, optional): One of `"hour"`, `"day"`, `"week"`,
+  `"month"`, `"year"`.
+
+## Direct usage
+
+```python
+from crewai_tools import PerplexitySearchTool
+
+tool = PerplexitySearchTool()
+output = tool.run(
+    query="When was the United Nations established?",
+    max_results=5,
+    search_domain_filter=["un.org"],
+    search_recency_filter="year",
+)
+print(output)
+```
+
+The tool returns a numbered, human-readable string of results. Each entry
+includes title, URL, optional date, and snippet.
+
+## Example with an agent
+
+```python
+import os
+from crewai import Agent, Task, Crew, LLM, Process
+from crewai_tools import PerplexitySearchTool
+
+llm = LLM(
+    model="gemini/gemini-2.0-flash",
+    temperature=0.5,
+    api_key=os.getenv("GEMINI_API_KEY"),
+)
+
+search = PerplexitySearchTool()
+
+researcher = Agent(
+    role="Web Researcher",
+    backstory="You are an expert web researcher.",
+    goal="Find cited, high-quality sources and provide a brief answer.",
+    tools=[search],
+    llm=llm,
+    verbose=True,
+)
+
+task = Task(
+    description="Research recent advances in retrieval-augmented generation and produce a short, cited answer.",
+    expected_output="A concise, sourced answer with URLs.",
+    agent=researcher,
+)
+
+crew = Crew(
+    agents=[researcher],
+    tasks=[task],
+    verbose=True,
+    process=Process.sequential,
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Behavior
+
+- Single-request web search; no scraping or post-processing needed.
+- Returns ranked `results` with `title`, `url`, `snippet`, and optional `date`.
+- Clear error handling on HTTP errors and timeouts.
+
+## References
+
+- Search API quickstart: https://docs.perplexity.ai/docs/search/quickstart
+- Search API reference: https://docs.perplexity.ai/api-reference/search-post
+- Domain filter: https://docs.perplexity.ai/docs/search/filters/domain-filter
+- Recency/date filter: https://docs.perplexity.ai/docs/search/filters/date-time-filters

--- a/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/__init__.py
@@ -1,0 +1,8 @@
+from crewai_tools.tools.perplexity_tools.perplexity_search_tool import (
+    PerplexitySearchTool,
+)
+
+
+__all__ = [
+    "PerplexitySearchTool",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/perplexity_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/perplexity_search_tool.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Literal
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+import requests
+
+
+class PerplexitySearchInput(BaseModel):
+    """Input schema for PerplexitySearchTool using Perplexity's Search API."""
+
+    query: str = Field(
+        ...,
+        description="The search query to send to Perplexity's Search API.",
+    )
+    max_results: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum number of search results to return.",
+    )
+    search_domain_filter: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional list of domains to allow or deny. Prefix a domain with '-' "
+            "to exclude it (e.g. '-pinterest.com'). Do not mix allow and deny in "
+            "the same list."
+        ),
+    )
+    search_recency_filter: Literal["hour", "day", "week", "month", "year"] | None = (
+        Field(
+            default=None,
+            description="Restrict results to a recency window.",
+        )
+    )
+
+
+class PerplexitySearchTool(BaseTool):
+    """Search the web with Perplexity's Search API.
+
+    Returns ranked web results (title, url, snippet, date) suitable for
+    grounding LLM answers.
+    """
+
+    name: str = "Perplexity Search"
+    description: str = (
+        "Search the web using Perplexity's Search API. Returns a ranked list of "
+        "web results (title, URL, snippet, date) for a given query. Supports "
+        "optional domain and recency filters."
+    )
+    args_schema: type[BaseModel] = PerplexitySearchInput
+
+    api_key: str | None = Field(
+        default=None,
+        description="API key for Perplexity. Falls back to PERPLEXITY_API_KEY / PPLX_API_KEY.",
+    )
+    search_url: str = "https://api.perplexity.ai/search"
+
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="PERPLEXITY_API_KEY",
+                description="API key for Perplexity",
+                required=True,
+            ),
+        ]
+    )
+    package_dependencies: list[str] = Field(default_factory=lambda: ["requests"])
+
+    def _resolve_api_key(self) -> str | None:
+        return (
+            self.api_key
+            or os.environ.get("PERPLEXITY_API_KEY")
+            or os.environ.get("PPLX_API_KEY")
+        )
+
+    def _run(
+        self,
+        query: str,
+        max_results: int = 5,
+        search_domain_filter: list[str] | None = None,
+        search_recency_filter: str | None = None,
+        **_: Any,
+    ) -> str:
+        api_key = self._resolve_api_key()
+        if not api_key:
+            return (
+                "Error: PERPLEXITY_API_KEY (or PPLX_API_KEY) environment variable "
+                "is required."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload: dict[str, Any] = {
+            "query": query,
+            "max_results": max_results,
+        }
+        if search_domain_filter:
+            payload["search_domain_filter"] = search_domain_filter
+        if search_recency_filter:
+            payload["search_recency_filter"] = search_recency_filter
+
+        try:
+            resp = requests.post(
+                self.search_url, json=payload, headers=headers, timeout=30
+            )
+        except requests.Timeout:
+            return "Perplexity Search API timeout. Please try again later."
+        except requests.RequestException as exc:
+            return f"Unexpected error calling Perplexity Search API: {exc}"
+
+        if resp.status_code >= 300:
+            return f"Perplexity Search API error: {resp.status_code} {resp.text[:200]}"
+
+        try:
+            data = resp.json()
+        except ValueError:
+            return (
+                f"Perplexity Search API returned non-JSON response: {resp.text[:200]}"
+            )
+
+        return self._format_results(data)
+
+    @staticmethod
+    def _format_results(data: dict[str, Any]) -> str:
+        results = data.get("results") or []
+        if not results:
+            return json.dumps(data or {}, ensure_ascii=False)
+
+        lines: list[str] = []
+        for idx, item in enumerate(results, start=1):
+            title = item.get("title") or "(no title)"
+            url = item.get("url") or ""
+            snippet = item.get("snippet") or ""
+            date = item.get("date")
+            header = f"{idx}. {title}\n   {url}"
+            if date:
+                header += f"\n   Date: {date}"
+            if snippet:
+                header += f"\n   {snippet}"
+            lines.append(header)
+        return "\n\n".join(lines)

--- a/lib/crewai-tools/tests/tools/test_perplexity_search_tool.py
+++ b/lib/crewai-tools/tests/tools/test_perplexity_search_tool.py
@@ -1,0 +1,116 @@
+from unittest.mock import patch
+
+from crewai_tools.tools.perplexity_tools.perplexity_search_tool import (
+    PerplexitySearchTool,
+)
+
+
+def test_requires_env_var(monkeypatch):
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.delenv("PPLX_API_KEY", raising=False)
+    tool = PerplexitySearchTool()
+    result = tool.run(query="test")
+    assert "PERPLEXITY_API_KEY" in result
+
+
+def test_accepts_pplx_api_key_alias(monkeypatch):
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.setenv("PPLX_API_KEY", "test-alias")
+
+    with patch(
+        "crewai_tools.tools.perplexity_tools.perplexity_search_tool.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"id": "x", "results": []}
+
+        tool = PerplexitySearchTool()
+        tool.run(query="hello")
+
+        assert mock_post.called
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer test-alias"
+
+
+@patch("crewai_tools.tools.perplexity_tools.perplexity_search_tool.requests.post")
+def test_happy_path_formats_results(mock_post, monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test")
+
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "id": "search_123",
+        "results": [
+            {
+                "title": "History of the United Nations",
+                "url": "https://www.un.org/en/about-us/history-of-the-un",
+                "snippet": "The United Nations officially began on 24 October 1945.",
+                "date": "1945-10-24",
+            },
+            {
+                "title": "UN Charter",
+                "url": "https://www.un.org/en/about-us/un-charter",
+                "snippet": "Founding document of the UN.",
+            },
+        ],
+    }
+
+    tool = PerplexitySearchTool()
+    result = tool.run(
+        query="When was the UN established?",
+        max_results=2,
+        search_recency_filter="year",
+    )
+
+    assert "1. History of the United Nations" in result
+    assert "https://www.un.org/en/about-us/history-of-the-un" in result
+    assert "Date: 1945-10-24" in result
+    assert "2. UN Charter" in result
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["query"] == "When was the UN established?"
+    assert payload["max_results"] == 2
+    assert payload["search_recency_filter"] == "year"
+    assert "search_domain_filter" not in payload
+
+
+@patch("crewai_tools.tools.perplexity_tools.perplexity_search_tool.requests.post")
+def test_passes_domain_filter(mock_post, monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test")
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"results": []}
+
+    tool = PerplexitySearchTool()
+    tool.run(
+        query="legal docs",
+        search_domain_filter=["nytimes.com", "-pinterest.com"],
+    )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["search_domain_filter"] == ["nytimes.com", "-pinterest.com"]
+
+
+@patch("crewai_tools.tools.perplexity_tools.perplexity_search_tool.requests.post")
+def test_http_error_returned_as_string(mock_post, monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test")
+    mock_post.return_value.status_code = 401
+    mock_post.return_value.text = "unauthorized"
+
+    tool = PerplexitySearchTool()
+    result = tool.run(query="hello")
+    assert "401" in result
+    assert "Perplexity Search API error" in result
+
+
+def test_explicit_api_key_overrides_env(monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "from-env")
+
+    with patch(
+        "crewai_tools.tools.perplexity_tools.perplexity_search_tool.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"results": []}
+
+        tool = PerplexitySearchTool(api_key="explicit")
+        tool.run(query="hi")
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer explicit"

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -18235,6 +18235,143 @@
       }
     },
     {
+      "description": "Search the web using Perplexity's Search API. Returns a ranked list of web results (title, URL, snippet, date) for a given query. Supports optional domain and recency filters.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for Perplexity",
+          "name": "PERPLEXITY_API_KEY",
+          "required": true
+        }
+      ],
+      "humanized_name": "Perplexity Search",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "description": "Search the web with Perplexity's Search API.\n\nReturns ranked web results (title, url, snippet, date) suitable for\ngrounding LLM answers.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "API key for Perplexity. Falls back to PERPLEXITY_API_KEY / PPLX_API_KEY.",
+            "title": "Api Key"
+          },
+          "search_url": {
+            "default": "https://api.perplexity.ai/search",
+            "title": "Search Url",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "title": "PerplexitySearchTool",
+        "type": "object"
+      },
+      "name": "PerplexitySearchTool",
+      "package_dependencies": [
+        "requests"
+      ],
+      "run_params_schema": {
+        "description": "Input schema for PerplexitySearchTool using Perplexity's Search API.",
+        "properties": {
+          "max_results": {
+            "default": 5,
+            "description": "Maximum number of search results to return.",
+            "minimum": 1,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "query": {
+            "description": "The search query to send to Perplexity's Search API.",
+            "title": "Query",
+            "type": "string"
+          },
+          "search_domain_filter": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional list of domains to allow or deny. Prefix a domain with '-' to exclude it (e.g. '-pinterest.com'). Do not mix allow and deny in the same list.",
+            "title": "Search Domain Filter"
+          },
+          "search_recency_filter": {
+            "anyOf": [
+              {
+                "enum": [
+                  "hour",
+                  "day",
+                  "week",
+                  "month",
+                  "year"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Restrict results to a recency window.",
+            "title": "Search Recency Filter"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "PerplexitySearchInput",
+        "type": "object"
+      }
+    },
+    {
       "description": "Search Qdrant vector DB for relevant documents.",
       "env_vars": [
         {


### PR DESCRIPTION
## Summary

Adds a native `PerplexitySearchTool` to `crewai-tools`, bringing Perplexity's Search API into parity with existing first-party search integrations (`EXASearchTool`, `TavilySearchTool`, `ParallelSearchTool`).

Refs #245, #2314.

## What's added

- `lib/crewai-tools/src/crewai_tools/tools/perplexity_tools/`
  - `perplexity_search_tool.py` — `PerplexitySearchTool` (BaseTool) wrapping `POST https://api.perplexity.ai/search`
  - `__init__.py` exporting `PerplexitySearchTool`
  - `README.md` — usage docs (mirrors `parallel_tools/README.md`)
- Registered in `lib/crewai-tools/src/crewai_tools/__init__.py` and `tools/__init__.py`
- `lib/crewai-tools/tests/tools/test_perplexity_search_tool.py` — six tests using `unittest.mock.patch` (mirrors `parallel_search_tool_test.py`)
- Regenerated `lib/crewai-tools/tool.specs.json` via `python -m crewai_tools.generate_tool_specs`

## Tool surface

- **Name:** `Perplexity Search`
- **Inputs (pydantic):**
  - `query: str` (required)
  - `max_results: int = 5`
  - `search_domain_filter: list[str] | None` (allow- or deny-list, prefix `-` to exclude)
  - `search_recency_filter: Literal["hour","day","week","month","year"] | None`
- **Auth:** `PERPLEXITY_API_KEY` env var (also accepts `PPLX_API_KEY`); explicit `api_key` constructor argument overrides env
- **Output:** numbered, human-readable string with title / URL / optional date / snippet per result, similar in spirit to what `EXASearchTool` returns to the agent

Endpoint and parameters follow the public Search API reference: https://docs.perplexity.ai/api-reference/search-post

## Implementation notes

Followed the `ParallelSearchTool` style (raw `requests` against the HTTP API) rather than pulling in an additional SDK dependency — the Search API has a small, stable surface and this keeps `requests` (already a top-level dep) as the only requirement. Errors and timeouts are returned as readable strings rather than raised, consistent with the existing pattern.

## Testing

```
cd lib/crewai-tools
uv run pytest tests/tools/test_perplexity_search_tool.py -v
```

All 6 tests pass:
- `test_requires_env_var`
- `test_accepts_pplx_api_key_alias`
- `test_happy_path_formats_results`
- `test_passes_domain_filter`
- `test_http_error_returned_as_string`
- `test_explicit_api_key_overrides_env`

Also ran `uv run ruff check` and `uv run ruff format --check` on the new files — clean.