### PR TITLE
docs: fix two "the the" typos in crewai-tools READMEs

### DIFF
--- a/lib/crewai-tools/README.md
+++ b/lib/crewai-tools/README.md
@@ -83,7 +83,7 @@ To quickly get started with MCP in CrewAI you have 2 options:
 
 ### Option 1: Fully managed connection
 
-In this scenario we use a contextmanager (`with` statement) to start and stop the the connection with the MCP server.
+In this scenario we use a contextmanager (`with` statement) to start and stop the connection with the MCP server.
 This is done in the background and you only get to interact with the CrewAI tools corresponding to the MCP server's tools.
 
 For an STDIO based MCP server:

--- a/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/README.md
+++ b/lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/README.md
@@ -123,7 +123,7 @@ async def main():
 
     # Create tasks for the agents
     navigation_task = Task(
-        description="Navigate to https://example.com, then click on the the 'More information...' link.",
+        description="Navigate to https://example.com, then click on the 'More information...' link.",
         expected_output="The status of the tool calls for this task.",
         agent=navigator_agent,
     )


### PR DESCRIPTION
## Summary

Two duplicate-word typos found in `lib/crewai-tools/` README files:

| File | Before | After |
|------|--------|-------|
| `lib/crewai-tools/README.md` (line 86) | `start and stop the the connection with the MCP server` | `start and stop the connection with the MCP server` |
| `lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/README.md` (line 126) | `click on the the 'More information...' link` | `click on the 'More information...' link` |

Pure prose-quality fix in two README files. No code, API, or runtime behaviour change.

## Why

Both files appear in user-facing READMEs that ship inside the `crewai-tools` package and on GitHub. The duplicate `the the` reads awkwardly and is the kind of nit that PR reviewers usually catch but slipped through here.

## How to test

```bash
grep -rn "the the" lib/crewai-tools/README.md lib/crewai-tools/src/crewai_tools/aws/bedrock/browser/README.md
# returns no matches after this PR
```

No tests, builds, or runtime behaviour are affected.