### PR TITLE
fix(converter): fall through when JSON regex match isn't valid JSON

### DIFF
--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -256,13 +256,23 @@ def handle_partial_json(
     """
     match = _JSON_PATTERN.search(result)
     if match:
+        candidate = match.group()
         try:
-            exported_result = model.model_validate_json(match.group())
+            json.loads(candidate)
+        except json.JSONDecodeError:
+            return convert_with_instructions(
+                result=result,
+                model=model,
+                is_json_output=is_json_output,
+                agent=agent,
+                converter_cls=converter_cls,
+            )
+
+        try:
+            exported_result = model.model_validate_json(candidate)
             if is_json_output:
                 return exported_result.model_dump()
             return exported_result
-        except json.JSONDecodeError:
-            pass
         except ValidationError:
             raise
         except Exception as e:

--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -256,9 +256,8 @@ def handle_partial_json(
     """
     match = _JSON_PATTERN.search(result)
     if match:
-        candidate = match.group()
         try:
-            json.loads(candidate)
+            parsed = json.loads(match.group())
         except json.JSONDecodeError:
             return convert_with_instructions(
                 result=result,
@@ -269,7 +268,7 @@ def handle_partial_json(
             )
 
         try:
-            exported_result = model.model_validate_json(candidate)
+            exported_result = model.model_validate(parsed)
             if is_json_output:
                 return exported_result.model_dump()
             return exported_result

--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -257,7 +257,7 @@ def handle_partial_json(
     match = _JSON_PATTERN.search(result)
     if match:
         try:
-            parsed = json.loads(match.group())
+            parsed = json.loads(match.group(), strict=False)
         except json.JSONDecodeError:
             return convert_with_instructions(
                 result=result,

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -177,6 +177,23 @@ def test_handle_partial_json_with_invalid_partial(mock_agent: Mock) -> None:
         assert output == "Converted result"
 
 
+def test_handle_partial_json_falls_through_for_non_json_curly_blocks(
+    mock_agent: Mock,
+) -> None:
+    """A regex match that is not actually JSON (e.g. GraphQL) must fall through
+    to convert_with_instructions instead of raising a ValidationError.
+    """
+    result = (
+        "type Query {\n  countries: [Country]\n}\n\n"
+        "type Country {\n  code: String\n  name: String\n}"
+    )
+    with patch("crewai.utilities.converter.convert_with_instructions") as mock_convert:
+        mock_convert.return_value = "Converted result"
+        output = handle_partial_json(result, SimpleModel, False, mock_agent)
+        assert output == "Converted result"
+        mock_convert.assert_called_once()
+
+
 # Tests for convert_with_instructions
 @patch("crewai.utilities.converter.create_converter")
 @patch("crewai.utilities.converter.get_conversion_instructions")

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -177,6 +177,17 @@ def test_handle_partial_json_with_invalid_partial(mock_agent: Mock) -> None:
         assert output == "Converted result"
 
 
+def test_handle_partial_json_accepts_literal_control_chars_in_strings() -> None:
+    """JSON values with literal newlines/tabs (lenient parsing) must still
+    validate, matching the prior model_validate_json behavior.
+    """
+    result = 'prefix {"name": "Charlie\nDoe", "age": 35} suffix'
+    output = handle_partial_json(result, SimpleModel, False, None)
+    assert isinstance(output, SimpleModel)
+    assert output.name == "Charlie\nDoe"
+    assert output.age == 35
+
+
 def test_handle_partial_json_falls_through_for_non_json_curly_blocks(
     mock_agent: Mock,
 ) -> None:


### PR DESCRIPTION
Closes #5460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core output parsing behavior; misclassification of JSON vs non-JSON blocks could change when the system validates directly vs invoking LLM-based conversion.
> 
> **Overview**
> `handle_partial_json` now first attempts a lenient `json.loads(..., strict=False)` on the regex-extracted `{...}` block and **falls back to `convert_with_instructions`** when that block isn’t valid JSON, instead of surfacing a Pydantic validation error for non-JSON curly-brace content.
> 
> Tests were added to lock in behavior for *literal control characters* in JSON strings (lenient parsing) and to ensure non-JSON curly blocks (e.g., GraphQL snippets) reliably trigger the fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25374176fec9c7ddfa43a489f37d235b535f2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->