### PR TITLE
fix: suppress disabled tracing status nags

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -2265,7 +2265,6 @@ class Crew(FlowTrackable, BaseModel):
     def _show_tracing_disabled_message() -> None:
         """Show a message when tracing is disabled."""
         from crewai.events.listeners.tracing.utils import (
-            has_user_declined_tracing,
             should_suppress_tracing_messages,
         )
 
@@ -2274,15 +2273,7 @@ class Crew(FlowTrackable, BaseModel):
 
         console = Console()
 
-        if has_user_declined_tracing():
-            message = """Info: Tracing is disabled.
-
-To enable tracing, do any one of these:
-• Set tracing=True in your Crew code
-• Set CREWAI_TRACING_ENABLED=true in your project's .env file
-• Run: crewai traces enable"""
-        else:
-            message = """Info: Tracing is disabled.
+        message = """Info: Tracing is disabled.
 
 To enable tracing, do any one of these:
 • Set tracing=True in your Crew code

--- a/lib/crewai/src/crewai/events/listeners/tracing/trace_listener.py
+++ b/lib/crewai/src/crewai/events/listeners/tracing/trace_listener.py
@@ -892,7 +892,6 @@ class TraceCollectionListener(BaseEventListener):
         from rich.panel import Panel
 
         from crewai.events.listeners.tracing.utils import (
-            has_user_declined_tracing,
             should_suppress_tracing_messages,
         )
 
@@ -901,15 +900,7 @@ class TraceCollectionListener(BaseEventListener):
 
         console = Console()
 
-        if has_user_declined_tracing():
-            message = """Info: Tracing is disabled.
-
-To enable tracing, do any one of these:
-• Set tracing=True in your Crew/Flow code
-• Set CREWAI_TRACING_ENABLED=true in your project's .env file
-• Run: crewai traces enable"""
-        else:
-            message = """Info: Tracing is disabled.
+        message = """Info: Tracing is disabled.
 
 To enable tracing, do any one of these:
 • Set tracing=True in your Crew/Flow code

--- a/lib/crewai/src/crewai/events/listeners/tracing/utils.py
+++ b/lib/crewai/src/crewai/events/listeners/tracing/utils.py
@@ -37,6 +37,9 @@ _suppress_tracing_messages: ContextVar[bool] = ContextVar(
     "_suppress_tracing_messages", default=False
 )
 
+_SUPPRESS_TRACING_MESSAGES_ENV_VAR = "CREWAI_SUPPRESS_TRACING_MESSAGES"
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
 
 def set_suppress_tracing_messages(suppress: bool) -> object:
     """Set whether to suppress tracing-related console messages.
@@ -56,7 +59,12 @@ def should_suppress_tracing_messages() -> bool:
     Returns:
         True if messages should be suppressed, False otherwise.
     """
-    return _suppress_tracing_messages.get()
+    env_value = os.getenv(_SUPPRESS_TRACING_MESSAGES_ENV_VAR, "").strip().lower()
+    return (
+        _suppress_tracing_messages.get()
+        or env_value in _TRUTHY_ENV_VALUES
+        or has_user_declined_tracing()
+    )
 
 
 def should_enable_tracing(*, override: bool | None = None) -> bool:

--- a/lib/crewai/src/crewai/events/utils/console_formatter.py
+++ b/lib/crewai/src/crewai/events/utils/console_formatter.py
@@ -131,7 +131,6 @@ To update, run: uv sync --upgrade-package crewai"""
             TraceCollectionListener,
         )
         from crewai.events.listeners.tracing.utils import (
-            has_user_declined_tracing,
             is_tracing_enabled_in_context,
             should_suppress_tracing_messages,
         )
@@ -146,15 +145,7 @@ To update, run: uv sync --upgrade-package crewai"""
             return
 
         if not is_tracing_enabled_in_context():
-            if has_user_declined_tracing():
-                message = """Info: Tracing is disabled.
-
-To enable tracing, do any one of these:
-• Set tracing=True in your Crew/Flow code
-• Set CREWAI_TRACING_ENABLED=true in your project's .env file
-• Run: crewai traces enable"""
-            else:
-                message = """Info: Tracing is disabled.
+            message = """Info: Tracing is disabled.
 
 To enable tracing, do any one of these:
 • Set tracing=True in your Crew/Flow code

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -66,7 +66,6 @@ from crewai.events.listeners.tracing.trace_listener import (
     TraceCollectionListener,
 )
 from crewai.events.listeners.tracing.utils import (
-    has_user_declined_tracing,
     set_tracing_enabled,
     should_enable_tracing,
     should_suppress_tracing_messages,
@@ -3612,15 +3611,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
 
         console = Console()
 
-        if has_user_declined_tracing():
-            message = """Info: Tracing is disabled.
-
-To enable tracing, do any one of these:
-• Set tracing=True in your Flow code
-• Set CREWAI_TRACING_ENABLED=true in your project's .env file
-• Run: crewai traces enable"""
-        else:
-            message = """Info: Tracing is disabled.
+        message = """Info: Tracing is disabled.
 
 To enable tracing, do any one of these:
 • Set tracing=True in your Flow code

--- a/lib/crewai/tests/tracing/test_trace_enable_disable.py
+++ b/lib/crewai/tests/tracing/test_trace_enable_disable.py
@@ -3,9 +3,30 @@
 VCR will record HTTP interactions. Inspect cassettes to verify tracing behavior.
 """
 
+from unittest.mock import patch
+
 import pytest
 from crewai import Agent, Crew, Task
+from crewai.events.listeners.tracing.utils import (
+    should_suppress_tracing_messages,
+)
 from tests.utils import wait_for_event_handlers
+
+
+def test_should_suppress_tracing_messages_via_env(monkeypatch):
+    monkeypatch.setenv("CREWAI_SUPPRESS_TRACING_MESSAGES", "true")
+
+    assert should_suppress_tracing_messages() is True
+
+
+def test_should_suppress_tracing_messages_when_user_declined(monkeypatch):
+    monkeypatch.delenv("CREWAI_SUPPRESS_TRACING_MESSAGES", raising=False)
+
+    with patch(
+        "crewai.events.listeners.tracing.utils._load_user_data",
+        return_value={"first_execution_done": True, "trace_consent": False},
+    ):
+        assert should_suppress_tracing_messages() is True
 
 
 class TestTraceEnableDisable:


### PR DESCRIPTION
## Summary
- Treat an explicit tracing opt-out as a request to suppress the repeated disabled-tracing status panel
- Add CREWAI_SUPPRESS_TRACING_MESSAGES as an explicit non-interactive escape hatch for disabled-tracing messages
- Collapse the duplicated declined/not-declined message branches so all callers share the same suppression path

Fixes #5665

## Validation
- uv run ruff check lib/crewai/src/crewai/events/listeners/tracing/utils.py lib/crewai/src/crewai/crew.py lib/crewai/src/crewai/flow/flow.py lib/crewai/src/crewai/events/listeners/tracing/trace_listener.py lib/crewai/src/crewai/events/utils/console_formatter.py lib/crewai/tests/tracing/test_trace_enable_disable.py
- uv run pytest lib/crewai/tests/tracing/test_trace_enable_disable.py -q