### PR TITLE
fix(task): use async output conversion in async execution

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -53,7 +53,7 @@ from crewai.tasks.task_output import TaskOutput
 from crewai.tools.base_tool import BaseTool
 from crewai.utilities.config import process_config
 from crewai.utilities.constants import NOT_SPECIFIED, _NotSpecified
-from crewai.utilities.converter import Converter, convert_to_model
+from crewai.utilities.converter import Converter, aconvert_to_model, convert_to_model
 from crewai.utilities.file_store import (
     clear_task_files,
     get_all_files,
@@ -681,7 +681,7 @@ class Task(BaseModel):
                     json_output = None
             elif not self._guardrails and not self._guardrail:
                 raw = result
-                pydantic_output, json_output = self._export_output(result)
+                pydantic_output, json_output = await self._aexport_output(result)
             else:
                 raw = result
                 pydantic_output, json_output = None, None
@@ -1136,6 +1136,33 @@ Follow these guidelines:
 
         return pydantic_output, json_output
 
+    async def _aexport_output(
+        self, result: str
+    ) -> tuple[BaseModel | None, dict[str, Any] | None]:
+        pydantic_output: BaseModel | None = None
+        json_output: dict[str, Any] | None = None
+
+        if self.output_pydantic or self.output_json:
+            model_output = await aconvert_to_model(
+                result,
+                self.output_pydantic,
+                self.output_json,
+                self.agent,
+                self.converter_cls,
+            )
+
+            if isinstance(model_output, BaseModel):
+                pydantic_output = model_output
+            elif isinstance(model_output, dict):
+                json_output = model_output
+            elif isinstance(model_output, str):
+                try:
+                    json_output = json.loads(model_output)
+                except json.JSONDecodeError:
+                    json_output = None
+
+        return pydantic_output, json_output
+
     def _get_output_format(self) -> OutputFormat:
         if self.output_json:
             return OutputFormat.JSON
@@ -1364,7 +1391,7 @@ Follow these guidelines:
 
                 if isinstance(guardrail_result.result, str):
                     task_output.raw = guardrail_result.result
-                    pydantic_output, json_output = self._export_output(
+                    pydantic_output, json_output = await self._aexport_output(
                         guardrail_result.result
                     )
                     task_output.pydantic = pydantic_output
@@ -1421,7 +1448,7 @@ Follow these guidelines:
                     json_output = None
             else:
                 raw = result
-                pydantic_output, json_output = self._export_output(result)
+                pydantic_output, json_output = await self._aexport_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,

--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Final, TypedDict
@@ -40,6 +42,15 @@ class ConverterError(Exception):
 
 class Converter(OutputConverter):
     """Class that converts text into either pydantic or json."""
+
+    async def _call_llm_async(self, *args: Any, **kwargs: Any) -> Any:
+        acall = getattr(self.llm, "acall", None)
+        if callable(acall):
+            response = acall(*args, **kwargs)
+            if inspect.isawaitable(response):
+                return await response
+            return response
+        return await asyncio.to_thread(self.llm.call, *args, **kwargs)
 
     def to_pydantic(self, current_attempt: int = 1) -> BaseModel:
         """Convert text to pydantic.
@@ -113,6 +124,65 @@ class Converter(OutputConverter):
                 f"Failed to convert text into a Pydantic model due to error: {e}"
             ) from e
 
+    async def ato_pydantic(self, current_attempt: int = 1) -> BaseModel:
+        """Convert text to pydantic without blocking the event loop."""
+        try:
+            if self.llm.supports_function_calling():
+                response = await self._call_llm_async(
+                    messages=[
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ],
+                    response_model=self.model,
+                )
+                if isinstance(response, BaseModel):
+                    result = response
+                else:
+                    result = self.model.model_validate_json(response)
+            else:
+                response = await self._call_llm_async(
+                    [
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ]
+                )
+                try:
+                    result = self.model.model_validate_json(response)
+                except ValidationError:
+                    result = await ahandle_partial_json(
+                        result=response,
+                        model=self.model,
+                        is_json_output=False,
+                        agent=None,
+                    )
+                    if not isinstance(result, BaseModel):
+                        if isinstance(result, dict):
+                            result = self.model.model_validate(result)
+                        elif isinstance(result, str):
+                            try:
+                                result = self.model.model_validate_json(result)
+                            except Exception as parse_err:
+                                raise ConverterError(
+                                    f"Failed to convert partial JSON result into Pydantic: {parse_err}"
+                                ) from parse_err
+                        else:
+                            raise ConverterError(
+                                "handle_partial_json returned an unexpected type."
+                            ) from None
+            return result
+        except ValidationError as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_pydantic(current_attempt + 1)
+            raise ConverterError(
+                f"Failed to convert text into a Pydantic model due to validation error: {e}"
+            ) from e
+        except Exception as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_pydantic(current_attempt + 1)
+            raise ConverterError(
+                f"Failed to convert text into a Pydantic model due to error: {e}"
+            ) from e
+
     def to_json(self, current_attempt: int = 1) -> str | ConverterError | Any:  # type: ignore[override]
         """Convert text to json.
 
@@ -140,6 +210,25 @@ class Converter(OutputConverter):
         except Exception as e:
             if current_attempt < self.max_attempts:
                 return self.to_json(current_attempt + 1)
+            return ConverterError(f"Failed to convert text into JSON, error: {e}.")
+
+    async def ato_json(self, current_attempt: int = 1) -> str | ConverterError | Any:
+        """Convert text to json without blocking the event loop."""
+        try:
+            if self.llm.supports_function_calling():
+                result = await self.ato_pydantic()
+                return result.model_dump_json(indent=2)
+            return json.dumps(
+                await self._call_llm_async(
+                    [
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ]
+                )
+            )
+        except Exception as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_json(current_attempt + 1)
             return ConverterError(f"Failed to convert text into JSON, error: {e}.")
 
     def _create_instructor(self) -> InternalInstructor[Any]:
@@ -200,6 +289,59 @@ def convert_to_model(
 
     except ValidationError:
         return handle_partial_json(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+
+    except Exception as e:
+        if agent and getattr(agent, "verbose", True):
+            PRINTER.print(
+                content=f"Unexpected error during model conversion: {type(e).__name__}: {e}. Returning original result.",
+                color="red",
+            )
+        return result
+
+
+async def aconvert_to_model(
+    result: str,
+    output_pydantic: type[BaseModel] | None,
+    output_json: type[BaseModel] | None,
+    agent: Agent | BaseAgent | None = None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Asynchronously convert a result string to a Pydantic model or JSON."""
+    model = output_pydantic or output_json
+    if model is None:
+        return result
+
+    if converter_cls:
+        return await aconvert_with_instructions(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+
+    try:
+        escaped_result = json.dumps(json.loads(result, strict=False))
+        return validate_model(
+            result=escaped_result, model=model, is_json_output=bool(output_json)
+        )
+    except json.JSONDecodeError:
+        return await ahandle_partial_json(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+
+    except ValidationError:
+        return await ahandle_partial_json(
             result=result,
             model=model,
             is_json_output=bool(output_json),
@@ -290,6 +432,50 @@ def handle_partial_json(
     )
 
 
+async def ahandle_partial_json(
+    result: str,
+    model: type[BaseModel],
+    is_json_output: bool,
+    agent: Agent | BaseAgent | None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Asynchronously handle partial JSON in a result string."""
+    match = _JSON_PATTERN.search(result)
+    if match:
+        try:
+            parsed = json.loads(match.group(), strict=False)
+        except json.JSONDecodeError:
+            return await aconvert_with_instructions(
+                result=result,
+                model=model,
+                is_json_output=is_json_output,
+                agent=agent,
+                converter_cls=converter_cls,
+            )
+
+        try:
+            exported_result = model.model_validate(parsed)
+            if is_json_output:
+                return exported_result.model_dump()
+            return exported_result
+        except ValidationError:
+            raise
+        except Exception as e:
+            if agent and getattr(agent, "verbose", True):
+                PRINTER.print(
+                    content=f"Unexpected error during partial JSON handling: {type(e).__name__}: {e}. Attempting alternative conversion method.",
+                    color="red",
+                )
+
+    return await aconvert_with_instructions(
+        result=result,
+        model=model,
+        is_json_output=is_json_output,
+        agent=agent,
+        converter_cls=converter_cls,
+    )
+
+
 def convert_with_instructions(
     result: str,
     model: type[BaseModel],
@@ -334,6 +520,48 @@ def convert_with_instructions(
     )
     exported_result = (
         converter.to_pydantic() if not is_json_output else converter.to_json()
+    )
+
+    if isinstance(exported_result, ConverterError):
+        if agent and getattr(agent, "verbose", True):
+            PRINTER.print(
+                content=f"Failed to convert result to model: {exported_result}",
+                color="red",
+            )
+        return result
+
+    return exported_result
+
+
+async def aconvert_with_instructions(
+    result: str,
+    model: type[BaseModel],
+    is_json_output: bool,
+    agent: Agent | BaseAgent | None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Asynchronously convert a result string using conversion instructions."""
+    if agent is None:
+        raise TypeError("Agent must be provided if converter_cls is not specified.")
+
+    llm = getattr(agent, "function_calling_llm", None) or agent.llm
+
+    if llm is None:
+        raise ValueError("Agent must have a valid LLM instance for conversion")
+
+    instructions = get_conversion_instructions(model=model, llm=llm)
+    converter = create_converter(
+        agent=agent,
+        converter_cls=converter_cls,
+        llm=llm,
+        text=result,
+        model=model,
+        instructions=instructions,
+    )
+    exported_result = (
+        await converter.ato_pydantic()
+        if not is_json_output
+        else await converter.ato_json()
     )
 
     if isinstance(exported_result, ConverterError):

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -6,7 +6,7 @@ import os
 import time
 from functools import partial
 from hashlib import md5
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -312,6 +312,36 @@ def test_output_pydantic_sequential():
     result = crew.kickoff()
     assert isinstance(result.pydantic, ScoreOutput)
     assert result.to_dict() == {"score": 4}
+
+
+@pytest.mark.asyncio
+async def test_aexport_output_uses_async_converter():
+    class ScoreOutput(BaseModel):
+        score: int
+
+    task = Task(
+        description="Give me a score",
+        expected_output="A score",
+        output_pydantic=ScoreOutput,
+    )
+
+    with patch(
+        "crewai.task.aconvert_to_model",
+        new_callable=AsyncMock,
+        return_value=ScoreOutput(score=4),
+    ) as mock_convert:
+        pydantic_output, json_output = await task._aexport_output("score: 4")
+
+    assert isinstance(pydantic_output, ScoreOutput)
+    assert pydantic_output.score == 4
+    assert json_output is None
+    mock_convert.assert_awaited_once_with(
+        "score: 4",
+        ScoreOutput,
+        None,
+        task.agent,
+        task.converter_cls,
+    )
 
 
 @pytest.mark.vcr()

--- a/lib/crewai/tests/utilities/test_converter.py
+++ b/lib/crewai/tests/utilities/test_converter.py
@@ -2,12 +2,13 @@
 from enum import Enum
 import json
 import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from crewai.llm import LLM
 from crewai.utilities.converter import (
     Converter,
     ConverterError,
+    aconvert_to_model,
     convert_to_model,
     convert_with_instructions,
     create_converter,
@@ -629,6 +630,37 @@ def test_converter_with_function_calling() -> None:
     llm.call.assert_called_once()
     call_args = llm.call.call_args
     assert call_args[1]["response_model"] == SimpleModel
+
+
+@pytest.mark.asyncio
+async def test_aconvert_to_model_uses_async_llm_call() -> None:
+    llm = Mock(spec=LLM)
+    llm.supports_function_calling.return_value = True
+    llm.acall = AsyncMock(return_value='{"name": "Eve", "age": 35}')
+    llm.call.side_effect = AssertionError("sync call should not be used")
+
+    agent = Mock()
+    agent.function_calling_llm = None
+    agent.llm = llm
+    agent.verbose = False
+    agent.get_output_converter = Mock(
+        side_effect=lambda *args, **kwargs: Converter(*args, **kwargs)
+    )
+
+    output = await aconvert_to_model(
+        "Name: Eve, Age: 35",
+        SimpleModel,
+        None,
+        agent,
+    )
+
+    assert isinstance(output, SimpleModel)
+    assert output.name == "Eve"
+    assert output.age == 35
+    llm.acall.assert_awaited_once()
+    call_args = llm.acall.call_args
+    assert call_args.kwargs["response_model"] == SimpleModel
+    llm.call.assert_not_called()
 
 
 def test_generate_model_description_union_field() -> None:


### PR DESCRIPTION
## Summary
- add async converter helpers that use `llm.acall()` when converting task output in async flows
- route `_aexecute_core()` and async guardrail regeneration through `_aexport_output()`
- keep the existing synchronous conversion path unchanged
- add regression coverage for async converter calls and async task output export

This prevents `akickoff()` / async task execution from calling the synchronous converter LLM path while formatting `output_pydantic` or `output_json` results.

## Tests
- `uv run pytest lib/crewai/tests/utilities/test_converter.py::test_aconvert_to_model_uses_async_llm_call lib/crewai/tests/test_task.py::test_aexport_output_uses_async_converter -q`
- `uv run ruff check lib/crewai/src/crewai/utilities/converter.py lib/crewai/src/crewai/task.py lib/crewai/tests/utilities/test_converter.py lib/crewai/tests/test_task.py`
- `uv run ruff format --check lib/crewai/src/crewai/utilities/converter.py lib/crewai/src/crewai/task.py lib/crewai/tests/utilities/test_converter.py lib/crewai/tests/test_task.py`
- `git diff --check`

Closes #5230