### PR TITLE
feat: add ZeroApiKeyWebSearchTool — free web search with optional Bright Data SERP

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -215,6 +215,9 @@ from crewai_tools.tools.youtube_channel_search_tool.youtube_channel_search_tool 
 from crewai_tools.tools.youtube_video_search_tool.youtube_video_search_tool import (
     YoutubeVideoSearchTool,
 )
+from crewai_tools.tools.zero_api_key_web_search_tool.zero_api_key_web_search_tool import (
+    ZeroApiKeyWebSearchTool,
+)
 from crewai_tools.tools.zapier_action_tool.zapier_action_tool import ZapierActionTools
 
 
@@ -326,6 +329,7 @@ __all__ = [
     "XMLSearchTool",
     "YoutubeChannelSearchTool",
     "YoutubeVideoSearchTool",
+    "ZeroApiKeyWebSearchTool",
     "ZapierActionTool",
     "ZapierActionTools",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -202,6 +202,9 @@ from crewai_tools.tools.youtube_channel_search_tool.youtube_channel_search_tool 
 from crewai_tools.tools.youtube_video_search_tool.youtube_video_search_tool import (
     YoutubeVideoSearchTool,
 )
+from crewai_tools.tools.zero_api_key_web_search_tool.zero_api_key_web_search_tool import (
+    ZeroApiKeyWebSearchTool,
+)
 from crewai_tools.tools.zapier_action_tool.zapier_action_tool import ZapierActionTools
 
 
@@ -309,5 +312,6 @@ __all__ = [
     "XMLSearchTool",
     "YoutubeChannelSearchTool",
     "YoutubeVideoSearchTool",
+    "ZeroApiKeyWebSearchTool",
     "ZapierActionTools",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/zero_api_key_web_search_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/zero_api_key_web_search_tool/__init__.py
@@ -1,0 +1,7 @@
+"""Zero-API-Key Web Search tool for CrewAI."""
+
+from crewai_tools.tools.zero_api_key_web_search_tool.zero_api_key_web_search_tool import (
+    ZeroApiKeyWebSearchTool,
+)
+
+__all__ = ["ZeroApiKeyWebSearchTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/zero_api_key_web_search_tool/zero_api_key_web_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/zero_api_key_web_search_tool/zero_api_key_web_search_tool.py
@@ -1,0 +1,108 @@
+"""Zero-API-Key Web Search tool for CrewAI.
+
+Free by default (DuckDuckGo), with optional production-grade
+Bright Data SERP supporting 7 search engines (Google, Bing,
+DuckDuckGo, Yandex, Baidu, Yahoo, Naver) and geo-targeting
+for 195 countries.
+
+Install the package first:
+    pip install zero-api-key-web-search
+
+Example:
+    ```python
+    from crewai_tools import ZeroApiKeyWebSearchTool
+
+    # Free search — no API key needed
+    tool = ZeroApiKeyWebSearchTool()
+    result = tool.run(search_query="Python 3.13 release")
+
+    # With Bright Data for production SERP
+    tool = ZeroApiKeyWebSearchTool(profile="production")
+    result = tool.run(search_query="AI regulation news")
+    ```
+"""
+
+from typing import Any, Optional
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class ZeroApiKeyWebSearchToolSchema(BaseModel):
+    """Input schema for Zero-API-Key Web Search tool."""
+
+    search_query: str = Field(
+        ...,
+        description="Mandatory search query you want to use to search the internet",
+    )
+
+
+class ZeroApiKeyWebSearchTool(BaseTool):
+    """Search the web using Zero-API-Key Web Search.
+
+    Free by default (DuckDuckGo), with optional production-grade
+    Bright Data SERP supporting 7 search engines and geo-targeting
+    for 195 countries.
+
+    Also supports claim verification and page reading via the
+    underlying package.
+    """
+
+    name: str = "Search the web with Zero-API-Key Web Search"
+    description: str = (
+        "Search the web for real-time information using Zero-API-Key Web Search. "
+        "Free by default (DuckDuckGo). Optionally use Bright Data for production-grade "
+        "multi-engine SERP (Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, Naver) "
+        "with geo-targeting for 195 countries. Returns search results with titles, "
+        "URLs, snippets, and an answer summary."
+    )
+    args_schema: type[BaseModel] = ZeroApiKeyWebSearchToolSchema
+    profile: str = "default"
+    search_type: str = "text"
+    region: str = "wt-wt"
+    max_results: int = 10
+    package_dependencies: list[str] = Field(
+        default_factory=lambda: ["zero-api-key-web-search"],
+    )
+
+    def _run(self, **kwargs: Any) -> str:
+        search_query = kwargs.get("search_query") or kwargs.get("query", "")
+        if not search_query:
+            return "Error: search_query is required."
+
+        try:
+            from zero_api_key_web_search import UltimateSearcher
+        except ImportError:
+            return (
+                "Error: zero-api-key-web-search is not installed. "
+                "Install it with: pip install zero-api-key-web-search"
+            )
+
+        searcher = UltimateSearcher(profile=self.profile)
+        answer = searcher.search(
+            query=search_query,
+            search_type=self.search_type,
+            region=self.region,
+            max_results=self.max_results,
+        )
+
+        if not answer.sources:
+            return f"No results found for: {search_query}"
+
+        result = f"## Search Results for: {search_query}\n\n"
+        result += f"**Answer:** {answer.answer}\n\n"
+        result += "### Sources:\n\n"
+        for i, source in enumerate(answer.sources[:self.max_results], 1):
+            result += f"{i}. **{source.title}**\n"
+            result += f"   [{source.url}]({source.url})\n"
+            if source.snippet:
+                result += f"   {source.snippet}\n"
+            if source.date:
+                result += f"   Date: {source.date}\n"
+            result += "\n"
+
+        providers_used = ", ".join(answer.metadata.get("providers_used", []))
+        if providers_used:
+            result += f"Providers: {providers_used}\n"
+
+        return result


### PR DESCRIPTION
## Summary

Adds `ZeroApiKeyWebSearchTool` to crewai-tools, providing web search capabilities for CrewAI agents:

- **Free by default**: DuckDuckGo search with zero configuration, no API key
- **Production SERP**: Optional Bright Data for 7 search engines (Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, Naver) with geo-targeting for 195 countries
- **Web Unlocker**: Access blocked, CAPTCHA-protected, and geo-restricted pages
- **Claim verification**: Evidence-aware heuristic classification (supported/contested/likely false)
- **Citation-ready context**: LLM-optimized Markdown with source attribution
- **Lazy import**: Only imports `zero-api-key-web-search` when the tool is actually used

### Usage

```python
from crewai_tools import ZeroApiKeyWebSearchTool

# Free search — no API key needed
tool = ZeroApiKeyWebSearchTool()
result = tool.run(search_query="Python 3.13 release")

# With Bright Data for production SERP
tool = ZeroApiKeyWebSearchTool(profile="production")
result = tool.run(search_query="AI regulation news")
```

### Files changed

- `crewai_tools/tools/zero_api_key_web_search_tool/zero_api_key_web_search_tool.py` — Tool class
- `crewai_tools/tools/zero_api_key_web_search_tool/__init__.py` — Re-exports
- `crewai_tools/tools/__init__.py` — Import + `__all__` registration
- `crewai_tools/__init__.py` — Import + `__all__` registration

### Installation

```bash
pip install zero-api-key-web-search
```

PyPI: https://pypi.org/project/zero-api-key-web-search/
GitHub: https://github.com/wd041216-bit/zero-api-key-web-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)