### PR TITLE
docs: add security tip for API key management in Arabic translation

### DIFF
--- a/docs/ar/quickstart.mdx
+++ b/docs/ar/quickstart.mdx
@@ -22,6 +22,11 @@ mode: "wide"
 - بيئة Python وواجهة سطر أوامر CrewAI (راجع [التثبيت](/ar/installation))
 - نموذج لغوي مهيأ بالمفاتيح الصحيحة — راجع [LLMs](/ar/concepts/llms#setting-up-your-llm)
 - مفتاح API من [Serper.dev](https://serper.dev/) (`SERPER_API_KEY`) للبحث على الويب في هذا الدرس
+<Tip>
+  <div dir="rtl">
+    <b>نصيحة أمنية:</b> لا تضع مفاتيح واجهة برمجة التطبيقات (API keys) مباشرة في الكود الخاص بك. قم بتخزينها في ملف `.env` في المجلد الرئيسي لمشروعك لضمان أمانها.
+  </div>
+</Tip>
 
 ## ابنِ أول Flow لك
 


### PR DESCRIPTION
Added a security tip in the Arabic documentation to advise users on safe API key management using .env files, ensuring consistency with the English version.
Note: Used dir="rtl" within the <Tip> component to ensure correct rendering of mixed Arabic and English text for a better user experience.