### PR TITLE
feat(crewai-tools): add VoidlyPayTool for x402-paid agent actions

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -206,6 +206,7 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
+from crewai_tools.tools.voidly_pay_tool.voidly_pay_tool import VoidlyPayTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
 from crewai_tools.tools.website_search.website_search_tool import WebsiteSearchTool
 from crewai_tools.tools.xml_search_tool.xml_search_tool import XMLSearchTool
@@ -321,6 +322,7 @@ __all__ = [
     "TavilyResearchTool",
     "TavilySearchTool",
     "VisionTool",
+    "VoidlyPayTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",
     "XMLSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -193,6 +193,7 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
+from crewai_tools.tools.voidly_pay_tool.voidly_pay_tool import VoidlyPayTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
 from crewai_tools.tools.website_search.website_search_tool import WebsiteSearchTool
 from crewai_tools.tools.xml_search_tool.xml_search_tool import XMLSearchTool
@@ -304,6 +305,7 @@ __all__ = [
     "TavilyResearchTool",
     "TavilySearchTool",
     "VisionTool",
+    "VoidlyPayTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",
     "XMLSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/README.md
@@ -1,0 +1,88 @@
+# VoidlyPayTool Documentation
+
+## Description
+
+`VoidlyPayTool` lets a CrewAI agent call any HTTP endpoint that speaks the
+[x402 protocol](https://x402.org) and pay for it automatically when the
+server returns `HTTP 402 Payment Required`.
+
+It wraps the official [`voidly-pay-crewai`](https://pypi.org/project/voidly-pay-crewai/)
+PyPI package; if that package is installed the tool delegates to its richer
+`VoidlyPayFetchTool`. Otherwise it falls back to a self-contained x402
+round-trip using [`voidly-pay`](https://pypi.org/project/voidly-pay/)
+directly so the import never breaks.
+
+Settles in <200ms via a Sourcify-verified USDC vault on Base mainnet
+([`0xb592...1c12`](https://repo.sourcify.dev/contracts/full_match/8453/0xb592512932a7b354969bb48039c2dc7ad6ad1c12/)).
+
+## Installation
+
+```shell
+pip install voidly-pay voidly-pay-crewai
+pip install 'crewai[tools]'
+```
+
+Then either set environment variables:
+
+```shell
+export VOIDLY_PAY_DID="did:voidly:..."
+export VOIDLY_PAY_SECRET="..."  # base64 secret key
+```
+
+…or visit <https://voidly.ai/pay/claim> to mint a DID + claim the
+free 10-credit faucet in the browser. The page shows you the secret to
+copy into the env vars.
+
+## Example
+
+```python
+from crewai import Agent, Crew, Task
+from crewai_tools import VoidlyPayTool
+
+researcher = Agent(
+    role="Research Analyst",
+    goal="Pay for premium APIs without managing API keys.",
+    backstory="Holds the team's wallet. Verifies before settling.",
+    tools=[VoidlyPayTool()],
+)
+
+task = Task(
+    description=(
+        "Use voidly_pay_fetch to call "
+        "https://api.voidly.ai/v1/pay/wiki?topic=Anthropic and summarise the "
+        "result in two sentences."
+    ),
+    agent=researcher,
+    expected_output="Two-sentence summary of the wiki entry.",
+)
+
+crew = Crew(agents=[researcher], tasks=[task])
+crew.kickoff()
+```
+
+## Args
+
+- `url` (str, required) — endpoint URL.
+- `method` (str, default `GET`) — HTTP method.
+- `body` (Any, optional) — JSON-serialisable body for POST/PUT.
+- `max_amount_credits` (float, default `0.05`) — guardrail on a single
+  auto-pay (1 credit = $0.001 USDC).
+
+## How it works
+
+1. The tool issues the request. If the server responds 200, it returns the
+   body unchanged.
+2. On 402, it parses the [voidly-credit accept option](https://api.voidly.ai/v1/pay/manifest.json):
+   `recipient_did`, `amount_micro`, `quote_id`.
+3. If the asking price exceeds `max_amount_credits`, the tool refuses
+   without spending.
+4. Otherwise, it Ed25519-signs a `pay()` transfer to the recipient DID.
+5. Re-issues the call with `?quote_id=<id>` and returns the resolved
+   response (with `transfer_id` for receipt tracking).
+
+## Discoverability
+
+- Marketplace of paid endpoints: <https://api.voidly.ai/v1/pay/marketplace>
+- List your own service: <https://voidly.ai/pay/list-your-service>
+- Manifest: <https://api.voidly.ai/v1/pay/manifest.json>
+- Public proof of reserves: <https://voidly.ai/pay/proof>

--- a/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/__init__.py
@@ -1,0 +1,4 @@
+from crewai_tools.tools.voidly_pay_tool.voidly_pay_tool import VoidlyPayTool
+
+
+__all__ = ["VoidlyPayTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/voidly_pay_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/voidly_pay_tool.py
@@ -1,0 +1,251 @@
+"""VoidlyPay tool wrapper for CrewAI.
+
+Lets a CrewAI agent call any HTTP endpoint that speaks the
+[x402 protocol](https://x402.org) and pay for it automatically when the
+server returns ``HTTP 402 Payment Required``. Wraps the official
+[`voidly-pay-crewai`](https://pypi.org/project/voidly-pay-crewai/) PyPI
+package — when that package is installed the tool delegates to its
+`VoidlyPayFetchTool` (full toolkit available via `VoidlyPayToolkit`).
+Falls back to a self-contained x402 round-trip using `voidly-pay`
+directly so the import never breaks at install time.
+
+Mirrors the ``ComposioTool`` / ``LinkupSearchTool`` shape: a single
+``BaseTool`` subclass with a Pydantic args schema that CrewAI can
+serialise.
+
+Install::
+
+    pip install voidly-pay voidly-pay-crewai
+
+Use::
+
+    from crewai_tools import VoidlyPayTool
+    from crewai import Agent
+
+    agent = Agent(
+        role="Researcher",
+        goal="Pay for premium APIs without managing API keys.",
+        tools=[VoidlyPayTool()],
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VoidlyPayToolSchema(BaseModel):
+    """Args for VoidlyPayTool."""
+
+    url: str = Field(
+        ...,
+        description=(
+            "HTTP URL to fetch. If the server returns 402 with a Voidly Pay "
+            "x402 quote, the tool transfers the asking amount and retries."
+        ),
+    )
+    method: str = Field(
+        default="GET",
+        description="HTTP method. Defaults to GET.",
+    )
+    body: Any | None = Field(
+        default=None,
+        description="JSON-serialisable body for POST/PUT.",
+    )
+    max_amount_credits: float = Field(
+        default=0.05,
+        description=(
+            "Cap (in Voidly credits, where 1 credit = $0.001 USDC) on a "
+            "single auto-pay. Default 0.05 = $0.05."
+        ),
+    )
+
+
+class VoidlyPayTool(BaseTool):
+    """Pay-on-402 fetch via the Voidly Pay rail.
+
+    Settles via a Sourcify-verified USDC vault on Base mainnet
+    (`0xb592512932a7b354969bb48039c2dc7ad6ad1c12`). Identity is loaded
+    from the Voidly Pay SDK's local keypair file (env var
+    ``VOIDLY_PAY_DID`` + ``VOIDLY_PAY_SECRET`` for explicit overrides).
+    """
+
+    name: str = "voidly_pay_fetch"
+    description: str = (
+        "Fetch any URL. If the server returns HTTP 402 with a Voidly Pay "
+        "x402 quote, the tool auto-transfers credits and retries. Use this "
+        "for paid endpoints behind an x402 paywall."
+    )
+    args_schema: type[BaseModel] = VoidlyPayToolSchema
+
+    env_vars: list[EnvVar] = [
+        EnvVar(
+            name="VOIDLY_PAY_DID",
+            description=(
+                "DID of a funded Voidly Pay wallet (e.g. 'did:voidly:...'). "
+                "If unset, the SDK loads ~/.voidly-pay/keypair.json. Mint a "
+                "DID + claim the faucet at https://voidly.ai/pay/claim."
+            ),
+            required=False,
+        ),
+        EnvVar(
+            name="VOIDLY_PAY_SECRET",
+            description=(
+                "base64-encoded Ed25519 secret key for VOIDLY_PAY_DID. "
+                "Treated as sensitive — never logged."
+            ),
+            required=False,
+        ),
+        EnvVar(
+            name="VOIDLY_PAY_API_BASE",
+            description=("Override the rail URL. Defaults to https://api.voidly.ai."),
+            required=False,
+        ),
+    ]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def _client(self) -> Any:
+        """Return a VoidlyPay SDK client, lazily."""
+        try:
+            from voidly_pay import VoidlyPay  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise ImportError(
+                "VoidlyPayTool requires the `voidly-pay` package. "
+                "Install with: pip install voidly-pay"
+            ) from e
+
+        kwargs: dict = {}
+        api_base = os.environ.get("VOIDLY_PAY_API_BASE")
+        if api_base:
+            kwargs["api_base"] = api_base
+        did = os.environ.get("VOIDLY_PAY_DID")
+        secret = os.environ.get("VOIDLY_PAY_SECRET")
+        if did and secret:
+            kwargs["did"] = did
+            kwargs["secret_base64"] = secret
+        return VoidlyPay(**kwargs)
+
+    def _run(
+        self,
+        url: str,
+        method: str = "GET",
+        body: Any = None,
+        max_amount_credits: float = 0.05,
+    ) -> str:
+        # Prefer the maintained crewAI integration when present — it has
+        # a more complete 402-handler + receipt verification path.
+        try:
+            from voidly_pay_crewai import (
+                VoidlyPayFetchTool,  # type: ignore[import-not-found]
+            )
+
+            return VoidlyPayFetchTool()._run(
+                url=url,
+                method=method,
+                body=body,
+                max_amount_credits=max_amount_credits,
+            )
+        except ImportError:
+            pass  # fall through to inline implementation
+
+        return _inline_x402_fetch(
+            self._client(),
+            url=url,
+            method=method,
+            body=body,
+            max_amount_credits=max_amount_credits,
+        )
+
+
+def _inline_x402_fetch(
+    pay: Any,
+    url: str,
+    method: str,
+    body: Any,
+    max_amount_credits: float,
+) -> str:
+    """Self-contained x402 round-trip — used when voidly-pay-crewai is absent.
+
+    1. Make the request. If non-402, return the body.
+    2. Parse the 402 envelope. Find the ``voidly-credit`` accept option.
+    3. If asking price > cap, return a guarded refusal.
+    4. Sign + submit the transfer to the recipient DID.
+    5. Retry with ``?quote_id=<id>`` and return the resolved response.
+    """
+    import requests
+
+    cap_micro = round(max_amount_credits * 1_000_000)
+
+    def _do(extra_url: str = url) -> requests.Response:
+        if body is not None:
+            return requests.request(method, extra_url, json=body, timeout=30)
+        return requests.request(method, extra_url, timeout=30)
+
+    initial = _do()
+    if initial.status_code != 402:
+        return _stringify(initial)
+
+    try:
+        envelope = initial.json()
+    except Exception:
+        return _stringify(initial)
+
+    accept = next(
+        (a for a in envelope.get("accepts", []) if a.get("scheme") == "voidly-credit"),
+        None,
+    )
+    if accept is None:
+        return json.dumps(
+            {"error": "no voidly-credit option in 402 envelope", "envelope": envelope},
+            default=str,
+        )
+
+    if accept["amount_micro"] > cap_micro:
+        return json.dumps(
+            {
+                "blocked_by_cap": True,
+                "asked_micro": accept["amount_micro"],
+                "cap_micro": cap_micro,
+                "hint": ("Raise max_amount_credits if you want to pay this endpoint."),
+            }
+        )
+
+    receipt = pay.pay(
+        to=accept["recipient_did"],
+        amount_micro=accept["amount_micro"],
+        memo=f"x402:{accept['quote_id']}",
+    )
+
+    sep = "&" if "?" in url else "?"
+    final = _do(f"{url}{sep}quote_id={accept['quote_id']}")
+    return json.dumps(
+        {
+            "settled": True,
+            "transfer_id": receipt.get("transfer_id"),
+            "amount_micro": accept["amount_micro"],
+            "recipient": accept["recipient_did"],
+            "response_status": final.status_code,
+            "response": _maybe_json(final),
+        },
+        default=str,
+    )
+
+
+def _stringify(r: Any) -> str:
+    return json.dumps({"status": r.status_code, "body": _maybe_json(r)}, default=str)
+
+
+def _maybe_json(r: Any) -> Any:
+    ct = r.headers.get("content-type", "") if hasattr(r, "headers") else ""
+    if ct.startswith("application/json"):
+        try:
+            return r.json()
+        except (ValueError, TypeError):
+            return r.text[:4000]
+    return r.text[:4000]


### PR DESCRIPTION
Subclasses `BaseTool` to let CrewAI agents pay for HTTP 402 endpoints
via [Voidly Pay](https://voidly.ai/pay) (Sourcify-verified USDC vault on
Base mainnet, [x402 protocol](https://x402.org)). Wraps the existing
[`voidly-pay-crewai`](https://pypi.org/project/voidly-pay-crewai/) PyPI
package as a tool spec, with a self-contained x402 round-trip as fallback
when that package isn't installed.

(`crewAIInc/crewAI-tools` is archived; this PR targets the monorepo
location at `lib/crewai-tools/`.)

Mirrors the `ComposioTool` shape (single tool class, Pydantic args
schema, `env_vars` list). Closes the gap for CrewAI users who want
pay-per-call agent actions without managing API keys per provider.

### Files

- `lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/voidly_pay_tool.py` (new)
- `lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/__init__.py` (new)
- `lib/crewai-tools/src/crewai_tools/tools/voidly_pay_tool/README.md` (new)
- `lib/crewai-tools/src/crewai_tools/tools/__init__.py` (added one import + one export)
- `lib/crewai-tools/src/crewai_tools/__init__.py` (re-export at top level)

### How a CrewAI agent uses it

```python
from crewai import Agent
from crewai_tools import VoidlyPayTool

agent = Agent(
    role="Researcher",
    goal="Pay for premium APIs without managing API keys.",
    tools=[VoidlyPayTool()],
)
```

The tool issues the request, parses the 402 envelope's `voidly-credit`
accept option, signs + submits a transfer to the recipient DID, then
retries with `?quote_id=<id>`. Settles in <200ms via the on-chain USDC
vault at [`0xb592...1c12`](https://repo.sourcify.dev/contracts/full_match/8453/0xb592512932a7b354969bb48039c2dc7ad6ad1c12/).

### Honest scope

Voidly Pay is an open marketplace (anyone can list a paid endpoint at
[/pay/list-your-service](https://voidly.ai/pay/list-your-service)). Real
volume is small today (~$4 in the vault); the value here is the working
pattern for x402-aware tool design, not the size of the rail.

### Lint

Passes ruff except the same `RUF012` (mutable default `env_vars`) that
already exists across `composio_tool` and other tools — followed the
project convention there.