### PR TITLE
fix: prevent shared LLM stop words mutation across agents

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1102,16 +1102,6 @@ class Agent(BaseAgent):
         self.agent_executor.tools_handler = self.tools_handler
         self.agent_executor.request_within_rpm_limit = rpm_limit_fn
 
-        if isinstance(self.agent_executor.llm, BaseLLM):
-            existing_stop = getattr(self.agent_executor.llm, "stop", [])
-            self.agent_executor.llm.stop = list(
-                set(
-                    existing_stop + stop_words
-                    if isinstance(existing_stop, list)
-                    else stop_words
-                )
-            )
-
     def get_delegation_tools(self, agents: Sequence[BaseAgent]) -> list[BaseTool]:
         agent_tools = AgentTools(agents=agents)
         return agent_tools.tools()

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -11,7 +11,6 @@ import asyncio
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
-import copy
 import inspect
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
@@ -142,14 +141,6 @@ class CrewAgentExecutor(BaseAgentExecutor):
             self.before_llm_call_hooks.extend(get_before_llm_call_hooks())
         if not self.after_llm_call_hooks:
             self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
-        if (
-            self.llm
-            and not isinstance(self.llm, str)
-            and self.llm.supports_stop_words()
-            and not set(self.stop).issubset(self.llm.stop)
-        ):
-            self.llm = copy.copy(self.llm)
-            self.llm.stop = list(set(self.llm.stop + self.stop))
 
     @property
     def use_stop_words(self) -> bool:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -11,6 +11,7 @@ import asyncio
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
+import copy
 import inspect
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
@@ -142,14 +143,9 @@ class CrewAgentExecutor(BaseAgentExecutor):
         if not self.after_llm_call_hooks:
             self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
         if self.llm and not isinstance(self.llm, str):
-            existing_stop = getattr(self.llm, "stop", [])
-            self.llm.stop = list(
-                set(
-                    existing_stop + self.stop
-                    if isinstance(existing_stop, list)
-                    else self.stop
-                )
-            )
+            if not set(self.stop).issubset(self.llm.stop):
+                self.llm = copy.copy(self.llm)
+                self.llm.stop = list(set(self.llm.stop + self.stop))
 
     @property
     def use_stop_words(self) -> bool:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -142,10 +142,14 @@ class CrewAgentExecutor(BaseAgentExecutor):
             self.before_llm_call_hooks.extend(get_before_llm_call_hooks())
         if not self.after_llm_call_hooks:
             self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
-        if self.llm and not isinstance(self.llm, str):
-            if not set(self.stop).issubset(self.llm.stop):
-                self.llm = copy.copy(self.llm)
-                self.llm.stop = list(set(self.llm.stop + self.stop))
+        if (
+            self.llm
+            and not isinstance(self.llm, str)
+            and self.llm.supports_stop_words()
+            and not set(self.stop).issubset(self.llm.stop)
+        ):
+            self.llm = copy.copy(self.llm)
+            self.llm.stop = list(set(self.llm.stop + self.stop))
 
     @property
     def use_stop_words(self) -> bool:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -49,6 +49,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.types.callback import SerializableCallable
 from crewai.utilities.agent_utils import (
+    _llm_stop_words_applied,
     aget_llm_response,
     convert_tools_to_openai_schema,
     enforce_rpm_limit,
@@ -201,21 +202,22 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         self.ask_for_human_input = bool(inputs.get("ask_for_human_input", False))
 
-        try:
-            formatted_answer = self._invoke_loop()
-        except AssertionError:
-            if self.agent.verbose:
-                PRINTER.print(
-                    content="Agent failed to reach a final answer. This is likely a bug - please report it.",
-                    color="red",
-                )
-            raise
-        except Exception as e:
-            handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
-            raise
+        with _llm_stop_words_applied(self.llm, self):
+            try:
+                formatted_answer = self._invoke_loop()
+            except AssertionError:
+                if self.agent.verbose:
+                    PRINTER.print(
+                        content="Agent failed to reach a final answer. This is likely a bug - please report it.",
+                        color="red",
+                    )
+                raise
+            except Exception as e:
+                handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
+                raise
 
-        if self.ask_for_human_input:
-            formatted_answer = self._handle_human_feedback(formatted_answer)
+            if self.ask_for_human_input:
+                formatted_answer = self._handle_human_feedback(formatted_answer)
 
         self._save_to_memory(formatted_answer)
         return {"output": formatted_answer.output}
@@ -1073,21 +1075,22 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         self.ask_for_human_input = bool(inputs.get("ask_for_human_input", False))
 
-        try:
-            formatted_answer = await self._ainvoke_loop()
-        except AssertionError:
-            if self.agent.verbose:
-                PRINTER.print(
-                    content="Agent failed to reach a final answer. This is likely a bug - please report it.",
-                    color="red",
-                )
-            raise
-        except Exception as e:
-            handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
-            raise
+        with _llm_stop_words_applied(self.llm, self):
+            try:
+                formatted_answer = await self._ainvoke_loop()
+            except AssertionError:
+                if self.agent.verbose:
+                    PRINTER.print(
+                        content="Agent failed to reach a final answer. This is likely a bug - please report it.",
+                        color="red",
+                    )
+                raise
+            except Exception as e:
+                handle_unknown_error(PRINTER, e, verbose=self.agent.verbose)
+                raise
 
-        if self.ask_for_human_input:
-            formatted_answer = await self._ahandle_human_feedback(formatted_answer)
+            if self.ask_for_human_input:
+                formatted_answer = await self._ahandle_human_feedback(formatted_answer)
 
         self._save_to_memory(formatted_answer)
         return {"output": formatted_answer.output}

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
-import copy
 from datetime import datetime
 import inspect
 import json
@@ -215,14 +214,6 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Configure executor after Pydantic field initialization."""
         self.before_llm_call_hooks.extend(get_before_llm_call_hooks())
         self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
-
-        if (
-            self.llm
-            and self.llm.supports_stop_words()
-            and not set(self.stop_words).issubset(self.llm.stop)
-        ):
-            self.llm = copy.copy(self.llm)
-            self.llm.stop = list(set(self.llm.stop + self.stop_words))
 
         self._state = AgentExecutorState()
         self.max_method_calls = self.max_iter * 10

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -5,6 +5,7 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
+import copy
 from datetime import datetime
 import inspect
 import json
@@ -216,10 +217,9 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
 
         if self.llm:
-            existing_stop = getattr(self.llm, "stop", [])
-            if not isinstance(existing_stop, list):
-                existing_stop = []
-            self.llm.stop = list(set(existing_stop + self.stop_words))
+            if not set(self.stop_words).issubset(self.llm.stop):
+                self.llm = copy.copy(self.llm)
+                self.llm.stop = list(set(self.llm.stop + self.stop_words))
 
         self._state = AgentExecutorState()
         self.max_method_calls = self.max_iter * 10

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -216,10 +216,13 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         self.before_llm_call_hooks.extend(get_before_llm_call_hooks())
         self.after_llm_call_hooks.extend(get_after_llm_call_hooks())
 
-        if self.llm:
-            if not set(self.stop_words).issubset(self.llm.stop):
-                self.llm = copy.copy(self.llm)
-                self.llm.stop = list(set(self.llm.stop + self.stop_words))
+        if (
+            self.llm
+            and self.llm.supports_stop_words()
+            and not set(self.stop_words).issubset(self.llm.stop)
+        ):
+            self.llm = copy.copy(self.llm)
+            self.llm.stop = list(set(self.llm.stop + self.stop_words))
 
         self._state = AgentExecutorState()
         self.max_method_calls = self.max_iter * 10

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -71,6 +71,7 @@ from crewai.hooks.types import (
 from crewai.tools.base_tool import BaseTool
 from crewai.tools.structured_tool import CrewStructuredTool
 from crewai.utilities.agent_utils import (
+    _llm_stop_words_applied,
     check_native_tool_support,
     enforce_rpm_limit,
     extract_tool_call_info,
@@ -2595,17 +2596,18 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 inputs.get("ask_for_human_input", False)
             )
 
-            self.kickoff()
+            with _llm_stop_words_applied(self.llm, self):
+                self.kickoff()
 
-            formatted_answer = self.state.current_answer
+                formatted_answer = self.state.current_answer
 
-            if not isinstance(formatted_answer, AgentFinish):
-                raise RuntimeError(
-                    "Agent execution ended without reaching a final answer."
-                )
+                if not isinstance(formatted_answer, AgentFinish):
+                    raise RuntimeError(
+                        "Agent execution ended without reaching a final answer."
+                    )
 
-            if self.state.ask_for_human_input:
-                formatted_answer = self._handle_human_feedback(formatted_answer)
+                if self.state.ask_for_human_input:
+                    formatted_answer = self._handle_human_feedback(formatted_answer)
 
             self._save_to_memory(formatted_answer)
 
@@ -2685,18 +2687,20 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 inputs.get("ask_for_human_input", False)
             )
 
-            # Use async kickoff directly since we're already in an async context
-            await self.kickoff_async()
+            with _llm_stop_words_applied(self.llm, self):
+                await self.kickoff_async()
 
-            formatted_answer = self.state.current_answer
+                formatted_answer = self.state.current_answer
 
-            if not isinstance(formatted_answer, AgentFinish):
-                raise RuntimeError(
-                    "Agent execution ended without reaching a final answer."
-                )
+                if not isinstance(formatted_answer, AgentFinish):
+                    raise RuntimeError(
+                        "Agent execution ended without reaching a final answer."
+                    )
 
-            if self.state.ask_for_human_input:
-                formatted_answer = await self._ahandle_human_feedback(formatted_answer)
+                if self.state.ask_for_human_input:
+                    formatted_answer = await self._ahandle_human_feedback(
+                        formatted_answer
+                    )
 
             self._save_to_memory(formatted_answer)
 

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -688,7 +688,7 @@ class LLM(BaseLLM):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "n": self.n,
-            "stop": (self._effective_stop() or None)
+            "stop": (self.stop_sequences or None)
             if self.supports_stop_words()
             else None,
             "max_tokens": self.max_tokens or self.max_completion_tokens,

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -688,7 +688,9 @@ class LLM(BaseLLM):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "n": self.n,
-            "stop": (self.stop or None) if self.supports_stop_words() else None,
+            "stop": (self._effective_stop() or None)
+            if self.supports_stop_words()
+            else None,
             "max_tokens": self.max_tokens or self.max_completion_tokens,
             "presence_penalty": self.presence_penalty,
             "frequency_penalty": self.frequency_penalty,

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -72,7 +72,7 @@ _JSON_EXTRACTION_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{.*}", re.DOTAL
 _current_call_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_current_call_id", default=None
 )
-_call_stop_override_var: contextvars.ContextVar[list[str] | None] = (
+_call_stop_override_var: contextvars.ContextVar[dict[int, list[str]] | None] = (
     contextvars.ContextVar("_call_stop_override_var", default=None)
 )
 
@@ -89,16 +89,24 @@ def llm_call_context() -> Generator[str, None, None]:
 
 
 @contextmanager
-def call_stop_override(stop: list[str] | None) -> Generator[None, None, None]:
-    """Override the active stop list for the current call scope.
+def call_stop_override(
+    llm: BaseLLM, stop: list[str] | None
+) -> Generator[None, None, None]:
+    """Override the stop list for ``llm`` within the current call scope.
 
-    Reads via :meth:`BaseLLM._effective_stop` (and therefore
-    :attr:`BaseLLM.stop_sequences`) return ``stop`` for the duration of the
-    context. Setting ``None`` clears any active override. The instance-level
-    ``stop`` field is never mutated, so the override is safe under concurrent
-    execution.
+    Only ``llm``'s reads via :attr:`BaseLLM.stop_sequences` see ``stop``;
+    other LLM instances (e.g. an agent's ``function_calling_llm``) keep their
+    own ``stop`` field. Passing ``None`` clears any prior override for ``llm``
+    in the same scope. The instance-level ``stop`` field is never mutated,
+    so the override is safe under concurrent execution.
     """
-    token = _call_stop_override_var.set(stop)
+    current = _call_stop_override_var.get()
+    new_overrides: dict[int, list[str]] = dict(current) if current else {}
+    if stop is None:
+        new_overrides.pop(id(llm), None)
+    else:
+        new_overrides[id(llm)] = stop
+    token = _call_stop_override_var.set(new_overrides)
     try:
         yield
     finally:
@@ -180,13 +188,17 @@ class BaseLLM(BaseModel, ABC):
     def stop_sequences(self) -> list[str]:
         """Stop list active for the current call.
 
-        Returns the per-call override set via :func:`call_stop_override` when
-        one is in effect; otherwise the instance-level ``stop`` field. Kept
-        under this name for backward compatibility with provider APIs that
-        already read ``stop_sequences``.
+        Returns the per-instance override set via :func:`call_stop_override`
+        when one is in effect for this LLM; otherwise the instance-level
+        ``stop`` field. Kept under this name for backward compatibility with
+        provider APIs that already read ``stop_sequences``.
         """
-        override = _call_stop_override_var.get()
-        return override if override is not None else self.stop
+        overrides = _call_stop_override_var.get()
+        if overrides is not None:
+            override = overrides.get(id(self))
+            if override is not None:
+                return override
+        return self.stop
 
     _token_usage: dict[str, int] = PrivateAttr(
         default_factory=lambda: {

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -178,19 +178,12 @@ class BaseLLM(BaseModel, ABC):
 
     @property
     def stop_sequences(self) -> list[str]:
-        """Alias for ``stop`` — kept for backward compatibility with provider APIs.
+        """Stop list active for the current call.
 
-        Honors the per-call stop override set via :func:`call_stop_override` so
-        that callers can supply additional stop sequences for a single call
-        without mutating the shared instance.
-        """
-        return self._effective_stop()
-
-    def _effective_stop(self) -> list[str]:
-        """Return the stop list active for the current call.
-
-        Falls back to the instance-level ``stop`` field when no per-call
-        override is in effect.
+        Returns the per-call override set via :func:`call_stop_override` when
+        one is in effect; otherwise the instance-level ``stop`` field. Kept
+        under this name for backward compatibility with provider APIs that
+        already read ``stop_sequences``.
         """
         override = _call_stop_override_var.get()
         return override if override is not None else self.stop
@@ -371,7 +364,7 @@ class BaseLLM(BaseModel, ABC):
         Returns:
             True if stop words are configured and can be applied
         """
-        return bool(self._effective_stop())
+        return bool(self.stop_sequences)
 
     def _apply_stop_words(self, content: str) -> str:
         """Apply stop words to truncate response content.
@@ -393,14 +386,14 @@ class BaseLLM(BaseModel, ABC):
             >>> llm._apply_stop_words(response)
             "I need to search.\\n\\nAction: search"
         """
-        effective_stop = self._effective_stop()
-        if not effective_stop or not content:
+        stops = self.stop_sequences
+        if not stops or not content:
             return content
 
         earliest_stop_pos = len(content)
         found_stop_word = None
 
-        for stop_word in effective_stop:
+        for stop_word in stops:
             stop_pos = content.find(stop_word)
             if stop_pos != -1 and stop_pos < earliest_stop_pos:
                 earliest_stop_pos = stop_pos

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -72,6 +72,9 @@ _JSON_EXTRACTION_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{.*}", re.DOTAL
 _current_call_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_current_call_id", default=None
 )
+_call_stop_override_var: contextvars.ContextVar[list[str] | None] = (
+    contextvars.ContextVar("_call_stop_override_var", default=None)
+)
 
 
 @contextmanager
@@ -83,6 +86,23 @@ def llm_call_context() -> Generator[str, None, None]:
         yield call_id
     finally:
         _current_call_id.reset(token)
+
+
+@contextmanager
+def call_stop_override(stop: list[str] | None) -> Generator[None, None, None]:
+    """Override the active stop list for the current call scope.
+
+    Reads via :meth:`BaseLLM._effective_stop` (and therefore
+    :attr:`BaseLLM.stop_sequences`) return ``stop`` for the duration of the
+    context. Setting ``None`` clears any active override. The instance-level
+    ``stop`` field is never mutated, so the override is safe under concurrent
+    execution.
+    """
+    token = _call_stop_override_var.set(stop)
+    try:
+        yield
+    finally:
+        _call_stop_override_var.reset(token)
 
 
 def get_current_call_id() -> str:
@@ -160,10 +180,20 @@ class BaseLLM(BaseModel, ABC):
     def stop_sequences(self) -> list[str]:
         """Alias for ``stop`` — kept for backward compatibility with provider APIs.
 
-        Writes are handled by ``__setattr__``, which normalizes and redirects
-        ``stop_sequences`` assignments to the ``stop`` field.
+        Honors the per-call stop override set via :func:`call_stop_override` so
+        that callers can supply additional stop sequences for a single call
+        without mutating the shared instance.
         """
-        return self.stop
+        return self._effective_stop()
+
+    def _effective_stop(self) -> list[str]:
+        """Return the stop list active for the current call.
+
+        Falls back to the instance-level ``stop`` field when no per-call
+        override is in effect.
+        """
+        override = _call_stop_override_var.get()
+        return override if override is not None else self.stop
 
     _token_usage: dict[str, int] = PrivateAttr(
         default_factory=lambda: {
@@ -341,7 +371,7 @@ class BaseLLM(BaseModel, ABC):
         Returns:
             True if stop words are configured and can be applied
         """
-        return bool(self.stop)
+        return bool(self._effective_stop())
 
     def _apply_stop_words(self, content: str) -> str:
         """Apply stop words to truncate response content.
@@ -363,14 +393,14 @@ class BaseLLM(BaseModel, ABC):
             >>> llm._apply_stop_words(response)
             "I need to search.\\n\\nAction: search"
         """
-        if not self.stop or not content:
+        effective_stop = self._effective_stop()
+        if not effective_stop or not content:
             return content
 
-        # Find the earliest occurrence of any stop word
         earliest_stop_pos = len(content)
         found_stop_word = None
 
-        for stop_word in self.stop:
+        for stop_word in effective_stop:
             stop_pos = content.find(stop_word)
             if stop_pos != -1 and stop_pos < earliest_stop_pos:
                 earliest_stop_pos = stop_pos

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -679,9 +679,9 @@ class AzureCompletion(BaseLLM):
             params["presence_penalty"] = self.presence_penalty
         if self.max_tokens is not None:
             params["max_tokens"] = self.max_tokens
-        effective_stop = self._effective_stop()
-        if effective_stop and self.supports_stop_words():
-            params["stop"] = effective_stop
+        stops = self.stop_sequences
+        if stops and self.supports_stop_words():
+            params["stop"] = stops
 
         # Handle tools/functions for Azure OpenAI models
         if tools and self.is_openai_model:

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -679,8 +679,9 @@ class AzureCompletion(BaseLLM):
             params["presence_penalty"] = self.presence_penalty
         if self.max_tokens is not None:
             params["max_tokens"] = self.max_tokens
-        if self.stop and self.supports_stop_words():
-            params["stop"] = self.stop
+        effective_stop = self._effective_stop()
+        if effective_stop and self.supports_stop_words():
+            params["stop"] = effective_stop
 
         # Handle tools/functions for Azure OpenAI models
         if tools and self.is_openai_model:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -492,16 +492,15 @@ def get_llm_response(
     """
     messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
 
-    with _llm_stop_words_applied(llm, executor_context):
-        answer = llm.call(
-            messages,
-            tools=tools,
-            callbacks=callbacks,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+    answer = llm.call(
+        messages,
+        tools=tools,
+        callbacks=callbacks,
+        available_functions=available_functions,
+        from_task=from_task,
+        from_agent=from_agent,
+        response_model=response_model,
+    )
 
     return _validate_and_finalize_llm_response(
         answer, executor_context, printer, verbose=verbose
@@ -546,16 +545,15 @@ async def aget_llm_response(
     """
     messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
 
-    with _llm_stop_words_applied(llm, executor_context):
-        answer = await llm.acall(
-            messages,
-            tools=tools,
-            callbacks=callbacks,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+    answer = await llm.acall(
+        messages,
+        tools=tools,
+        callbacks=callbacks,
+        available_functions=available_functions,
+        from_task=from_task,
+        from_agent=from_agent,
+        response_model=response_model,
+    )
 
     return _validate_and_finalize_llm_response(
         answer, executor_context, printer, verbose=verbose

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -23,7 +23,7 @@ from crewai.agents.parser import (
     parse,
 )
 from crewai.cli.config import Settings
-from crewai.llms.base_llm import BaseLLM
+from crewai.llms.base_llm import BaseLLM, call_stop_override
 from crewai.tools import BaseTool as CrewAITool
 from crewai.tools.base_tool import BaseTool
 from crewai.tools.structured_tool import CrewStructuredTool
@@ -256,10 +256,12 @@ def _llm_stop_words_applied(
     llm: LLM | BaseLLM,
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
 ) -> Iterator[None]:
-    """Temporarily merge the executor's stop words into the LLM's ``stop`` list.
+    """Apply the executor's stop words to the LLM for the duration of one call.
 
-    Restores the original list on exit so the user's LLM instance is never
-    permanently mutated and stop words don't leak across agents or kickoffs.
+    Uses :func:`crewai.llms.base_llm.call_stop_override` so the LLM's stop
+    field is never mutated. Safe under concurrent execution: the override is
+    propagated via a :class:`contextvars.ContextVar` and is scoped to this
+    call's task / thread context.
     """
     extra = _executor_stop_words(executor_context)
     if (
@@ -270,12 +272,8 @@ def _llm_stop_words_applied(
     ):
         yield
         return
-    saved = llm.stop
-    llm.stop = list(set(saved + extra))
-    try:
+    with call_stop_override(list(set(llm.stop + extra))):
         yield
-    finally:
-        llm.stop = saved
 
 
 def has_reached_max_iterations(iterations: int, max_iterations: int) -> bool:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -267,7 +267,7 @@ def _llm_stop_words_applied(
     if not extra or not isinstance(llm, BaseLLM) or set(extra).issubset(llm.stop):
         yield
         return
-    with call_stop_override(list(set(llm.stop + extra))):
+    with call_stop_override(llm, list(set(llm.stop + extra))):
         yield
 
 

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -264,12 +264,7 @@ def _llm_stop_words_applied(
     call's task / thread context.
     """
     extra = _executor_stop_words(executor_context)
-    if (
-        not extra
-        or not isinstance(llm, BaseLLM)
-        or not llm.supports_stop_words()
-        or set(extra).issubset(llm.stop)
-    ):
+    if not extra or not isinstance(llm, BaseLLM) or set(extra).issubset(llm.stop):
         yield
         return
     with call_stop_override(list(set(llm.stop + extra))):

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 import concurrent.futures
+import contextlib
 import contextvars
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -238,6 +239,45 @@ def extract_task_section(text: str) -> str:
     return text
 
 
+def _executor_stop_words(
+    executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
+) -> list[str]:
+    """Return the executor's stop words, regardless of which field name it uses."""
+    if executor_context is None:
+        return []
+    stops = getattr(executor_context, "stop", None)
+    if stops is None:
+        stops = getattr(executor_context, "stop_words", None)
+    return list(stops) if stops else []
+
+
+@contextlib.contextmanager
+def _llm_stop_words_applied(
+    llm: LLM | BaseLLM,
+    executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
+) -> Iterator[None]:
+    """Temporarily merge the executor's stop words into the LLM's ``stop`` list.
+
+    Restores the original list on exit so the user's LLM instance is never
+    permanently mutated and stop words don't leak across agents or kickoffs.
+    """
+    extra = _executor_stop_words(executor_context)
+    if (
+        not extra
+        or not isinstance(llm, BaseLLM)
+        or not llm.supports_stop_words()
+        or set(extra).issubset(llm.stop)
+    ):
+        yield
+        return
+    saved = llm.stop
+    llm.stop = list(set(saved + extra))
+    try:
+        yield
+    finally:
+        llm.stop = saved
+
+
 def has_reached_max_iterations(iterations: int, max_iterations: int) -> bool:
     """Check if the maximum number of iterations has been reached.
 
@@ -459,7 +499,7 @@ def get_llm_response(
     """
     messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
 
-    try:
+    with _llm_stop_words_applied(llm, executor_context):
         answer = llm.call(
             messages,
             tools=tools,
@@ -469,8 +509,6 @@ def get_llm_response(
             from_agent=from_agent,
             response_model=response_model,
         )
-    except Exception as e:
-        raise e
 
     return _validate_and_finalize_llm_response(
         answer, executor_context, printer, verbose=verbose
@@ -515,7 +553,7 @@ async def aget_llm_response(
     """
     messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
 
-    try:
+    with _llm_stop_words_applied(llm, executor_context):
         answer = await llm.acall(
             messages,
             tools=tools,
@@ -525,8 +563,6 @@ async def aget_llm_response(
             from_agent=from_agent,
             response_model=response_model,
         )
-    except Exception as e:
-        raise e
 
     return _validate_and_finalize_llm_response(
         answer, executor_context, printer, verbose=verbose

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2522,8 +2522,16 @@ class TestSharedLLMStopWords:
         assert shared.stop == ["Original:"]
         assert shared.stop_sequences == ["Original:"]
 
-    def test_no_override_when_llm_does_not_support_stop_words(self) -> None:
-        """LLMs that ignore stop words must not see a per-call override."""
+    def test_override_applies_for_post_processing_when_api_lacks_stop_support(
+        self,
+    ) -> None:
+        """Models that lack API-level stop support still need the override.
+
+        Native providers (e.g. Azure on gpt-5/o-series) read ``stop_sequences``
+        in ``_apply_stop_words`` to truncate the response post-hoc even when
+        ``supports_stop_words()`` returns False, so the override must be set
+        regardless of API-level support. (Issue raised by Cursor Bugbot.)
+        """
         from unittest.mock import patch
         from crewai.utilities.agent_utils import _llm_stop_words_applied
 
@@ -2532,9 +2540,10 @@ class TestSharedLLMStopWords:
 
         with patch.object(shared, "supports_stop_words", return_value=False):
             with _llm_stop_words_applied(shared, executor):
-                assert shared.stop_sequences == ["Original:"]
+                assert set(shared.stop_sequences) == {"Original:", "Observation:"}
 
         assert shared.stop == ["Original:"]
+        assert shared.stop_sequences == ["Original:"]
 
     def test_concurrent_overrides_do_not_collide(self) -> None:
         """Concurrent agents on a shared LLM must each see their own effective stop."""

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2515,9 +2515,11 @@ class TestSharedLLMStopWords:
         shared = LLM(model="gpt-4", stop=["Original:"])
         executor = self._make_executor(shared, stop_words=["Observation:"])
 
-        with pytest.raises(RuntimeError):
+        try:
             with _llm_stop_words_applied(shared, executor):
                 raise RuntimeError("boom")
+        except RuntimeError:
+            pass
 
         assert shared.stop == ["Original:"]
         assert shared.stop_sequences == ["Original:"]

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2502,12 +2502,11 @@ class TestSharedLLMStopWords:
         executor = self._make_executor(shared, stop_words=["Observation:"])
 
         with _llm_stop_words_applied(shared, executor):
-            assert set(shared._effective_stop()) == {"Original:", "Observation:"}
             assert set(shared.stop_sequences) == {"Original:", "Observation:"}
             assert shared.stop == ["Original:"]
 
         assert shared.stop == ["Original:"]
-        assert shared._effective_stop() == ["Original:"]
+        assert shared.stop_sequences == ["Original:"]
 
     def test_override_cleared_when_context_raises(self) -> None:
         """A failed call must still clear the per-call stop override."""
@@ -2521,7 +2520,7 @@ class TestSharedLLMStopWords:
                 raise RuntimeError("boom")
 
         assert shared.stop == ["Original:"]
-        assert shared._effective_stop() == ["Original:"]
+        assert shared.stop_sequences == ["Original:"]
 
     def test_no_override_when_llm_does_not_support_stop_words(self) -> None:
         """LLMs that ignore stop words must not see a per-call override."""
@@ -2533,7 +2532,7 @@ class TestSharedLLMStopWords:
 
         with patch.object(shared, "supports_stop_words", return_value=False):
             with _llm_stop_words_applied(shared, executor):
-                assert shared._effective_stop() == ["Original:"]
+                assert shared.stop_sequences == ["Original:"]
 
         assert shared.stop == ["Original:"]
 
@@ -2549,7 +2548,7 @@ class TestSharedLLMStopWords:
         async def run(executor: CrewAgentExecutor, expected: str) -> set[str]:
             with _llm_stop_words_applied(shared, executor):
                 await asyncio.sleep(0)
-                seen = set(shared._effective_stop())
+                seen = set(shared.stop_sequences)
                 assert expected in seen
                 return seen
 
@@ -2562,4 +2561,4 @@ class TestSharedLLMStopWords:
         assert a_seen == {"Original:", "StopA:"}
         assert b_seen == {"Original:", "StopB:"}
         assert shared.stop == ["Original:"]
-        assert shared._effective_stop() == ["Original:"]
+        assert shared.stop_sequences == ["Original:"]

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2574,6 +2574,25 @@ class TestSharedLLMStopWords:
         assert shared.stop == ["Original:"]
         assert shared.stop_sequences == ["Original:"]
 
+    def test_override_does_not_leak_to_other_llm_instances(self) -> None:
+        """Override for one LLM must not affect another LLM (e.g. function_calling_llm).
+
+        Regression for Cursor Bugbot: a global ContextVar would leak the
+        override to every BaseLLM that reads stop_sequences during the scope.
+        """
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
+        target = LLM(model="gpt-4", stop=["TargetStop:"])
+        other = LLM(model="gpt-4", stop=["OtherStop:"])
+        executor = self._make_executor(target, stop_words=["Observation:"])
+
+        with _llm_stop_words_applied(target, executor):
+            assert set(target.stop_sequences) == {"TargetStop:", "Observation:"}
+            assert other.stop_sequences == ["OtherStop:"]
+
+        assert target.stop_sequences == ["TargetStop:"]
+        assert other.stop_sequences == ["OtherStop:"]
+
     def test_override_propagates_to_nested_direct_llm_calls(self) -> None:
         """Once invoke wraps with the override, nested direct llm.call sites
         (StepExecutor, handle_max_iterations_exceeded) see the merged stops.

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2573,3 +2573,27 @@ class TestSharedLLMStopWords:
         assert b_seen == {"Original:", "StopB:"}
         assert shared.stop == ["Original:"]
         assert shared.stop_sequences == ["Original:"]
+
+    def test_override_propagates_to_nested_direct_llm_calls(self) -> None:
+        """Once invoke wraps with the override, nested direct llm.call sites
+        (StepExecutor, handle_max_iterations_exceeded) see the merged stops.
+
+        Regression for Cursor Bugbot: those direct call sites bypass
+        get_llm_response, so the override must be set at executor entry, not
+        only around get_llm_response.
+        """
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        executor = self._make_executor(shared, stop_words=["Observation:"])
+
+        seen: list[set[str]] = []
+
+        def nested_direct_call() -> None:
+            seen.append(set(shared.stop_sequences))
+
+        with _llm_stop_words_applied(shared, executor):
+            nested_direct_call()
+
+        assert seen == [{"Original:", "Observation:"}]
+        assert shared.stop == ["Original:"]

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2452,3 +2452,70 @@ def test_agent_mcps_accepts_legacy_prefix_with_tool():
         mcps=["crewai-amp:notion#get_page"],
     )
     assert agent.mcps == ["crewai-amp:notion#get_page"]
+
+
+class TestCrewAgentExecutorSharedLLMStopWords:
+    """Regression tests for shared LLM stop words mutation (issue #5141)."""
+
+    @staticmethod
+    def _make_executor(llm: LLM, stop_words: list[str]) -> CrewAgentExecutor:
+        """Build a CrewAgentExecutor with minimal deps."""
+        from crewai.agents.tools_handler import ToolsHandler
+
+        agent = Agent(role="r", goal="g", backstory="b")
+        task = Task(description="d", expected_output="o", agent=agent)
+        return CrewAgentExecutor(
+            agent=agent,
+            task=task,
+            llm=llm,
+            crew=None,
+            prompt={"prompt": "p {input} {tool_names} {tools}"},
+            max_iter=5,
+            tools=[],
+            tools_names="",
+            stop_words=stop_words,
+            tools_description="",
+            tools_handler=ToolsHandler(),
+        )
+
+    def test_shared_llm_stop_not_mutated(self) -> None:
+        """Constructing an executor must not mutate the shared LLM's stop list."""
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        original = list(shared.stop)
+
+        self._make_executor(shared, stop_words=["Observation:"])
+
+        assert shared.stop == original
+
+    def test_multiple_executors_isolate_stop_words(self) -> None:
+        """Each executor sharing an LLM gets its own merged stop list."""
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        original = list(shared.stop)
+
+        a = self._make_executor(shared, stop_words=["StopA:"])
+        b = self._make_executor(shared, stop_words=["StopB:"])
+
+        assert shared.stop == original
+        assert a.llm is not shared
+        assert b.llm is not shared
+        assert a.llm is not b.llm
+        assert set(a.llm.stop) == {"Original:", "StopA:"}
+        assert set(b.llm.stop) == {"Original:", "StopB:"}
+
+    def test_no_copy_when_stop_words_already_present(self) -> None:
+        """When the executor adds nothing new, the shared LLM is reused as-is."""
+        shared = LLM(model="gpt-4", stop=["Original:"])
+
+        executor = self._make_executor(shared, stop_words=["Original:"])
+
+        assert executor.llm is shared
+
+    def test_stop_words_do_not_accumulate_across_kickoffs(self) -> None:
+        """Repeated executor construction must not grow the shared LLM's stop list."""
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        original = list(shared.stop)
+
+        for _ in range(5):
+            self._make_executor(shared, stop_words=["Observation:"])
+
+        assert shared.stop == original

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2494,20 +2494,23 @@ class TestSharedLLMStopWords:
         assert a.llm is shared
         assert b.llm is shared
 
-    def test_stop_words_restored_after_llm_call(self) -> None:
-        """The merge applied around llm.call must be reverted afterwards."""
+    def test_effective_stop_reflects_override_inside_context(self) -> None:
+        """Inside the helper, the effective stop list includes the executor's words."""
         from crewai.utilities.agent_utils import _llm_stop_words_applied
 
         shared = LLM(model="gpt-4", stop=["Original:"])
         executor = self._make_executor(shared, stop_words=["Observation:"])
 
         with _llm_stop_words_applied(shared, executor):
-            assert set(shared.stop) == {"Original:", "Observation:"}
+            assert set(shared._effective_stop()) == {"Original:", "Observation:"}
+            assert set(shared.stop_sequences) == {"Original:", "Observation:"}
+            assert shared.stop == ["Original:"]
 
         assert shared.stop == ["Original:"]
+        assert shared._effective_stop() == ["Original:"]
 
-    def test_stop_words_restored_when_call_raises(self) -> None:
-        """A failed call must still restore the LLM's stop list."""
+    def test_override_cleared_when_context_raises(self) -> None:
+        """A failed call must still clear the per-call stop override."""
         from crewai.utilities.agent_utils import _llm_stop_words_applied
 
         shared = LLM(model="gpt-4", stop=["Original:"])
@@ -2518,9 +2521,10 @@ class TestSharedLLMStopWords:
                 raise RuntimeError("boom")
 
         assert shared.stop == ["Original:"]
+        assert shared._effective_stop() == ["Original:"]
 
-    def test_no_merge_when_llm_does_not_support_stop_words(self) -> None:
-        """LLMs that ignore stop words must not have their stop list touched."""
+    def test_no_override_when_llm_does_not_support_stop_words(self) -> None:
+        """LLMs that ignore stop words must not see a per-call override."""
         from unittest.mock import patch
         from crewai.utilities.agent_utils import _llm_stop_words_applied
 
@@ -2529,19 +2533,33 @@ class TestSharedLLMStopWords:
 
         with patch.object(shared, "supports_stop_words", return_value=False):
             with _llm_stop_words_applied(shared, executor):
-                assert shared.stop == ["Original:"]
+                assert shared._effective_stop() == ["Original:"]
 
         assert shared.stop == ["Original:"]
 
-    def test_no_accumulation_across_repeated_calls(self) -> None:
-        """Repeated entries into the helper must not grow the shared LLM's stop list."""
+    def test_concurrent_overrides_do_not_collide(self) -> None:
+        """Concurrent agents on a shared LLM must each see their own effective stop."""
+        import asyncio
         from crewai.utilities.agent_utils import _llm_stop_words_applied
 
         shared = LLM(model="gpt-4", stop=["Original:"])
-        executor = self._make_executor(shared, stop_words=["Observation:"])
+        exec_a = self._make_executor(shared, stop_words=["StopA:"])
+        exec_b = self._make_executor(shared, stop_words=["StopB:"])
 
-        for _ in range(5):
+        async def run(executor: CrewAgentExecutor, expected: str) -> set[str]:
             with _llm_stop_words_applied(shared, executor):
-                pass
+                await asyncio.sleep(0)
+                seen = set(shared._effective_stop())
+                assert expected in seen
+                return seen
 
+        async def main() -> tuple[set[str], set[str]]:
+            return await asyncio.gather(
+                run(exec_a, "StopA:"), run(exec_b, "StopB:")
+            )
+
+        a_seen, b_seen = asyncio.run(main())
+        assert a_seen == {"Original:", "StopA:"}
+        assert b_seen == {"Original:", "StopB:"}
         assert shared.stop == ["Original:"]
+        assert shared._effective_stop() == ["Original:"]

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2454,8 +2454,12 @@ def test_agent_mcps_accepts_legacy_prefix_with_tool():
     assert agent.mcps == ["crewai-amp:notion#get_page"]
 
 
-class TestCrewAgentExecutorSharedLLMStopWords:
-    """Regression tests for shared LLM stop words mutation (issue #5141)."""
+class TestSharedLLMStopWords:
+    """Regression tests for shared LLM stop words mutation (issue #5141).
+
+    Stop words from one executor must not leak into the shared LLM permanently
+    or pollute other agents sharing that LLM.
+    """
 
     @staticmethod
     def _make_executor(llm: LLM, stop_words: list[str]) -> CrewAgentExecutor:
@@ -2478,17 +2482,8 @@ class TestCrewAgentExecutorSharedLLMStopWords:
             tools_handler=ToolsHandler(),
         )
 
-    def test_shared_llm_stop_not_mutated(self) -> None:
-        """Constructing an executor must not mutate the shared LLM's stop list."""
-        shared = LLM(model="gpt-4", stop=["Original:"])
-        original = list(shared.stop)
-
-        self._make_executor(shared, stop_words=["Observation:"])
-
-        assert shared.stop == original
-
-    def test_multiple_executors_isolate_stop_words(self) -> None:
-        """Each executor sharing an LLM gets its own merged stop list."""
+    def test_executor_init_does_not_mutate_shared_llm(self) -> None:
+        """Constructing executors must not touch the shared LLM's stop list."""
         shared = LLM(model="gpt-4", stop=["Original:"])
         original = list(shared.stop)
 
@@ -2496,26 +2491,57 @@ class TestCrewAgentExecutorSharedLLMStopWords:
         b = self._make_executor(shared, stop_words=["StopB:"])
 
         assert shared.stop == original
-        assert a.llm is not shared
-        assert b.llm is not shared
-        assert a.llm is not b.llm
-        assert set(a.llm.stop) == {"Original:", "StopA:"}
-        assert set(b.llm.stop) == {"Original:", "StopB:"}
+        assert a.llm is shared
+        assert b.llm is shared
 
-    def test_no_copy_when_stop_words_already_present(self) -> None:
-        """When the executor adds nothing new, the shared LLM is reused as-is."""
+    def test_stop_words_restored_after_llm_call(self) -> None:
+        """The merge applied around llm.call must be reverted afterwards."""
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
         shared = LLM(model="gpt-4", stop=["Original:"])
+        executor = self._make_executor(shared, stop_words=["Observation:"])
 
-        executor = self._make_executor(shared, stop_words=["Original:"])
+        with _llm_stop_words_applied(shared, executor):
+            assert set(shared.stop) == {"Original:", "Observation:"}
 
-        assert executor.llm is shared
+        assert shared.stop == ["Original:"]
 
-    def test_stop_words_do_not_accumulate_across_kickoffs(self) -> None:
-        """Repeated executor construction must not grow the shared LLM's stop list."""
+    def test_stop_words_restored_when_call_raises(self) -> None:
+        """A failed call must still restore the LLM's stop list."""
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
         shared = LLM(model="gpt-4", stop=["Original:"])
-        original = list(shared.stop)
+        executor = self._make_executor(shared, stop_words=["Observation:"])
+
+        with pytest.raises(RuntimeError):
+            with _llm_stop_words_applied(shared, executor):
+                raise RuntimeError("boom")
+
+        assert shared.stop == ["Original:"]
+
+    def test_no_merge_when_llm_does_not_support_stop_words(self) -> None:
+        """LLMs that ignore stop words must not have their stop list touched."""
+        from unittest.mock import patch
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        executor = self._make_executor(shared, stop_words=["Observation:"])
+
+        with patch.object(shared, "supports_stop_words", return_value=False):
+            with _llm_stop_words_applied(shared, executor):
+                assert shared.stop == ["Original:"]
+
+        assert shared.stop == ["Original:"]
+
+    def test_no_accumulation_across_repeated_calls(self) -> None:
+        """Repeated entries into the helper must not grow the shared LLM's stop list."""
+        from crewai.utilities.agent_utils import _llm_stop_words_applied
+
+        shared = LLM(model="gpt-4", stop=["Original:"])
+        executor = self._make_executor(shared, stop_words=["Observation:"])
 
         for _ in range(5):
-            self._make_executor(shared, stop_words=["Observation:"])
+            with _llm_stop_words_applied(shared, executor):
+                pass
 
-        assert shared.stop == original
+        assert shared.stop == ["Original:"]


### PR DESCRIPTION
Closes #5141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LLM stop-sequence handling across multiple executors/providers; behavior changes are scoped but could affect response truncation and tool/agent loops if stop sequences are misapplied or missed in some call paths.
> 
> **Overview**
> Prevents stop words from leaking between agents that share the same LLM by **removing in-place mutation of `llm.stop`** during executor setup and instead applying executor stop words **per invocation** via a new context-scoped override.
> 
> Adds `call_stop_override()` and a per-call `stop_sequences` view on `BaseLLM` (backed by `contextvars`), updates LLM/provider code paths to read `stop_sequences` (including post-processing truncation), and wraps `CrewAgentExecutor`/experimental `AgentExecutor` execution entrypoints in `_llm_stop_words_applied`. Includes regression tests covering non-mutation, exception cleanup, concurrency isolation, and ensuring overrides don’t affect other LLM instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3c776de26858ccba1b44d2ecb0ed9546b192a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->