### PR TITLE
feat: tag runtime tool instances with private identity metadata

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
@@ -26,6 +26,8 @@ class CrewAIPlatformActionTool(BaseTool):
         description: str,
         action_name: str,
         action_schema: dict[str, Any],
+        provider: str | None = None,
+        provider_id: str | None = None,
     ):
         parameters = action_schema.get("function", {}).get("parameters", {})
 
@@ -48,6 +50,12 @@ class CrewAIPlatformActionTool(BaseTool):
         )
         self.action_name = action_name
         self.action_schema = action_schema
+        # Private metadata used by enterprise tooling to recover the canonical
+        # tool_id (e.g. "crewai_oauth:google_drive" or "paragon:<uuid>") for
+        # ACP rule evaluation. Set by CrewaiPlatformToolBuilder; remains None
+        # for direct construction.
+        self._provider = provider
+        self._provider_id = provider_id
 
     def _run(self, **kwargs: Any) -> str:
         try:

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
@@ -75,6 +75,7 @@ class CrewaiPlatformToolBuilder:
                                 ),
                                 "parameters": action.get("parameters", {}),
                                 "app": app,
+                                "provider": action.get("provider"),
                             }
                         }
                         self._actions_schema[action_name] = action_schema
@@ -91,6 +92,8 @@ class CrewaiPlatformToolBuilder:
                 description=description,
                 action_name=action_name,
                 action_schema=action_schema,
+                provider=function_details.get("provider"),
+                provider_id=function_details.get("app"),
             )
 
             tools.append(tool)

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_provider_tagging.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_provider_tagging.py
@@ -1,0 +1,120 @@
+"""Tests for the _provider / _provider_id metadata attached to platform tools.
+
+These attributes are private metadata used by enterprise tooling to recover
+the canonical tool_id (e.g. ``crewai_oauth:google_drive`` or
+``paragon:<uuid>``) for ACP rule evaluation.
+"""
+
+from unittest.mock import Mock, patch
+
+from crewai_tools.tools.crewai_platform_tools import (
+    CrewAIPlatformActionTool,
+    CrewaiPlatformToolBuilder,
+)
+
+
+class TestActionToolProviderAttrs:
+    def setup_method(self):
+        self.action_schema = {
+            "function": {
+                "name": "test_action",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        }
+
+    def test_defaults_to_none_when_not_provided(self):
+        tool = CrewAIPlatformActionTool(
+            description="x",
+            action_name="test_action",
+            action_schema=self.action_schema,
+        )
+        assert tool._provider is None
+        assert tool._provider_id is None
+
+    def test_stores_explicit_values(self):
+        tool = CrewAIPlatformActionTool(
+            description="x",
+            action_name="test_action",
+            action_schema=self.action_schema,
+            provider="crewai_oauth",
+            provider_id="google_drive",
+        )
+        assert tool._provider == "crewai_oauth"
+        assert tool._provider_id == "google_drive"
+
+
+class TestBuilderProviderThreading:
+    @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
+    @patch(
+        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+    )
+    def test_builder_threads_provider_and_app_into_each_tool(self, mock_get):
+        mock_api_response = {
+            "actions": {
+                "google_drive": [
+                    {
+                        "name": "create_file",
+                        "description": "Create a file",
+                        "parameters": {"type": "object", "properties": {}},
+                        "provider": "crewai_oauth",
+                    }
+                ],
+                "1b5f2395-65a5-4da8-9b2f-c10eafc83a0b": [
+                    {
+                        "name": "send_invoice",
+                        "description": "Send an invoice",
+                        "parameters": {"type": "object", "properties": {}},
+                        "provider": "paragon",
+                    }
+                ],
+            }
+        }
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = mock_api_response
+        mock_get.return_value = mock_response
+
+        builder = CrewaiPlatformToolBuilder(
+            apps=["google_drive", "1b5f2395-65a5-4da8-9b2f-c10eafc83a0b"]
+        )
+        tools = builder.tools()
+
+        by_action = {tool.action_name: tool for tool in tools}
+
+        oauth_tool = by_action["create_file"]
+        assert oauth_tool._provider == "crewai_oauth"
+        assert oauth_tool._provider_id == "google_drive"
+
+        paragon_tool = by_action["send_invoice"]
+        assert paragon_tool._provider == "paragon"
+        assert paragon_tool._provider_id == "1b5f2395-65a5-4da8-9b2f-c10eafc83a0b"
+
+    @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
+    @patch(
+        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+    )
+    def test_builder_handles_response_without_provider_field(self, mock_get):
+        # Older crewai-plus versions return actions without a "provider" key.
+        # The builder must remain compatible: provider_id is set, provider is None.
+        mock_api_response = {
+            "actions": {
+                "github": [
+                    {
+                        "name": "create_issue",
+                        "description": "Create issue",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ]
+            }
+        }
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = mock_api_response
+        mock_get.return_value = mock_response
+
+        builder = CrewaiPlatformToolBuilder(apps=["github"])
+        tools = builder.tools()
+
+        assert len(tools) == 1
+        assert tools[0]._provider is None
+        assert tools[0]._provider_id == "github"

--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -153,7 +153,7 @@ class MCPToolResolver:
             try:
                 tools, clients = self._resolve_native(mcp_server_config)
                 for tool in tools:
-                    tool._amp_slug = slug
+                    tool._amp_slug = slug  # type: ignore[attr-defined]
                 resolved_cache[slug] = (tools, clients)
                 all_clients.extend(clients)
             except Exception as e:

--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -152,6 +152,8 @@ class MCPToolResolver:
 
             try:
                 tools, clients = self._resolve_native(mcp_server_config)
+                for tool in tools:
+                    tool._amp_slug = slug
                 resolved_cache[slug] = (tools, clients)
                 all_clients.extend(clients)
             except Exception as e:

--- a/lib/crewai/src/crewai/tools/mcp_native_tool.py
+++ b/lib/crewai/src/crewai/tools/mcp_native_tool.py
@@ -59,6 +59,11 @@ class MCPNativeTool(BaseTool):
         self._client_factory = client_factory
         self._original_tool_name = original_tool_name or tool_name
         self._server_name = server_name
+        # Set by MCPToolResolver._resolve_amp when this tool is produced for
+        # an AMP slug; remains None for direct config / external URL refs.
+        # Consumed downstream by enterprise tooling to recover the canonical
+        # tool_id (e.g. "crewai_oauth:<slug>|mcp").
+        self._amp_slug: str | None = None
 
     @property
     def original_tool_name(self) -> str:

--- a/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
+++ b/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
@@ -54,6 +54,11 @@ class MCPToolWrapper(BaseTool):
         self._mcp_server_params = mcp_server_params
         self._original_tool_name = tool_name
         self._server_name = server_name
+        # Set by MCPToolResolver._resolve_amp when this wrapper is produced for
+        # an AMP slug; remains None for direct config / external URL refs.
+        # Consumed downstream by enterprise tooling to recover the canonical
+        # tool_id (e.g. "crewai_oauth:<slug>|mcp").
+        self._amp_slug: str | None = None
 
     @property
     def mcp_server_params(self) -> dict[str, Any]:

--- a/lib/crewai/tests/mcp/test_tool_resolver_amp_slug.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_amp_slug.py
@@ -1,0 +1,135 @@
+"""Tests for the _amp_slug attribute set by MCPToolResolver._resolve_amp.
+
+The slug is private metadata used downstream by enterprise tooling to recover
+the canonical tool_id (e.g. ``crewai_oauth:<slug>|mcp``) for ACP rule
+evaluation.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from crewai.agent.core import Agent
+from crewai.mcp.config import MCPServerHTTP
+from crewai.mcp.tool_resolver import MCPToolResolver
+from crewai.tools.mcp_native_tool import MCPNativeTool
+from crewai.tools.mcp_tool_wrapper import MCPToolWrapper
+
+
+@pytest.fixture
+def agent():
+    return Agent(
+        role="Test Agent",
+        goal="Test goal",
+        backstory="Test backstory",
+    )
+
+
+@pytest.fixture
+def resolver(agent):
+    return MCPToolResolver(agent=agent, logger=agent._logger)
+
+
+class TestAmpSlugDefaultsNone:
+    def test_native_tool_default_amp_slug_is_none(self):
+        tool = MCPNativeTool(
+            client_factory=lambda: None,
+            tool_name="search",
+            tool_schema={"description": "Search"},
+            server_name="notion",
+        )
+        assert tool._amp_slug is None
+
+    def test_wrapper_tool_default_amp_slug_is_none(self):
+        tool = MCPToolWrapper(
+            mcp_server_params={"url": "https://mcp.example.com"},
+            tool_name="search",
+            tool_schema={"description": "Search"},
+            server_name="notion",
+        )
+        assert tool._amp_slug is None
+
+
+class TestAmpSlugSetByResolveAmp:
+    @patch("crewai.mcp.tool_resolver.MCPToolResolver._resolve_native")
+    @patch("crewai.mcp.tool_resolver.MCPToolResolver._fetch_amp_mcp_configs")
+    def test_resolve_amp_tags_each_tool_with_its_slug(
+        self, mock_fetch_configs, mock_resolve_native, resolver
+    ):
+        mock_fetch_configs.return_value = {
+            "notion": {"url": "https://mcp.crewai.com/notion"},
+            "github": {"url": "https://mcp.crewai.com/github"},
+        }
+
+        notion_tool = MCPNativeTool(
+            client_factory=lambda: None,
+            tool_name="search",
+            tool_schema={"description": "search Notion"},
+            server_name="notion",
+        )
+        github_tool = MCPNativeTool(
+            client_factory=lambda: None,
+            tool_name="list_repos",
+            tool_schema={"description": "list github repos"},
+            server_name="github",
+        )
+
+        def fake_resolve_native(config):
+            url = config.url if hasattr(config, "url") else config["url"]
+            if "notion" in url:
+                return ([notion_tool], [MagicMock()])
+            return ([github_tool], [MagicMock()])
+
+        mock_resolve_native.side_effect = fake_resolve_native
+
+        tools, _ = resolver._resolve_amp(
+            [("notion", None), ("github", None)]
+        )
+
+        assert {tool._amp_slug for tool in tools} == {"notion", "github"}
+
+    @patch("crewai.mcp.tool_resolver.MCPToolResolver._fetch_amp_mcp_configs")
+    def test_resolve_amp_does_not_tag_when_config_missing(
+        self, mock_fetch_configs, resolver
+    ):
+        mock_fetch_configs.return_value = {}
+
+        tools, _ = resolver._resolve_amp([("unknown", None)])
+
+        assert tools == []
+
+
+class TestAmpSlugUntaggedForOtherPaths:
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_resolve_external_does_not_set_amp_slug(self, mock_client_class, resolver):
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[{"name": "search", "description": "Search"}]
+        )
+        mock_client.connected = False
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        with patch.object(
+            resolver, "_get_mcp_tool_schemas", return_value={"search": {"description": "Search"}}
+        ):
+            tools = resolver._resolve_external("https://mcp.example.com/api")
+
+        assert len(tools) == 1
+        assert tools[0]._amp_slug is None
+
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_resolve_native_does_not_set_amp_slug(self, mock_client_class, resolver):
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[{"name": "search", "description": "Search"}]
+        )
+        mock_client.connected = False
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        config = MCPServerHTTP(url="https://mcp.example.com/api")
+        tools, _ = resolver._resolve_native(config)
+
+        assert all(tool._amp_slug is None for tool in tools)


### PR DESCRIPTION
### Overview

  Tags runtime tool instances with private metadata so downstream tooling (specifically CrewAI Enterprise) can recover their canonical `tool_id` for ACP rule evaluation.
  - **MCP tools** (`lib/crewai/`) get an `_amp_slug` set by `MCPToolResolver._resolve_amp` — covers [CON-139].
  - **Platform action tools** (`lib/crewai-tools/`) get `_provider` / `_provider_id` set by `CrewaiPlatformToolBuilder` — covers [CON-140] (Python side).

  Both attributes are private, default `None`, and have no impact on existing users. The information they carry is consumed by the enterprise `/inspect.tools` resolver to emit canonical IDs
  like `crewai_oauth:notion-244f20d5|mcp` or `paragon:<uuid>`.

  ### Main Technical Changes

  **`lib/crewai/` — CON-139:**
  - `tools/mcp_tool_wrapper.py`, `tools/mcp_native_tool.py` — new private `_amp_slug: str | None = None` attribute on each wrapper class.
  - `mcp/tool_resolver.py::_resolve_amp` — after wrappers are produced for a given AMP slug, sets `tool._amp_slug = slug` on each (with `# type: ignore[attr-defined]` matching the repo's existing pattern for dynamic attribute assignment on BaseTool subclasses).
  - New tests under `tests/mcp/test_tool_resolver_amp_slug.py` covering: defaults, slug propagation through `_resolve_amp`, missing-config no-op, and untagged behavior on `_resolve_native` / `_resolve_external` paths.

  **`lib/crewai-tools/` — CON-140 (Python):**
  - `crewai_platform_tools/crewai_platform_action_tool.py` — `__init__` accepts `provider: str | None = None` and `provider_id: str | None = None`, stores as private attrs.
  - `crewai_platform_tools/crewai_platform_tool_builder.py` — reads the new `provider` field from `/integrations/actions` response, passes both through. Outer key (`app`) → `provider_id`.
  - New tests under `tests/tools/crewai_platform_tools/test_provider_tagging.py` covering: defaults, full threading from response, and backward-compat when the response lacks the `provider` field.

  ### Notes for reviewers

  - Public API change is minimal: two new optional kwargs on `CrewAIPlatformActionTool.__init__`, both default `None`.
  - The crewai-tools side tolerates an older crewai-plus that doesn't yet return `provider` — `_provider` stays `None` in that case. So this PR can land before or after the matching crewai-plus PR ([CON-140] server side) without breaking anything.