### PR TITLE
fix(task): add async output-conversion path to avoid blocking the event loop in akickoff()

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -53,7 +53,7 @@ from crewai.tasks.task_output import TaskOutput
 from crewai.tools.base_tool import BaseTool
 from crewai.utilities.config import process_config
 from crewai.utilities.constants import NOT_SPECIFIED, _NotSpecified
-from crewai.utilities.converter import Converter, convert_to_model
+from crewai.utilities.converter import Converter, async_convert_to_model, convert_to_model
 from crewai.utilities.file_store import (
     clear_task_files,
     get_all_files,
@@ -681,7 +681,7 @@ class Task(BaseModel):
                     json_output = None
             elif not self._guardrails and not self._guardrail:
                 raw = result
-                pydantic_output, json_output = self._export_output(result)
+                pydantic_output, json_output = await self._aexport_output(result)
             else:
                 raw = result
                 pydantic_output, json_output = None, None
@@ -1136,6 +1136,34 @@ Follow these guidelines:
 
         return pydantic_output, json_output
 
+    async def _aexport_output(
+        self, result: str | BaseModel
+    ) -> tuple[BaseModel | None, dict[str, Any] | None]:
+        """Async version of _export_output — uses acall so the event loop is not blocked."""
+        pydantic_output: BaseModel | None = None
+        json_output: dict[str, Any] | None = None
+
+        if self.output_pydantic or self.output_json:
+            model_output = await async_convert_to_model(
+                result,
+                self.output_pydantic,
+                self.output_json,
+                self.agent,
+                self.converter_cls,
+            )
+
+            if isinstance(model_output, BaseModel):
+                pydantic_output = model_output
+            elif isinstance(model_output, dict):
+                json_output = model_output
+            elif isinstance(model_output, str):
+                try:
+                    json_output = json.loads(model_output)
+                except json.JSONDecodeError:
+                    json_output = None
+
+        return pydantic_output, json_output
+
     def _get_output_format(self) -> OutputFormat:
         if self.output_json:
             return OutputFormat.JSON
@@ -1364,7 +1392,7 @@ Follow these guidelines:
 
                 if isinstance(guardrail_result.result, str):
                     task_output.raw = guardrail_result.result
-                    pydantic_output, json_output = self._export_output(
+                    pydantic_output, json_output = await self._aexport_output(
                         guardrail_result.result
                     )
                     task_output.pydantic = pydantic_output
@@ -1421,7 +1449,7 @@ Follow these guidelines:
                     json_output = None
             else:
                 raw = result
-                pydantic_output, json_output = self._export_output(result)
+                pydantic_output, json_output = await self._aexport_output(result)
 
             task_output = TaskOutput(
                 name=self.name or self.description,

--- a/lib/crewai/src/crewai/utilities/converter.py
+++ b/lib/crewai/src/crewai/utilities/converter.py
@@ -113,6 +113,65 @@ class Converter(OutputConverter):
                 f"Failed to convert text into a Pydantic model due to error: {e}"
             ) from e
 
+    async def ato_pydantic(self, current_attempt: int = 1) -> BaseModel:
+        """Async version of to_pydantic — uses acall to avoid blocking the event loop."""
+        try:
+            if self.llm.supports_function_calling():
+                response = await self.llm.acall(
+                    messages=[
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ],
+                    response_model=self.model,
+                )
+                if isinstance(response, BaseModel):
+                    result = response
+                else:
+                    result = self.model.model_validate_json(response)
+            else:
+                response = await self.llm.acall(
+                    [
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ]
+                )
+                try:
+                    result = self.model.model_validate_json(response)
+                except ValidationError:
+                    result = handle_partial_json(  # type: ignore[assignment]
+                        result=response,
+                        model=self.model,
+                        is_json_output=False,
+                        agent=None,
+                    )
+                    if not isinstance(result, BaseModel):
+                        if isinstance(result, dict):
+                            result = self.model.model_validate(result)
+                        elif isinstance(result, str):
+                            try:
+                                result = self.model.model_validate_json(result)
+                            except Exception as parse_err:
+                                raise ConverterError(
+                                    f"Failed to convert partial JSON result into Pydantic: {parse_err}"
+                                ) from parse_err
+                        else:
+                            raise ConverterError(
+                                "handle_partial_json returned an unexpected type."
+                            ) from None
+            return result
+        except ValidationError as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_pydantic(current_attempt + 1)
+            raise ConverterError(
+                f"Failed to convert text into a Pydantic model due to validation error: {e}"
+            ) from e
+        except Exception as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_pydantic(current_attempt + 1)
+            raise ConverterError(
+                f"Failed to convert text into a Pydantic model due to error: {e}"
+            ) from e
+
     def to_json(self, current_attempt: int = 1) -> str | ConverterError | Any:  # type: ignore[override]
         """Convert text to json.
 
@@ -140,6 +199,24 @@ class Converter(OutputConverter):
         except Exception as e:
             if current_attempt < self.max_attempts:
                 return self.to_json(current_attempt + 1)
+            return ConverterError(f"Failed to convert text into JSON, error: {e}.")
+
+    async def ato_json(self, current_attempt: int = 1) -> str | ConverterError | Any:
+        """Async version of to_json — uses acall to avoid blocking the event loop."""
+        try:
+            if self.llm.supports_function_calling():
+                return self._create_instructor().to_json()
+            return json.dumps(
+                await self.llm.acall(
+                    [
+                        {"role": "system", "content": self.instructions},
+                        {"role": "user", "content": self.text},
+                    ]
+                )
+            )
+        except Exception as e:
+            if current_attempt < self.max_attempts:
+                return await self.ato_json(current_attempt + 1)
             return ConverterError(f"Failed to convert text into JSON, error: {e}.")
 
     def _create_instructor(self) -> InternalInstructor[Any]:
@@ -403,6 +480,146 @@ class CreateConverterKwargs(TypedDict, total=False):
     text: str
     model: type[BaseModel]
     instructions: str
+
+
+async def async_convert_to_model(
+    result: str | BaseModel,
+    output_pydantic: type[BaseModel] | None,
+    output_json: type[BaseModel] | None,
+    agent: Agent | BaseAgent | None = None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Async version of convert_to_model — delegates LLM calls to acall."""
+    model = output_pydantic or output_json
+    if model is None:
+        return result
+
+    if isinstance(result, BaseModel):
+        if isinstance(result, model):
+            return result.model_dump() if output_json else result
+        result = result.model_dump_json()
+
+    if converter_cls:
+        return await async_convert_with_instructions(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+
+    try:
+        escaped_result = json.dumps(json.loads(result, strict=False))
+        return validate_model(
+            result=escaped_result, model=model, is_json_output=bool(output_json)
+        )
+    except json.JSONDecodeError:
+        return await async_handle_partial_json(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+    except ValidationError:
+        return await async_handle_partial_json(
+            result=result,
+            model=model,
+            is_json_output=bool(output_json),
+            agent=agent,
+            converter_cls=converter_cls,
+        )
+    except Exception as e:
+        if agent and getattr(agent, "verbose", True):
+            PRINTER.print(
+                content=f"Unexpected error during model conversion: {type(e).__name__}: {e}. Returning original result.",
+                color="red",
+            )
+        return result
+
+
+async def async_handle_partial_json(
+    result: str,
+    model: type[BaseModel],
+    is_json_output: bool,
+    agent: Agent | BaseAgent | None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Async version of handle_partial_json."""
+    match = _JSON_PATTERN.search(result)
+    if match:
+        try:
+            parsed = json.loads(match.group(), strict=False)
+        except json.JSONDecodeError:
+            return await async_convert_with_instructions(
+                result=result,
+                model=model,
+                is_json_output=is_json_output,
+                agent=agent,
+                converter_cls=converter_cls,
+            )
+
+        try:
+            exported_result = model.model_validate(parsed)
+            if is_json_output:
+                return exported_result.model_dump()
+            return exported_result
+        except ValidationError:
+            raise
+        except Exception as e:
+            if agent and getattr(agent, "verbose", True):
+                PRINTER.print(
+                    content=f"Unexpected error during partial JSON handling: {type(e).__name__}: {e}. Attempting alternative conversion method.",
+                    color="red",
+                )
+
+    return await async_convert_with_instructions(
+        result=result,
+        model=model,
+        is_json_output=is_json_output,
+        agent=agent,
+        converter_cls=converter_cls,
+    )
+
+
+async def async_convert_with_instructions(
+    result: str,
+    model: type[BaseModel],
+    is_json_output: bool,
+    agent: Agent | BaseAgent | None,
+    converter_cls: type[Converter] | None = None,
+) -> dict[str, Any] | BaseModel | str:
+    """Async version of convert_with_instructions — uses ato_pydantic/ato_json."""
+    if agent is None:
+        raise TypeError("Agent must be provided if converter_cls is not specified.")
+
+    llm = getattr(agent, "function_calling_llm", None) or agent.llm
+
+    if llm is None:
+        raise ValueError("Agent must have a valid LLM instance for conversion")
+
+    instructions = get_conversion_instructions(model=model, llm=llm)
+    converter = create_converter(
+        agent=agent,
+        converter_cls=converter_cls,
+        llm=llm,
+        text=result,
+        model=model,
+        instructions=instructions,
+    )
+    exported_result = (
+        await converter.ato_pydantic() if not is_json_output else await converter.ato_json()
+    )
+
+    if isinstance(exported_result, ConverterError):
+        if agent and getattr(agent, "verbose", True):
+            PRINTER.print(
+                content=f"Failed to convert result to model: {exported_result}",
+                color="red",
+            )
+        return result
+
+    return exported_result
 
 
 def create_converter(


### PR DESCRIPTION
> **AI-generated contribution notice** (per CONTRIBUTING.md): This PR was authored by Claude Code (an AI assistant). The `llm-generated` label required by CONTRIBUTING.md does not currently exist in this repository and cannot be applied from a fork — please apply it manually if needed.

## Summary

When a `Task` with `output_pydantic` or `output_json` is executed through `aexecute_sync()` / `akickoff()`, the output-conversion step was silently calling the synchronous `LLM.call()` deep inside the converter stack (`_export_output` → `convert_to_model` → `convert_with_instructions` → `Converter.to_pydantic()`). Because `LLM.call()` performs a blocking HTTP round-trip, every such conversion froze the entire asyncio event loop for the duration of the API call — preventing any other coroutines from running concurrently.

The synchronous `_execute_core` / `_invoke_guardrail_function` paths are left untouched; only the three async callsites that were calling the blocking helper are updated.

## Issue

Fixes #5230

## Changes

**`lib/crewai/src/crewai/utilities/converter.py`**

- `Converter.ato_pydantic()` — async mirror of `to_pydantic()` that replaces `self.llm.call(…)` with `await self.llm.acall(…)`.
- `Converter.ato_json()` — async mirror of `to_json()`, same substitution.
- `async_convert_with_instructions()` — async mirror of `convert_with_instructions()`, calls `await converter.ato_pydantic()` / `await converter.ato_json()`.
- `async_handle_partial_json()` — async mirror of `handle_partial_json()`, calls `await async_convert_with_instructions()`.
- `async_convert_to_model()` — async mirror of `convert_to_model()`, calls the above async helpers.

**`lib/crewai/src/crewai/task.py`**

- `Task._aexport_output()` — async mirror of `_export_output()`, calls `await async_convert_to_model()`.
- Three callsites in `_aexecute_core` and `_ainvoke_guardrail_function` updated to `await self._aexport_output(result)`.

## Local verification

```
$ cd lib/crewai

$ uv run python -m pytest tests/utilities/test_converter.py tests/task/test_async_task.py tests/test_task_guardrails.py tests/test_task.py -q -k "not non_existent and not function_calling_false"

155 passed, 257 warnings in 17.70s

$ uv run python -c "
import asyncio
from unittest.mock import AsyncMock, MagicMock
from pydantic import BaseModel
from crewai.utilities.converter import Converter

class SampleOutput(BaseModel):
    result: str

async def test():
    mock_llm = MagicMock()
    mock_llm.supports_function_calling.return_value = False
    mock_llm.acall = AsyncMock(return_value='{\"result\": \"hello\"}')
    mock_llm.call = MagicMock(side_effect=AssertionError('call() must NOT be invoked'))
    conv = Converter(llm=mock_llm, model=SampleOutput, text='x', instructions='y', max_attempts=1)
    result = await conv.ato_pydantic()
    assert isinstance(result, SampleOutput) and result.result == 'hello'
    mock_llm.call.assert_not_called()
    print('ato_pydantic uses acall only — OK')

asyncio.run(test())
"
ato_pydantic uses acall only — OK
=== LOCAL_TEST_PASSED ===
```

## Risk

Only the async code paths change; every synchronous path (`_execute_core`, `_invoke_guardrail_function`, sync `Converter.to_pydantic`/`to_json`) is unchanged. The new async functions are exact mirrors of their synchronous counterparts, substituting `await self.llm.acall(…)` for `self.llm.call(…)`. The `InternalInstructor` (function-calling / instructor-backed) path inside `ato_json` remains synchronous for now, since no async instructor wrapper exists; this is the minority path and does not add a new regression relative to the current code.
