### PR TITLE
docs: add Synap memory backend integration

### DIFF
--- a/docs/en/tools/database-data/synap-memory.mdx
+++ b/docs/en/tools/database-data/synap-memory.mdx
@@ -1,0 +1,57 @@
+---
+title: Synap Memory Backend
+description: Add persistent, cross-session user memory to your CrewAI agents with Synap.
+icon: database
+---
+
+## Overview
+
+[Synap](https://maximem.ai) is a managed memory layer for AI agents. `SynapStorageBackend` is a custom `StorageBackend` that plugs directly into CrewAI's unified `Memory` class — so memories persist across crew runs, deployments, and devices without any manual bookkeeping.
+
+## Installation
+
+```bash
+pip install maximem-synap-crewai
+```
+
+Get an API key at [synap.maximem.ai](https://synap.maximem.ai).
+
+## Usage
+
+Pass `SynapStorageBackend` as the `storage` parameter when constructing `Memory`:
+
+```python
+from crewai import Crew, Agent, Task
+from crewai.memory import Memory
+from maximem_synap import MaximemSynapSDK
+from synap_crewai import SynapStorageBackend
+
+sdk = MaximemSynapSDK(api_key="sk-...")
+
+backend = SynapStorageBackend(
+    sdk=sdk,
+    user_id="user_123",
+    customer_id="acme_corp",
+)
+
+memory = Memory(storage=backend)
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    memory=memory,
+)
+
+result = crew.kickoff()
+```
+
+## How It Works
+
+CrewAI handles what to remember — the LLM analyzes content, infers scope, categories, and importance, and calls `StorageBackend.save()` and `StorageBackend.search()`. Synap handles persistence and retrieval, scoped to the `user_id` and `customer_id` you provide. In multi-tenant crews, different customers never share memory.
+
+## More Resources
+
+- [Synap Documentation](https://docs.maximem.ai)
+- [CrewAI Integration Guide](https://docs.maximem.ai/integrations/crewai)
+- [Dashboard](https://synap.maximem.ai)
+- [PyPI: maximem-synap-crewai](https://pypi.org/project/maximem-synap-crewai/)


### PR DESCRIPTION
Adds a documentation page for [Synap](https://maximem.ai) as a custom `StorageBackend` for CrewAI's unified `Memory` class.

## What's added

`docs/en/tools/database-data/synap-memory.mdx` — covers installation, usage, and how it works.

## How it works

`SynapStorageBackend` plugs directly into `Memory(storage=backend)`. CrewAI continues to handle what to remember (LLM analysis, categorisation, importance scoring). Synap handles persistence and retrieval, scoped to `user_id` and `customer_id` — so memories persist across crew runs and different customers in a multi-tenant crew never share memory.

```python
from crewai.memory import Memory
from synap_crewai import SynapStorageBackend

backend = SynapStorageBackend(sdk=sdk, user_id="user_123", customer_id="acme_corp")
memory = Memory(storage=backend)
crew = Crew(agents=[...], tasks=[...], memory=memory)
```

**Install:** `pip install maximem-synap-crewai`
**PyPI:** https://pypi.org/project/maximem-synap-crewai/
**Docs:** https://docs.maximem.ai/integrations/crewai
**Open source:** Integration package source at [`maximem-ai/maximem_synap_sdk`](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations) — contributions welcome