### PR TITLE
fix: prevent result_as_answer from returning hook-block message as final answer

### DIFF
--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1597,6 +1597,7 @@ def execute_single_native_tool_call(
         and hasattr(original_tool, "result_as_answer")
         and original_tool.result_as_answer
         and not error_event_emitted
+        and not hook_blocked
     )
 
     return NativeToolCallResult(

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -1078,3 +1078,48 @@ class TestExecuteSingleNativeToolCall:
         assert isinstance(result, NativeToolCallResult)
         assert result.result_as_answer is False
         assert "Error executing tool" in result.result
+
+    def test_result_as_answer_false_when_hook_blocks(self) -> None:
+        """When a before-hook blocks a tool with result_as_answer=True, result_as_answer must be False."""
+        from unittest.mock import MagicMock
+
+        from crewai.hooks.tool_hooks import (
+            clear_before_tool_call_hooks,
+            register_before_tool_call_hook,
+        )
+
+        class BlockedTool(BaseTool):
+            name: str = "blocked_tool"
+            description: str = "A tool whose execution will be blocked by a hook"
+            result_as_answer: bool = True
+
+            def _run(self, **kwargs: Any) -> str:
+                return "should not run"
+
+        tool = BlockedTool()
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function.name = "blocked_tool"
+        tool_call.function.arguments = "{}"
+
+        register_before_tool_call_hook(lambda _ctx: False)
+        try:
+            result = execute_single_native_tool_call(
+                tool_call,
+                available_functions={"blocked_tool": tool._run},
+                original_tools=[tool],
+                structured_tools=None,
+                tools_handler=None,
+                agent=None,
+                task=None,
+                crew=None,
+                event_source=MagicMock(),
+                printer=None,
+                verbose=False,
+            )
+        finally:
+            clear_before_tool_call_hooks()
+
+        assert isinstance(result, NativeToolCallResult)
+        assert result.result_as_answer is False
+        assert "blocked by hook" in result.result


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small boolean gating change plus a regression test; behavior only changes when a before-tool hook blocks execution.
> 
> **Overview**
> Prevents `execute_single_native_tool_call` from setting `result_as_answer=True` when a before-tool hook blocks execution, so the hook-block message can’t be returned as the agent’s final answer.
> 
> Adds a regression test ensuring `result_as_answer` stays `False` for `result_as_answer=True` tools when blocked by a registered before-hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca3e89d1cfadbe68c4bf1c7352bc07df5cc7c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->