### PR TITLE
docs: update changelog and version for v1.14.5a2

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,34 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="4 مايو 2026">
+  ## v1.14.5a2
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a2)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - إصلاح استعادة مخرجات المهام في كتلة finally
+  - تضمين `thoughts_token_count` في رموز الإكمال
+  - الحفاظ على مخرجات المهام عبر تفريغ دفعات غير متزامنة
+  - تمرير kwargs إلى استدعاءات المحمل في `CrewAIRagAdapter`
+  - منع `result_as_answer` من إرجاع رسالة كتلة الخطاف كإجابة نهائية
+  - منع `result_as_answer` من إرجاع خطأ كإجابة نهائية
+  - استخدام `acall` لتحويل المخرجات في المسارات غير المتزامنة
+  - منع تغيير كلمات التوقف المشتركة في LLM عبر الوكلاء
+  - التعامل مع مدخلات `BaseModel` في `convert_to_model`
+
+  ### الوثائق
+  - توثيق متغيرات البيئة الإضافية
+  - تحديث سجل التغييرات والإصدار لـ v1.14.5a1
+
+  ## المساهمون
+
+  @NIK-TIGER-BILL, @greysonlalonde, @lorenzejay, @minasami-pr, @theCyberTech, @wishhyt
+
+</Update>
+
 <Update label="1 مايو 2026">
   ## v1.14.5a1
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,34 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="May 04, 2026">
+  ## v1.14.5a2
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a2)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Fix task output restoration in finally block
+  - Include `thoughts_token_count` in completion tokens
+  - Preserve task outputs across async batch flush
+  - Forward kwargs to loader calls in `CrewAIRagAdapter`
+  - Prevent `result_as_answer` from returning hook-block message as final answer
+  - Prevent `result_as_answer` from returning error as final answer
+  - Use `acall` for output conversion in async paths
+  - Prevent shared LLM stop words mutation across agents
+  - Handle `BaseModel` input in `convert_to_model`
+
+  ### Documentation
+  - Document additional environment variables
+  - Update changelog and version for v1.14.5a1
+
+  ## Contributors
+
+  @NIK-TIGER-BILL, @greysonlalonde, @lorenzejay, @minasami-pr, @theCyberTech, @wishhyt
+
+</Update>
+
 <Update label="May 01, 2026">
   ## v1.14.5a1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,34 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 5월 4일">
+  ## v1.14.5a2
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a2)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - finally 블록에서 작업 출력 복원 수정
+  - 완료 토큰에 `thoughts_token_count` 포함
+  - 비동기 배치 플러시 간 작업 출력 보존
+  - `CrewAIRagAdapter`의 로더 호출에 kwargs 전달
+  - `result_as_answer`가 후크 차단 메시지를 최종 답변으로 반환하지 않도록 방지
+  - `result_as_answer`가 오류를 최종 답변으로 반환하지 않도록 방지
+  - 비동기 경로에서 출력 변환을 위해 `acall` 사용
+  - 에이전트 간 공유 LLM 중지 단어 변형 방지
+  - `convert_to_model`에서 `BaseModel` 입력 처리
+
+  ### 문서화
+  - 추가 환경 변수 문서화
+  - v1.14.5a1에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @NIK-TIGER-BILL, @greysonlalonde, @lorenzejay, @minasami-pr, @theCyberTech, @wishhyt
+
+</Update>
+
 <Update label="2026년 5월 1일">
   ## v1.14.5a1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,34 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="04 mai 2026">
+  ## v1.14.5a2
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a2)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Corrigir a restauração da saída da tarefa no bloco finally
+  - Incluir `thoughts_token_count` nos tokens de conclusão
+  - Preservar as saídas das tarefas durante o descarregamento assíncrono em lote
+  - Encaminhar kwargs para chamadas de carregador em `CrewAIRagAdapter`
+  - Impedir que `result_as_answer` retorne mensagem de bloqueio de hook como resposta final
+  - Impedir que `result_as_answer` retorne erro como resposta final
+  - Usar `acall` para conversão de saída em caminhos assíncronos
+  - Prevenir a mutação de palavras de parada compartilhadas do LLM entre agentes
+  - Lidar com entrada `BaseModel` em `convert_to_model`
+
+  ### Documentação
+  - Documentar variáveis de ambiente adicionais
+  - Atualizar changelog e versão para v1.14.5a1
+
+  ## Contribuidores
+
+  @NIK-TIGER-BILL, @greysonlalonde, @lorenzejay, @minasami-pr, @theCyberTech, @wishhyt
+
+</Update>
+
 <Update label="01 mai 2026">
   ## v1.14.5a1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that appends a new changelog entry; low risk aside from potential formatting/translation inconsistencies in MDX.
> 
> **Overview**
> Adds a new `v1.14.5a2` changelog entry (dated May 04, 2026) across the Arabic, English, Korean, and pt-BR docs, including the GitHub release link, lists of bug fixes/documentation updates, and updated contributor credits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804101bf3a784645aa7227bbd44f19e74e9d3902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->