### PR TITLE
Update CrewAI Toolkit docs links to active repository

### DIFF
--- a/docs/en/concepts/agents.mdx
+++ b/docs/en/concepts/agents.mdx
@@ -343,7 +343,7 @@ multimodal_agent = Agent(
 
 Agents can be equipped with various tools to enhance their capabilities. CrewAI supports tools from:
 
-- [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools)
+- [CrewAI Toolkit](https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools)
 - [LangChain Tools](https://python.langchain.com/docs/integrations/tools)
 
 Here's how to add tools to an agent:

--- a/docs/en/concepts/tasks.mdx
+++ b/docs/en/concepts/tasks.mdx
@@ -797,7 +797,7 @@ By using output_pydantic or output_json, you ensure that your tasks produce outp
 
 ## Integrating Tools with Tasks
 
-Leverage tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools) for enhanced task performance and agent interaction.
+Leverage tools from the [CrewAI Toolkit](https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools) for enhanced task performance and agent interaction.
 
 ## Creating a Task with Tools
 

--- a/docs/en/concepts/tools.mdx
+++ b/docs/en/concepts/tools.mdx
@@ -17,7 +17,7 @@ This documentation outlines how to create, integrate, and leverage these tools w
 ## What is a Tool?
 
 A tool in CrewAI is a skill or function that agents can utilize to perform various actions.
-This includes tools from the [CrewAI Toolkit](https://github.com/joaomdmoura/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools),
+This includes tools from the [CrewAI Toolkit](https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools) and [LangChain Tools](https://python.langchain.com/docs/integrations/tools),
 enabling everything from simple searches to complex interactions and effective teamwork among agents.
 
 <Note type="info" title="Enterprise Enhancement: Tools Repository">


### PR DESCRIPTION
## Summary
- Update CrewAI Toolkit documentation links to the maintained repository location under crewAIInc/crewAI.

## Testing
- Not run (per instruction).
