### PR TITLE
fix(cli): honor --provider flag in create_crew() and fix loop variable shadow

### DIFF
--- a/lib/crewai/src/crewai/cli/create_crew.py
+++ b/lib/crewai/src/crewai/cli/create_crew.py
@@ -205,18 +205,13 @@ def create_crew(
     folder_path, folder_name, class_name = create_folder_structure(name, parent_folder)
     env_vars = load_env_vars(folder_path)
     if not skip_provider:
-        if not provider:
-            provider_models = get_provider_data()
-            if not provider_models:
-                return
-
         existing_provider = None
-        for provider, env_keys in ENV_VARS.items():
+        for env_provider, env_keys in ENV_VARS.items():
             if any(
                 "key_name" in details and details["key_name"] in env_vars
                 for details in env_keys
             ):
-                existing_provider = provider
+                existing_provider = env_provider
                 break
 
         if existing_provider:
@@ -230,18 +225,23 @@ def create_crew(
         if not provider_models:
             return
 
-        while True:
-            selected_provider = select_provider(provider_models)
-            if selected_provider is None:  # User typed 'q'
-                click.secho("Exiting...", fg="yellow")
-                sys.exit(0)
-            if selected_provider and isinstance(
-                selected_provider, str
-            ):  # Valid selection
-                break
-            click.secho(
-                "No provider selected. Please try again or press 'q' to exit.", fg="red"
-            )
+        if provider:
+            # --provider was passed on the CLI; use it directly without prompting.
+            selected_provider = provider.lower()
+        else:
+            while True:
+                selected_provider = select_provider(provider_models)
+                if selected_provider is None:  # User typed 'q'
+                    click.secho("Exiting...", fg="yellow")
+                    sys.exit(0)
+                if selected_provider and isinstance(
+                    selected_provider, str
+                ):  # Valid selection
+                    break
+                click.secho(
+                    "No provider selected. Please try again or press 'q' to exit.",
+                    fg="red",
+                )
 
         # Check if the selected provider has predefined models
         if MODELS.get(selected_provider):

--- a/lib/crewai/tests/cli/test_create_crew.py
+++ b/lib/crewai/tests/cli/test_create_crew.py
@@ -345,3 +345,41 @@ def test_env_vars_are_uppercased_in_env_file(
     env_file_path = crew_path / ".env"
     content = env_file_path.read_text()
     assert "MODEL=" in content
+
+
+@mock.patch("crewai.cli.create_crew.create_folder_structure")
+@mock.patch("crewai.cli.create_crew.copy_template")
+@mock.patch("crewai.cli.create_crew.load_env_vars")
+@mock.patch("crewai.cli.create_crew.get_provider_data")
+@mock.patch("crewai.cli.create_crew.select_provider")
+@mock.patch("click.prompt")
+def test_provider_param_skips_interactive_selection(
+    mock_prompt,
+    mock_select_provider,
+    mock_get_provider_data,
+    mock_load_env_vars,
+    mock_copy_template,
+    mock_create_folder_structure,
+    tmp_path,
+):
+    """Verify that passing --provider skips the interactive provider prompt.
+
+    Regression test for: https://github.com/crewAIInc/crewAI/issues/5270
+
+    The `create_crew()` `provider` parameter was shadowed by a loop variable
+    (`for provider, env_keys in ENV_VARS.items()`), so the interactive
+    `select_provider()` prompt was *always* shown even when `--provider` was
+    explicitly passed on the CLI.
+    """
+    crew_path = tmp_path / "test_crew"
+    crew_path.mkdir()
+    mock_create_folder_structure.return_value = (crew_path, "test_crew", "TestCrew")
+
+    mock_load_env_vars.return_value = {}
+    mock_get_provider_data.return_value = {"openai": ["gpt-4o"], "anthropic": []}
+    mock_prompt.return_value = "fake-api-key"
+
+    create_crew("Test Crew", provider="openai")
+
+    # select_provider() must NOT have been called — the CLI flag pre-selects it.
+    mock_select_provider.assert_not_called()


### PR DESCRIPTION
## Summary
- The `for provider, env_keys in ENV_VARS.items()` loop was silently overwriting the `provider` function parameter, making the `--provider` CLI flag a no-op
- The function always fell through to the interactive `select_provider()` prompt regardless of whether `--provider openai` was passed
- Renamed the loop variable to `env_provider` (eliminating the shadow) and added an early-out path that uses the supplied `provider` directly when it is non-`None`

Closes #5270

## Testing
```
pytest lib/crewai/tests/cli/test_create_crew.py::test_provider_param_skips_interactive_selection -v
```
<output>
PASSED lib/crewai/tests/cli/test_create_crew.py::test_provider_param_skips_interactive_selection
</output>