### PR TITLE
docs: update changelog and version for v1.14.5a3

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,29 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="7 مايو 2026">
+  ## v1.14.5a3
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a3)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - إصلاح مسار نقطة النهاية للحالة من /{kickoff_id}/status إلى /status/{kickoff_id}
+  - تحديث تبعية gitpython إلى الإصدار >=3.1.47 للامتثال الأمني
+
+  ### إعادة هيكلة
+  - استخراج واجهة سطر الأوامر إلى حزمة crewai-cli المستقلة
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار للإصدار v1.14.5a2
+
+  ## المساهمون
+
+  @greysonlalonde, @iris-clawd
+
+</Update>
+
 <Update label="4 مايو 2026">
   ## v1.14.5a2
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,29 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="May 07, 2026">
+  ## v1.14.5a3
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a3)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Fix status endpoint path from /{kickoff_id}/status to /status/{kickoff_id}
+  - Bump gitpython dependency to version >=3.1.47 for security compliance
+
+  ### Refactoring
+  - Extract CLI into standalone crewai-cli package
+
+  ### Documentation
+  - Update changelog and version for v1.14.5a2
+
+  ## Contributors
+
+  @greysonlalonde, @iris-clawd
+
+</Update>
+
 <Update label="May 04, 2026">
   ## v1.14.5a2
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,29 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 5월 7일">
+  ## v1.14.5a3
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a3)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - 상태 엔드포인트 경로를 /{kickoff_id}/status에서 /status/{kickoff_id}로 수정
+  - 보안 준수를 위해 gitpython 의존성을 버전 >=3.1.47로 업데이트
+
+  ### 리팩토링
+  - CLI를 독립형 crewai-cli 패키지로 분리
+
+  ### 문서
+  - v1.14.5a2에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde, @iris-clawd
+
+</Update>
+
 <Update label="2026년 5월 4일">
   ## v1.14.5a2
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,29 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="07 mai 2026">
+  ## v1.14.5a3
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a3)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Corrigir o caminho do endpoint de status de /{kickoff_id}/status para /status/{kickoff_id}
+  - Atualizar a dependência gitpython para a versão >=3.1.47 para conformidade de segurança
+
+  ### Refatoração
+  - Extrair CLI para o pacote independente crewai-cli
+
+  ### Documentação
+  - Atualizar o changelog e a versão para v1.14.5a2
+
+  ## Contributors
+
+  @greysonlalonde, @iris-clawd
+
+</Update>
+
 <Update label="04 mai 2026">
   ## v1.14.5a2
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new release entry to localized changelog pages; no runtime code or dependency behavior is modified in this PR.
> 
> **Overview**
> Adds a new `v1.14.5a3` changelog entry (dated May 07, 2026) across the Arabic, English, Korean, and pt-BR docs, including the GitHub release link, a brief list of bug fixes (status endpoint path correction, `gitpython` security bump), a refactor note (CLI extracted to `crewai-cli`), and updated contributor credits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491b9d243118530f2568a34128d2f19906ae0036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->