### PR TITLE
fix(deps): move textual to crewai-cli and add certifi

### DIFF
--- a/lib/cli/pyproject.toml
+++ b/lib/cli/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "packaging>=23.0",
     "python-dotenv>=1.2.2,<2",
     "uv~=0.11.6",
+    "textual>=7.5.0",
+    "certifi",
 ]
 
 [project.urls]

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -28,8 +28,6 @@ dependencies = [
     # Authentication and Security
     "python-dotenv>=1.2.2,<2",
     "pyjwt>=2.9.0,<3",
-    # TUI
-    "textual>=7.5.0",
     # Configuration and Utils
     "click~=8.1.7",
     "appdirs~=1.4.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "textual" },
     { name = "tokenizers" },
     { name = "tomli" },
     { name = "tomli-w" },
@@ -1421,7 +1420,6 @@ requires-dist = [
     { name = "qdrant-client", extras = ["fastembed"], marker = "extra == 'qdrant'", specifier = "~=1.14.3" },
     { name = "qdrant-edge-py", marker = "extra == 'qdrant-edge'", specifier = ">=0.6.0" },
     { name = "regex", specifier = "~=2026.1.15" },
-    { name = "textual", specifier = ">=7.5.0" },
     { name = "tiktoken", marker = "extra == 'embeddings'", specifier = ">=0.8.0,<0.13" },
     { name = "tokenizers", specifier = ">=0.21,<1" },
     { name = "tomli", specifier = "~=2.0.2" },
@@ -1435,6 +1433,7 @@ name = "crewai-cli"
 source = { editable = "lib/cli" }
 dependencies = [
     { name = "appdirs" },
+    { name = "certifi" },
     { name = "click" },
     { name = "crewai-core" },
     { name = "cryptography" },
@@ -1445,6 +1444,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "textual" },
     { name = "tomli" },
     { name = "tomli-w" },
     { name = "uv" },
@@ -1453,6 +1453,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "appdirs", specifier = "~=1.4.4" },
+    { name = "certifi" },
     { name = "click", specifier = "~=8.1.7" },
     { name = "crewai-core", editable = "lib/crewai-core" },
     { name = "cryptography", specifier = ">=42.0" },
@@ -1463,6 +1464,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.9.0,<3" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },
     { name = "rich", specifier = ">=13.7.1" },
+    { name = "textual", specifier = ">=7.5.0" },
     { name = "tomli", specifier = "~=2.0.2" },
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "uv", specifier = "~=0.11.6" },


### PR DESCRIPTION
`crewai-cli` imports `textual` (in `checkpoint_tui.py`, `memory_tui.py`) and `certifi` (in `provider.py`) but neither was declared in `lib/cli/pyproject.toml`. A clean PyPI install of `crewai-cli` would crash with `ModuleNotFoundError: No module named 'textual'` on `crewai checkpoint`. `textual` was instead declared on the umbrella `crewai` package — a leftover from before the CLI was extracted; nothing in `lib/crewai/src/crewai/` actually imports it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change that corrects packaging metadata so `crewai-cli` installs runtime imports (`textual`, `certifi`) without relying on the umbrella `crewai` package.
> 
> **Overview**
> Fixes `crewai-cli` packaging by **adding missing runtime dependencies** `textual` and `certifi` to `lib/cli/pyproject.toml`.
> 
> Removes `textual` from the umbrella `crewai` package dependencies and updates `uv.lock` so `textual`/`certifi` are associated with `crewai-cli` rather than `crewai`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a763ea40fffa04ca9990b90233db42280c48c0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->