### PR TITLE
refactor(agents): default Agent.executor_class to AgentExecutor

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -165,7 +165,7 @@ class Agent(BaseAgent):
     The agent can also have memory, can operate in verbose mode, and can delegate tasks to other agents.
 
     Attributes:
-            agent_executor: An instance of the CrewAgentExecutor or AgentExecutor class.
+            agent_executor: An instance of the agent executor (defaults to AgentExecutor).
             role: The role of the agent.
             goal: The objective of the agent.
             backstory: The backstory of the agent.
@@ -318,15 +318,15 @@ class Agent(BaseAgent):
         """,
     )
     agent_executor: CrewAgentExecutor | AgentExecutor | None = Field(
-        default=None, description="An instance of the CrewAgentExecutor class."
+        default=None, description="An instance of the agent executor."
     )
     executor_class: Annotated[
         type[CrewAgentExecutor] | type[AgentExecutor],
         BeforeValidator(_validate_executor_class),
         PlainSerializer(_serialize_executor_class, return_type=str, when_used="json"),
     ] = Field(
-        default=CrewAgentExecutor,
-        description="Class to use for the agent executor. Defaults to CrewAgentExecutor, can optionally use AgentExecutor.",
+        default=AgentExecutor,
+        description="Class to use for the agent executor. Defaults to AgentExecutor (Flow-based). The legacy CrewAgentExecutor is deprecated and will be removed in a future release.",
     )
 
     @model_validator(mode="before")
@@ -1014,7 +1014,7 @@ class Agent(BaseAgent):
         """Create an agent executor for the agent.
 
         Returns:
-            An instance of the CrewAgentExecutor class.
+            An instance of the configured executor class (defaults to AgentExecutor).
         """
         raw_tools: list[BaseTool] = tools or self.tools or []
         parsed_tools = parse_tools(raw_tools)

--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -178,7 +178,7 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
         allow_delegation (bool): Allow delegation of tasks to agents.
         tools (list[Any] | None): Tools at the agent's disposal.
         max_iter (int): Maximum iterations for an agent to execute a task.
-        agent_executor: An instance of the CrewAgentExecutor class.
+        agent_executor: An instance of the agent executor (defaults to AgentExecutor).
         llm (Any): Language model that will run the agent.
         crew (Any): Crew to which the agent belongs.
 
@@ -252,7 +252,7 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
         default=25, description="Maximum iterations for an agent to execute a task"
     )
     agent_executor: SerializeAsAny[BaseAgentExecutor] | None = Field(
-        default=None, description="An instance of the CrewAgentExecutor class."
+        default=None, description="An instance of the agent executor."
     )
 
     @field_validator("agent_executor", mode="before")

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -14,6 +14,7 @@ import contextvars
 import inspect
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+import warnings
 
 from crewai_core.printer import PRINTER
 from pydantic import (
@@ -137,6 +138,13 @@ class CrewAgentExecutor(BaseAgentExecutor):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
     def __init__(self, **kwargs: Any) -> None:
+        warnings.warn(
+            "CrewAgentExecutor is deprecated and will be removed in a future release. "
+            "Use AgentExecutor (the default for Agent.executor_class) instead. "
+            "See https://github.com/crewAIInc/crewAI/issues/5736 for migration guidance.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
         if not self.before_llm_call_hooks:
             self.before_llm_call_hooks.extend(get_before_llm_call_hooks())


### PR DESCRIPTION
Closes #5736.

## Summary

Two parallel agent executors currently coexist:

- `crewai.agents.crew_agent_executor.CrewAgentExecutor` (1,615 lines, the historical default for `Agent.execute_task()`)
- `crewai.experimental.agent_executor.AgentExecutor` (2,963 lines, a `Flow[AgentExecutorState]`, used unconditionally by `Agent.kickoff()` and exported from `crewai/__init__.py`)

Both subclass `BaseAgentExecutor`, expose `invoke()`, register the same hooks, and reuse the helpers in `crewai.utilities.agent_utils`. A single `Agent` instance can flow through either, depending on entry point — and `_is_resuming_agent_executor()` only works when `agent_executor` is an `AgentExecutor`, so checkpoint resume is silently broken under the current default.

This PR consolidates the runtime default without removing the legacy class:

- `Agent.executor_class` now defaults to `AgentExecutor`. `Agent.kickoff()` and `Agent.execute_task()` go through the same executor by default.
- `CrewAgentExecutor.__init__` emits a `DeprecationWarning` pointing to #5736.
- Stale "instance of the CrewAgentExecutor class" docstrings updated.

## Out of scope (follow-ups)

- Moving `AgentExecutor` out of `crewai.experimental.*` into `crewai.agents.*`. Touches ~27 files of imports and is mechanical — separate PR.
- Deleting `CrewAgentExecutor`. Needs at least one minor release of deprecation runway.
- Merging `tests/agents/test_agent_executor.py` and `tests/agents/test_async_agent_executor.py` along sync/async lines instead of legacy/experimental.
- Reasoning consolidation: `handle_reasoning` (`crewai/agent/utils.py`) and `AgentExecutor.generate_plan()` are intentional duals — both still work, the legacy helper is gated by `if self.executor_class is not AgentExecutor` ([agent/core.py:515](lib/crewai/src/crewai/agent/core.py#L515)). Left alone here; they can converge after the legacy class is removed.

## Files changed

| File | Change |
|---|---|
| `lib/crewai/src/crewai/agent/core.py` | Default `executor_class` flipped; field description + Agent docstring + `create_agent_executor` docstring updated |
| `lib/crewai/src/crewai/agents/agent_builder/base_agent.py` | Stale `agent_executor` description corrected |
| `lib/crewai/src/crewai/agents/crew_agent_executor.py` | `DeprecationWarning` added in `__init__`; `import warnings` added |

Diff size: +15 / -7. No public API removed; existing user code that explicitly opts into `executor_class=CrewAgentExecutor` keeps working (with a warning).

## Test plan

I was unable to run the test suite locally (no resolved venv on the dev machine). Reviewers should confirm:

- [ ] `uv run pytest lib/crewai/tests/agents/ -x -q`
- [ ] `uv run pytest lib/crewai/tests/agents/test_async_agent_executor.py -x -q -W "default::DeprecationWarning"` — this file directly instantiates `CrewAgentExecutor` and will now emit warnings; confirm none are promoted to errors elsewhere
- [ ] `uv run pytest lib/crewai/tests/agents/test_agent.py -x -q`
- [ ] `uv run mypy lib/crewai/src/crewai/agent/core.py lib/crewai/src/crewai/agents/`
- [ ] Spot-check that any test asserting `executor_class == CrewAgentExecutor` is either removed or updated (none found in a grep, but worth double-checking)

Risks I'm aware of:

- Downstream code that subclasses `CrewAgentExecutor` will now see a warning at instantiation. If their CI treats `DeprecationWarning` as an error, they'll need `filterwarnings`. The repo itself has no such global filter, so internal tests should be unaffected.
- Behavior change: `Agent.execute_task()` now runs through the Flow-based executor by default. The Flow path stores the plan in `state.plan` instead of mutating `task.description` (an intentional improvement noted in the source), but consumers that read `task.description` post-execution to recover the plan text will need to read `agent_executor._state.plan` instead.
