### PR TITLE
fix(bedrock): JSON-parse accumulated_tool_input at contentBlockStop in streaming handlers

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -1054,6 +1054,13 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
+                            # accumulated_tool_input holds the full JSON string for streaming tool calls.
+                            # Parse it back to a dict; fall back to empty dict on failure.
+                            if accumulated_tool_input:
+                                try:
+                                    current_tool_use["input"] = json.loads(accumulated_tool_input)
+                                except (json.JSONDecodeError, ValueError):
+                                    current_tool_use["input"] = {}
                             function_args = cast(
                                 dict[str, Any], current_tool_use.get("input", {})
                             )
@@ -1636,6 +1643,13 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
+                            # accumulated_tool_input holds the full JSON string for streaming tool calls.
+                            # Parse it back to a dict; fall back to empty dict on failure.
+                            if accumulated_tool_input:
+                                try:
+                                    current_tool_use["input"] = json.loads(accumulated_tool_input)
+                                except (json.JSONDecodeError, ValueError):
+                                    current_tool_use["input"] = {}
                             function_args = cast(
                                 dict[str, Any], current_tool_use.get("input", {})
                             )


### PR DESCRIPTION
Fixes #4972

## Problem

When using the Bedrock Converse API in **streaming** mode, tool input arrives as incremental JSON string deltas that get concatenated into `accumulated_tool_input`. At `contentBlockStop`, the code reads `current_tool_use.get("input", {})` — but `current_tool_use["input"]` was never updated during streaming; it still holds the initial empty value from `contentBlockStart`.

The accumulated JSON string lives only in `accumulated_tool_input`, never in `current_tool_use["input"]`. So every streaming tool call receives `{}` as its arguments, causing:

```
Field required [type=missing, input_value={}, input_type=dict]
```

Non-streaming Bedrock calls are unaffected because `function_args` is read directly from the completed response block.

## Fix

At `contentBlockStop`, in both the sync (`_handle_converse_stream`) and async (`_ahandle_converse_stream`) handlers: if `accumulated_tool_input` is non-empty, JSON-parse it and write the result back to `current_tool_use["input"]` before reading `function_args`. Falls back to an empty dict on parse failure.