### PR TITLE
chore(deps): use 3-day exclude-newer window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,8 @@ exclude-newer = "3 days"
 # cryptography 46.0.6 has CVE-2026-39892; force 46.0.7+.
 # pypdf <6.10.2 has GHSA-4pxv-j86v-mhcw, GHSA-7gw9-cf7v-778f, GHSA-x284-j5p8-9c5p; force 6.10.2+.
 # uv <0.11.6 has GHSA-pjjw-68hj-v9mw; force 0.11.6+.
-# python-multipart <0.0.26 has GHSA-mj87-hwqh-73pj; force 0.0.26+.
+# python-multipart <0.0.27 has GHSA-pp6c-gr5w-3c5g (DoS via unbounded multipart headers).
+# gitpython <3.1.49 has GHSA-v87r-6q3f-2j67 (newline injection -> RCE via core.hooksPath).
 # langsmith <0.7.31 has GHSA-rr7j-v2q5-chgv (streaming token redaction bypass); force 0.7.31+.
 # authlib <1.6.11 has GHSA-jj8c-mmj3-mmgv (CSRF bypass in cache-based state storage).
 # litellm 1.83.8+ hard-pins openai==2.24.0, missing openai.types.responses used by crewai;
@@ -198,7 +199,8 @@ override-dependencies = [
     "cryptography>=46.0.7",
     "pypdf>=6.10.2,<7",
     "uv>=0.11.6,<1",
-    "python-multipart>=0.0.26,<1",
+    "python-multipart>=0.0.27,<1",
+    "gitpython>=3.1.49,<4",
     "langsmith>=0.7.31,<0.8",
     "authlib>=1.6.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,10 +170,7 @@ info = "Commits must follow Conventional Commits 1.0.0."
 
 
 [tool.uv]
-# Pinned to include the security patch releases (authlib 1.6.11,
-# langchain-text-splitters 1.1.2) uploaded on 2026-04-16, and the
-# litellm 1.83.7+ SSTI fix (GHSA-xqmj-j6mv-4862) uploaded on 2026-04-13.
-exclude-newer = "2026-04-27"
+exclude-newer = "3 days"
 
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-04T14:38:17.686404Z"
+exclude-newer = "2026-05-04T15:35:41.745265Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -28,6 +28,7 @@ members = [
 overrides = [
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "gitpython", specifier = ">=3.1.49,<4" },
     { name = "langchain-core", specifier = ">=1.2.31,<2" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2,<2" },
     { name = "langsmith", specifier = ">=0.7.31,<0.8" },
@@ -35,7 +36,7 @@ overrides = [
     { name = "openai", specifier = ">=2.30.0,<3" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pypdf", specifier = ">=6.10.2,<7" },
-    { name = "python-multipart", specifier = ">=0.0.26,<1" },
+    { name = "python-multipart", specifier = ">=0.0.27,<1" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "transformers", marker = "python_full_version >= '3.10'", specifier = ">=5.4.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
@@ -2699,14 +2700,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]
@@ -7380,11 +7381,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-27T16:00:00Z"
+exclude-newer = "2026-05-04T14:38:17.686404Z"
+exclude-newer-span = "P3D"
 
 [manifest]
 members = [


### PR DESCRIPTION
## Summary
- Switch root `[tool.uv] exclude-newer` from the fixed `2026-04-27` to `"3 days"`, matching the per-package pyprojects (`lib/crewai`, `lib/crewai-tools`, `lib/crewai-files`, `lib/devtools` all use `"3 days"` already).
- Drops the now-obsolete "Pinned to include the security patch releases…" comment — those patches (litellm 1.83.7 from 2026-04-13, authlib 1.6.11 / langchain-text-splitters 1.1.2 from 2026-04-16) remain inside any rolling 3-day window from today onward.
- Lockfile metadata updates to record the new span; no dependency versions change.

## Why
The fixed cutoff blocks legitimate dependency bumps. Concretely, #5740 bumps `daytona ~=0.140.0` → `~=0.171`, but `daytona 0.171` was first published 2026-04-30, after the cutoff, so `uv sync` fails to resolve.

## Test plan
- [ ] `uv sync --all-groups --all-extras --no-install-project` succeeds locally
- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes dependency resolution policy and updates pinned transitive tooling deps (`gitpython`, `python-multipart`), which could affect reproducibility or CI if the lockfile is regenerated.
> 
> **Overview**
> Switches root `pyproject.toml` `tool.uv.exclude-newer` from a fixed timestamp to a rolling `"3 days"` window, and updates accompanying comments to reflect current security pin rationale.
> 
> Refreshes `override-dependencies`/`uv.lock` to incorporate security-related minimums, including bumping `python-multipart` to `0.0.27` and adding/upgrading `gitpython` to `>=3.1.49,<4` (lock now resolves `gitpython` `3.1.49`), plus lockfile metadata updates (`exclude-newer-span`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e559d037bfe81ae60a094ff7b977f3edc50073b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->