### PR TITLE
fix(ci): stamp and pin all workspace packages in nightly publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for commits in last 24h
+      - name: Check for recent commits
         id: check
         run: |
-          RECENT=$(git log --since="24 hours ago" --oneline | head -1)
+          # 25h window absorbs cron-vs-commit timing skew at the boundary.
+          RECENT=$(git log --since="25 hours ago" --oneline | head -1)
           if [ -n "$RECENT" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
@@ -38,34 +39,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.3"
+          python-version: "3.12"
+          enable-cache: false
 
       - name: Stamp nightly versions
         run: |
           DATE=$(date +%Y%m%d)
+
+          # All workspace packages share the same base version and are released together.
+          BASE=$(python -c "
+          import re
+          print(re.search(r'__version__\s*=\s*\"(.*?)\"', open('lib/crewai/src/crewai/__init__.py').read()).group(1))
+          ")
+          NIGHTLY="${BASE}.dev${DATE}"
+          echo "Nightly version: ${NIGHTLY}"
+
           for init_file in \
             lib/crewai/src/crewai/__init__.py \
+            lib/crewai-core/src/crewai_core/__init__.py \
             lib/crewai-tools/src/crewai_tools/__init__.py \
-            lib/crewai-files/src/crewai_files/__init__.py; do
-            CURRENT=$(python -c "
-          import re
-          text = open('$init_file').read()
-          print(re.search(r'__version__\s*=\s*\"(.*?)\"\s*$', text, re.MULTILINE).group(1))
-          ")
-            NIGHTLY="${CURRENT}.dev${DATE}"
+            lib/crewai-files/src/crewai_files/__init__.py \
+            lib/cli/src/crewai_cli/__init__.py; do
             sed -i "s/__version__ = .*/__version__ = \"${NIGHTLY}\"/" "$init_file"
-            echo "$init_file: $CURRENT -> $NIGHTLY"
+            echo "Stamped $init_file -> $NIGHTLY"
           done
 
-          # Update cross-package dependency pins to nightly versions
-          sed -i "s/\"crewai-tools==[^\"]*\"/\"crewai-tools==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          # Update all cross-package dependency pins to the nightly version.
           sed -i "s/\"crewai==[^\"]*\"/\"crewai==${NIGHTLY}\"/" lib/crewai-tools/pyproject.toml
+          sed -i "s/\"crewai-core==[^\"]*\"/\"crewai-core==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          sed -i "s/\"crewai-cli==[^\"]*\"/\"crewai-cli==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          sed -i "s/\"crewai-tools==[^\"]*\"/\"crewai-tools==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          sed -i "s/\"crewai-files==[^\"]*\"/\"crewai-files==${NIGHTLY}\"/" lib/crewai/pyproject.toml
+          sed -i "s/\"crewai-core==[^\"]*\"/\"crewai-core==${NIGHTLY}\"/" lib/cli/pyproject.toml
           echo "Updated cross-package dependency pins to ${NIGHTLY}"
 
       - name: Build packages

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -105,7 +105,7 @@ a2a = [
      "aiocache[redis,memcached]~=0.12.3",
 ]
 file-processing = [
-    "crewai-files",
+    "crewai-files==1.14.5a3",
 ]
 qdrant-edge = [
     "qdrant-edge-py>=0.6.0",


### PR DESCRIPTION
## Summary
- Stamp `crewai-cli` and `crewai-core` (previously skipped) along with `crewai`, `crewai-tools`, `crewai-files` so the nightly job no longer collides with stable `1.14.5a3` on PyPI.
- Rewrite every cross-package pin (`crewai`, `crewai-core`, `crewai-cli`, `crewai-tools`, `crewai-files`) so installed nightlies don't mix with stable transitives.
- Compute `NIGHTLY` once from a single source instead of relying on the loop's last-iteration variable.
- Pin `crewai-files==1.14.5a3` in the `file-processing` extra so it gets rewritten with the rest.
- Align `setup-uv` to `@v6` / `0.11.3` across build and publish, drop the redundant `setup-python`.
- Widen the recent-commit check to 25h to absorb cron-vs-commit boundary skew.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the nightly build/publish workflow to rewrite versions and dependency pins across multiple packages, which can affect what gets built and published to PyPI. Risk is mainly CI/release correctness (version collisions or mixed dependency installs) rather than runtime behavior.
> 
> **Overview**
> Nightly CI now stamps a single computed `${BASE}.dev${DATE}` version across *all* workspace packages (including `crewai-core` and `crewai-cli`) and rewrites cross-package dependency pins so nightly installs don’t mix stable and nightly transitives.
> 
> The workflow also widens the “recent commits” window to 25 hours to reduce cron boundary misses, and standardizes on `astral-sh/setup-uv@v6` (`uv` `0.11.3`) while removing the separate `setup-python` step.
> 
> Additionally, `lib/crewai`’s `file-processing` extra pins `crewai-files==1.14.5a3` so it can be rewritten along with the other nightly dependency pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02fb4e6a167147799e883a246205a5e0dc7791e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->