### PR TITLE
fix(ci): make nightly publish idempotent and serialized

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6 * * *' # daily at 6am UTC
   workflow_dispatch:
 
+concurrency:
+  group: nightly-publish
+  cancel-in-progress: false
+
 jobs:
   check:
     name: Check for new commits
@@ -94,13 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/crewai
     permissions:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -125,7 +126,8 @@ jobs:
               continue
             fi
             echo "Publishing $package"
-            if ! uv publish "$package"; then
+            # --check-url skips files already on PyPI so manual re-runs on the same day are idempotent.
+            if ! uv publish --check-url https://pypi.org/simple/ "$package"; then
               echo "Failed to publish $package"
               failed=1
             fi


### PR DESCRIPTION
## Summary
- Add `--check-url https://pypi.org/simple/` to `uv publish` so manual re-runs on the same day skip already-uploaded files instead of failing on PyPI 400s.
- Add a workflow-level `concurrency` group so a `workflow_dispatch` triggered while a cron run is in flight queues instead of racing.
- Drop the misleading `environment.url` (pointed at one of five published packages) and the unused `actions/checkout@v4` in the publish job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: serializes the nightly workflow and makes PyPI uploads skip already-published artifacts, reducing rerun flakiness without affecting application runtime.
> 
> **Overview**
> The nightly release workflow is now **serialized** via a workflow-level `concurrency` group so cron and manual runs don’t race each other.
> 
> Nightly publishing is made **idempotent** by adding `uv publish --check-url https://pypi.org/simple/`, allowing reruns to skip files already on PyPI instead of failing. It also removes an unused `actions/checkout` step and drops the misleading `environment.url` in the publish job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a598334c3f3c9ffdac67df16a57cc4e412b34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->