### PR TITLE
fix(devtools): refresh all published workspace packages on uv lock/sync

### DIFF
--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -1351,6 +1351,14 @@ def _repin_crewai_install(run_value: str, version: str) -> str:
 
 _DEPLOYMENT_TEST_REPO: Final[str] = "crewAIInc/crew_deployment_test"
 
+_PUBLISHED_WORKSPACE_PACKAGES: Final[tuple[str, ...]] = (
+    "crewai",
+    "crewai-cli",
+    "crewai-core",
+    "crewai-files",
+    "crewai-tools",
+)
+
 _PYPI_POLL_INTERVAL: Final[int] = 15
 _PYPI_POLL_TIMEOUT: Final[int] = 600
 
@@ -1403,14 +1411,9 @@ def _update_deployment_test_repo(version: str, is_prerelease: bool) -> None:
         ]
 
         if pyproject_changed:
-            lock_cmd = [
-                "uv",
-                "lock",
-                "--refresh-package",
-                "crewai",
-                "--refresh-package",
-                "crewai-tools",
-            ]
+            lock_cmd = ["uv", "lock"]
+            for pkg in _PUBLISHED_WORKSPACE_PACKAGES:
+                lock_cmd.extend(["--refresh-package", pkg])
             if is_prerelease:
                 lock_cmd.append("--prerelease=allow")
 
@@ -1615,16 +1618,9 @@ def _release_enterprise(version: str, is_prerelease: bool, dry_run: bool) -> Non
         _wait_for_pypi("crewai", version)
 
         console.print("\nSyncing workspace...")
-        sync_cmd = [
-            "uv",
-            "sync",
-            "--refresh-package",
-            "crewai",
-            "--refresh-package",
-            "crewai-tools",
-            "--refresh-package",
-            "crewai-files",
-        ]
+        sync_cmd = ["uv", "sync"]
+        for pkg in _PUBLISHED_WORKSPACE_PACKAGES:
+            sync_cmd.extend(["--refresh-package", pkg])
         if is_prerelease:
             sync_cmd.append("--prerelease=allow")
 


### PR DESCRIPTION
## Summary
- Phase 2 (deployment-test repo) and Phase 3 (enterprise sync) of `devtools release` only passed `--refresh-package` for `crewai` and `crewai-tools` (Phase 3 also `crewai-files`). uv's cached metadata for `crewai-cli`, `crewai-core`, and `crewai-files` then made resolution fail with `no version of crewai-cli==<new>` even after PyPI publish.
- Add `_PUBLISHED_WORKSPACE_PACKAGES` and refresh all 5 published packages in both `uv lock` (deploy-test) and `uv sync` (enterprise).

## Test plan
- [ ] Next prerelease bump completes Phase 2 / Phase 3 without manual intervention

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `devtools release` automation commands to refresh additional packages during `uv lock`/`uv sync`, without changing runtime product behavior.
> 
> **Overview**
> Fixes release automation flakiness by refreshing *all* published workspace packages during `devtools release`.
> 
> Adds `_PUBLISHED_WORKSPACE_PACKAGES` and updates Phase 2 (`_update_deployment_test_repo` `uv lock`) and Phase 3 (`_release_enterprise` `uv sync`) to pass `--refresh-package` for each of `crewai`, `crewai-cli`, `crewai-core`, `crewai-files`, and `crewai-tools` (including prerelease handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5c98e012f68aae02ba55c90eb22686b0d17628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized workspace package configuration in development tooling to improve consistency across deployment and enterprise release workflows.
  * Enhanced package dependency refresh coverage during the enterprise release phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->