### PR TITLE
fix: suppress response_model during native tool loop for non-OpenAI providers

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1336,6 +1336,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 enforce_rpm_limit(self.request_within_rpm_limit)
 
+                # Suppress response_model while tools are active (mirrors sync fix).
+                # See _invoke_loop_native_tools for the full explanation.
                 answer = await aget_llm_response(
                     llm=cast("BaseLLM", self.llm),
                     messages=self.messages,
@@ -1345,7 +1347,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     available_functions=None,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )
@@ -1362,13 +1364,38 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     continue
 
                 if isinstance(answer, str):
+                    if self.response_model is not None:
+                        enforce_rpm_limit(self.request_within_rpm_limit)
+                        answer = await aget_llm_response(
+                            llm=cast("BaseLLM", self.llm),
+                            messages=self.messages,
+                            callbacks=self.callbacks,
+                            printer=PRINTER,
+                            from_task=self.task,
+                            from_agent=self.agent,
+                            response_model=self.response_model,
+                            executor_context=self,
+                            verbose=self.agent.verbose,
+                        )
+                    if isinstance(answer, BaseModel):
+                        output_json = answer.model_dump_json()
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer,
+                            text=output_json,
+                        )
+                        await self._ainvoke_step_callback(formatted_answer)
+                        self._append_message(output_json)
+                        self._show_logs(formatted_answer)
+                        return formatted_answer
+                    answer_str = str(answer) if not isinstance(answer, str) else answer
                     formatted_answer = AgentFinish(
                         thought="",
-                        output=answer,
-                        text=answer,
+                        output=answer_str,
+                        text=answer_str,
                     )
                     await self._ainvoke_step_callback(formatted_answer)
-                    self._append_message(answer)
+                    self._append_message(answer_str)
                     self._show_logs(formatted_answer)
                     return formatted_answer
 

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -493,6 +493,11 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 enforce_rpm_limit(self.request_within_rpm_limit)
 
+                # Suppress response_model while tools are active: providers such as
+                # Gemini and Anthropic treat response_format (structured output) as
+                # higher priority than tools, causing tool calls to be skipped when
+                # both are passed together. response_model is applied after the tool
+                # loop completes via a final extraction call below.
                 answer = get_llm_response(
                     llm=cast("BaseLLM", self.llm),
                     messages=self.messages,
@@ -502,7 +507,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     available_functions=None,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )
@@ -520,13 +525,39 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     continue
 
                 if isinstance(answer, str):
+                    # Tool loop is done. If structured output is required, make one
+                    # final call without tools so the provider can apply the schema.
+                    if self.response_model is not None:
+                        answer = get_llm_response(
+                            llm=cast("BaseLLM", self.llm),
+                            messages=self.messages,
+                            callbacks=self.callbacks,
+                            printer=PRINTER,
+                            from_task=self.task,
+                            from_agent=self.agent,
+                            response_model=self.response_model,
+                            executor_context=self,
+                            verbose=self.agent.verbose,
+                        )
+                    if isinstance(answer, BaseModel):
+                        output_json = answer.model_dump_json()
+                        formatted_answer = AgentFinish(
+                            thought="",
+                            output=answer,
+                            text=output_json,
+                        )
+                        self._invoke_step_callback(formatted_answer)
+                        self._append_message(output_json)
+                        self._show_logs(formatted_answer)
+                        return formatted_answer
+                    answer_str = str(answer) if not isinstance(answer, str) else answer
                     formatted_answer = AgentFinish(
                         thought="",
-                        output=answer,
-                        text=answer,
+                        output=answer_str,
+                        text=answer_str,
                     )
                     self._invoke_step_callback(formatted_answer)
-                    self._append_message(answer)
+                    self._append_message(answer_str)
                     self._show_logs(formatted_answer)
                     return formatted_answer
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1309,7 +1309,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             enforce_rpm_limit(self.request_within_rpm_limit)
 
-            # Call LLM with native tools
+            # Call LLM with native tools. Suppress response_model here so that
+            # providers like Gemini and Anthropic don't skip tool calls in favour
+            # of returning structured output immediately. response_model is applied
+            # in a separate extraction call once the tool loop produces a text answer,
+            # consistent with how the Plan-and-Execute path handles it (synthesis step).
             answer = get_llm_response(
                 llm=self.llm,
                 messages=list(self.state.messages),
@@ -1319,7 +1323,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 available_functions=None,
                 from_task=self.task,
                 from_agent=self.agent,
-                response_model=self.response_model,
+                response_model=None,
                 executor_context=self,
                 verbose=self.agent.verbose,
             )
@@ -1340,16 +1344,38 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 self._append_message_to_state(answer.model_dump_json())
                 return self._route_finish_with_todos("native_finished")
 
-            # Text response - this is the final answer
+            # Text response - tool loop is done. Apply response_model now if set.
             if isinstance(answer, str):
+                if self.response_model is not None:
+                    enforce_rpm_limit(self.request_within_rpm_limit)
+                    answer = get_llm_response(
+                        llm=self.llm,
+                        messages=list(self.state.messages),
+                        callbacks=self.callbacks,
+                        printer=PRINTER,
+                        from_task=self.task,
+                        from_agent=self.agent,
+                        response_model=self.response_model,
+                        executor_context=self,
+                        verbose=self.agent.verbose,
+                    )
+                if isinstance(answer, BaseModel):
+                    self.state.current_answer = AgentFinish(
+                        thought="",
+                        output=answer,
+                        text=answer.model_dump_json(),
+                    )
+                    self._invoke_step_callback(self.state.current_answer)
+                    self._append_message_to_state(answer.model_dump_json())
+                    return self._route_finish_with_todos("native_finished")
+                answer_str = str(answer) if not isinstance(answer, str) else answer
                 self.state.current_answer = AgentFinish(
                     thought="",
-                    output=answer,
-                    text=answer,
+                    output=answer_str,
+                    text=answer_str,
                 )
                 self._invoke_step_callback(self.state.current_answer)
-                self._append_message_to_state(answer)
-
+                self._append_message_to_state(answer_str)
                 return self._route_finish_with_todos("native_finished")
 
             # Unexpected response type, treat as final answer


### PR DESCRIPTION
Fixes #5472.

Since v1.9.0, `response_model` is passed alongside `tools` on every iteration of the native tool loop in both `CrewAgentExecutor` and the new `AgentExecutor`. Providers like Gemini and Anthropic treat `response_format` as higher priority than tools, so the LLM skips tool calls entirely and returns structured output on the first call.

Changed both `_invoke_loop_native_tools` (CrewAgentExecutor) and `call_llm_native_tools` (AgentExecutor) to pass `response_model=None` during tool iterations, then make one final extraction call without tools once the loop produces a text answer. The new AgentExecutor already uses this pattern correctly in its Plan-and-Execute synthesis step - this brings the native tools path in line with it. Also applied the same fix to the async path in `CrewAgentExecutor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool invocation reliability when structured output is enabled. The system now correctly prioritizes tool calls over structured formatting and applies the schema after tool execution completes for more predictable responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5767)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->