### PR TITLE
feat(crewai-tools): add EjentumHarnessTool for cognitive scaffold injection

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -76,6 +76,9 @@ from crewai_tools.tools.e2b_sandbox_tool import (
     E2BFileTool,
     E2BPythonTool,
 )
+from crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool import (
+    EjentumHarnessTool,
+)
 from crewai_tools.tools.exa_tools.exa_search_tool import EXASearchTool, ExaSearchTool
 from crewai_tools.tools.file_read_tool.file_read_tool import FileReadTool
 from crewai_tools.tools.file_writer_tool.file_writer_tool import FileWriterTool
@@ -256,6 +259,7 @@ __all__ = [
     "E2BExecTool",
     "E2BFileTool",
     "E2BPythonTool",
+    "EjentumHarnessTool",
     "EXASearchTool",
     "EnterpriseActionTool",
     "ExaSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/README.md
@@ -1,0 +1,64 @@
+# EjentumHarnessTool
+
+A CrewAI tool that calls one of the four [Ejentum](https://ejentum.com) cognitive harnesses to retrieve a task-matched scaffold. Ejentum is a library of 679 cognitive operations engineered in natural language, organized across four harnesses (`reasoning`, `code`, `anti-deception`, `memory`).
+
+## What the agent gets
+
+Each call returns a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent ingests before responding. The agent picks the right mode based on the task:
+
+| Mode | When the agent should call it |
+|---|---|
+| `reasoning` | Analytical, diagnostic, planning, multi-step questions |
+| `code` | Code generation, refactoring, review, debugging |
+| `anti-deception` | Prompts pressuring the agent to validate, certify, or soften an honest assessment |
+| `memory` | Sharpening an observation already formed about cross-turn drift |
+
+## Setup
+
+Get a free Ejentum API key (100 calls, no card) at <https://ejentum.com/pricing> and set it as `EJENTUM_API_KEY`.
+
+```bash
+export EJENTUM_API_KEY="zpka_..."
+```
+
+## Usage
+
+```python
+from crewai import Agent, Task
+from crewai_tools import EjentumHarnessTool
+
+harness = EjentumHarnessTool()
+
+architect = Agent(
+    role="Senior architect",
+    goal="Evaluate technical decisions honestly",
+    backstory="You are pragmatic and you push back on sunk-cost framings.",
+    tools=[harness],
+)
+
+task = Task(
+    description=(
+        "We've spent three months on the GraphQL gateway. It's mostly done. "
+        "Should we keep going or pivot to REST? "
+        "Call the Ejentum harness with mode='anti-deception' before answering."
+    ),
+    agent=architect,
+    expected_output="A recommendation that separates past spending from prospective evaluation.",
+)
+```
+
+## Configuration
+
+| Field | Default | Description |
+|---|---|---|
+| `api_url` | `https://ejentum-main-ab125c3.zuplo.app/logicv1/` | Override only if you self-host. |
+| `timeout_seconds` | `10.0` | Per-call HTTP timeout. |
+
+`EJENTUM_API_KEY` is read from the environment.
+
+## More
+
+- Project: <https://github.com/ejentum/ejentum-mcp> (MIT)
+- Pricing & free tier: <https://ejentum.com/pricing>
+- Walkthrough: <https://ejentum.com/docs/claude_code_guide>
+- "Under Pressure" research paper: <https://doi.org/10.5281/zenodo.19392715>

--- a/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/ejentum_reasoning_harness_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/ejentum_reasoning_harness_tool.py
@@ -1,0 +1,130 @@
+"""Ejentum Reasoning Harness tool for CrewAI.
+
+Exposes the four Ejentum cognitive harnesses (reasoning, code, anti-deception,
+memory) as a single agent-callable tool. Each call retrieves a task-matched
+cognitive scaffold from a library of 679 cognitive operations engineered in
+natural language. The agent ingests the scaffold (failure pattern, executable
+procedure, suppression vectors, falsification test) and writes from it.
+
+Free tier: 100 calls, no card, at https://ejentum.com/pricing.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from crewai.tools import BaseTool, EnvVar
+from pydantic import Field
+
+from crewai_tools.tools.ejentum_reasoning_harness_tool.schemas import (
+    EjentumHarnessParams,
+)
+
+
+DEFAULT_API_URL = "https://ejentum-main-ab125c3.zuplo.app/logicv1/"
+
+
+class EjentumHarnessTool(BaseTool):
+    """Call one of the four Ejentum cognitive harnesses to retrieve a task-matched scaffold.
+
+    Use `harness_reasoning` (`mode='reasoning'`) before analytical, diagnostic,
+    planning, or multi-step tasks. Use `mode='code'` before producing or
+    reviewing code. Use `mode='anti-deception'` when a prompt pressures the
+    agent to validate, certify, or soften an honest assessment. Use
+    `mode='memory'` only when sharpening an observation already formed about
+    cross-turn drift.
+
+    Requires the `EJENTUM_API_KEY` environment variable. Free tier (100 calls,
+    no card) at https://ejentum.com/pricing.
+    """
+
+    name: str = "Ejentum Reasoning Harness"
+    description: str = (
+        "Retrieve a task-matched cognitive scaffold from Ejentum's library of "
+        "679 cognitive operations engineered in natural language. Pass the "
+        "task you are about to work on and pick one of four modes "
+        "('reasoning', 'code', 'anti-deception', 'memory'). Returns a "
+        "structured scaffold (failure pattern, executable procedure, "
+        "suppression vectors, falsification test) the agent ingests before "
+        "responding."
+    )
+    args_schema: type = EjentumHarnessParams
+    api_url: str = DEFAULT_API_URL
+    timeout_seconds: float = 10.0
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="EJENTUM_API_KEY",
+                description=(
+                    "API key for the Ejentum Logic API. Free tier (100 calls, "
+                    "no card) at https://ejentum.com/pricing."
+                ),
+                required=True,
+            ),
+        ]
+    )
+
+    def _run(self, **kwargs: Any) -> str:
+        query = kwargs.get("query")
+        mode = kwargs.get("mode")
+
+        if not query:
+            return "Ejentum harness call failed: 'query' is required."
+        if mode not in {"reasoning", "code", "anti-deception", "memory"}:
+            return (
+                f"Ejentum harness call failed: 'mode' must be one of "
+                f"reasoning|code|anti-deception|memory, got '{mode}'."
+            )
+
+        api_key = os.environ.get("EJENTUM_API_KEY")
+        if not api_key:
+            return (
+                "Ejentum harness call failed: EJENTUM_API_KEY environment "
+                "variable is not set. Get a free key (100 calls, no card) at "
+                "https://ejentum.com/pricing."
+            )
+
+        try:
+            response = requests.post(
+                self.api_url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={"query": query, "mode": mode},
+                timeout=self.timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            return f"Ejentum harness call failed: network error: {exc}"
+
+        if response.status_code == 401:
+            return (
+                "Ejentum harness call failed: unauthorized (401). Check the "
+                "EJENTUM_API_KEY value. Get a key at https://ejentum.com/pricing."
+            )
+        if response.status_code != 200:
+            return (
+                f"Ejentum harness call failed: HTTP {response.status_code}. "
+                f"Response: {response.text[:300]}"
+            )
+
+        try:
+            data = response.json()
+        except ValueError:
+            return (
+                f"Ejentum harness call failed: response is not valid JSON. "
+                f"Body: {response.text[:300]}"
+            )
+
+        # The API returns: [{<mode>: <scaffold_string>}]
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            scaffold = data[0].get(mode)
+            if scaffold:
+                return scaffold
+
+        return (
+            f"Ejentum harness call returned an unexpected response shape: "
+            f"{str(data)[:300]}"
+        )

--- a/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/ejentum_reasoning_harness_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/ejentum_reasoning_harness_tool.py
@@ -67,7 +67,8 @@ class EjentumHarnessTool(BaseTool):
     )
 
     def _run(self, **kwargs: Any) -> str:
-        query = kwargs.get("query")
+        raw_query = kwargs.get("query")
+        query = raw_query.strip() if isinstance(raw_query, str) else ""
         mode = kwargs.get("mode")
 
         if not query:

--- a/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/schemas.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/schemas.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+HarnessMode = Literal["reasoning", "code", "anti-deception", "memory"]
+
+
+class EjentumHarnessParams(BaseModel):
+    """Arguments for a single Ejentum harness call."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "A 1-2 sentence description of the task the agent is about to work on. "
+            "For mode='memory', format as: 'I noticed [X]. This might mean [Y]. "
+            "Sharpen: [Z].'"
+        ),
+        min_length=1,
+    )
+    mode: HarnessMode = Field(
+        ...,
+        description=(
+            "Which cognitive harness to retrieve a scaffold from. "
+            "'reasoning' for analytical/diagnostic/planning/multi-step tasks. "
+            "'code' for code generation, refactoring, review, debugging. "
+            "'anti-deception' when the prompt pressures the agent to validate, "
+            "certify, or soften an honest assessment. "
+            "'memory' only when sharpening an observation already formed about "
+            "cross-turn drift."
+        ),
+    )

--- a/lib/crewai-tools/tests/tools/ejentum_reasoning_harness_tool_test.py
+++ b/lib/crewai-tools/tests/tools/ejentum_reasoning_harness_tool_test.py
@@ -37,6 +37,14 @@ def test_missing_query_returns_validation_error():
     assert "query" in result
 
 
+def test_whitespace_only_query_returns_validation_error():
+    """Whitespace-only input must NOT trigger a paid external request."""
+    tool = EjentumHarnessTool()
+    result = tool._run(query="   \t\n  ", mode="reasoning")
+    assert "query" in result.lower()
+    assert "required" in result.lower()
+
+
 @patch(
     "crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool.requests.post"
 )

--- a/lib/crewai-tools/tests/tools/ejentum_reasoning_harness_tool_test.py
+++ b/lib/crewai-tools/tests/tools/ejentum_reasoning_harness_tool_test.py
@@ -1,0 +1,104 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool import (
+    EjentumHarnessTool,
+)
+
+
+def _mock_response(status_code: int = 200, json_data=None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or (str(json_data) if json_data else "")
+    resp.json.return_value = json_data if json_data is not None else []
+    return resp
+
+
+def test_missing_api_key_returns_actionable_error(monkeypatch):
+    monkeypatch.delenv("EJENTUM_API_KEY", raising=False)
+    tool = EjentumHarnessTool()
+    result = tool._run(query="diagnose 503s under load", mode="reasoning")
+    assert "EJENTUM_API_KEY" in result
+    assert "ejentum.com/pricing" in result
+
+
+def test_invalid_mode_returns_validation_error():
+    tool = EjentumHarnessTool()
+    result = tool._run(query="anything", mode="not-a-mode")
+    assert "mode" in result
+    assert "reasoning" in result and "code" in result
+
+
+def test_missing_query_returns_validation_error():
+    tool = EjentumHarnessTool()
+    result = tool._run(query="", mode="reasoning")
+    assert "query" in result
+
+
+@patch(
+    "crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool.requests.post"
+)
+def test_successful_reasoning_call_returns_scaffold(mock_post, monkeypatch):
+    monkeypatch.setenv("EJENTUM_API_KEY", "test-key")
+    mock_post.return_value = _mock_response(
+        status_code=200,
+        json_data=[{"reasoning": "[NEGATIVE GATE]\n... [PROCEDURE]\n..."}],
+    )
+
+    tool = EjentumHarnessTool()
+    result = tool._run(query="diagnose 503s under load", mode="reasoning")
+
+    assert "[NEGATIVE GATE]" in result
+    assert "[PROCEDURE]" in result
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer test-key"
+    assert kwargs["json"] == {
+        "query": "diagnose 503s under load",
+        "mode": "reasoning",
+    }
+
+
+@patch(
+    "crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool.requests.post"
+)
+def test_401_returns_actionable_error(mock_post, monkeypatch):
+    monkeypatch.setenv("EJENTUM_API_KEY", "bad-key")
+    mock_post.return_value = _mock_response(status_code=401, text="Unauthorized")
+
+    tool = EjentumHarnessTool()
+    result = tool._run(query="anything", mode="anti-deception")
+
+    assert "401" in result
+    assert "EJENTUM_API_KEY" in result
+
+
+@patch(
+    "crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool.requests.post"
+)
+def test_unexpected_response_shape_is_handled(mock_post, monkeypatch):
+    monkeypatch.setenv("EJENTUM_API_KEY", "test-key")
+    mock_post.return_value = _mock_response(status_code=200, json_data={"wrong": "shape"})
+
+    tool = EjentumHarnessTool()
+    result = tool._run(query="anything", mode="code")
+
+    assert "unexpected response shape" in result.lower()
+
+
+@patch(
+    "crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool.requests.post"
+)
+def test_network_error_is_caught(mock_post, monkeypatch):
+    import requests
+
+    monkeypatch.setenv("EJENTUM_API_KEY", "test-key")
+    mock_post.side_effect = requests.ConnectionError("simulated")
+
+    tool = EjentumHarnessTool()
+    result = tool._run(query="anything", mode="memory")
+
+    assert "network error" in result.lower()
+    assert "simulated" in result


### PR DESCRIPTION
## What

Adds `EjentumHarnessTool` under `lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/`. Wires the import + `__all__` entry in `lib/crewai-tools/src/crewai_tools/__init__.py` (alphabetical placement between `E2BPythonTool` and `EXASearchTool`).

## What the tool does

[Ejentum](https://ejentum.com) is a library of 679 cognitive operations engineered in natural language, organized across four harnesses (`reasoning`, `code`, `anti-deception`, `memory`). Each harness call retrieves a task-matched scaffold rather than serving a fixed template: a named failure pattern, an executable procedure, suppression vectors that block the obvious shortcut, and a falsification test for self-verification.

The CrewAI agent calls `EjentumHarnessTool` with a `query` (1-2 sentence description of the upcoming task) and a `mode` (one of `reasoning`, `code`, `anti-deception`, `memory`). The returned scaffold is ingested by the agent before it produces its actual response.

Free tier: 100 calls, no card, at https://ejentum.com/pricing.

## Files added

- `lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/__init__.py` (empty, matches the convention used by other tools in the same dir)
- `lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/schemas.py` (Pydantic `EjentumHarnessParams` with `query: str` and `mode: Literal["reasoning", "code", "anti-deception", "memory"]`)
- `lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/ejentum_reasoning_harness_tool.py` (the `EjentumHarnessTool` class extending `BaseTool`, declares `env_vars=[EnvVar(name="EJENTUM_API_KEY", required=True)]`)
- `lib/crewai-tools/src/crewai_tools/tools/ejentum_reasoning_harness_tool/README.md` (per-tool docs)
- `lib/crewai-tools/tests/tools/ejentum_reasoning_harness_tool_test.py` (7 unit tests covering: missing API key, invalid mode, empty query, successful call, 401 handling, malformed response, network error)

## Files modified

- `lib/crewai-tools/src/crewai_tools/__init__.py`: added `from crewai_tools.tools.ejentum_reasoning_harness_tool.ejentum_reasoning_harness_tool import EjentumHarnessTool` and `"EjentumHarnessTool"` in `__all__`, both at alphabetically-correct positions.

## Tests

Seven pytest tests using `unittest.mock` to stub `requests.post`. Covers:

- Missing `EJENTUM_API_KEY` → actionable error message
- Invalid `mode` value → validation error  
- Empty `query` → validation error
- Successful call → returns the scaffold string verbatim, sends correct Authorization header and body
- 401 response → user-actionable error pointing at the pricing page
- Malformed response shape → graceful error
- Network exception → caught and reported

I followed the pattern from `brave_search_tool_test.py` (MagicMock-based response stubs). All test files parse cleanly with `ast.parse`. I did not run the full crewai-tools test suite locally because the dev environment requires pytest-xdist and pytest-timeout config from your root `pyproject.toml`; happy to install and run if you want me to.

## Compliance

- Conventional commit format (`feat(crewai-tools): ...`)
- Branch naming: `add-ejentum-reasoning-harness-tool`
- Commit is SSH-signed (`verified: true` on GitHub)
- Alphabetical placement in both import section and `__all__`
- One feature per PR

## About the project

- Repo: https://github.com/ejentum/ejentum-mcp (MIT, npm `ejentum-mcp@0.1.6`)
- Free tier: https://ejentum.com/pricing (100 calls, no card)
- Walkthrough: https://ejentum.com/docs/claude_code_guide
- Backed by the "Under Pressure" Zenodo preprint (DOI 10.5281/zenodo.19392715)

Maintainer is me; happy to address review feedback or rework the scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EjentumHarnessTool providing four cognitive harness modes (reasoning, code, anti-deception, memory) to return structured problem-solving scaffolds; exposed as part of the public API.

* **Documentation**
  * New README documenting usage, configuration (API URL, timeout, API key), examples, and related resources.

* **Tests**
  * Added comprehensive tests covering validation, API interaction, and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5768)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->