### PR TITLE
Fix #4345: exclude system scripts from reserved names so 'test' can b…

### DIFF
--- a/lib/cli/src/crewai_cli/create_crew.py
+++ b/lib/cli/src/crewai_cli/create_crew.py
@@ -31,7 +31,8 @@ def get_reserved_script_names() -> set[str]:
     template_content = template_content.replace("{{crew_name}}", "Placeholder")
 
     template_data = tomli.loads(template_content)
-    script_names = set(template_data.get("project", {}).get("scripts", {}).keys())
+    system_scripts = {"test", "run_crew", "train", "replay", "run_with_trigger"}
+    script_names = set(template_data.get("project", {}).get("scripts", {}).keys()) - system_scripts
     script_names.discard("_placeholder_")
     return script_names
 


### PR DESCRIPTION
…e used as a crew name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reserved script name detection during crew creation to properly exclude system script names from being used as crew folder names, preventing naming conflicts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->