### PR TITLE
fix(devtools): include all workspace packages in bump pin rewrites

### DIFF
--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -323,8 +323,11 @@ def update_pyproject_version(file_path: Path, new_version: str) -> bool:
 
 _DEFAULT_WORKSPACE_PACKAGES: Final[list[str]] = [
     "crewai",
-    "crewai-tools",
+    "crewai-cli",
+    "crewai-core",
     "crewai-devtools",
+    "crewai-files",
+    "crewai-tools",
 ]
 
 

--- a/lib/devtools/tests/test_toml_updates.py
+++ b/lib/devtools/tests/test_toml_updates.py
@@ -238,14 +238,14 @@ class TestUpdatePyprojectDependencies:
         Without this, a version bump silently leaves stale pins behind for any
         workspace package missing from the list (see incident with 1.14.5a5).
         """
+        import tomlkit
+
         workspace_root = Path(__file__).resolve().parents[3]
         root_pyproject = (workspace_root / "pyproject.toml").read_text()
 
-        import tomllib
-
-        members = tomllib.loads(root_pyproject)["tool"]["uv"]["workspace"]["members"]
+        members = tomlkit.parse(root_pyproject)["tool"]["uv"]["workspace"]["members"]
         expected = {
-            tomllib.loads((workspace_root / m / "pyproject.toml").read_text())[
+            tomlkit.parse((workspace_root / m / "pyproject.toml").read_text())[
                 "project"
             ]["name"]
             for m in members

--- a/lib/devtools/tests/test_toml_updates.py
+++ b/lib/devtools/tests/test_toml_updates.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from textwrap import dedent
 
 from crewai_devtools.cli import (
+    _DEFAULT_WORKSPACE_PACKAGES,
     _pin_crewai_deps,
     _repin_crewai_install,
+    update_pyproject_dependencies,
     update_pyproject_version,
     update_template_dependencies,
 )
@@ -224,6 +226,79 @@ class TestRepinCrewaiInstall:
     def test_no_version_specifier_unchanged(self) -> None:
         cmd = 'pip install "crewai[tools]>=1.0"'
         assert _repin_crewai_install(cmd, "2.0.0") == cmd
+
+
+# --- update_pyproject_dependencies ---
+
+
+class TestUpdatePyprojectDependencies:
+    def test_default_packages_cover_all_workspace_members(self) -> None:
+        """Every workspace member must be in the default rewrite list.
+
+        Without this, a version bump silently leaves stale pins behind for any
+        workspace package missing from the list (see incident with 1.14.5a5).
+        """
+        workspace_root = Path(__file__).resolve().parents[3]
+        root_pyproject = (workspace_root / "pyproject.toml").read_text()
+
+        import tomllib
+
+        members = tomllib.loads(root_pyproject)["tool"]["uv"]["workspace"]["members"]
+        expected = {
+            tomllib.loads((workspace_root / m / "pyproject.toml").read_text())[
+                "project"
+            ]["name"]
+            for m in members
+        }
+
+        assert expected.issubset(set(_DEFAULT_WORKSPACE_PACKAGES))
+
+    def test_rewrites_all_workspace_pins(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            dedent("""\
+            [project]
+            dependencies = [
+                "crewai-core==1.0.0",
+                "crewai-cli==1.0.0",
+                "requests>=2.0",
+            ]
+
+            [project.optional-dependencies]
+            tools = [
+                "crewai-tools==1.0.0",
+            ]
+            files = [
+                "crewai-files==1.0.0",
+            ]
+        """)
+        )
+
+        assert update_pyproject_dependencies(pyproject, "2.0.0") is True
+        result = pyproject.read_text()
+        assert '"crewai-core==2.0.0"' in result
+        assert '"crewai-cli==2.0.0"' in result
+        assert '"crewai-tools==2.0.0"' in result
+        assert '"crewai-files==2.0.0"' in result
+        assert '"requests>=2.0"' in result
+
+    def test_leaves_bare_crewai_pin_alone(self, tmp_path: Path) -> None:
+        """`crewai==` must not collide with `crewai-core==` etc."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            dedent("""\
+            [project]
+            dependencies = [
+                "crewai==1.0.0",
+                "crewai-core==1.0.0",
+            ]
+        """)
+        )
+
+        update_pyproject_dependencies(pyproject, "2.0.0")
+        result = pyproject.read_text()
+        assert '"crewai==2.0.0"' in result
+        assert '"crewai-core==2.0.0"' in result
 
 
 # --- update_template_dependencies ---


### PR DESCRIPTION
## Summary
- `_DEFAULT_WORKSPACE_PACKAGES` only listed `crewai`, `crewai-tools`, `crewai-devtools`, so version bumps silently left `crewai-core`, `crewai-cli`, and `crewai-files` pins on the previous version. This is what caused the stale `1.14.5a4` pins in `lib/crewai/pyproject.toml` and `lib/cli/pyproject.toml` flagged on the 1.14.5a5 bump (Cursor bugbot on a3b3d13).
- Adds the missing packages and a regression test that fails if any `[tool.uv.workspace] members` entry is absent from the rewrite list.

## Test plan
- [x] `uv run pytest lib/devtools/tests/test_toml_updates.py` — 28 passed
- [x] Simulated bump on `lib/crewai/pyproject.toml` now rewrites all four pins (`crewai-core`, `crewai-cli`, `crewai-tools`, `crewai-files`)
- [ ] After merge, re-run the 1.14.5a5 bump (or any future bump) and confirm no stale pins remain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to devtools version-bump pin rewrites and add regression tests to prevent missing workspace packages; no runtime product logic is affected.
> 
> **Overview**
> Fixes `devtools` version bumping so `update_pyproject_dependencies` rewrites pins for *all* workspace packages by expanding `_DEFAULT_WORKSPACE_PACKAGES` to include `crewai-cli`, `crewai-core`, and `crewai-files`.
> 
> Adds tests ensuring every `[tool.uv.workspace]` member is covered by the default rewrite list, that pins across `dependencies` and `optional-dependencies` are updated, and that `crewai==...` does not incorrectly collide with `crewai-core==...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57566766058e7b26ae15f6767d80b2fc0645fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace dependency update logic to target additional crewai packages (including crewai-cli, crewai-core, crewai-files) during version bumps and releases.

* **Tests**
  * Added comprehensive tests to ensure all workspace packages are covered, workspace-scoped dependency pins are rewritten to the provided version, unrelated constraints remain unchanged, and bare package entries aren’t confused with similarly named packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5778)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->