### PR TITLE
feat(tools): add CoinbaseAgenticWalletTool with x402 payment support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -315,6 +315,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -798,6 +799,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -1281,6 +1283,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -1765,6 +1768,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -2249,6 +2253,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -2733,6 +2738,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -3217,6 +3223,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -3700,6 +3707,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -4182,6 +4190,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -4664,6 +4673,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -5146,6 +5156,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -5630,6 +5641,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"
@@ -6113,6 +6125,7 @@
                         "pages": [
                           "en/tools/automation/overview",
                           "en/tools/automation/apifyactorstool",
+                          "en/tools/automation/coinbase-agentic-wallet-tool",
                           "en/tools/automation/composiotool",
                           "en/tools/automation/multiontool",
                           "en/tools/automation/zapieractionstool"

--- a/docs/en/tools/automation/coinbase-agentic-wallet-tool.mdx
+++ b/docs/en/tools/automation/coinbase-agentic-wallet-tool.mdx
@@ -7,9 +7,9 @@ mode: "wide"
 
 # Coinbase Agentic Wallet Tool
 
-`CoinbaseAgenticWalletTool` connects CrewAI agents to the [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome). Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+`CoinbaseAgenticWalletTool` connects CrewAI agents to the [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome). Agents can discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet. Funding happens through the built-in Coinbase Onramp when needed, with no API keys or seed phrases to manage.
 
-The tool wraps CrewAI's `MCPServerAdapter` around the local MCP bundle installed by `npx @coinbase/payments-mcp` and returns the MCP tools as CrewAI-compatible tools.
+The tool wraps CrewAI's `MCPServerAdapter` around the local MCP bundle installed by `npx @coinbase/payments-mcp install --client other` and returns the MCP tools as CrewAI-compatible tools.
 
 ## Installation
 

--- a/docs/en/tools/automation/coinbase-agentic-wallet-tool.mdx
+++ b/docs/en/tools/automation/coinbase-agentic-wallet-tool.mdx
@@ -1,0 +1,90 @@
+---
+title: Coinbase Agentic Wallet Tool
+description: Connect CrewAI agents to Coinbase Agentic Wallet MCP tools for autonomous x402 API discovery and USDC payments.
+icon: wallet
+mode: "wide"
+---
+
+# Coinbase Agentic Wallet Tool
+
+`CoinbaseAgenticWalletTool` connects CrewAI agents to the [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome). Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+
+The tool wraps CrewAI's `MCPServerAdapter` around the local MCP bundle installed by `npx @coinbase/payments-mcp` and returns the MCP tools as CrewAI-compatible tools.
+
+## Installation
+
+```shell
+pip install "crewai-tools[mcp]"
+```
+
+Install Node.js so `npx` can run the Coinbase installer and `node` can launch the local MCP bundle.
+
+Run the Coinbase installer once:
+
+```shell
+npx @coinbase/payments-mcp install --client other
+```
+
+The installer creates the stdio server bundle at `~/.payments-mcp/bundle.js`.
+
+## Usage
+
+Use the context manager so the MCP server is stopped after the crew run:
+
+```python
+from crewai import Agent, Crew, Task
+from crewai_tools import CoinbaseAgenticWalletTool
+
+with CoinbaseAgenticWalletTool() as coinbase_tools:
+    agent = Agent(
+        role="Payments Researcher",
+        goal="Discover paid APIs and use them when they are useful",
+        backstory=(
+            "You can search the x402 bazaar, inspect payment requirements, "
+            "and pay for HTTP APIs in USDC."
+        ),
+        tools=coinbase_tools,
+    )
+
+    task = Task(
+        description="Find a paid weather API and get today's forecast for San Francisco.",
+        expected_output="A concise forecast with the paid API response summarized.",
+        agent=agent,
+    )
+
+    crew = Crew(agents=[agent], tasks=[task])
+    crew.kickoff()
+```
+
+## Manual lifecycle
+
+If your crew setup cannot use a context manager, call `stop()` after the run:
+
+```python
+from crewai import Agent
+from crewai_tools import CoinbaseAgenticWalletTool
+
+wallet = CoinbaseAgenticWalletTool(connect_timeout=90)
+try:
+    agent = Agent(
+        role="Payments Researcher",
+        goal="Use x402 APIs",
+        backstory="You can discover and pay for x402 APIs.",
+        tools=wallet.tools,
+    )
+finally:
+    wallet.stop()
+```
+
+## Authentication
+
+On first use, the MCP server opens a companion window for email and OTP sign-in. This creates a Coinbase-managed embedded wallet, so you do not need to manage a seed phrase. Fund the wallet through the built-in Coinbase Onramp.
+
+## Available actions
+
+The MCP server lets agents search the x402 bazaar, inspect payment requirements, pay for HTTP APIs in USDC, and check wallet address and balance. See the [Agentic Wallet MCP tool reference](https://docs.cdp.coinbase.com/agentic-wallet/mcp/mcp-tools/overview) for the full catalog.
+
+## Resources
+
+- [Coinbase Agentic Wallet MCP docs](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome)
+- [x402 protocol docs](https://docs.cdp.coinbase.com/x402/welcome)

--- a/docs/en/tools/automation/overview.mdx
+++ b/docs/en/tools/automation/overview.mdx
@@ -14,6 +14,10 @@ These tools enable your agents to automate workflows, integrate with external pl
     Run Apify actors for web scraping and automation tasks.
   </Card>
 
+  <Card title="Coinbase Agentic Wallet Tool" icon="wallet" href="/en/tools/automation/coinbase-agentic-wallet-tool">
+    Discover and pay for x402 APIs with a Coinbase-managed embedded wallet.
+  </Card>
+
   <Card title="Composio Tool" icon="puzzle-piece" href="/en/tools/automation/composiotool">
     Integrate with hundreds of apps and services through Composio.
   </Card>

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -35,6 +35,7 @@ from crewai_tools.tools.browserbase_load_tool.browserbase_load_tool import (
 from crewai_tools.tools.code_docs_search_tool.code_docs_search_tool import (
     CodeDocsSearchTool,
 )
+from crewai_tools.tools.coinbase_agentic_wallet_tool import CoinbaseAgenticWalletTool
 from crewai_tools.tools.composio_tool.composio_tool import ComposioTool
 from crewai_tools.tools.contextualai_create_agent_tool.contextual_create_agent_tool import (
     ContextualAICreateAgentTool,
@@ -238,6 +239,7 @@ __all__ = [
     "BrowserbaseLoadTool",
     "CSVSearchTool",
     "CodeDocsSearchTool",
+    "CoinbaseAgenticWalletTool",
     "ComposioTool",
     "ContextualAICreateAgentTool",
     "ContextualAIParseTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -24,6 +24,7 @@ from crewai_tools.tools.browserbase_load_tool.browserbase_load_tool import (
 from crewai_tools.tools.code_docs_search_tool.code_docs_search_tool import (
     CodeDocsSearchTool,
 )
+from crewai_tools.tools.coinbase_agentic_wallet_tool import CoinbaseAgenticWalletTool
 from crewai_tools.tools.composio_tool.composio_tool import ComposioTool
 from crewai_tools.tools.contextualai_create_agent_tool.contextual_create_agent_tool import (
     ContextualAICreateAgentTool,
@@ -223,6 +224,7 @@ __all__ = [
     "BrowserbaseLoadTool",
     "CSVSearchTool",
     "CodeDocsSearchTool",
+    "CoinbaseAgenticWalletTool",
     "ComposioTool",
     "ContextualAICreateAgentTool",
     "ContextualAIParseTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/README.md
@@ -1,0 +1,76 @@
+# Coinbase Agentic Wallet Tool
+
+## Description
+
+`CoinbaseAgenticWalletTool` exposes the Coinbase Agentic Wallet MCP server to CrewAI agents. Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+
+The wrapper starts the local MCP bundle installed by `npx @coinbase/payments-mcp` through CrewAI's `MCPServerAdapter` and returns the MCP tools as CrewAI-compatible tools.
+
+## Installation
+
+Install CrewAI tools with MCP support:
+
+```shell
+pip install "crewai-tools[mcp]"
+```
+
+Install Node.js so `npx` can run the Coinbase installer and `node` can launch the local MCP bundle.
+
+Run the Coinbase installer once:
+
+```shell
+npx @coinbase/payments-mcp install --client other
+```
+
+The installer creates the stdio server bundle at `~/.payments-mcp/bundle.js`.
+
+## Usage
+
+```python
+from crewai import Agent, Crew, Task
+from crewai_tools import CoinbaseAgenticWalletTool
+
+with CoinbaseAgenticWalletTool() as coinbase_tools:
+    agent = Agent(
+        role="Payments Researcher",
+        goal="Find paid APIs and use them when they are useful",
+        backstory=(
+            "You can search the x402 bazaar, inspect payment requirements, "
+            "and pay for HTTP APIs in USDC."
+        ),
+        tools=coinbase_tools,
+    )
+
+    task = Task(
+        description="Find a paid weather API and get today's forecast for San Francisco.",
+        expected_output="A concise forecast with the paid API response summarized.",
+        agent=agent,
+    )
+
+    crew = Crew(agents=[agent], tasks=[task])
+    crew.kickoff()
+```
+
+You can also manage the lifecycle manually:
+
+```python
+wallet = CoinbaseAgenticWalletTool(connect_timeout=90)
+try:
+    agent = Agent(
+        role="Payments Researcher",
+        goal="Use x402 APIs",
+        backstory="You can discover and pay for x402 APIs.",
+        tools=wallet.tools,
+    )
+finally:
+    wallet.stop()
+```
+
+## Authentication
+
+On first use, the MCP server opens a companion window for email and OTP sign-in. This creates a Coinbase-managed embedded wallet, so you do not need to manage a seed phrase. Fund the wallet through the built-in Coinbase Onramp.
+
+## Resources
+
+- [Coinbase Agentic Wallet MCP docs](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome)
+- [x402 protocol docs](https://docs.cdp.coinbase.com/x402/welcome)

--- a/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-`CoinbaseAgenticWalletTool` exposes the Coinbase Agentic Wallet MCP server to CrewAI agents. Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+`CoinbaseAgenticWalletTool` exposes the Coinbase Agentic Wallet MCP server to CrewAI agents. Agents can discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet. Funding happens through the built-in Coinbase Onramp when needed, with no API keys or seed phrases to manage.
 
-The wrapper starts the local MCP bundle installed by `npx @coinbase/payments-mcp` through CrewAI's `MCPServerAdapter` and returns the MCP tools as CrewAI-compatible tools.
+The wrapper starts the local MCP bundle installed by `npx @coinbase/payments-mcp install --client other` through CrewAI's `MCPServerAdapter` and returns the MCP tools as CrewAI-compatible tools.
 
 ## Installation
 

--- a/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/__init__.py
@@ -1,0 +1,6 @@
+from crewai_tools.tools.coinbase_agentic_wallet_tool.coinbase_agentic_wallet_tool import (
+    CoinbaseAgenticWalletTool,
+)
+
+
+__all__ = ["CoinbaseAgenticWalletTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/coinbase_agentic_wallet_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/coinbase_agentic_wallet_tool.py
@@ -25,11 +25,13 @@ class CoinbaseAgenticWalletTool:
         *tool_names: str,
         connect_timeout: int = 60,
     ) -> None:
+        """Create a wrapper for the installed Coinbase Agentic Wallet MCP bundle."""
         self.tool_names = tool_names
         self.connect_timeout = connect_timeout
         self._adapter: MCPServerAdapter | None = None
 
     def _server_params(self) -> Any:
+        """Build stdio parameters for the installed MCP bundle."""
         from mcp import StdioServerParameters
 
         return StdioServerParameters(
@@ -41,6 +43,12 @@ class CoinbaseAgenticWalletTool:
     def start(self) -> ToolCollection[BaseTool]:
         """Start the MCP server and return the adapted CrewAI tools."""
         if self._adapter is None:
+            if not self.bundle_path.is_file():
+                raise FileNotFoundError(
+                    "Coinbase Agentic Wallet MCP bundle not found at "
+                    f"{self.bundle_path}. Run: "
+                    "npx @coinbase/payments-mcp install --client other"
+                )
             self._adapter = MCPServerAdapter(
                 self._server_params(),
                 *self.tool_names,
@@ -62,13 +70,16 @@ class CoinbaseAgenticWalletTool:
     def stop(self) -> None:
         """Stop the MCP server if it has been started."""
         if self._adapter is not None:
-            self._adapter.stop()
+            adapter = self._adapter
             self._adapter = None
+            adapter.stop()
 
     def __enter__(self) -> ToolCollection[BaseTool]:
+        """Start the MCP server and return the adapted CrewAI tools."""
         return self.start()
 
     def __exit__(
         self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any
     ) -> None:
+        """Stop the MCP server when leaving a context manager block."""
         self.stop()

--- a/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/coinbase_agentic_wallet_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/coinbase_agentic_wallet_tool.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from crewai.tools import BaseTool
+
+from crewai_tools.adapters.mcp_adapter import MCPServerAdapter
+from crewai_tools.adapters.tool_collection import ToolCollection
+
+
+class CoinbaseAgenticWalletTool:
+    """Expose Coinbase Agentic Wallet MCP tools to CrewAI agents.
+
+    Wraps the local MCP bundle installed by `npx @coinbase/payments-mcp` so
+    agents can discover and pay for x402-monetized HTTP APIs with USDC through
+    a Coinbase-managed embedded wallet.
+    """
+
+    command = "node"
+    bundle_path: ClassVar[Path] = Path.home() / ".payments-mcp" / "bundle.js"
+
+    def __init__(
+        self,
+        *tool_names: str,
+        connect_timeout: int = 60,
+    ) -> None:
+        self.tool_names = tool_names
+        self.connect_timeout = connect_timeout
+        self._adapter: MCPServerAdapter | None = None
+
+    def _server_params(self) -> Any:
+        from mcp import StdioServerParameters
+
+        return StdioServerParameters(
+            command=self.command,
+            args=[str(self.bundle_path)],
+            env=None,
+        )
+
+    def start(self) -> ToolCollection[BaseTool]:
+        """Start the MCP server and return the adapted CrewAI tools."""
+        if self._adapter is None:
+            self._adapter = MCPServerAdapter(
+                self._server_params(),
+                *self.tool_names,
+                connect_timeout=self.connect_timeout,
+            )
+        return self.tools
+
+    @property
+    def tools(self) -> ToolCollection[BaseTool]:
+        """Return the adapted MCP tools, starting the server if needed."""
+        if self._adapter is None:
+            self.start()
+
+        if self._adapter is None:
+            raise RuntimeError("Coinbase Agentic Wallet MCP adapter did not start")
+
+        return self._adapter.tools
+
+    def stop(self) -> None:
+        """Stop the MCP server if it has been started."""
+        if self._adapter is not None:
+            self._adapter.stop()
+            self._adapter = None
+
+    def __enter__(self) -> ToolCollection[BaseTool]:
+        return self.start()
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any
+    ) -> None:
+        self.stop()

--- a/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
+++ b/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from crewai_tools.tools.coinbase_agentic_wallet_tool import CoinbaseAgenticWalletTool
 
 
@@ -12,12 +14,15 @@ def test_coinbase_agentic_wallet_tool_defaults():
     assert tool.tool_names == ()
 
 
-def test_coinbase_agentic_wallet_tool_starts_adapter_lazily():
+def test_coinbase_agentic_wallet_tool_starts_adapter_lazily(tmp_path):
     adapted_tools = ["search_bazaar", "pay"]
+    bundle_path = tmp_path / "bundle.js"
+    bundle_path.write_text("")
     adapter = Mock()
     adapter.tools = adapted_tools
 
     with (
+        patch.object(CoinbaseAgenticWalletTool, "bundle_path", bundle_path),
         patch.object(CoinbaseAgenticWalletTool, "_server_params", return_value="params"),
         patch(
             "crewai_tools.tools.coinbase_agentic_wallet_tool.coinbase_agentic_wallet_tool.MCPServerAdapter",
@@ -26,8 +31,29 @@ def test_coinbase_agentic_wallet_tool_starts_adapter_lazily():
     ):
         tool = CoinbaseAgenticWalletTool("pay", connect_timeout=90)
 
+        adapter_class.assert_not_called()
+        assert tool._adapter is None
         assert tool.tools == adapted_tools
         adapter_class.assert_called_once_with("params", "pay", connect_timeout=90)
 
         tool.stop()
         adapter.stop.assert_called_once()
+
+
+def test_coinbase_agentic_wallet_tool_requires_installed_bundle(tmp_path):
+    missing_bundle = tmp_path / "missing-bundle.js"
+
+    with (
+        patch.object(CoinbaseAgenticWalletTool, "bundle_path", missing_bundle),
+        patch(
+            "crewai_tools.tools.coinbase_agentic_wallet_tool.coinbase_agentic_wallet_tool.MCPServerAdapter",
+        ) as adapter_class,
+    ):
+        tool = CoinbaseAgenticWalletTool()
+
+        with pytest.raises(
+            FileNotFoundError,
+            match="npx @coinbase/payments-mcp install --client other",
+        ):
+            tool.start()
+        adapter_class.assert_not_called()

--- a/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
+++ b/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
@@ -6,6 +6,7 @@ from crewai_tools.tools.coinbase_agentic_wallet_tool import CoinbaseAgenticWalle
 
 
 def test_coinbase_agentic_wallet_tool_defaults():
+    """Verify the wrapper defaults to the installed Coinbase MCP bundle."""
     tool = CoinbaseAgenticWalletTool()
 
     assert tool.command == "node"
@@ -15,6 +16,7 @@ def test_coinbase_agentic_wallet_tool_defaults():
 
 
 def test_coinbase_agentic_wallet_tool_starts_adapter_lazily(tmp_path):
+    """Verify the MCP adapter is created only when tools are first accessed."""
     adapted_tools = ["search_bazaar", "pay"]
     bundle_path = tmp_path / "bundle.js"
     bundle_path.write_text("")
@@ -41,6 +43,7 @@ def test_coinbase_agentic_wallet_tool_starts_adapter_lazily(tmp_path):
 
 
 def test_coinbase_agentic_wallet_tool_requires_installed_bundle(tmp_path):
+    """Verify users get an actionable error before adapter startup."""
     missing_bundle = tmp_path / "missing-bundle.js"
 
     with (

--- a/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
+++ b/lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock, patch
+
+from crewai_tools.tools.coinbase_agentic_wallet_tool import CoinbaseAgenticWalletTool
+
+
+def test_coinbase_agentic_wallet_tool_defaults():
+    tool = CoinbaseAgenticWalletTool()
+
+    assert tool.command == "node"
+    assert str(tool.bundle_path).endswith(".payments-mcp/bundle.js")
+    assert tool.connect_timeout == 60
+    assert tool.tool_names == ()
+
+
+def test_coinbase_agentic_wallet_tool_starts_adapter_lazily():
+    adapted_tools = ["search_bazaar", "pay"]
+    adapter = Mock()
+    adapter.tools = adapted_tools
+
+    with (
+        patch.object(CoinbaseAgenticWalletTool, "_server_params", return_value="params"),
+        patch(
+            "crewai_tools.tools.coinbase_agentic_wallet_tool.coinbase_agentic_wallet_tool.MCPServerAdapter",
+            return_value=adapter,
+        ) as adapter_class,
+    ):
+        tool = CoinbaseAgenticWalletTool("pay", connect_timeout=90)
+
+        assert tool.tools == adapted_tools
+        adapter_class.assert_called_once_with("params", "pay", connect_timeout=90)
+
+        tool.stop()
+        adapter.stop.assert_called_once()


### PR DESCRIPTION
## Summary

Adds `CoinbaseAgenticWalletTool`, a lifecycle wrapper around CrewAI's `MCPServerAdapter` for the Coinbase Agentic Wallet MCP bundle. It keeps the adapter alive while CrewAI uses the MCP tools and exposes a context-manager API for cleanup.

Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.

## Changes

- Adds `crewai_tools.tools.coinbase_agentic_wallet_tool` and exports `CoinbaseAgenticWalletTool`.
- Adds an automation docs page and navigation card for the tool.
- Adds a unit test for defaults and lazy adapter startup.

## Testing

- `python3 -m py_compile lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool/coinbase_agentic_wallet_tool.py lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py`
- `uv run ruff check lib/crewai-tools/src/crewai_tools/tools/coinbase_agentic_wallet_tool lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py`
- `uv run pytest lib/crewai-tools/tests/test_coinbase_agentic_wallet_tool.py`
- `uv run python lib/crewai-tools/src/crewai_tools/generate_tool_specs.py`

Note: tool spec generation completed with existing Pydantic JSON schema warnings and did not change `tool.specs.json` because this wrapper returns MCP-adapted tools rather than subclassing `BaseTool` directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Coinbase Agentic Wallet integration so agents can discover payment APIs, inspect requirements, and initiate USDC payments.

* **Documentation**
  * Added full guide for installation, authentication (email/OTP), usage patterns, lifecycle management, and links to Coinbase MCP/x402 docs.
  * Added a tool card to the Available Tools overview.

* **Tests**
  * Added tests for defaults, lazy startup/teardown, and missing-bundle error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5785)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->