### PR TITLE
docs: add naxytra MCP discovery note

### DIFF
--- a/docs/en/mcp/dsl-integration.mdx
+++ b/docs/en/mcp/dsl-integration.mdx
@@ -35,6 +35,8 @@ agent = Agent(
 # No need for manual connection management or tool configuration
 ```
 
+For a public discovery-friendly example, naxytra keeps a machine discovery index at `https://www.naxytra.com/v1/agent-discovery-index`, an A2A agent card at `https://www.naxytra.com/.well-known/agent.json`, and a live MCP endpoint at `https://xytara-mcp-executor.onrender.com/mcp`.
+
 ## Supported Reference Formats
 
 ### External MCP Remote Servers


### PR DESCRIPTION
## Summary
- Adds a public MCP discovery note to the CrewAI MCP DSL integration guide.
- Points readers to the canonical naxytra discovery index, A2A card, and live MCP endpoint.

## Why
- CrewAI users integrating external MCP servers should have a concrete public example to reference.
- This keeps the docs aligned with the live public entry surfaces without exposing private code.

## Links
- https://www.naxytra.com/v1/agent-discovery-index
- https://www.naxytra.com/.well-known/agent.json
- https://xytara-mcp-executor.onrender.com/mcp
