### PR TITLE
Feat+Fix: Let Tools returning multimodal data

### DIFF
--- a/docs/ar/learn/multimodal-agents.mdx
+++ b/docs/ar/learn/multimodal-agents.mdx
@@ -96,6 +96,53 @@ crew = Crew(
 result = crew.kickoff()
 ```
 
+### بناء أدوات تُعيد محتوى متعدد الوسائط
+
+يمكنك بناء أدوات مخصصة تُمرر الصور والصوت والفيديو وملفات PDF مباشرةً إلى نموذج اللغة عن طريق إعادة قيمة `MultimodalToolResult`. يتم حقن الملفات تلقائياً في المحادثة بالتنسيق الصحيح لكل مزود — دون الحاجة إلى إعداد خاص للوكيل.
+
+**متطلب مسبق**: يجب تثبيت `crewai-files` (`pip install crewai-files`).
+
+```python
+from crewai.tools import BaseTool, MultimodalToolResult
+from crewai_files import ImageFile
+
+class ScreenshotTool(BaseTool):
+    name: str = "take_screenshot"
+    description: str = "Capture a screenshot of a URL and return it to the LLM"
+
+    def _run(self, url: str) -> MultimodalToolResult:
+        image_data = capture_screenshot(url)  # returns bytes
+        return MultimodalToolResult(
+            text="Screenshot captured successfully",
+            files={"screenshot": ImageFile(source=image_data)},
+        )
+```
+
+يربط قاموس `files` أسماء مفاتيح اعتباطية بأي كائن ملف من `crewai_files` (`ImageFile` أو `AudioFile` أو `VideoFile` أو `PDFFile` أو `TextFile` أو `File` العام). يتم إرسال جميع الملفات الموجودة في القاموس إلى نموذج اللغة إلى جانب نص الملاحظة `text`.
+
+**مصادر الملفات المدعومة**:
+- `bytes` — محتوى ثنائي خام
+- `str` / `pathlib.Path` — مسار ملف محلي
+- سلسلة URL تبدأ بـ `http://` أو `https://` — مورد بعيد
+
+```python
+# From bytes
+ImageFile(source=raw_bytes)
+
+# From a local path
+ImageFile(source="/path/to/image.png")
+
+# From a URL
+ImageFile(source="https://example.com/image.png")
+```
+
+**إعادة ملف مباشرةً**: كبديل لـ `MultimodalToolResult`، يمكن للأداة إعادة كائن `FileInput` واحد مباشرةً وسيقوم CrewAI بتغليفه تلقائياً:
+
+```python
+def _run(self, query: str) -> ImageFile:
+    return ImageFile(source=generate_image(query))
+```
+
 ### تفاصيل الأداة
 
 عند العمل مع الوكلاء متعددي الوسائط، يتم إعداد `AddImageTool` تلقائياً بالمخطط التالي:

--- a/docs/en/learn/multimodal-agents.mdx
+++ b/docs/en/learn/multimodal-agents.mdx
@@ -96,6 +96,53 @@ crew = Crew(
 result = crew.kickoff()
 ```
 
+### Building Tools That Return Multimodal Content
+
+You can build custom tools that pass images, audio, video, or PDF files directly to the LLM by returning a `MultimodalToolResult`. The files are automatically injected into the conversation in the correct provider format — no special agent configuration needed.
+
+**Installation prerequisite**: `crewai-files` must be installed (`pip install crewai-files`).
+
+```python
+from crewai.tools import BaseTool, MultimodalToolResult
+from crewai_files import ImageFile
+
+class ScreenshotTool(BaseTool):
+    name: str = "take_screenshot"
+    description: str = "Capture a screenshot of a URL and return it to the LLM"
+
+    def _run(self, url: str) -> MultimodalToolResult:
+        image_data = capture_screenshot(url)  # returns bytes
+        return MultimodalToolResult(
+            text="Screenshot captured successfully",
+            files={"screenshot": ImageFile(source=image_data)},
+        )
+```
+
+The `files` dict maps arbitrary key names to any `crewai_files` file object (`ImageFile`, `AudioFile`, `VideoFile`, `PDFFile`, `TextFile`, or the generic `File`). All files in the dict are forwarded to the LLM alongside the `text` observation.
+
+**Supported file sources**:
+- `bytes` — raw binary content
+- `str` / `pathlib.Path` — local file path
+- URL string starting with `http://` or `https://` — remote resource
+
+```python
+# From bytes
+ImageFile(source=raw_bytes)
+
+# From a local path
+ImageFile(source="/path/to/image.png")
+
+# From a URL
+ImageFile(source="https://example.com/image.png")
+```
+
+**Returning a file directly**: As an alternative to `MultimodalToolResult`, a tool can return a single `FileInput` object directly and CrewAI will wrap it automatically:
+
+```python
+def _run(self, query: str) -> ImageFile:
+    return ImageFile(source=generate_image(query))
+```
+
 ### Tool Details
 
 When working with multimodal agents, the `AddImageTool` is automatically configured with the following schema:

--- a/docs/ko/learn/multimodal-agents.mdx
+++ b/docs/ko/learn/multimodal-agents.mdx
@@ -96,6 +96,53 @@ crew = Crew(
 result = crew.kickoff()
 ```
 
+### 멀티모달 콘텐츠를 반환하는 도구 만들기
+
+`MultimodalToolResult`를 반환하여 이미지, 오디오, 비디오, PDF 파일을 LLM에 직접 전달하는 커스텀 도구를 만들 수 있습니다. 파일은 올바른 프로바이더 형식으로 자동으로 대화에 삽입됩니다 — 에이전트 특별 설정이 필요 없습니다.
+
+**설치 전제 조건**: `crewai-files`가 설치되어 있어야 합니다 (`pip install crewai-files`).
+
+```python
+from crewai.tools import BaseTool, MultimodalToolResult
+from crewai_files import ImageFile
+
+class ScreenshotTool(BaseTool):
+    name: str = "take_screenshot"
+    description: str = "Capture a screenshot of a URL and return it to the LLM"
+
+    def _run(self, url: str) -> MultimodalToolResult:
+        image_data = capture_screenshot(url)  # returns bytes
+        return MultimodalToolResult(
+            text="Screenshot captured successfully",
+            files={"screenshot": ImageFile(source=image_data)},
+        )
+```
+
+`files` 딕셔너리는 임의의 키 이름을 `crewai_files` 파일 객체(`ImageFile`, `AudioFile`, `VideoFile`, `PDFFile`, `TextFile`, 또는 일반 `File`)에 매핑합니다. 딕셔너리의 모든 파일은 `text` 관찰 내용과 함께 LLM에 전달됩니다.
+
+**지원되는 파일 소스**:
+- `bytes` — 원시 바이너리 콘텐츠
+- `str` / `pathlib.Path` — 로컬 파일 경로
+- `http://` 또는 `https://`로 시작하는 URL 문자열 — 원격 리소스
+
+```python
+# From bytes
+ImageFile(source=raw_bytes)
+
+# From a local path
+ImageFile(source="/path/to/image.png")
+
+# From a URL
+ImageFile(source="https://example.com/image.png")
+```
+
+**파일 직접 반환**: `MultimodalToolResult`의 대안으로, 도구가 단일 `FileInput` 객체를 직접 반환할 수 있으며 CrewAI가 자동으로 래핑합니다:
+
+```python
+def _run(self, query: str) -> ImageFile:
+    return ImageFile(source=generate_image(query))
+```
+
 ### 도구 세부 정보
 
 멀티모달 에이전트를 사용할 때, `AddImageTool`은 다음 스키마로 자동 구성됩니다:

--- a/docs/pt-BR/learn/multimodal-agents.mdx
+++ b/docs/pt-BR/learn/multimodal-agents.mdx
@@ -96,6 +96,53 @@ crew = Crew(
 result = crew.kickoff()
 ```
 
+### Criando Ferramentas que Retornam Conteúdo Multimodal
+
+Você pode criar ferramentas personalizadas que passam imagens, áudio, vídeo ou arquivos PDF diretamente para o LLM retornando um `MultimodalToolResult`. Os arquivos são injetados automaticamente na conversa no formato correto do provedor — sem necessidade de configuração especial do agente.
+
+**Pré-requisito de instalação**: `crewai-files` deve estar instalado (`pip install crewai-files`).
+
+```python
+from crewai.tools import BaseTool, MultimodalToolResult
+from crewai_files import ImageFile
+
+class ScreenshotTool(BaseTool):
+    name: str = "take_screenshot"
+    description: str = "Capture a screenshot of a URL and return it to the LLM"
+
+    def _run(self, url: str) -> MultimodalToolResult:
+        image_data = capture_screenshot(url)  # returns bytes
+        return MultimodalToolResult(
+            text="Screenshot captured successfully",
+            files={"screenshot": ImageFile(source=image_data)},
+        )
+```
+
+O dicionário `files` mapeia nomes de chaves arbitrárias para qualquer objeto de arquivo `crewai_files` (`ImageFile`, `AudioFile`, `VideoFile`, `PDFFile`, `TextFile`, ou o `File` genérico). Todos os arquivos no dicionário são encaminhados ao LLM juntamente com a observação `text`.
+
+**Fontes de arquivo suportadas**:
+- `bytes` — conteúdo binário bruto
+- `str` / `pathlib.Path` — caminho de arquivo local
+- String de URL começando com `http://` ou `https://` — recurso remoto
+
+```python
+# From bytes
+ImageFile(source=raw_bytes)
+
+# From a local path
+ImageFile(source="/path/to/image.png")
+
+# From a URL
+ImageFile(source="https://example.com/image.png")
+```
+
+**Retornando um arquivo diretamente**: Como alternativa ao `MultimodalToolResult`, uma ferramenta pode retornar um único objeto `FileInput` diretamente e o CrewAI o envolverá automaticamente:
+
+```python
+def _run(self, query: str) -> ImageFile:
+    return ImageFile(source=generate_image(query))
+```
+
 ### Detalhes da Ferramenta
 
 Ao trabalhar com agentes multimodais, a `AddImageTool` é automaticamente configurada com o seguinte esquema:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1037,7 +1037,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
             "content": result,
         }
         if files:
-            tool_message["files"] = files  # type: ignore[typeddict-unknown-key]
+            tool_message["files"] = files
         self.messages.append(tool_message)
 
         if self.agent and self.agent.verbose:
@@ -1434,7 +1434,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
         for i in range(len(self.messages) - 1, -1, -1):
             msg = self.messages[i]
             if msg.get("role") == "user":
-                existing: dict[str, Any] = msg.get("files", {})  # type: ignore[assignment]
+                existing: dict[str, Any] = msg.get("files", {})
                 existing.update(files)
                 msg["files"] = existing
                 break
@@ -1447,8 +1447,9 @@ class CrewAgentExecutor(BaseAgentExecutor):
         falls back to str() for all other types.
         """
         try:
-            from crewai.tools.tool_types import MultimodalToolResult
             from crewai_files.core.types import BaseFile
+
+            from crewai.tools.tool_types import MultimodalToolResult
         except ImportError:
             return (raw if isinstance(raw, str) else str(raw), {})
 
@@ -1457,6 +1458,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         if isinstance(raw, BaseFile):
             from pathlib import PurePosixPath
+
             raw_name = raw.filename or "file"
             key = PurePosixPath(raw_name).stem or "file"
             return f"[{type(raw).__name__}: {raw_name}]", {key: raw}

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -402,6 +402,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 self._invoke_step_callback(formatted_answer)
                 self._append_message(formatted_answer.text)
+                if isinstance(formatted_answer, AgentAction) and tool_result.files:
+                    self._inject_files_into_last_user_message(tool_result.files)
 
             except OutputParserError as e:
                 formatted_answer = handle_output_parser_exception(  # type: ignore[assignment]
@@ -865,6 +867,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         from_cache = False
         result: str = "Tool not found"
+        result_files: dict[str, Any] = {}
         input_str = json.dumps(args_dict) if args_dict else ""
         if self.tools_handler and self.tools_handler.cache:
             cached_result = self.tools_handler.cache.read(
@@ -952,9 +955,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                             tool=func_name, input=input_str, output=raw_result
                         )
 
-                result = (
-                    str(raw_result) if not isinstance(raw_result, str) else raw_result
-                )
+                result, result_files = self._extract_native_tool_result(raw_result)
             except Exception as e:
                 result = f"Error executing tool: {e}"
                 if self.task:
@@ -1016,6 +1017,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
             "result": result,
             "from_cache": from_cache,
             "original_tool": original_tool,
+            "files": result_files,
         }
 
     def _append_tool_result_and_check_finality(
@@ -1026,6 +1028,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
         result = cast(str, execution_result["result"])
         from_cache = cast(bool, execution_result["from_cache"])
         original_tool = execution_result["original_tool"]
+        files: dict[str, Any] = execution_result.get("files", {})
 
         tool_message: LLMMessage = {
             "role": "tool",
@@ -1033,6 +1036,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
             "name": func_name,
             "content": result,
         }
+        if files:
+            tool_message["files"] = files  # type: ignore[typeddict-unknown-key]
         self.messages.append(tool_message)
 
         if self.agent and self.agent.verbose:
@@ -1214,6 +1219,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 await self._ainvoke_step_callback(formatted_answer)
                 self._append_message(formatted_answer.text)
+                if isinstance(formatted_answer, AgentAction) and tool_result.files:
+                    self._inject_files_into_last_user_message(tool_result.files)
 
             except OutputParserError as e:
                 formatted_answer = handle_output_parser_exception(  # type: ignore[assignment]
@@ -1409,15 +1416,6 @@ class CrewAgentExecutor(BaseAgentExecutor):
         Returns:
             Updated action or final answer.
         """
-        add_image_tool = I18N_DEFAULT.tools("add_image")
-        if (
-            isinstance(add_image_tool, dict)
-            and formatted_answer.tool.casefold().strip()
-            == add_image_tool.get("name", "").casefold().strip()
-        ):
-            self.messages.append({"role": "assistant", "content": tool_result.result})
-            return formatted_answer
-
         return handle_agent_action_core(
             formatted_answer=formatted_answer,
             tool_result=tool_result,
@@ -1425,6 +1423,45 @@ class CrewAgentExecutor(BaseAgentExecutor):
             step_callback=self.step_callback,
             show_logs=self._show_logs,
         )
+
+    def _inject_files_into_last_user_message(self, files: dict[str, Any]) -> None:
+        """Attach files to the most-recent role='user' message.
+
+        Called after _append_message() so that the observation message produced
+        by a tool carrying a MultimodalToolResult receives the file payload,
+        which _process_message_files() will convert to provider content blocks.
+        """
+        for i in range(len(self.messages) - 1, -1, -1):
+            msg = self.messages[i]
+            if msg.get("role") == "user":
+                existing: dict[str, Any] = msg.get("files", {})  # type: ignore[assignment]
+                existing.update(files)
+                msg["files"] = existing
+                break
+
+    @staticmethod
+    def _extract_native_tool_result(raw: Any) -> tuple[str, dict[str, Any]]:
+        """Convert a raw tool return value into (text, files).
+
+        Handles MultimodalToolResult and FileInput (BaseFile) transparently;
+        falls back to str() for all other types.
+        """
+        try:
+            from crewai.tools.tool_types import MultimodalToolResult
+            from crewai_files.core.types import BaseFile
+        except ImportError:
+            return (raw if isinstance(raw, str) else str(raw), {})
+
+        if isinstance(raw, MultimodalToolResult):
+            return raw.text, dict(raw.files)
+
+        if isinstance(raw, BaseFile):
+            from pathlib import PurePosixPath
+            raw_name = raw.filename or "file"
+            key = PurePosixPath(raw_name).stem or "file"
+            return f"[{type(raw).__name__}: {raw_name}]", {key: raw}
+
+        return (raw if isinstance(raw, str) else str(raw), {})
 
     def _invoke_step_callback(
         self, formatted_answer: AgentAction | AgentFinish

--- a/lib/crewai/src/crewai/agents/step_executor.py
+++ b/lib/crewai/src/crewai/agents/step_executor.py
@@ -314,6 +314,8 @@ class StepExecutor:
                 tool_result = self._execute_text_tool_with_events(formatted)
                 last_tool_result = tool_result.result
                 messages.append({"role": "assistant", "content": answer_str})
+                if tool_result.result_as_answer:
+                    return tool_result.result
                 obs_msg = self._build_observation_message(tool_result.result)
                 if tool_result.files:
                     obs_msg["files"] = tool_result.files

--- a/lib/crewai/src/crewai/agents/step_executor.py
+++ b/lib/crewai/src/crewai/agents/step_executor.py
@@ -43,6 +43,7 @@ from crewai.utilities.i18n import I18N_DEFAULT
 from crewai.utilities.planning_types import TodoItem
 from crewai.utilities.step_execution_context import StepExecutionContext, StepResult
 from crewai.utilities.string_utils import sanitize_tool_name
+from crewai.tools.tool_types import ToolResult
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from crewai.utilities.types import LLMMessage
 
@@ -311,16 +312,19 @@ class StepExecutor:
             if isinstance(formatted, AgentAction):
                 tool_calls_made.append(formatted.tool)
                 tool_result = self._execute_text_tool_with_events(formatted)
-                last_tool_result = tool_result
+                last_tool_result = tool_result.result
                 messages.append({"role": "assistant", "content": answer_str})
-                messages.append(self._build_observation_message(tool_result))
+                obs_msg = self._build_observation_message(tool_result.result)
+                if tool_result.files:
+                    obs_msg["files"] = tool_result.files  # type: ignore[typeddict-unknown-key]
+                messages.append(obs_msg)
                 continue
 
             return answer_str
 
         return last_tool_result
 
-    def _execute_text_tool_with_events(self, formatted: AgentAction) -> str:
+    def _execute_text_tool_with_events(self, formatted: AgentAction) -> ToolResult:
         """Execute text-parsed tool calls with tool usage events."""
         args_dict = self._parse_tool_args(formatted.tool_input)
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
@@ -386,7 +390,7 @@ class StepExecutor:
                 finished_at=datetime.now(),
             ),
         )
-        return str(tool_result.result)
+        return tool_result
 
     def _parse_tool_args(self, tool_input: Any) -> dict[str, Any]:
         """Parse tool args from the parser output into a dict payload for events."""

--- a/lib/crewai/src/crewai/agents/step_executor.py
+++ b/lib/crewai/src/crewai/agents/step_executor.py
@@ -28,6 +28,7 @@ from crewai.events.types.tool_usage_events import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
+from crewai.tools.tool_types import ToolResult
 from crewai.utilities.agent_utils import (
     build_tool_calls_assistant_message,
     check_native_tool_support,
@@ -43,7 +44,6 @@ from crewai.utilities.i18n import I18N_DEFAULT
 from crewai.utilities.planning_types import TodoItem
 from crewai.utilities.step_execution_context import StepExecutionContext, StepResult
 from crewai.utilities.string_utils import sanitize_tool_name
-from crewai.tools.tool_types import ToolResult
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from crewai.utilities.types import LLMMessage
 
@@ -316,7 +316,7 @@ class StepExecutor:
                 messages.append({"role": "assistant", "content": answer_str})
                 obs_msg = self._build_observation_message(tool_result.result)
                 if tool_result.files:
-                    obs_msg["files"] = tool_result.files  # type: ignore[typeddict-unknown-key]
+                    obs_msg["files"] = tool_result.files
                 messages.append(obs_msg)
                 continue
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2752,7 +2752,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         for i in range(len(self.state.messages) - 1, -1, -1):
             msg = self.state.messages[i]
             if msg.get("role") == "user":
-                existing: dict[str, Any] = msg.get("files", {})  # type: ignore[assignment]
+                existing: dict[str, Any] = msg.get("files", {})
                 existing.update(files)
                 msg["files"] = existing
                 break

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1455,6 +1455,8 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         if hasattr(result, "text"):
             self._append_message_to_state(result.text)
+            if isinstance(result, AgentAction) and tool_result.files:
+                self._inject_files_into_last_user_message(tool_result.files)
 
         if isinstance(result, AgentFinish):
             self.state.is_finished = True
@@ -2737,17 +2739,6 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         Returns:
             Updated action or final answer.
         """
-        add_image_tool = I18N_DEFAULT.tools("add_image")
-        if (
-            isinstance(add_image_tool, dict)
-            and formatted_answer.tool.casefold().strip()
-            == add_image_tool.get("name", "").casefold().strip()
-        ):
-            self.state.messages.append(
-                {"role": "assistant", "content": tool_result.result}
-            )
-            return formatted_answer
-
         return handle_agent_action_core(
             formatted_answer=formatted_answer,
             tool_result=tool_result,
@@ -2755,6 +2746,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             step_callback=self.step_callback,
             show_logs=self._show_logs,
         )
+
+    def _inject_files_into_last_user_message(self, files: dict[str, Any]) -> None:
+        """Attach files to the most-recent role='user' message in state.messages."""
+        for i in range(len(self.state.messages) - 1, -1, -1):
+            msg = self.state.messages[i]
+            if msg.get("role") == "user":
+                existing: dict[str, Any] = msg.get("files", {})  # type: ignore[assignment]
+                existing.update(files)
+                msg["files"] = existing
+                break
 
     def _invoke_step_callback(
         self, formatted_answer: AgentAction | AgentFinish

--- a/lib/crewai/src/crewai/tools/__init__.py
+++ b/lib/crewai/src/crewai/tools/__init__.py
@@ -1,8 +1,10 @@
 from crewai.tools.base_tool import BaseTool, EnvVar, tool
+from crewai.tools.tool_types import MultimodalToolResult
 
 
 __all__ = [
     "BaseTool",
     "EnvVar",
+    "MultimodalToolResult",
     "tool",
 ]

--- a/lib/crewai/src/crewai/tools/agent_tools/add_image_tool.py
+++ b/lib/crewai/src/crewai/tools/agent_tools/add_image_tool.py
@@ -1,8 +1,7 @@
-from typing import Any
-
 from pydantic import BaseModel, Field
 
 from crewai.tools.base_tool import BaseTool
+from crewai.tools.tool_types import MultimodalToolResult
 from crewai.utilities.i18n import I18N_DEFAULT
 
 
@@ -14,7 +13,7 @@ class AddImageToolSchema(BaseModel):
 
 
 class AddImageTool(BaseTool):
-    """Tool for adding images to the content"""
+    """Tool for adding images to the conversation."""
 
     name: str = Field(default_factory=lambda: I18N_DEFAULT.tools("add_image")["name"])  # type: ignore[index]
     description: str = Field(
@@ -26,17 +25,16 @@ class AddImageTool(BaseTool):
         self,
         image_url: str,
         action: str | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        action = action or I18N_DEFAULT.tools("add_image")["default_action"]  # type: ignore
-        content = [
-            {"type": "text", "text": action},
-            {
-                "type": "image_url",
-                "image_url": {
-                    "url": image_url,
-                },
-            },
-        ]
+    ) -> MultimodalToolResult | str:
+        action_text: str = action or I18N_DEFAULT.tools("add_image")["default_action"]  # type: ignore[index]
 
-        return {"role": "user", "content": content}
+        try:
+            from crewai_files import ImageFile
+
+            return MultimodalToolResult(
+                text=action_text,
+                files={"image": ImageFile(image_url)},
+            )
+        except ImportError:
+            # crewai-files not installed: fall back to text-only observation.
+            return action_text

--- a/lib/crewai/src/crewai/tools/agent_tools/add_image_tool.py
+++ b/lib/crewai/src/crewai/tools/agent_tools/add_image_tool.py
@@ -33,7 +33,7 @@ class AddImageTool(BaseTool):
 
             return MultimodalToolResult(
                 text=action_text,
-                files={"image": ImageFile(image_url)},
+                files={"image": ImageFile(source=image_url)},
             )
         except ImportError:
             # crewai-files not installed: fall back to text-only observation.

--- a/lib/crewai/src/crewai/tools/tool_types.py
+++ b/lib/crewai/src/crewai/tools/tool_types.py
@@ -1,9 +1,47 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from crewai_files import FileInput
+
+
+@dataclass
+class MultimodalToolResult:
+    """Multimodal result returned by a tool.
+
+    Allows tool authors to return both a text observation and file attachments
+    (images, audio, video, PDFs) in a single value. The files are injected into
+    the LLM message via the existing ``files`` pipeline so every vision-capable
+    provider receives them in the correct format.
+
+    Example::
+
+        from crewai.tools import BaseTool, MultimodalToolResult
+        from crewai_files import ImageFile
+
+        class ScreenshotTool(BaseTool):
+            name = "take_screenshot"
+            description = "Capture a screenshot of a URL"
+
+            def _run(self, url: str) -> MultimodalToolResult:
+                data = capture(url)
+                return MultimodalToolResult(
+                    text="Screenshot captured",
+                    files={"screenshot": ImageFile(data)},
+                )
+    """
+
+    text: str
+    files: dict[str, FileInput] = field(default_factory=dict)
+    result_as_answer: bool = False
 
 
 @dataclass
 class ToolResult:
-    """Result of tool execution."""
+    """Internal result of tool execution propagated through the pipeline."""
 
     result: str
     result_as_answer: bool = False
+    files: dict[str, FileInput] = field(default_factory=dict)

--- a/lib/crewai/src/crewai/tools/tool_types.py
+++ b/lib/crewai/src/crewai/tools/tool_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from crewai_files import FileInput
 
@@ -20,6 +21,7 @@ class MultimodalToolResult:
 
         from crewai.tools import BaseTool, MultimodalToolResult
         from crewai_files import ImageFile
+
 
         class ScreenshotTool(BaseTool):
             name = "take_screenshot"

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -106,6 +106,9 @@ class ToolUsage:
         self.action = action
         self.function_calling_llm = function_calling_llm
         self.fingerprint_context = fingerprint_context or {}
+        # Populated by _format_result when a MultimodalToolResult or FileInput is returned.
+        # Callers (execute_tool_and_check_finality) read this to build ToolResult.files.
+        self._result_files: dict[str, Any] = {}
 
         # Set the maximum parsing attempts for bigger models
         if (
@@ -142,23 +145,7 @@ class ToolUsage:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
             return error
 
-        if (
-            isinstance(tool, CrewStructuredTool)
-            and sanitize_tool_name(tool.name)
-            == sanitize_tool_name(I18N_DEFAULT.tools("add_image")["name"])  # type: ignore
-        ):
-            try:
-                return self._use(tool_string=tool_string, tool=tool, calling=calling)
-
-            except Exception as e:
-                error = getattr(e, "message", str(e))
-                if self.task:
-                    self.task.increment_tools_errors()
-                if self.agent and self.agent.verbose:
-                    PRINTER.print(content=f"\n\n{error}\n", color="red")
-                return error
-
-        return f"{self._use(tool_string=tool_string, tool=tool, calling=calling)}"
+        return self._use(tool_string=tool_string, tool=tool, calling=calling)
 
     async def ause(
         self, calling: ToolCalling | InstructorToolCalling, tool_string: str
@@ -190,26 +177,7 @@ class ToolUsage:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
             return error
 
-        if (
-            isinstance(tool, CrewStructuredTool)
-            and sanitize_tool_name(tool.name)
-            == sanitize_tool_name(I18N_DEFAULT.tools("add_image")["name"])  # type: ignore
-        ):
-            try:
-                return await self._ause(
-                    tool_string=tool_string, tool=tool, calling=calling
-                )
-            except Exception as e:
-                error = getattr(e, "message", str(e))
-                if self.task:
-                    self.task.increment_tools_errors()
-                if self.agent and self.agent.verbose:
-                    PRINTER.print(content=f"\n\n{error}\n", color="red")
-                return error
-
-        return (
-            f"{await self._ause(tool_string=tool_string, tool=tool, calling=calling)}"
-        )
+        return await self._ause(tool_string=tool_string, tool=tool, calling=calling)
 
     async def _ause(
         self,
@@ -687,9 +655,39 @@ class ToolUsage:
     def _format_result(self, result: Any) -> str:
         if self.task:
             self.task.used_tools += 1
+
+        text = self._extract_multimodal_files(result)
+        if text is not None:
+            if self._should_remember_format():
+                text = self._remember_format(result=text)
+            return text
+
         if self._should_remember_format():
             result = self._remember_format(result=result)
         return str(result)
+
+    def _extract_multimodal_files(self, result: Any) -> str | None:
+        """If result is MultimodalToolResult or a FileInput, extract files into
+        ``self._result_files`` and return the text portion.  Returns None when
+        result is neither so normal str() conversion applies."""
+        try:
+            from crewai.tools.tool_types import MultimodalToolResult
+            from crewai_files.core.types import BaseFile
+        except ImportError:
+            return None
+
+        if isinstance(result, MultimodalToolResult):
+            self._result_files = dict(result.files)
+            return result.text
+
+        if isinstance(result, BaseFile):
+            from pathlib import PurePosixPath
+            raw_name = result.filename or "file"
+            key = PurePosixPath(raw_name).stem or "file"
+            self._result_files = {key: result}
+            return f"[{type(result).__name__}: {raw_name}]"
+
+        return None
 
     def _should_remember_format(self) -> bool:
         if self.task:

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -671,8 +671,9 @@ class ToolUsage:
         ``self._result_files`` and return the text portion.  Returns None when
         result is neither so normal str() conversion applies."""
         try:
-            from crewai.tools.tool_types import MultimodalToolResult
             from crewai_files.core.types import BaseFile
+
+            from crewai.tools.tool_types import MultimodalToolResult
         except ImportError:
             return None
 
@@ -682,6 +683,7 @@ class ToolUsage:
 
         if isinstance(result, BaseFile):
             from pathlib import PurePosixPath
+
             raw_name = result.filename or "file"
             key = PurePosixPath(raw_name).stem or "file"
             self._result_files = {key: result}

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -656,6 +656,7 @@ class ToolUsage:
         if self.task:
             self.task.used_tools += 1
 
+        self._result_files = {}
         text = self._extract_multimodal_files(result)
         if text is not None:
             if self._should_remember_format():

--- a/lib/crewai/src/crewai/utilities/tool_utils.py
+++ b/lib/crewai/src/crewai/utilities/tool_utils.py
@@ -116,6 +116,7 @@ async def aexecute_tool_and_check_finality(
             logger.log("error", f"Error in before_tool_call hook: {e}")
 
         tool_result = await tool_usage.ause(tool_calling, agent_action.text)
+        result_files = tool_usage._result_files
 
         after_hook_context = ToolCallHookContext(
             tool_name=sanitized_tool_name,
@@ -138,7 +139,7 @@ async def aexecute_tool_and_check_finality(
         except Exception as e:
             logger.log("error", f"Error in after_tool_call hook: {e}")
 
-        return ToolResult(modified_result, tool.result_as_answer)
+        return ToolResult(modified_result, tool.result_as_answer, files=result_files)
 
     tool_result = I18N_DEFAULT.errors("wrong_tool_name").format(
         tool=sanitized_tool_name,
@@ -234,6 +235,7 @@ def execute_tool_and_check_finality(
             logger.log("error", f"Error in before_tool_call hook: {e}")
 
         tool_result = tool_usage.use(tool_calling, agent_action.text)
+        result_files = tool_usage._result_files
 
         after_hook_context = ToolCallHookContext(
             tool_name=sanitized_tool_name,
@@ -257,7 +259,7 @@ def execute_tool_and_check_finality(
         except Exception as e:
             logger.log("error", f"Error in after_tool_call hook: {e}")
 
-        return ToolResult(modified_result, tool.result_as_answer)
+        return ToolResult(modified_result, tool.result_as_answer, files=result_files)
 
     tool_result = I18N_DEFAULT.errors("wrong_tool_name").format(
         tool=sanitized_tool_name,

--- a/lib/crewai/tests/tools/test_multimodal_tool_result.py
+++ b/lib/crewai/tests/tools/test_multimodal_tool_result.py
@@ -179,7 +179,7 @@ class TestFormatResult:
         assert tu._result_files == {}
 
     def test_result_files_cleared_on_plain_result(self):
-        """_result_files should reflect the MOST RECENT call."""
+        """A plain _format_result call must clear files set by a prior multimodal call."""
         tu = _make_tool_usage()
         tu.task.used_tools = 0
         img = ImageFile(source=_PNG_BYTES)
@@ -189,10 +189,7 @@ class TestFormatResult:
 
         tu.task.used_tools = 1
         tu._format_result("plain follow-up")
-        # _extract_multimodal_files returns None; _result_files not touched by _format_result itself
-        # (it preserves whatever _extract set). This test documents current behaviour:
-        # a second plain call does NOT wipe files — callers create a fresh ToolUsage per invocation.
-        # This is fine because execute_tool_and_check_finality reads _result_files once then discards.
+        assert tu._result_files == {}
 
 
 # ---------------------------------------------------------------------------

--- a/lib/crewai/tests/tools/test_multimodal_tool_result.py
+++ b/lib/crewai/tests/tools/test_multimodal_tool_result.py
@@ -1,0 +1,233 @@
+"""Tests for MultimodalToolResult and the multimodal pipeline in tool_usage."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from crewai_files import ImageFile
+from crewai_files.core.types import BaseFile
+
+from crewai.tools.tool_types import MultimodalToolResult, ToolResult
+from crewai.tools.tool_usage import ToolUsage
+
+# Minimal 1×1 white PNG bytes used across tests.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00"
+    b"\x00\x11\x00\x01\xd9\x7f\xd3\r\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_usage() -> ToolUsage:
+    return ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[],
+        task=MagicMock(),
+        function_calling_llm=MagicMock(),
+        agent=MagicMock(),
+        action=MagicMock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# MultimodalToolResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalToolResult:
+    def test_text_only_defaults(self):
+        r = MultimodalToolResult(text="hello")
+        assert r.text == "hello"
+        assert r.files == {}
+        assert r.result_as_answer is False
+
+    def test_files_stored(self):
+        img = ImageFile(source=_PNG_BYTES)
+        r = MultimodalToolResult(text="captured", files={"img": img})
+        assert r.files["img"] is img
+
+    def test_result_as_answer_flag(self):
+        r = MultimodalToolResult(text="final", result_as_answer=True)
+        assert r.result_as_answer is True
+
+
+# ---------------------------------------------------------------------------
+# ToolResult.files field
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultFiles:
+    def test_default_files_empty(self):
+        r = ToolResult(result="ok")
+        assert r.files == {}
+
+    def test_files_stored(self):
+        img = ImageFile(source=_PNG_BYTES)
+        r = ToolResult(result="ok", files={"img": img})
+        assert r.files["img"] is img
+
+
+# ---------------------------------------------------------------------------
+# ToolUsage._extract_multimodal_files
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMultimodalFiles:
+    def test_plain_string_returns_none(self):
+        tu = _make_tool_usage()
+        assert tu._extract_multimodal_files("plain text") is None
+        assert tu._result_files == {}
+
+    def test_plain_int_returns_none(self):
+        tu = _make_tool_usage()
+        assert tu._extract_multimodal_files(42) is None
+
+    def test_multimodal_tool_result_extracts_text(self):
+        tu = _make_tool_usage()
+        img = ImageFile(source=_PNG_BYTES)
+        mtr = MultimodalToolResult(text="captured", files={"screenshot": img})
+
+        result = tu._extract_multimodal_files(mtr)
+
+        assert result == "captured"
+        assert tu._result_files == {"screenshot": img}
+
+    def test_multimodal_tool_result_empty_files(self):
+        tu = _make_tool_usage()
+        mtr = MultimodalToolResult(text="text only")
+
+        result = tu._extract_multimodal_files(mtr)
+
+        assert result == "text only"
+        assert tu._result_files == {}
+
+    def test_base_file_bytes_source(self):
+        tu = _make_tool_usage()
+        img = ImageFile(source=_PNG_BYTES)
+
+        result = tu._extract_multimodal_files(img)
+
+        # bytes source has no filename → key falls back to "file"
+        assert result is not None
+        assert "ImageFile" in result
+        assert "file" in tu._result_files
+        assert tu._result_files["file"] is img
+
+    def test_base_file_named_source(self):
+        import tempfile, pathlib
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(_PNG_BYTES)
+            tmp = pathlib.Path(f.name)
+
+        try:
+            tu = _make_tool_usage()
+            img = ImageFile(source=tmp)
+            result = tu._extract_multimodal_files(img)
+
+            stem = tmp.stem
+            assert result == f"[ImageFile: {tmp.name}]"
+            assert stem in tu._result_files
+            assert tu._result_files[stem] is img
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_result_files_reset_between_calls(self):
+        tu = _make_tool_usage()
+        img = ImageFile(source=_PNG_BYTES)
+        mtr = MultimodalToolResult(text="first", files={"img": img})
+        tu._extract_multimodal_files(mtr)
+        assert tu._result_files != {}
+
+        # plain call should NOT reset _result_files (caller is _format_result)
+        tu._extract_multimodal_files("plain")
+        # returns None, _result_files unchanged
+        assert tu._result_files != {}
+
+
+# ---------------------------------------------------------------------------
+# ToolUsage._format_result integration
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResult:
+    def test_plain_string_passthrough(self):
+        tu = _make_tool_usage()
+        tu.task.used_tools = 0
+        assert tu._format_result("hello world") == "hello world"
+        assert tu._result_files == {}
+
+    def test_multimodal_result_returns_text(self):
+        tu = _make_tool_usage()
+        tu.task.used_tools = 0
+        img = ImageFile(source=_PNG_BYTES)
+        mtr = MultimodalToolResult(text="image ready", files={"img": img})
+
+        text = tu._format_result(mtr)
+
+        assert text == "image ready"
+        assert tu._result_files == {"img": img}
+
+    def test_integer_converted_to_str(self):
+        tu = _make_tool_usage()
+        tu.task.used_tools = 0
+        assert tu._format_result(42) == "42"
+        assert tu._result_files == {}
+
+    def test_result_files_cleared_on_plain_result(self):
+        """_result_files should reflect the MOST RECENT call."""
+        tu = _make_tool_usage()
+        tu.task.used_tools = 0
+        img = ImageFile(source=_PNG_BYTES)
+        mtr = MultimodalToolResult(text="with file", files={"img": img})
+        tu._format_result(mtr)
+        assert tu._result_files != {}
+
+        tu.task.used_tools = 1
+        tu._format_result("plain follow-up")
+        # _extract_multimodal_files returns None; _result_files not touched by _format_result itself
+        # (it preserves whatever _extract set). This test documents current behaviour:
+        # a second plain call does NOT wipe files — callers create a fresh ToolUsage per invocation.
+        # This is fine because execute_tool_and_check_finality reads _result_files once then discards.
+
+
+# ---------------------------------------------------------------------------
+# AddImageTool
+# ---------------------------------------------------------------------------
+
+
+class TestAddImageTool:
+    def test_run_returns_multimodal_tool_result(self):
+        from crewai.tools.agent_tools.add_image_tool import AddImageTool
+
+        tool = AddImageTool()
+        result = tool._run(image_url="https://example.com/photo.jpg")
+
+        assert isinstance(result, MultimodalToolResult)
+        assert "image" in result.files
+        assert isinstance(result.files["image"], BaseFile)
+
+    def test_run_with_action_text(self):
+        from crewai.tools.agent_tools.add_image_tool import AddImageTool
+
+        tool = AddImageTool()
+        result = tool._run(
+            image_url="https://example.com/photo.jpg",
+            action="Describe what you see",
+        )
+
+        assert isinstance(result, MultimodalToolResult)
+        assert result.text == "Describe what you see"
+
+    def test_run_default_action_text_not_empty(self):
+        from crewai.tools.agent_tools.add_image_tool import AddImageTool
+
+        tool = AddImageTool()
+        result = tool._run(image_url="https://example.com/photo.jpg")
+
+        assert isinstance(result, MultimodalToolResult)
+        assert result.text  # non-empty default action


### PR DESCRIPTION
## Summary

This PR introduces a first-class public API for tool authors to return multimodal content (images, audio, video, PDFs) from any `BaseTool`, and wires up the full pipeline so those files reach the LLM in the correct provider format.

Previously, `AddImageTool` was the only path for injecting images into the conversation, implemented via a fragile name-based special case that called `str()` on the result dict — meaning it silently produced a Python `repr` string instead of actual image content. Any other tool returning a `FileInput` would have its multimodal structure destroyed by `_format_result()`'s unconditional `str()` conversion.

**Before** — tool authors had no supported way to return multimodal data:
```python
# No public API existed; only AddImageTool had a (broken) special case
class MyTool(BaseTool):
    def _run(self, query: str) -> str:
        ...  # forced to return text only
```

**After** — any tool can return multimodal content:
```python
from crewai.tools import BaseTool, MultimodalToolResult
from crewai_files import ImageFile

class ScreenshotTool(BaseTool):
    name: str = "take_screenshot"
    description: str = "Capture a screenshot of a URL"

    def _run(self, url: str) -> MultimodalToolResult:
        data = capture(url)
        return MultimodalToolResult(
            text="Screenshot captured",
            files={"screenshot": ImageFile(source=data)},
        )
```

## Changes

### New public API (`tools/tool_types.py`, `tools/__init__.py`)
- Added `MultimodalToolResult` dataclass: `text: str`, `files: dict[str, FileInput]`, `result_as_answer: bool`
- Added `files: dict[str, FileInput]` field to the internal `ToolResult` dataclass
- Exported `MultimodalToolResult` from `crewai.tools`

### Core pipeline (`tools/tool_usage.py`)
- Added `self._result_files: dict[str, Any] = {}` side-channel to `ToolUsage`
- Added `_extract_multimodal_files()` helper: intercepts `MultimodalToolResult` and bare `BaseFile` objects before `str()` conversion, extracts files into `_result_files`
- Updated `_format_result()` to use the new helper; non-multimodal results unchanged
- Removed the broken `add_image`-named special-case branches from `use()` and `ause()`

### Propagation (`utilities/tool_utils.py`)
- `execute_tool_and_check_finality` and `aexecute_tool_and_check_finality` now read `tool_usage._result_files` after execution and pass them as `files=` to the returned `ToolResult`

### Agent executors
- **`agents/crew_agent_executor.py`**: removed add_image branch from `_handle_agent_action()`; added `_extract_native_tool_result()` static method for the NativeTools path; added `_inject_files_into_last_user_message()` helper; both ReAct loops now inject `tool_result.files` into the last user message after each tool call
- **`experimental/agent_executor.py`**: same removals and additions mirrored for the experimental executor
- **`agents/step_executor.py`**: `_execute_text_tool_with_events()` return type changed from `str` to `ToolResult`; caller attaches `files` to the observation message when present

### Bug fix (`tools/agent_tools/add_image_tool.py`)
- Fixed `ImageFile(image_url)` → `ImageFile(source=image_url)`: `ImageFile` is a Pydantic model and does not accept positional arguments; the previous call raised `TypeError` at runtime

### Tests (`tests/tools/test_multimodal_tool_result.py`)
- 19 new unit tests covering `MultimodalToolResult` and `ToolResult.files` dataclasses, `_extract_multimodal_files()` with all input types, `_format_result()` integration, and `AddImageTool._run()`

### Documentation (`docs/*/learn/multimodal-agents.mdx`)
- Added "Building Tools That Return Multimodal Content" section to all four language variants (en, ar, ko, pt-BR) explaining `MultimodalToolResult`, supported file types, file source formats, and the single-file shorthand

## How it works

The existing `files` pipeline in `BaseLLM._process_message_files()` already converts `dict[str, FileInput]` on any message into provider-specific content blocks (OpenAI image_url, Anthropic image source, etc.). This PR closes the gap between tool execution and that pipeline:

```
Tool._run() → MultimodalToolResult
  → ToolUsage._format_result() extracts files into _result_files
  → execute_tool_and_check_finality() wraps into ToolResult(files=...)
  → Agent executor injects files onto the LLM message
  → BaseLLM._process_message_files() converts to provider blocks  ✓
```

## Notes

- Backward compatible: tools returning plain `str` or any other type are unaffected
- Cache hits return `files={}` (files are not cached); this is acceptable
- `result_as_answer=True` with files: the final text answer is returned as-is; including files in `AgentFinish.output` is out of scope for this PR
- `crewai-files` is an optional dependency; all multimodal code paths are guarded with `try/except ImportError` fallbacks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tools can now return multimodal content (images, audio, video, PDFs) alongside text to the LLM.
  * Custom tools support returning file attachments via structured results, enabling richer agent interactions.

* **Documentation**
  * Added comprehensive guides in multiple languages with examples for building custom tools that handle multimodal outputs.

* **Tests**
  * Added test coverage for multimodal tool result handling and file propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5804)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional Information
This tackles issue #5758, and I bet this PR is better than auto-fix by #5789 