### PR TITLE
docs: add AI Agents portfolio example to mobile section

### DIFF
--- a/docs/ar/examples/example.mdx
+++ b/docs/ar/examples/example.mdx
@@ -1,86 +1,89 @@
----
-title: أمثلة CrewAI
-description: استكشف أمثلة منسّقة مرتبة حسب Crews وFlows والتكاملات ودفاتر الملاحظات.
-icon: rocket-launch
-mode: "wide"
----
+  ---
+  title: أمثلة CrewAI
+  description: استكشف أمثلة منسّقة مرتبة حسب Crews وFlows والتكاملات ودفاتر الملاحظات.
+  icon: rocket-launch
+  mode: "wide"
+  ---
 
-## Crews
+  ## Crews
 
-<CardGroup cols={3}>
-  <Card title="استراتيجية التسويق" icon="bullhorn" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/marketing_strategy">
-    تخطيط حملات تسويقية متعددة الـ Agents.
+  <CardGroup cols={3}>
+    <Card title="استراتيجية التسويق" icon="bullhorn" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/marketing_strategy">
+      تخطيط حملات تسويقية متعددة الـ Agents.
+    </Card>
+    <Card title="رحلة مفاجئة" icon="plane" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/surprise_trip">
+      تخطيط رحلات مفاجئة مخصصة.
+    </Card>
+    <Card title="مطابقة الملف الشخصي بالوظائف" icon="id-card" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/match_profile_to_positions">
+      مطابقة السيرة الذاتية بالوظائف باستخدام البحث المتجهي.
+    </Card>
+    <Card title="نشر وظيفة" icon="newspaper" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/job-posting">
+      إنشاء أوصاف وظيفية آلية.
+    </Card>
+    <Card title="فريق بناء الألعاب" icon="gamepad" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/game-builder-crew">
+      فريق متعدد الـ Agents يصمم ويبني ألعاب Python.
+    </Card>
+    <Card title="التوظيف" icon="user-group" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/recruitment">
+      استقطاب المرشحين وتقييمهم.
+    </Card>
+    <Card title="تصفح جميع الـ Crews" icon="users" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews">
+      عرض القائمة الكاملة لأمثلة الـ Crews.
+    </Card>
+    <Card title="AI Agents" icon="mobile" href="https://github.com/ogulcannarin/AI-Agents-Portfolio.git">
+    Analyze App Store trends and user sentiments using AI Agents.
   </Card>
-  <Card title="رحلة مفاجئة" icon="plane" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/surprise_trip">
-    تخطيط رحلات مفاجئة مخصصة.
-  </Card>
-  <Card title="مطابقة الملف الشخصي بالوظائف" icon="id-card" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/match_profile_to_positions">
-    مطابقة السيرة الذاتية بالوظائف باستخدام البحث المتجهي.
-  </Card>
-  <Card title="نشر وظيفة" icon="newspaper" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/job-posting">
-    إنشاء أوصاف وظيفية آلية.
-  </Card>
-  <Card title="فريق بناء الألعاب" icon="gamepad" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/game-builder-crew">
-    فريق متعدد الـ Agents يصمم ويبني ألعاب Python.
-  </Card>
-  <Card title="التوظيف" icon="user-group" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews/recruitment">
-    استقطاب المرشحين وتقييمهم.
-  </Card>
-  <Card title="تصفح جميع الـ Crews" icon="users" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews">
-    عرض القائمة الكاملة لأمثلة الـ Crews.
-  </Card>
-</CardGroup>
+  </CardGroup>
 
-## Flows
+  ## Flows
 
-<CardGroup cols={3}>
-  <Card title="Flow إنشاء المحتوى" icon="pen" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/content_creator_flow">
-    إنشاء محتوى متعدد الـ Crews مع التوجيه.
-  </Card>
-  <Card title="الرد التلقائي على البريد الإلكتروني" icon="envelope" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/email_auto_responder_flow">
-    مراقبة البريد الإلكتروني والرد الآلي.
-  </Card>
-  <Card title="Flow تقييم العملاء المحتملين" icon="chart-line" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/lead_score_flow">
-    تأهيل العملاء المحتملين مع تدخل بشري.
-  </Card>
-  <Card title="Flow مساعد الاجتماعات" icon="calendar" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/meeting_assistant_flow">
-    معالجة الملاحظات مع التكاملات.
-  </Card>
-  <Card title="حلقة التقييم الذاتي" icon="rotate" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/self_evaluation_loop_flow">
-    سير عمل التحسين الذاتي التكراري.
-  </Card>
-  <Card title="كتابة كتاب (Flows)" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/write_a_book_with_flows">
-    إنشاء الفصول بالتوازي.
-  </Card>
-  <Card title="تصفح جميع الـ Flows" icon="diagram-project" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows">
-    عرض القائمة الكاملة لأمثلة الـ Flows.
-  </Card>
-</CardGroup>
+  <CardGroup cols={3}>
+    <Card title="Flow إنشاء المحتوى" icon="pen" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/content_creator_flow">
+      إنشاء محتوى متعدد الـ Crews مع التوجيه.
+    </Card>
+    <Card title="الرد التلقائي على البريد الإلكتروني" icon="envelope" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/email_auto_responder_flow">
+      مراقبة البريد الإلكتروني والرد الآلي.
+    </Card>
+    <Card title="Flow تقييم العملاء المحتملين" icon="chart-line" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/lead_score_flow">
+      تأهيل العملاء المحتملين مع تدخل بشري.
+    </Card>
+    <Card title="Flow مساعد الاجتماعات" icon="calendar" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/meeting_assistant_flow">
+      معالجة الملاحظات مع التكاملات.
+    </Card>
+    <Card title="حلقة التقييم الذاتي" icon="rotate" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/self_evaluation_loop_flow">
+      سير عمل التحسين الذاتي التكراري.
+    </Card>
+    <Card title="كتابة كتاب (Flows)" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows/write_a_book_with_flows">
+      إنشاء الفصول بالتوازي.
+    </Card>
+    <Card title="تصفح جميع الـ Flows" icon="diagram-project" href="https://github.com/crewAIInc/crewAI-examples/tree/main/flows">
+      عرض القائمة الكاملة لأمثلة الـ Flows.
+    </Card>
+  </CardGroup>
 
-## التكاملات
+  ## التكاملات
 
-<CardGroup cols={3}>
-  <Card title="CrewAI ↔ LangGraph" icon="link" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/crewai-langgraph">
-    التكامل مع إطار عمل LangGraph.
-  </Card>
-  <Card title="Azure OpenAI" icon="cloud" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/azure_model">
-    استخدام CrewAI مع Azure OpenAI.
-  </Card>
-  <Card title="نماذج NVIDIA" icon="microchip" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/nvidia_models">
-    تكاملات منظومة NVIDIA.
-  </Card>
-  <Card title="تصفح التكاملات" icon="puzzle-piece" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations">
-    عرض جميع أمثلة التكاملات.
-  </Card>
-</CardGroup>
+  <CardGroup cols={3}>
+    <Card title="CrewAI ↔ LangGraph" icon="link" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/crewai-langgraph">
+      التكامل مع إطار عمل LangGraph.
+    </Card>
+    <Card title="Azure OpenAI" icon="cloud" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/azure_model">
+      استخدام CrewAI مع Azure OpenAI.
+    </Card>
+    <Card title="نماذج NVIDIA" icon="microchip" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/nvidia_models">
+      تكاملات منظومة NVIDIA.
+    </Card>
+    <Card title="تصفح التكاملات" icon="puzzle-piece" href="https://github.com/crewAIInc/crewAI-examples/tree/main/integrations">
+      عرض جميع أمثلة التكاملات.
+    </Card>
+  </CardGroup>
 
-## دفاتر الملاحظات
+  ## دفاتر الملاحظات
 
-<CardGroup cols={2}>
-  <Card title="Simple QA Crew + Flow" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/Notebooks/Simple%20QA%20Crew%20%2B%20Flow">
-    Simple QA Crew + Flow.
-  </Card>
-  <Card title="جميع دفاتر الملاحظات" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/Notebooks">
-    أمثلة تفاعلية للتعلم والتجريب.
-  </Card>
-</CardGroup>
+  <CardGroup cols={2}>
+    <Card title="Simple QA Crew + Flow" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/Notebooks/Simple%20QA%20Crew%20%2B%20Flow">
+      Simple QA Crew + Flow.
+    </Card>
+    <Card title="جميع دفاتر الملاحظات" icon="book" href="https://github.com/crewAIInc/crewAI-examples/tree/main/Notebooks">
+      أمثلة تفاعلية للتعلم والتجريب.
+    </Card>
+  </CardGroup>

--- a/docs/ar/examples/example.mdx
+++ b/docs/ar/examples/example.mdx
@@ -29,9 +29,10 @@
     <Card title="تصفح جميع الـ Crews" icon="users" href="https://github.com/crewAIInc/crewAI-examples/tree/main/crews">
       عرض القائمة الكاملة لأمثلة الـ Crews.
     </Card>
-    <Card title="AI Agents" icon="mobile" href="https://github.com/ogulcannarin/AI-Agents-Portfolio.git">
-    Analyze App Store trends and user sentiments using AI Agents.
+    <Card title="وكلاء الذكاء الاصطناعي" icon="Agents" href="https://github.com/ogulcannarin/AI-Agents-Portfolio.git">
+  تحليل اتجاهات متجر التطبيقات ومشاعر المستخدمين باستخدام وكلاء ذكاء اصطناعي.
   </Card>
+ 
   </CardGroup>
 
   ## Flows


### PR DESCRIPTION
I have integrated a new example card specifically focused on AI Agent orchestration. This addition showcases an AI Agents Portfolio, demonstrating how multiple autonomous agents can be leveraged to analyze complex datasets and trends within the mobile ecosystem. It serves as a practical reference for developers looking to build specialized agentic workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "AI Agents" example card to the Crews examples gallery, linking to an external AI Agents portfolio with an English description.
  * Kept existing frontmatter and the Flows, التكاملات, and دفاتر الملاحظات card lists/layouts unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5813)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->