### PR TITLE
Add TheCrawlerScrapeWebsiteTool to crewai-tools

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -204,6 +204,9 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool import (
+    TheCrawlerScrapeWebsiteTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
@@ -320,6 +323,7 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TheCrawlerScrapeWebsiteTool",
     "VisionTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -191,6 +191,9 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool import (
+    TheCrawlerScrapeWebsiteTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
@@ -303,6 +306,7 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TheCrawlerScrapeWebsiteTool",
     "VisionTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/README.md
@@ -23,7 +23,7 @@ so agents can branch on the failure mode instead of regex-matching strings.
   to the tool constructor.
 - Install `crewai[tools]`:
 
-```
+```bash
 pip install 'crewai[tools]'
 ```
 

--- a/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/README.md
@@ -1,0 +1,69 @@
+# TheCrawlerScrapeWebsiteTool
+
+## Description
+
+[TheCrawler](https://github.com/manchittlab/TheCrawler) is an open-source
+(AGPL-3.0) web scraper with LLM-powered structured extraction. The hosted
+REST API at [miaibot.ai](https://www.miaibot.ai) runs the same engine and
+is pay-per-use with Bearer-token auth.
+
+The scrape endpoint returns boilerplate-stripped Markdown suitable for RAG
+ingestion, plus structured metadata (title, description, links, JSON-LD,
+OG/Twitter tags, commerce data, forms, analytics-tracker detection). On
+failure it returns a structured `errorType` enum and `errorRetryable` flag
+so agents can branch on the failure mode instead of regex-matching strings.
+
+> Note on licensing: TheCrawler's source is AGPL-3.0. Calling the hosted REST
+> API does not bind consumer code to AGPL-3.0 — it is a hosted service.
+
+## Installation
+
+- Get an API key from [miaibot.ai](https://www.miaibot.ai).
+- Set the key in the `THECRAWLER_API_KEY` environment variable, or pass it
+  to the tool constructor.
+- Install `crewai[tools]`:
+
+```
+pip install 'crewai[tools]'
+```
+
+## Example
+
+```python
+from crewai_tools import TheCrawlerScrapeWebsiteTool
+
+tool = TheCrawlerScrapeWebsiteTool()
+result = tool.run(url="https://example.com")
+```
+
+The result is the JSON response from the API, which includes an `items`
+array of `PageData` objects. Each `PageData` contains `status`, `markdown`,
+`title`, `description`, `links`, `meta`, `jsonLd`, `errorType`,
+`errorRetryable`, and other fields.
+
+## Arguments
+
+- `api_key`: Optional. TheCrawler API key (`mai_live_<32-hex>`). Defaults to
+  the `THECRAWLER_API_KEY` environment variable.
+- `config`: Optional. Dict of extra request-body fields forwarded to the
+  `POST /v1/crawl` endpoint.
+- `api_base`: Optional. Override the API base URL. Defaults to
+  `https://www.miaibot.ai/api/v1`.
+- `timeout`: Optional. HTTP request timeout in seconds. Defaults to 60.
+
+### Default configuration
+
+```python
+{
+    "extractMarkdown": True,
+}
+```
+
+Additional fields commonly forwarded via `config`:
+
+- `usePlaywright` (bool): Force Playwright rendering for JS-heavy pages. The
+  engine adaptively falls back to Playwright on its own when it detects an
+  SPA shell, so most callers do not need this.
+- `retries` (int): Retries on transient failures (5xx, network, timeout).
+  Default is 3.
+- `timeout` (int): Per-request fetch timeout in milliseconds. Default 30000.

--- a/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/thecrawler_scrape_website_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/thecrawler_scrape_website_tool.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field
+import requests
+
+from crewai_tools.security.safe_path import validate_url
+
+
+THECRAWLER_API_BASE = "https://www.miaibot.ai/api/v1"
+
+
+class TheCrawlerScrapeWebsiteToolSchema(BaseModel):
+    url: str = Field(description="Website URL to scrape")
+
+
+class TheCrawlerScrapeWebsiteTool(BaseTool):
+    """Tool for scraping webpages via the TheCrawler hosted REST API.
+
+    TheCrawler returns boilerplate-stripped Markdown suitable for RAG ingestion,
+    along with structured metadata (title, description, links, JSON-LD, OG/Twitter
+    tags, commerce data, forms, analytics-tracker detection). On failure it
+    returns a structured ``errorType`` enum (``dns``, ``timeout``, ``rate-limit``,
+    ``blocked-bot``, ``js-required``, ``http-4xx``, ``http-5xx``, ``parse``,
+    ``network``, ``unknown``) and an ``errorRetryable`` flag so agents can
+    branch on the failure mode instead of regex-matching error strings.
+
+    The hosted endpoint at ``https://www.miaibot.ai/api/v1/crawl`` is a
+    pay-per-use service authenticated with a Bearer API key. The underlying
+    scraper is open source (AGPL-3.0); using the hosted API does not bind
+    consumer code to AGPL-3.0.
+
+    Args:
+        api_key: TheCrawler API key (``mai_live_<32-hex>``). Defaults to the
+            ``THECRAWLER_API_KEY`` environment variable.
+        config: Optional dict of extra request-body fields forwarded to
+            ``POST /v1/crawl``. See "Default configuration" below.
+        api_base: Override the API base URL. Defaults to
+            ``https://www.miaibot.ai/api/v1``.
+        timeout: HTTP request timeout in seconds. Defaults to 60.
+
+    Default configuration (forwarded to the crawl endpoint):
+        extractMarkdown (bool): Return boilerplate-stripped Markdown. Default: True
+        usePlaywright (bool): Force Playwright rendering for JS-heavy pages.
+            Default: False (engine adaptively falls back to Playwright on its own).
+        retries (int): Retries on transient failures (5xx, network, timeout).
+            Default: 3.
+        timeout (int): Per-request fetch timeout in ms. Default: 30000.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True, frozen=False
+    )
+    name: str = "TheCrawler web scrape tool"
+    description: str = (
+        "Scrape a webpage using TheCrawler and return boilerplate-stripped "
+        "Markdown plus structured metadata. Useful for RAG ingestion and "
+        "agentic web research."
+    )
+    args_schema: type[BaseModel] = TheCrawlerScrapeWebsiteToolSchema
+    api_key: str | None = None
+    api_base: str = THECRAWLER_API_BASE
+    timeout: int = 60
+    config: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "extractMarkdown": True,
+        }
+    )
+
+    package_dependencies: list[str] = Field(default_factory=lambda: ["requests"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="THECRAWLER_API_KEY",
+                description="API key for TheCrawler hosted API (miaibot.ai).",
+                required=True,
+            ),
+        ]
+    )
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        config: dict[str, Any] | None = None,
+        api_base: str | None = None,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.api_key = api_key or os.environ.get("THECRAWLER_API_KEY")
+        if config is not None:
+            self.config = config
+        if api_base is not None:
+            self.api_base = api_base
+        if timeout is not None:
+            self.timeout = timeout
+
+    def _run(self, url: str) -> Any:
+        if not self.api_key:
+            raise ValueError(
+                "TheCrawler API key is required. Pass api_key=... or set "
+                "THECRAWLER_API_KEY in the environment."
+            )
+
+        url = validate_url(url)
+        payload: dict[str, Any] = {"urls": [url], **self.config}
+
+        response = requests.post(
+            f"{self.api_base}/crawl",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/thecrawler_scrape_website_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/thecrawler_scrape_website_tool.py
@@ -92,7 +92,9 @@ class TheCrawlerScrapeWebsiteTool(BaseTool):
         super().__init__(**kwargs)
         self.api_key = api_key or os.environ.get("THECRAWLER_API_KEY")
         if config is not None:
-            self.config = config
+            # Merge into defaults so caller can override individual fields
+            # without dropping the rest (e.g. retries, timeoutSecs).
+            self.config = {**self.config, **config}
         if api_base is not None:
             self.api_base = api_base
         if timeout is not None:
@@ -106,7 +108,8 @@ class TheCrawlerScrapeWebsiteTool(BaseTool):
             )
 
         url = validate_url(url)
-        payload: dict[str, Any] = {"urls": [url], **self.config}
+        # `urls` is set last so it cannot be overridden by `self.config`.
+        payload: dict[str, Any] = {**self.config, "urls": [url]}
 
         response = requests.post(
             f"{self.api_base}/crawl",

--- a/lib/crewai-tools/tests/tools/thecrawler_scrape_website_tool_test.py
+++ b/lib/crewai-tools/tests/tools/thecrawler_scrape_website_tool_test.py
@@ -1,0 +1,124 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as requests_lib
+
+from crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool import (
+    TheCrawlerScrapeWebsiteTool,
+)
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=requests_lib.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 400
+    resp.json.return_value = json_data if json_data is not None else {}
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _thecrawler_env():
+    with patch.dict(os.environ, {"THECRAWLER_API_KEY": "mai_live_" + "a" * 32}):
+        yield
+
+
+def test_thecrawler_scrape_tool_init_reads_env() -> None:
+    tool = TheCrawlerScrapeWebsiteTool()
+    assert tool.api_key == "mai_live_" + "a" * 32
+    assert tool.api_base == "https://www.miaibot.ai/api/v1"
+    assert tool.config == {"extractMarkdown": True}
+
+
+def test_thecrawler_scrape_tool_init_explicit_key() -> None:
+    tool = TheCrawlerScrapeWebsiteTool(api_key="mai_live_" + "b" * 32)
+    assert tool.api_key == "mai_live_" + "b" * 32
+
+
+def test_thecrawler_scrape_tool_run_posts_to_crawl_endpoint() -> None:
+    tool = TheCrawlerScrapeWebsiteTool()
+    mock_resp = _mock_response(
+        status_code=200,
+        json_data={
+            "ok": True,
+            "items": [
+                {
+                    "status": "success",
+                    "url": "https://example.com",
+                    "markdown": "# Example Domain\n\nExample text.",
+                    "title": "Example Domain",
+                    "errorType": None,
+                    "errorRetryable": False,
+                }
+            ],
+            "successCount": 1,
+            "errorCount": 0,
+            "creditsCharged": 1,
+            "balance": 999,
+        },
+    )
+
+    with patch(
+        "crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool.requests.post",
+        return_value=mock_resp,
+    ) as mock_post:
+        result = tool.run(url="https://example.com")
+
+    mock_post.assert_called_once()
+    called_url = mock_post.call_args.args[0]
+    called_kwargs = mock_post.call_args.kwargs
+    assert called_url == "https://www.miaibot.ai/api/v1/crawl"
+    assert called_kwargs["json"] == {
+        "urls": ["https://example.com"],
+        "extractMarkdown": True,
+    }
+    assert called_kwargs["headers"]["Authorization"].startswith("Bearer mai_live_")
+    assert called_kwargs["headers"]["Content-Type"] == "application/json"
+
+    assert result["ok"] is True
+    assert result["items"][0]["markdown"].startswith("# Example Domain")
+
+
+def test_thecrawler_scrape_tool_custom_config_merged() -> None:
+    tool = TheCrawlerScrapeWebsiteTool(
+        config={"extractMarkdown": True, "usePlaywright": True, "retries": 5},
+    )
+    mock_resp = _mock_response(
+        status_code=200, json_data={"ok": True, "items": []}
+    )
+
+    with patch(
+        "crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool.requests.post",
+        return_value=mock_resp,
+    ) as mock_post:
+        tool.run(url="https://example.com")
+
+    sent = mock_post.call_args.kwargs["json"]
+    assert sent["urls"] == ["https://example.com"]
+    assert sent["usePlaywright"] is True
+    assert sent["retries"] == 5
+
+
+def test_thecrawler_scrape_tool_missing_key_raises() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        tool = TheCrawlerScrapeWebsiteTool()
+        with pytest.raises(ValueError, match="API key"):
+            tool.run(url="https://example.com")
+
+
+def test_thecrawler_scrape_tool_custom_api_base() -> None:
+    tool = TheCrawlerScrapeWebsiteTool(api_base="https://api.example.test/v1")
+    mock_resp = _mock_response(
+        status_code=200, json_data={"ok": True, "items": []}
+    )
+
+    with patch(
+        "crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool.requests.post",
+        return_value=mock_resp,
+    ) as mock_post:
+        tool.run(url="https://example.com")
+
+    assert mock_post.call_args.args[0] == "https://api.example.test/v1/crawl"

--- a/lib/crewai-tools/tests/tools/thecrawler_scrape_website_tool_test.py
+++ b/lib/crewai-tools/tests/tools/thecrawler_scrape_website_tool_test.py
@@ -83,8 +83,10 @@ def test_thecrawler_scrape_tool_run_posts_to_crawl_endpoint() -> None:
 
 
 def test_thecrawler_scrape_tool_custom_config_merged() -> None:
+    # The default config has `extractMarkdown: True`. A caller passing a custom
+    # config should ADD their fields to the defaults, not REPLACE the whole map.
     tool = TheCrawlerScrapeWebsiteTool(
-        config={"extractMarkdown": True, "usePlaywright": True, "retries": 5},
+        config={"usePlaywright": True, "retries": 5},
     )
     mock_resp = _mock_response(
         status_code=200, json_data={"ok": True, "items": []}
@@ -98,8 +100,32 @@ def test_thecrawler_scrape_tool_custom_config_merged() -> None:
 
     sent = mock_post.call_args.kwargs["json"]
     assert sent["urls"] == ["https://example.com"]
+    # Default field survives the merge.
+    assert sent["extractMarkdown"] is True
+    # Caller-supplied fields are applied.
     assert sent["usePlaywright"] is True
     assert sent["retries"] == 5
+
+
+def test_thecrawler_scrape_tool_config_urls_cannot_override_runtime_url() -> None:
+    # Security: if a caller (or a downstream config source) sneaks a `urls` key
+    # into config, the runtime-validated `url` arg must still win. Otherwise
+    # validate_url() would be bypassed.
+    tool = TheCrawlerScrapeWebsiteTool(
+        config={"urls": ["https://malicious.test"]},
+    )
+    mock_resp = _mock_response(
+        status_code=200, json_data={"ok": True, "items": []}
+    )
+
+    with patch(
+        "crewai_tools.tools.thecrawler_scrape_website_tool.thecrawler_scrape_website_tool.requests.post",
+        return_value=mock_resp,
+    ) as mock_post:
+        tool.run(url="https://example.com")
+
+    sent = mock_post.call_args.kwargs["json"]
+    assert sent["urls"] == ["https://example.com"]
 
 
 def test_thecrawler_scrape_tool_missing_key_raises() -> None:


### PR DESCRIPTION
## Summary

Adds `TheCrawlerScrapeWebsiteTool`, a new `BaseTool` that wraps the
[TheCrawler](https://github.com/manchittlab/TheCrawler) hosted REST API at
`https://www.miaibot.ai/api/v1/crawl`. TheCrawler is an open-source web
scraper (AGPL-3.0 source; the hosted REST API is a pay-per-use service,
so consumers of the API are not bound by AGPL-3.0). It returns
boilerplate-stripped Markdown suitable for RAG ingestion, plus structured
page metadata (title, description, links, JSON-LD, OG/Twitter tags,
commerce data, forms, 16-tracker analytics detection).

## Why this fits crewai-tools

- **RAG ingestion** — clean Markdown out of the box, no post-processing
  needed before chunking and embedding.
- **Structured errors** — every response carries an `errorType` enum
  (`dns | timeout | rate-limit | blocked-bot | js-required | http-4xx |
  http-5xx | parse | network | unknown`) and an `errorRetryable` bool.
  Agents can branch on the failure mode instead of regex-matching error
  strings, which is exactly what agentic retry logic wants.
- **Adaptive rendering** — the engine tries Cheerio first and falls back
  to Playwright when it detects an SPA shell, so the same tool call
  handles static HTML, JS-heavy pages, PDFs, and DOCX URLs.

## Pattern matched

- `JinaScrapeWebsiteTool` — for the plain-`requests` HTTP shape (no SDK
  dependency, Bearer auth header).
- `FirecrawlScrapeWebsiteTool` — for the `config` dict / `EnvVar` /
  `args_schema` / docstring layout.

The new tool is registered in both `crewai_tools/__init__.py` and
`crewai_tools/tools/__init__.py`, alphabetically placed between
`Tavily*` and `TXT*`/`Vision*`.

## Files

- `lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/thecrawler_scrape_website_tool.py`
- `lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/__init__.py`
- `lib/crewai-tools/src/crewai_tools/tools/thecrawler_scrape_website_tool/README.md`
- `lib/crewai-tools/tests/tools/thecrawler_scrape_website_tool_test.py`
- Edits to `lib/crewai-tools/src/crewai_tools/__init__.py` and
  `lib/crewai-tools/src/crewai_tools/tools/__init__.py` to register the
  new tool.

## Tests

Tests use `unittest.mock` to stub `requests.post` — no live API calls,
so CI does not need a TheCrawler API key. Coverage:

- Env-var pickup for `THECRAWLER_API_KEY`.
- Explicit `api_key` parameter override.
- POST body and Bearer header are correctly constructed against
  `/v1/crawl`.
- Custom `config` dict is merged into the request body.
- Custom `api_base` is honored.
- Missing API key raises a clear `ValueError`.

Local `uvx ruff check` and `uvx ruff format` pass on all changed files.
mypy is clean on the new tool file (the existing 191 errors in the
repo are all pre-existing in unrelated optional-SDK tools — none touch
the new file).

## Notes

- This is a fresh contribution — I have not opened a prior issue or
  conversation with maintainers. Happy to iterate based on review.
- The `tool.specs.json` file was not regenerated locally; I assumed
  maintainers' CI / a release step handles that. Happy to run
  `python -m crewai_tools.generate_tool_specs` and commit the diff if
  preferred.
- A `TheCrawlerExtractTool` (LLM-powered structured extraction via
  JSON Schema, mapping to `POST /v1/extract`) is a natural follow-up.
  I left it out of this PR to keep the surface area focused on one
  reviewable unit; happy to add it here or in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a website scraping tool powered by TheCrawler API that returns Markdown with structured metadata; supports configurable API key, endpoint, timeout, and request options.
* **Documentation**
  * Added a user guide with installation, configuration details, and a minimal usage example for the new scraping tool.
* **Tests**
  * Added unit tests covering initialization, request/response handling, configuration merging, error cases, and custom endpoint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5814)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->