### PR TITLE
fix: surface streamed tool calls when available_functions is absent

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -940,6 +940,21 @@ class LLM(BaseLLM):
                 self._track_token_usage_internal(usage_info)
             self._handle_streaming_callbacks(callbacks, usage_info, last_chunk)
 
+            if accumulated_tool_args and not available_functions:
+                tool_calls_list: list[ChatCompletionDeltaToolCall] = [
+                    ChatCompletionDeltaToolCall(
+                        index=idx,
+                        function=Function(
+                            name=tool_arg.function.name,
+                            arguments=tool_arg.function.arguments,
+                        ),
+                    )
+                    for idx, tool_arg in sorted(accumulated_tool_args.items())
+                    if tool_arg.function.name
+                ]
+                if tool_calls_list:
+                    return tool_calls_list
+
             if not tool_calls or not available_functions:
                 if response_model and self.is_litellm:
                     instructor_instance = InternalInstructor(
@@ -1535,8 +1550,7 @@ class LLM(BaseLLM):
             if usage_info:
                 self._track_token_usage_internal(usage_info)
 
-            if accumulated_tool_args and available_functions:
-                # Convert accumulated tool args to ChatCompletionDeltaToolCall objects
+            if accumulated_tool_args:
                 tool_calls_list: list[ChatCompletionDeltaToolCall] = [
                     ChatCompletionDeltaToolCall(
                         index=idx,
@@ -1545,21 +1559,24 @@ class LLM(BaseLLM):
                             arguments=tool_arg.function.arguments,
                         ),
                     )
-                    for idx, tool_arg in accumulated_tool_args.items()
+                    for idx, tool_arg in sorted(accumulated_tool_args.items())
                     if tool_arg.function.name
                 ]
 
                 if tool_calls_list:
-                    result = self._handle_streaming_tool_calls(
-                        tool_calls=tool_calls_list,
-                        accumulated_tool_args=accumulated_tool_args,
-                        available_functions=available_functions,
-                        from_task=from_task,
-                        from_agent=from_agent,
-                        response_id=response_id,
-                    )
-                    if result is not None:
-                        return result
+                    if available_functions:
+                        result = self._handle_streaming_tool_calls(
+                            tool_calls=tool_calls_list,
+                            accumulated_tool_args=accumulated_tool_args,
+                            available_functions=available_functions,
+                            from_task=from_task,
+                            from_agent=from_agent,
+                            response_id=response_id,
+                        )
+                        if result is not None:
+                            return result
+                    else:
+                        return tool_calls_list
 
             usage_dict = self._usage_to_dict(usage_info)
             self._handle_emit_call_events(

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -624,12 +624,15 @@ def test_handle_streaming_tool_calls_no_available_functions(
         ],
         tools=[get_weather_tool_schema],
     )
-    assert response == ""
+    assert isinstance(response, list)
+    assert len(response) == 1
+    assert response[0].function.name == "get_weather"
+    assert response[0].function.arguments == '{"location":"New York, NY"}'
 
     assert_event_count(
         mock_emit=mock_emit,
         expected_stream_chunk=9,
-        expected_completed_llm_call=1,
+        expected_completed_llm_call=0,
         expected_final_chunk_result='{"location":"New York, NY"}',
     )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the streaming `LLM.call` return value in tool-calling scenarios (from empty string to a list of tool-call objects) and adjusts event emission expectations, which may affect callers relying on previous behavior.
> 
> **Overview**
> Fixes streaming tool-call handling so that when tool-call arguments are accumulated but `available_functions` is not provided, the LLM returns the accumulated tool calls (as `ChatCompletionDeltaToolCall` objects) instead of falling back to an empty/normal text response.
> 
> Aligns async streaming with the same behavior and makes tool-call list construction deterministic by sorting indices; updates the streaming tests to assert the new return type and updated completed-event counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5027a481bb1807b9d8e60d8a01190995a8a8bbcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected streaming behavior so accumulated tool-call arguments are returned as tool-call objects or executed appropriately in both synchronous and asynchronous streams, even when callable definitions are not provided.
* **Tests**
  * Updated streaming tests to assert the new return behavior and adjusted expected event counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5815)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->