### PR TITLE
fix: stop output_pydantic from leaking into tool-calling loop (#5472)

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1063,11 +1063,7 @@ class Agent(BaseAgent):
                 respect_context_window=self.respect_context_window,
                 request_within_rpm_limit=rpm_limit_fn,
                 callbacks=[TokenCalcHandler(self._token_process)],
-                response_model=(
-                    task.response_model or task.output_pydantic or task.output_json
-                )
-                if task
-                else None,
+                response_model=task.response_model if task else None,
             )
 
     def _update_executor_parameters(
@@ -1104,9 +1100,7 @@ class Agent(BaseAgent):
         self.agent_executor.tools_names = get_tool_names(tools)
         self.agent_executor.tools_description = render_text_description_and_args(tools)
         self.agent_executor.response_model = (
-            (task.response_model or task.output_pydantic or task.output_json)
-            if task
-            else None
+            task.response_model if task else None
         )
 
         self.agent_executor.tools_handler = self.tools_handler

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -502,7 +502,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     available_functions=None,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )
@@ -1314,7 +1314,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                     available_functions=None,
                     from_task=self.task,
                     from_agent=self.agent,
-                    response_model=self.response_model,
+                    response_model=None,
                     executor_context=self,
                     verbose=self.agent.verbose,
                 )

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1319,7 +1319,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 available_functions=None,
                 from_task=self.task,
                 from_agent=self.agent,
-                response_model=self.response_model,
+                response_model=None,
                 executor_context=self,
                 verbose=self.agent.verbose,
             )

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2622,3 +2622,84 @@ class TestSharedLLMStopWords:
 
         assert seen == [{"Original:", "Observation:"}]
         assert shared.stop == ["Original:"]
+
+
+class TestOutputPydanticDoesNotLeakIntoResponseModel:
+    """Regression tests for issue #5472.
+
+    output_pydantic / output_json should NOT be mapped onto
+    executor.response_model. Only explicit task.response_model
+    should use native structured output.
+    """
+
+    def test_output_pydantic_does_not_set_response_model(self):
+        from pydantic import BaseModel, Field
+
+        class MyOutput(BaseModel):
+            answer: str = Field(description="The answer")
+
+        agent = Agent(role="test", goal="test", backstory="test")
+        task = Task(
+            description="test",
+            expected_output="test",
+            output_pydantic=MyOutput,
+        )
+
+        agent.create_agent_executor(task=task)
+        assert agent.agent_executor.response_model is None
+
+    def test_output_json_does_not_set_response_model(self):
+        from pydantic import BaseModel, Field
+
+        class MyOutput(BaseModel):
+            answer: str = Field(description="The answer")
+
+        agent = Agent(role="test", goal="test", backstory="test")
+        task = Task(
+            description="test",
+            expected_output="test",
+            output_json=MyOutput,
+        )
+
+        agent.create_agent_executor(task=task)
+        assert agent.agent_executor.response_model is None
+
+    def test_explicit_response_model_still_works(self):
+        from pydantic import BaseModel, Field
+
+        class MyOutput(BaseModel):
+            answer: str = Field(description="The answer")
+
+        agent = Agent(role="test", goal="test", backstory="test")
+        task = Task(
+            description="test",
+            expected_output="test",
+            response_model=MyOutput,
+        )
+
+        agent.create_agent_executor(task=task)
+        assert agent.agent_executor.response_model is MyOutput
+
+    def test_update_executor_parameters_respects_fix(self):
+        from pydantic import BaseModel, Field
+
+        class MyOutput(BaseModel):
+            answer: str = Field(description="The answer")
+
+        agent = Agent(role="test", goal="test", backstory="test")
+        task_with_pydantic = Task(
+            description="test",
+            expected_output="test",
+            output_pydantic=MyOutput,
+        )
+        task_with_response_model = Task(
+            description="test",
+            expected_output="test",
+            response_model=MyOutput,
+        )
+
+        agent.create_agent_executor(task=task_with_pydantic)
+        assert agent.agent_executor.response_model is None
+
+        agent.create_agent_executor(task=task_with_response_model)
+        assert agent.agent_executor.response_model is MyOutput

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2633,6 +2633,7 @@ class TestOutputPydanticDoesNotLeakIntoResponseModel:
     """
 
     def test_output_pydantic_does_not_set_response_model(self):
+        """output_pydantic should stay in post-processing, not set response_model."""
         from pydantic import BaseModel, Field
 
         class MyOutput(BaseModel):
@@ -2649,6 +2650,7 @@ class TestOutputPydanticDoesNotLeakIntoResponseModel:
         assert agent.agent_executor.response_model is None
 
     def test_output_json_does_not_set_response_model(self):
+        """output_json should stay in post-processing, not set response_model."""
         from pydantic import BaseModel, Field
 
         class MyOutput(BaseModel):
@@ -2665,6 +2667,7 @@ class TestOutputPydanticDoesNotLeakIntoResponseModel:
         assert agent.agent_executor.response_model is None
 
     def test_explicit_response_model_still_works(self):
+        """Explicit task.response_model should still propagate to the executor."""
         from pydantic import BaseModel, Field
 
         class MyOutput(BaseModel):
@@ -2681,6 +2684,7 @@ class TestOutputPydanticDoesNotLeakIntoResponseModel:
         assert agent.agent_executor.response_model is MyOutput
 
     def test_update_executor_parameters_respects_fix(self):
+        """_update_executor_parameters should apply the same mapping fix."""
         from pydantic import BaseModel, Field
 
         class MyOutput(BaseModel):


### PR DESCRIPTION
Fixes #5472

### What's wrong

Since v1.9.0, `Task(output_pydantic=...)` and `Task(output_json=...)` get mapped onto `response_model` in the agent executor. This means every LLM call in the tool loop sends both `tools` and `response_format` at the same time.

OpenAI kinda handles this, but vLLM, Gemini, Anthropic, and anything going through LiteLLM's `InternalInstructor` -- they all treat `response_format` as higher priority. The LLM returns structured JSON immediately and never calls any tools.

The post-processing path (`Task._export_output()` -> `convert_to_model()`) already handles converting raw output to Pydantic models after the loop. That's how it worked before v1.9.0 and it works fine.

### What this PR does

1. **`agent/core.py`** -- Only `task.response_model` (explicit opt-in) gets passed as `response_model`. `output_pydantic` and `output_json` stay in post-processing where they belong.

2. **`crew_agent_executor.py`** -- Pass `response_model=None` in `_invoke_loop_native_tools` (sync + async). When tools are present, structured output shouldn't compete with them.

3. **`experimental/agent_executor.py`** -- Same fix for `call_llm_native_tools()`.

4. **Tests** -- 4 regression tests covering `output_pydantic`, `output_json`, explicit `response_model`, and `_update_executor_parameters`.

### How I tested

- All 4 new tests pass
- Full `test_agent.py` suite passes (84 passed, pre-existing failures from missing optional deps unchanged)

### Note

There are two existing PRs for this -- #5680 (stops the mapping at source) and #5767 (suppresses during loop iterations). This PR combines both approaches: fix the mapping AND defensively suppress during tool loops as a safety net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Executor response-model is now derived only from an explicit task response model and no longer falls back to legacy output formats.
  * Disabled response-model parsing during native tool invocation to prevent unnecessary validation of tool-call responses.

* **Tests**
  * Added regression tests to ensure correct response-model behavior across task variants and executor updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->