### PR TITLE
fix: add idempotency guard for tool re-execution on task retry

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -197,6 +197,7 @@ class Agent(BaseAgent):
     model_config = ConfigDict()
 
     _times_executed: int = PrivateAttr(default=0)
+    _current_task_id: str | None = PrivateAttr(default=None)
     _mcp_resolver: MCPToolResolver | None = PrivateAttr(default=None)
     _last_messages: list[LLMMessage] = PrivateAttr(default_factory=list)
     max_execution_time: int | None = Field(
@@ -751,6 +752,10 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
+        task_id = getattr(task, "id", None) or str(id(task))
+        if self._current_task_id != task_id:
+            self._times_executed = 0
+            self._current_task_id = task_id
         task_prompt = self._prepare_task_execution(task, context)
 
         knowledge_config = get_knowledge_config(self)
@@ -887,6 +892,10 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
+        task_id = getattr(task, "id", None) or str(id(task))
+        if self._current_task_id != task_id:
+            self._times_executed = 0
+            self._current_task_id = task_id
         task_prompt = self._prepare_task_execution(task, context)
 
         knowledge_config = get_knowledge_config(self)

--- a/lib/crewai/src/crewai/agents/cache/__init__.py
+++ b/lib/crewai/src/crewai/agents/cache/__init__.py
@@ -1,4 +1,12 @@
+from crewai.agents.cache.cache_backend import CacheBackend
 from crewai.agents.cache.cache_handler import CacheHandler
+from crewai.agents.cache.in_memory_backend import InMemoryCacheBackend
+from crewai.agents.cache.sqlite_backend import SQLiteCacheBackend
 
 
-__all__ = ["CacheHandler"]
+__all__ = [
+    "CacheBackend",
+    "CacheHandler",
+    "InMemoryCacheBackend",
+    "SQLiteCacheBackend",
+]

--- a/lib/crewai/src/crewai/agents/cache/cache_backend.py
+++ b/lib/crewai/src/crewai/agents/cache/cache_backend.py
@@ -1,0 +1,50 @@
+"""Pluggable cache backend protocol for tool result caching."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CacheBackend(Protocol):
+    """Protocol for pluggable cache storage backends.
+
+    Implementations must be thread-safe. The default in-memory backend
+    uses a read-write lock; persistent backends (e.g. SQLite) should
+    use their own appropriate locking strategy.
+    """
+
+    def get(self, key: str) -> Any | None:
+        """Retrieve a cached value by key.
+
+        Args:
+            key: The cache key.
+
+        Returns:
+            The cached value, or None if the key is not present.
+        """
+        ...
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a value in the cache.
+
+        Args:
+            key: The cache key.
+            value: The value to cache.
+        """
+        ...
+
+    def claim_if_absent(self, key: str, sentinel: Any) -> tuple[bool, Any | None]:
+        """Atomically read the cache and write a sentinel if the key is absent.
+
+        This is the core primitive for idempotent tool deduplication.
+
+        Args:
+            key: The cache key.
+            sentinel: The sentinel value to write if the key is absent.
+
+        Returns:
+            (True, None) if the sentinel was written (caller owns the claim).
+            (False, existing_value) if the key already existed.
+        """
+        ...

--- a/lib/crewai/src/crewai/agents/cache/cache_handler.py
+++ b/lib/crewai/src/crewai/agents/cache/cache_handler.py
@@ -59,8 +59,7 @@ class CacheHandler(BaseModel):
         """
         key = f"{tool}-{input}"
         with self._lock.w_locked():
-            existing = self._cache.get(key)
-            if existing is not None:
-                return False, existing
+            if key in self._cache:
+                return False, self._cache[key]
             self._cache[key] = sentinel
             return True, None

--- a/lib/crewai/src/crewai/agents/cache/cache_handler.py
+++ b/lib/crewai/src/crewai/agents/cache/cache_handler.py
@@ -49,3 +49,18 @@ class CacheHandler(BaseModel):
         """
         with self._lock.r_locked():
             return self._cache.get(f"{tool}-{input}")
+
+    def claim_if_absent(self, tool: str, input: str, sentinel: Any) -> tuple[bool, Any | None]:
+        """Atomically read the cache and write a sentinel if absent.
+
+        Returns:
+            (True, None) if the sentinel was written (caller owns the claim).
+            (False, existing_value) if the key already existed.
+        """
+        key = f"{tool}-{input}"
+        with self._lock.w_locked():
+            existing = self._cache.get(key)
+            if existing is not None:
+                return False, existing
+            self._cache[key] = sentinel
+            return True, None

--- a/lib/crewai/src/crewai/agents/cache/cache_handler.py
+++ b/lib/crewai/src/crewai/agents/cache/cache_handler.py
@@ -1,24 +1,36 @@
 """Cache handler for tool usage results."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from pydantic import BaseModel, PrivateAttr
 
-from crewai.utilities.rw_lock import RWLock
+from crewai.agents.cache.cache_backend import CacheBackend
+from crewai.agents.cache.in_memory_backend import InMemoryCacheBackend
 
 
 class CacheHandler(BaseModel):
     """Handles caching of tool execution results.
 
-    Provides thread-safe in-memory caching for tool outputs based on tool name and input.
-    Uses a read-write lock to allow concurrent reads while ensuring exclusive write access.
+    Delegates all storage to a pluggable :class:`CacheBackend`.
+    The default backend is :class:`InMemoryCacheBackend` (single-process,
+    thread-safe).  For cross-process / distributed deduplication pass a
+    :class:`SQLiteCacheBackend` (or any other ``CacheBackend`` implementation).
+
+    Args:
+        backend: Optional cache backend.  When *None* an
+            :class:`InMemoryCacheBackend` is created automatically.
 
     Notes:
         - TODO: Rename 'input' parameter to avoid shadowing builtin.
     """
 
-    _cache: dict[str, Any] = PrivateAttr(default_factory=dict)
-    _lock: RWLock = PrivateAttr(default_factory=RWLock)
+    _backend: CacheBackend = PrivateAttr()
+
+    def __init__(self, backend: CacheBackend | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._backend = backend if backend is not None else InMemoryCacheBackend()
 
     def add(self, tool: str, input: str, output: Any) -> None:
         """Add a tool result to the cache.
@@ -31,8 +43,7 @@ class CacheHandler(BaseModel):
         Notes:
             - TODO: Rename 'input' parameter to avoid shadowing builtin.
         """
-        with self._lock.w_locked():
-            self._cache[f"{tool}-{input}"] = output
+        self._backend.set(f"{tool}-{input}", output)
 
     def read(self, tool: str, input: str) -> Any | None:
         """Retrieve a cached tool result.
@@ -47,8 +58,7 @@ class CacheHandler(BaseModel):
         Notes:
             - TODO: Rename 'input' parameter to avoid shadowing builtin.
         """
-        with self._lock.r_locked():
-            return self._cache.get(f"{tool}-{input}")
+        return self._backend.get(f"{tool}-{input}")
 
     def claim_if_absent(self, tool: str, input: str, sentinel: Any) -> tuple[bool, Any | None]:
         """Atomically read the cache and write a sentinel if absent.
@@ -57,9 +67,4 @@ class CacheHandler(BaseModel):
             (True, None) if the sentinel was written (caller owns the claim).
             (False, existing_value) if the key already existed.
         """
-        key = f"{tool}-{input}"
-        with self._lock.w_locked():
-            if key in self._cache:
-                return False, self._cache[key]
-            self._cache[key] = sentinel
-            return True, None
+        return self._backend.claim_if_absent(f"{tool}-{input}", sentinel)

--- a/lib/crewai/src/crewai/agents/cache/in_memory_backend.py
+++ b/lib/crewai/src/crewai/agents/cache/in_memory_backend.py
@@ -1,0 +1,38 @@
+"""In-memory cache backend (default)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from crewai.utilities.rw_lock import RWLock
+
+
+class InMemoryCacheBackend:
+    """Thread-safe in-memory cache backend.
+
+    This is the default backend used by CacheHandler. It stores values in
+    a plain dict guarded by a read-write lock, allowing concurrent reads
+    with exclusive writes.
+
+    Suitable for single-process use. For cross-process / distributed
+    deduplication, use SQLiteCacheBackend or another persistent backend.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
+        self._lock = RWLock()
+
+    def get(self, key: str) -> Any | None:
+        with self._lock.r_locked():
+            return self._cache.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock.w_locked():
+            self._cache[key] = value
+
+    def claim_if_absent(self, key: str, sentinel: Any) -> tuple[bool, Any | None]:
+        with self._lock.w_locked():
+            if key in self._cache:
+                return False, self._cache[key]
+            self._cache[key] = sentinel
+            return True, None

--- a/lib/crewai/src/crewai/agents/cache/sqlite_backend.py
+++ b/lib/crewai/src/crewai/agents/cache/sqlite_backend.py
@@ -1,0 +1,110 @@
+"""SQLite-based cache backend for cross-process idempotent deduplication."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from crewai_core.lock_store import lock as store_lock
+from crewai_core.paths import db_storage_path
+
+
+_DEFAULT_DB_NAME = "cache_handler.db"
+
+
+class SQLiteCacheBackend:
+    """Persistent cache backend backed by SQLite.
+
+    Uses file-level locking (via crewai_core.lock_store) so that multiple
+    processes writing to the same database file correctly serialize access.
+
+    Args:
+        db_path: Full path to the SQLite database file. Defaults to
+            ``<db_storage_path>/cache_handler.db``.
+    """
+
+    def __init__(self, db_path: str | None = None) -> None:
+        if db_path is None:
+            db_path = str(Path(db_storage_path()) / _DEFAULT_DB_NAME)
+        self._db_path = db_path
+        self._lock_name = f"cache_backend_{Path(db_path).stem}"
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Schema setup
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        with store_lock(self._lock_name):
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS tool_cache (
+                        key   TEXT PRIMARY KEY,
+                        value TEXT NOT NULL
+                    )
+                    """
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Protocol methods
+    # ------------------------------------------------------------------
+
+    def get(self, key: str) -> Any | None:
+        with store_lock(self._lock_name):
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT value FROM tool_cache WHERE key = ?", (key,)
+                ).fetchone()
+                if row is None:
+                    return None
+                return json.loads(row[0])
+            finally:
+                conn.close()
+
+    def set(self, key: str, value: Any) -> None:
+        with store_lock(self._lock_name):
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO tool_cache (key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (key, json.dumps(value)),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def claim_if_absent(self, key: str, sentinel: Any) -> tuple[bool, Any | None]:
+        with store_lock(self._lock_name):
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT value FROM tool_cache WHERE key = ?", (key,)
+                ).fetchone()
+                if row is not None:
+                    return False, json.loads(row[0])
+                conn.execute(
+                    "INSERT INTO tool_cache (key, value) VALUES (?, ?)",
+                    (key, json.dumps(sentinel)),
+                )
+                conn.commit()
+                return True, None
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._db_path)

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -886,7 +886,11 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         from_cache = False
         result: str = "Tool not found"
-        input_str = json.dumps(args_dict) if args_dict else ""
+        input_str = (
+            json.dumps(args_dict, sort_keys=True, separators=(",", ":"))
+            if args_dict
+            else ""
+        )
         if self.tools_handler and self.tools_handler.cache:
             cached_result = self.tools_handler.cache.read(
                 tool=func_name, input=input_str

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -956,6 +956,16 @@ class CrewAgentExecutor(BaseAgentExecutor):
             result = f"Tool '{func_name}' has reached its usage limit of {original_tool.max_usage_count} times and cannot be used anymore."
         elif not from_cache and func_name in available_functions:
             try:
+                is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
+                if is_idempotent and self.tools_handler and self.tools_handler.cache:
+                    from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+                    self.tools_handler.cache.add(
+                        tool=func_name,
+                        input=input_str,
+                        output=IDEMPOTENT_EXECUTION_SENTINEL,
+                    )
+
                 raw_result = available_functions[func_name](**(args_dict or {}))
 
                 if self.tools_handler and self.tools_handler.cache:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -891,22 +891,37 @@ class CrewAgentExecutor(BaseAgentExecutor):
             if args_dict
             else ""
         )
-        if self.tools_handler and self.tools_handler.cache:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+        is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
 
-                if is_idempotent_sentinel(cached_result):
-                    result = IDEMPOTENT_SENTINEL_MESSAGE
-                else:
+        if self.tools_handler and self.tools_handler.cache:
+            if is_idempotent:
+                from crewai.tools.base_tool import (
+                    IDEMPOTENT_EXECUTION_SENTINEL,
+                    IDEMPOTENT_SENTINEL_MESSAGE,
+                    is_idempotent_sentinel,
+                )
+
+                claimed, existing = self.tools_handler.cache.claim_if_absent(
+                    tool=func_name, input=input_str, sentinel=IDEMPOTENT_EXECUTION_SENTINEL,
+                )
+                if not claimed:
+                    result = (
+                        IDEMPOTENT_SENTINEL_MESSAGE
+                        if is_idempotent_sentinel(existing)
+                        else str(existing) if not isinstance(existing, str) else existing
+                    )
+                    from_cache = True
+            else:
+                cached_result = self.tools_handler.cache.read(
+                    tool=func_name, input=input_str
+                )
+                if cached_result is not None:
                     result = (
                         str(cached_result)
                         if not isinstance(cached_result, str)
                         else cached_result
                     )
-                from_cache = True
+                    from_cache = True
 
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
         started_at = datetime.now()
@@ -965,16 +980,6 @@ class CrewAgentExecutor(BaseAgentExecutor):
             result = f"Tool '{func_name}' has reached its usage limit of {original_tool.max_usage_count} times and cannot be used anymore."
         elif not from_cache and func_name in available_functions:
             try:
-                is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
-                if is_idempotent and self.tools_handler and self.tools_handler.cache:
-                    from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
-
-                    self.tools_handler.cache.add(
-                        tool=func_name,
-                        input=input_str,
-                        output=IDEMPOTENT_EXECUTION_SENTINEL,
-                    )
-
                 raw_result = available_functions[func_name](**(args_dict or {}))
 
                 if self.tools_handler and self.tools_handler.cache:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -892,11 +892,16 @@ class CrewAgentExecutor(BaseAgentExecutor):
                 tool=func_name, input=input_str
             )
             if cached_result is not None:
-                result = (
-                    str(cached_result)
-                    if not isinstance(cached_result, str)
-                    else cached_result
-                )
+                from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+
+                if is_idempotent_sentinel(cached_result):
+                    result = IDEMPOTENT_SENTINEL_MESSAGE
+                else:
+                    result = (
+                        str(cached_result)
+                        if not isinstance(cached_result, str)
+                        else cached_result
+                    )
                 from_cache = True
 
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
@@ -969,19 +974,24 @@ class CrewAgentExecutor(BaseAgentExecutor):
                 raw_result = available_functions[func_name](**(args_dict or {}))
 
                 if self.tools_handler and self.tools_handler.cache:
-                    should_cache = True
-                    if (
-                        original_tool
-                        and hasattr(original_tool, "cache_function")
-                        and callable(original_tool.cache_function)
-                    ):
-                        should_cache = original_tool.cache_function(
-                            args_dict or {}, raw_result
-                        )
-                    if should_cache:
+                    if is_idempotent:
                         self.tools_handler.cache.add(
                             tool=func_name, input=input_str, output=raw_result
                         )
+                    else:
+                        should_cache = True
+                        if (
+                            original_tool
+                            and hasattr(original_tool, "cache_function")
+                            and callable(original_tool.cache_function)
+                        ):
+                            should_cache = original_tool.cache_function(
+                                args_dict or {}, raw_result
+                            )
+                        if should_cache:
+                            self.tools_handler.cache.add(
+                                tool=func_name, input=input_str, output=raw_result
+                            )
 
                 result = (
                     str(raw_result) if not isinstance(raw_result, str) else raw_result

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -910,7 +910,13 @@ class CrewAgentExecutor(BaseAgentExecutor):
                         if is_idempotent_sentinel(existing)
                         else str(existing) if not isinstance(existing, str) else existing
                     )
-                    from_cache = True
+                    return {
+                        "call_id": call_id,
+                        "func_name": func_name,
+                        "result": result,
+                        "from_cache": True,
+                        "original_tool": original_tool,
+                    }
             else:
                 cached_result = self.tools_handler.cache.read(
                     tool=func_name, input=input_str

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -216,6 +216,16 @@ class Crew(FlowTrackable, BaseModel):
 
     name: str | None = Field(default="crew")
     cache: bool = Field(default=True)
+    cache_backend: Any = Field(
+        default=None,
+        description=(
+            "Pluggable cache backend for tool-result caching. "
+            "Pass an SQLiteCacheBackend for cross-process idempotent "
+            "deduplication, or any CacheBackend implementation. "
+            "Defaults to InMemoryCacheBackend when None."
+        ),
+        exclude=True,
+    )
     tasks: list[Task] = Field(default_factory=list)
     agents: Annotated[
         list[BaseAgent],
@@ -551,7 +561,7 @@ class Crew(FlowTrackable, BaseModel):
     def set_private_attrs(self) -> Crew:
         """set private attributes."""
         if not getattr(self, "_cache_handler", None):
-            self._cache_handler = CacheHandler()
+            self._cache_handler = CacheHandler(backend=self.cache_backend)
         event_listener = EventListener()
 
         # Determine and set tracing state once for this execution

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1740,11 +1740,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 tool=func_name, input=input_str
             )
             if cached_result is not None:
-                result = (
-                    str(cached_result)
-                    if not isinstance(cached_result, str)
-                    else cached_result
-                )
+                from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+
+                if is_idempotent_sentinel(cached_result):
+                    result = IDEMPOTENT_SENTINEL_MESSAGE
+                else:
+                    result = (
+                        str(cached_result)
+                        if not isinstance(cached_result, str)
+                        else cached_result
+                    )
                 from_cache = True
 
         # Emit tool usage started event
@@ -1817,17 +1822,22 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     tool_func = self._available_functions[func_name]
                     raw_result = tool_func(**args_dict)
 
-                    # Add to cache after successful execution (before string conversion)
+                    # Always overwrite sentinel for idempotent tools; respect cache_function for others
                     if self.tools_handler and self.tools_handler.cache:
-                        should_cache = True
-                        if original_tool:
-                            should_cache = original_tool.cache_function(
-                                args_dict, raw_result
-                            )
-                        if should_cache:
+                        if is_idempotent:
                             self.tools_handler.cache.add(
                                 tool=func_name, input=input_str, output=raw_result
                             )
+                        else:
+                            should_cache = True
+                            if original_tool:
+                                should_cache = original_tool.cache_function(
+                                    args_dict, raw_result
+                                )
+                            if should_cache:
+                                self.tools_handler.cache.add(
+                                    tool=func_name, input=input_str, output=raw_result
+                                )
 
                     # Convert to string for message
                     result = (

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1739,22 +1739,37 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             if args_dict
             else ""
         )
-        if self.tools_handler and self.tools_handler.cache:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+        is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
 
-                if is_idempotent_sentinel(cached_result):
-                    result = IDEMPOTENT_SENTINEL_MESSAGE
-                else:
+        if self.tools_handler and self.tools_handler.cache:
+            if is_idempotent:
+                from crewai.tools.base_tool import (
+                    IDEMPOTENT_EXECUTION_SENTINEL,
+                    IDEMPOTENT_SENTINEL_MESSAGE,
+                    is_idempotent_sentinel,
+                )
+
+                claimed, existing = self.tools_handler.cache.claim_if_absent(
+                    tool=func_name, input=input_str, sentinel=IDEMPOTENT_EXECUTION_SENTINEL,
+                )
+                if not claimed:
+                    result = (
+                        IDEMPOTENT_SENTINEL_MESSAGE
+                        if is_idempotent_sentinel(existing)
+                        else str(existing) if not isinstance(existing, str) else existing
+                    )
+                    from_cache = True
+            else:
+                cached_result = self.tools_handler.cache.read(
+                    tool=func_name, input=input_str
+                )
+                if cached_result is not None:
                     result = (
                         str(cached_result)
                         if not isinstance(cached_result, str)
                         else cached_result
                     )
-                from_cache = True
+                    from_cache = True
 
         # Emit tool usage started event
         started_at = datetime.now()
@@ -1813,16 +1828,6 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             result = "Tool not found"
             if func_name in self._available_functions:
                 try:
-                    is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
-                    if is_idempotent and self.tools_handler and self.tools_handler.cache:
-                        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
-
-                        self.tools_handler.cache.add(
-                            tool=func_name,
-                            input=input_str,
-                            output=IDEMPOTENT_EXECUTION_SENTINEL,
-                        )
-
                     tool_func = self._available_functions[func_name]
                     raw_result = tool_func(**args_dict)
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1734,7 +1734,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         # Check cache before executing
         from_cache = False
-        input_str = json.dumps(args_dict) if args_dict else ""
+        input_str = (
+            json.dumps(args_dict, sort_keys=True, separators=(",", ":"))
+            if args_dict
+            else ""
+        )
         if self.tools_handler and self.tools_handler.cache:
             cached_result = self.tools_handler.cache.read(
                 tool=func_name, input=input_str

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1804,6 +1804,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             result = "Tool not found"
             if func_name in self._available_functions:
                 try:
+                    is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
+                    if is_idempotent and self.tools_handler and self.tools_handler.cache:
+                        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+                        self.tools_handler.cache.add(
+                            tool=func_name,
+                            input=input_str,
+                            output=IDEMPOTENT_EXECUTION_SENTINEL,
+                        )
+
                     tool_func = self._available_functions[func_name]
                     raw_result = tool_func(**args_dict)
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1758,7 +1758,13 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         if is_idempotent_sentinel(existing)
                         else str(existing) if not isinstance(existing, str) else existing
                     )
-                    from_cache = True
+                    return {
+                        "call_id": call_id,
+                        "func_name": func_name,
+                        "result": result,
+                        "from_cache": True,
+                        "original_tool": original_tool,
+                    }
             else:
                 cached_result = self.tools_handler.cache.read(
                     tool=func_name, input=input_str

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -82,10 +82,21 @@ def _default_cache_function(_args: Any = None, _result: Any = None) -> bool:
     return True
 
 
-IDEMPOTENT_EXECUTION_SENTINEL = (
-    "This tool was already executed with these arguments. "
-    "The original result was not captured due to an interruption."
-)
+IDEMPOTENT_EXECUTION_SENTINEL = {
+    "__crewai_idempotent_sentinel": True,
+    "status": "pending",
+    "message": (
+        "This tool was already executed with these arguments. "
+        "The original result was not captured due to an interruption."
+    ),
+}
+
+IDEMPOTENT_SENTINEL_MESSAGE = IDEMPOTENT_EXECUTION_SENTINEL["message"]
+
+
+def is_idempotent_sentinel(value: object) -> bool:
+    """Check whether a cached value is the idempotent pre-claim sentinel."""
+    return isinstance(value, dict) and value.get("__crewai_idempotent_sentinel") is True
 
 
 def _is_async_callable(func: Callable[..., Any]) -> bool:

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -82,6 +82,12 @@ def _default_cache_function(_args: Any = None, _result: Any = None) -> bool:
     return True
 
 
+IDEMPOTENT_EXECUTION_SENTINEL = (
+    "This tool was already executed with these arguments. "
+    "The original result was not captured due to an interruption."
+)
+
+
 def _is_async_callable(func: Callable[..., Any]) -> bool:
     """Check if a callable is async."""
     return asyncio.iscoroutinefunction(func)
@@ -173,6 +179,10 @@ class BaseTool(BaseModel, ABC):
     current_usage_count: int = Field(
         default=0,
         description="Current number of times this tool has been used.",
+    )
+    idempotent: bool = Field(
+        default=False,
+        description="When True, identical calls return cached results on retry instead of re-executing.",
     )
     _usage_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
@@ -621,6 +631,7 @@ def tool(
     *,
     result_as_answer: bool = ...,
     max_usage_count: int | None = ...,
+    idempotent: bool = ...,
 ) -> Callable[[Callable[P2, R2]], Tool[P2, R2]]: ...
 
 
@@ -629,6 +640,7 @@ def tool(
     *,
     result_as_answer: bool = ...,
     max_usage_count: int | None = ...,
+    idempotent: bool = ...,
 ) -> Callable[[Callable[P2, R2]], Tool[P2, R2]]: ...
 
 
@@ -636,6 +648,7 @@ def tool(
     *args: Callable[P2, R2] | str,
     result_as_answer: bool = False,
     max_usage_count: int | None = None,
+    idempotent: bool = False,
 ) -> Tool[P2, R2] | Callable[[Callable[P2, R2]], Tool[P2, R2]]:
     """Decorator to create a Tool from a function.
 
@@ -697,6 +710,7 @@ def tool(
                 result_as_answer=result_as_answer,
                 max_usage_count=max_usage_count,
                 current_usage_count=0,
+                idempotent=idempotent,
             )
 
         return _make_tool

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -275,7 +275,9 @@ class ToolUsage:
                 input_str = ""
                 if calling.arguments:
                     if isinstance(calling.arguments, dict):
-                        input_str = json.dumps(calling.arguments)
+                        input_str = json.dumps(
+                            calling.arguments, sort_keys=True, separators=(",", ":")
+                        )
                     else:
                         input_str = str(calling.arguments)
 
@@ -328,15 +330,9 @@ class ToolUsage:
                     if is_idempotent and self.tools_handler and self.tools_handler.cache:
                         from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
 
-                        idempotent_input = ""
-                        if calling.arguments:
-                            if isinstance(calling.arguments, dict):
-                                idempotent_input = json.dumps(calling.arguments)
-                            else:
-                                idempotent_input = str(calling.arguments)
                         self.tools_handler.cache.add(
                             tool=sanitize_tool_name(calling.tool_name),
-                            input=idempotent_input,
+                            input=input_str,
                             output=IDEMPOTENT_EXECUTION_SENTINEL,
                         )
 
@@ -530,7 +526,9 @@ class ToolUsage:
                 input_str = ""
                 if calling.arguments:
                     if isinstance(calling.arguments, dict):
-                        input_str = json.dumps(calling.arguments)
+                        input_str = json.dumps(
+                            calling.arguments, sort_keys=True, separators=(",", ":")
+                        )
                     else:
                         input_str = str(calling.arguments)
 
@@ -583,15 +581,9 @@ class ToolUsage:
                     if is_idempotent and self.tools_handler and self.tools_handler.cache:
                         from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
 
-                        idempotent_input = ""
-                        if calling.arguments:
-                            if isinstance(calling.arguments, dict):
-                                idempotent_input = json.dumps(calling.arguments)
-                            else:
-                                idempotent_input = str(calling.arguments)
                         self.tools_handler.cache.add(
                             tool=sanitize_tool_name(calling.tool_name),
-                            input=idempotent_input,
+                            input=input_str,
                             output=IDEMPOTENT_EXECUTION_SENTINEL,
                         )
 

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -318,6 +318,23 @@ class ToolUsage:
 
                     fingerprint_config = self._build_fingerprint_config()
 
+                    original_tool = getattr(available_tool, "_original_tool", None)
+                    is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
+                    if is_idempotent and self.tools_handler and self.tools_handler.cache:
+                        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+                        idempotent_input = ""
+                        if calling.arguments:
+                            if isinstance(calling.arguments, dict):
+                                idempotent_input = json.dumps(calling.arguments)
+                            else:
+                                idempotent_input = str(calling.arguments)
+                        self.tools_handler.cache.add(
+                            tool=sanitize_tool_name(calling.tool_name),
+                            input=idempotent_input,
+                            output=IDEMPOTENT_EXECUTION_SENTINEL,
+                        )
+
                     if calling.arguments:
                         try:
                             acceptable_args = tool.args_schema.model_json_schema()[
@@ -550,6 +567,23 @@ class ToolUsage:
                             self.task.increment_delegations(coworker)
 
                     fingerprint_config = self._build_fingerprint_config()
+
+                    original_tool = getattr(available_tool, "_original_tool", None)
+                    is_idempotent = original_tool and getattr(original_tool, "idempotent", False)
+                    if is_idempotent and self.tools_handler and self.tools_handler.cache:
+                        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+                        idempotent_input = ""
+                        if calling.arguments:
+                            if isinstance(calling.arguments, dict):
+                                idempotent_input = json.dumps(calling.arguments)
+                            else:
+                                idempotent_input = str(calling.arguments)
+                        self.tools_handler.cache.add(
+                            tool=sanitize_tool_name(calling.tool_name),
+                            input=idempotent_input,
+                            output=IDEMPOTENT_EXECUTION_SENTINEL,
+                        )
 
                     if calling.arguments:
                         try:

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -282,7 +282,12 @@ class ToolUsage:
                 result = self.tools_handler.cache.read(
                     tool=sanitize_tool_name(calling.tool_name), input=input_str
                 )  # type: ignore
-                from_cache = result is not None
+                if result is not None:
+                    from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+
+                    if is_idempotent_sentinel(result):
+                        result = IDEMPOTENT_SENTINEL_MESSAGE
+                    from_cache = True
 
             available_tool = next(
                 (
@@ -532,7 +537,12 @@ class ToolUsage:
                 result = self.tools_handler.cache.read(
                     tool=sanitize_tool_name(calling.tool_name), input=input_str
                 )  # type: ignore
-                from_cache = result is not None
+                if result is not None:
+                    from crewai.tools.base_tool import is_idempotent_sentinel, IDEMPOTENT_SENTINEL_MESSAGE
+
+                    if is_idempotent_sentinel(result):
+                        result = IDEMPOTENT_SENTINEL_MESSAGE
+                    from_cache = True
 
             available_tool = next(
                 (

--- a/lib/crewai/tests/agents/cache/test_cache_backends.py
+++ b/lib/crewai/tests/agents/cache/test_cache_backends.py
@@ -1,0 +1,141 @@
+"""Tests for pluggable cache backends."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from crewai.agents.cache.cache_backend import CacheBackend
+from crewai.agents.cache.cache_handler import CacheHandler
+from crewai.agents.cache.in_memory_backend import InMemoryCacheBackend
+from crewai.agents.cache.sqlite_backend import SQLiteCacheBackend
+
+
+# -------------------------------------------------------------------
+# Protocol conformance
+# -------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_in_memory_is_cache_backend(self):
+        assert isinstance(InMemoryCacheBackend(), CacheBackend)
+
+    def test_sqlite_is_cache_backend(self, tmp_path: Path):
+        backend = SQLiteCacheBackend(str(tmp_path / "test.db"))
+        assert isinstance(backend, CacheBackend)
+
+
+# -------------------------------------------------------------------
+# InMemoryCacheBackend
+# -------------------------------------------------------------------
+
+
+class TestInMemoryCacheBackend:
+    def test_get_missing_key(self):
+        backend = InMemoryCacheBackend()
+        assert backend.get("no-such-key") is None
+
+    def test_set_and_get(self):
+        backend = InMemoryCacheBackend()
+        backend.set("k", "v")
+        assert backend.get("k") == "v"
+
+    def test_set_overwrites(self):
+        backend = InMemoryCacheBackend()
+        backend.set("k", "v1")
+        backend.set("k", "v2")
+        assert backend.get("k") == "v2"
+
+    def test_claim_if_absent_claims(self):
+        backend = InMemoryCacheBackend()
+        claimed, existing = backend.claim_if_absent("k", "sentinel")
+        assert claimed is True
+        assert existing is None
+        assert backend.get("k") == "sentinel"
+
+    def test_claim_if_absent_returns_existing(self):
+        backend = InMemoryCacheBackend()
+        backend.set("k", "real-value")
+        claimed, existing = backend.claim_if_absent("k", "sentinel")
+        assert claimed is False
+        assert existing == "real-value"
+
+
+# -------------------------------------------------------------------
+# SQLiteCacheBackend
+# -------------------------------------------------------------------
+
+
+class TestSQLiteCacheBackend:
+    @pytest.fixture()
+    def backend(self, tmp_path: Path) -> SQLiteCacheBackend:
+        return SQLiteCacheBackend(str(tmp_path / "test_cache.db"))
+
+    def test_get_missing_key(self, backend: SQLiteCacheBackend):
+        assert backend.get("no-such-key") is None
+
+    def test_set_and_get(self, backend: SQLiteCacheBackend):
+        backend.set("k", {"result": 42})
+        assert backend.get("k") == {"result": 42}
+
+    def test_set_overwrites(self, backend: SQLiteCacheBackend):
+        backend.set("k", "v1")
+        backend.set("k", "v2")
+        assert backend.get("k") == "v2"
+
+    def test_claim_if_absent_claims(self, backend: SQLiteCacheBackend):
+        claimed, existing = backend.claim_if_absent("k", {"sentinel": True})
+        assert claimed is True
+        assert existing is None
+        assert backend.get("k") == {"sentinel": True}
+
+    def test_claim_if_absent_returns_existing(self, backend: SQLiteCacheBackend):
+        backend.set("k", "real-value")
+        claimed, existing = backend.claim_if_absent("k", {"sentinel": True})
+        assert claimed is False
+        assert existing == "real-value"
+
+    def test_cross_instance_visibility(self, tmp_path: Path):
+        """Two SQLiteCacheBackend instances sharing the same DB should see each other's writes."""
+        db = str(tmp_path / "shared.db")
+        a = SQLiteCacheBackend(db)
+        b = SQLiteCacheBackend(db)
+        a.set("key", "from-a")
+        assert b.get("key") == "from-a"
+
+    def test_cross_instance_claim(self, tmp_path: Path):
+        db = str(tmp_path / "shared.db")
+        a = SQLiteCacheBackend(db)
+        b = SQLiteCacheBackend(db)
+        claimed_a, _ = a.claim_if_absent("key", {"owner": "a"})
+        claimed_b, existing = b.claim_if_absent("key", {"owner": "b"})
+        assert claimed_a is True
+        assert claimed_b is False
+        assert existing == {"owner": "a"}
+
+
+# -------------------------------------------------------------------
+# CacheHandler with pluggable backend
+# -------------------------------------------------------------------
+
+
+class TestCacheHandlerWithBackend:
+    def test_default_backend_is_in_memory(self):
+        handler = CacheHandler()
+        assert isinstance(handler._backend, InMemoryCacheBackend)
+
+    def test_custom_backend_is_used(self, tmp_path: Path):
+        backend = SQLiteCacheBackend(str(tmp_path / "test.db"))
+        handler = CacheHandler(backend=backend)
+        handler.add("tool", '{"arg": 1}', "result-1")
+        assert handler.read("tool", '{"arg": 1}') == "result-1"
+
+    def test_claim_if_absent_delegates(self):
+        handler = CacheHandler()
+        claimed, _ = handler.claim_if_absent("tool", "input", "sentinel")
+        assert claimed is True
+        claimed2, existing = handler.claim_if_absent("tool", "input", "sentinel2")
+        assert claimed2 is False
+        assert existing == "sentinel"

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1169,15 +1169,16 @@ def test_times_executed_resets_between_tasks():
         with pytest.raises(Exception):
             agent.execute_task(task=task1)
 
-        times_after_task1 = agent._times_executed
-        assert times_after_task1 > 0
+        calls_after_task1 = invoke_mock.call_count
+        assert calls_after_task1 == agent.max_retry_limit + 1
 
         agent.create_agent_executor(task=task2)
         with pytest.raises(Exception):
             agent.execute_task(task=task2)
 
-        assert agent._times_executed > 0, (
-            "_times_executed should be positive after second task errors"
+        calls_after_task2 = invoke_mock.call_count - calls_after_task1
+        assert calls_after_task2 == agent.max_retry_limit + 1, (
+            f"task2 should get its own full retry budget, got {calls_after_task2} calls"
         )
 
 

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1140,6 +1140,47 @@ def test_agent_max_retry_limit():
         )
 
 
+def test_times_executed_resets_between_tasks():
+    agent = Agent(
+        role="test role",
+        goal="test goal",
+        backstory="test backstory",
+        max_retry_limit=2,
+    )
+
+    task1 = Task(
+        agent=agent,
+        description="First task",
+        expected_output="result",
+    )
+    task2 = Task(
+        agent=agent,
+        description="Second task",
+        expected_output="result",
+    )
+
+    agent.create_agent_executor(task=task1)
+
+    from crewai.experimental.agent_executor import AgentExecutor
+
+    with patch.object(AgentExecutor, "invoke") as invoke_mock:
+        invoke_mock.side_effect = Exception("fail")
+
+        with pytest.raises(Exception):
+            agent.execute_task(task=task1)
+
+        times_after_task1 = agent._times_executed
+        assert times_after_task1 > 0
+
+        agent.create_agent_executor(task=task2)
+        with pytest.raises(Exception):
+            agent.execute_task(task=task2)
+
+        assert agent._times_executed > 0, (
+            "_times_executed should be positive after second task errors"
+        )
+
+
 def test_agent_with_llm():
     agent = Agent(
         role="test role",

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1341,7 +1341,7 @@ class TestIdempotentToolPreClaim:
 
     def test_idempotent_tool_sentinel_survives_failure(self) -> None:
         """If an idempotent tool raises after side effect, sentinel remains in cache."""
-        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+        from crewai.tools.base_tool import is_idempotent_sentinel
 
         class FailingTool(BaseTool):
             name: str = "failing_tool"
@@ -1368,7 +1368,48 @@ class TestIdempotentToolPreClaim:
         cached = executor.tools_handler.cache.read(
             tool="failing_tool", input='{"data": "payload"}'
         )
-        assert cached == IDEMPOTENT_EXECUTION_SENTINEL
+        assert is_idempotent_sentinel(cached)
+
+    def test_idempotent_tool_retry_reads_sentinel(self) -> None:
+        """Second call with same args reads sentinel from cache and returns a clear message."""
+        from crewai.tools.base_tool import IDEMPOTENT_SENTINEL_MESSAGE
+
+        call_count = 0
+
+        class FailingTool(BaseTool):
+            name: str = "failing_tool"
+            description: str = "Fails after side effect"
+            idempotent: bool = True
+
+            def _run(self, data: str) -> str:
+                nonlocal call_count
+                call_count += 1
+                raise RuntimeError("connection lost")
+
+        tool_instance = FailingTool()
+        executor = self._make_executor([tool_instance])
+
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+        _, available_functions, _ = convert_tools_to_openai_schema([tool_instance])
+
+        executor._execute_single_native_tool_call(
+            call_id="call_first",
+            func_name="failing_tool",
+            func_args={"data": "payload"},
+            available_functions=available_functions,
+        )
+        assert call_count == 1
+
+        result = executor._execute_single_native_tool_call(
+            call_id="call_retry",
+            func_name="failing_tool",
+            func_args={"data": "payload"},
+            available_functions=available_functions,
+        )
+
+        assert call_count == 1, "Tool should not be called again on retry"
+        assert result["from_cache"] is True
+        assert result["result"] == IDEMPOTENT_SENTINEL_MESSAGE
 
     def test_non_idempotent_tool_no_preclaim(self) -> None:
         """Non-idempotent tools should not write sentinel before execution."""

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1335,7 +1335,7 @@ class TestIdempotentToolPreClaim:
 
         assert result["result"] == "sent to bob@test.com"
         cached = executor.tools_handler.cache.read(
-            tool="send_email", input='{"to": "bob@test.com", "body": "hello"}'
+            tool="send_email", input='{"body":"hello","to":"bob@test.com"}'
         )
         assert cached == "sent to bob@test.com"
 
@@ -1366,7 +1366,7 @@ class TestIdempotentToolPreClaim:
 
         assert "Error executing tool" in result["result"]
         cached = executor.tools_handler.cache.read(
-            tool="failing_tool", input='{"data": "payload"}'
+            tool="failing_tool", input='{"data":"payload"}'
         )
         assert is_idempotent_sentinel(cached)
 
@@ -1436,6 +1436,6 @@ class TestIdempotentToolPreClaim:
 
         assert "Error executing tool" in result["result"]
         cached = executor.tools_handler.cache.read(
-            tool="normal_tool", input='{"x": "val"}'
+            tool="normal_tool", input='{"x":"val"}'
         )
         assert cached is None

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1272,3 +1272,129 @@ class TestNativeToolCallingJsonParseError:
 
         assert "Error" in result["result"]
         assert "validation failed" in result["result"].lower() or "missing" in result["result"].lower()
+
+
+class TestIdempotentToolPreClaim:
+    """Tests that idempotent tools write a sentinel to cache before execution."""
+
+    def _make_executor(self, tools: list[BaseTool]) -> "CrewAgentExecutor":
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+        from crewai.agents.cache import CacheHandler
+        from crewai.agents.tools_handler import ToolsHandler
+        from crewai.tools.base_tool import to_langchain
+
+        structured_tools = to_langchain(tools)
+        mock_agent = Mock()
+        mock_agent.key = "test_agent"
+        mock_agent.role = "tester"
+        mock_agent.verbose = False
+        mock_agent.fingerprint = None
+        mock_agent.tools_results = []
+
+        mock_task = Mock()
+        mock_task.name = "test"
+        mock_task.description = "test"
+        mock_task.id = "test-id"
+
+        cache = CacheHandler()
+        tools_handler = ToolsHandler(cache=cache)
+
+        executor = CrewAgentExecutor(
+            tools=structured_tools,
+            original_tools=tools,
+            tools_handler=tools_handler,
+        )
+        executor.agent = mock_agent
+        executor.task = mock_task
+        return executor
+
+    def test_idempotent_tool_preclaims_cache(self) -> None:
+        """Idempotent tool should write sentinel to cache before execution."""
+        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+        class SendEmailTool(BaseTool):
+            name: str = "send_email"
+            description: str = "Send an email"
+            idempotent: bool = True
+
+            def _run(self, to: str, body: str) -> str:
+                return f"sent to {to}"
+
+        tool_instance = SendEmailTool()
+        executor = self._make_executor([tool_instance])
+
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+        _, available_functions, _ = convert_tools_to_openai_schema([tool_instance])
+
+        result = executor._execute_single_native_tool_call(
+            call_id="call_1",
+            func_name="send_email",
+            func_args={"to": "bob@test.com", "body": "hello"},
+            available_functions=available_functions,
+        )
+
+        assert result["result"] == "sent to bob@test.com"
+        cached = executor.tools_handler.cache.read(
+            tool="send_email", input='{"to": "bob@test.com", "body": "hello"}'
+        )
+        assert cached == "sent to bob@test.com"
+
+    def test_idempotent_tool_sentinel_survives_failure(self) -> None:
+        """If an idempotent tool raises after side effect, sentinel remains in cache."""
+        from crewai.tools.base_tool import IDEMPOTENT_EXECUTION_SENTINEL
+
+        class FailingTool(BaseTool):
+            name: str = "failing_tool"
+            description: str = "Fails after side effect"
+            idempotent: bool = True
+
+            def _run(self, data: str) -> str:
+                raise RuntimeError("connection lost")
+
+        tool_instance = FailingTool()
+        executor = self._make_executor([tool_instance])
+
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+        _, available_functions, _ = convert_tools_to_openai_schema([tool_instance])
+
+        result = executor._execute_single_native_tool_call(
+            call_id="call_2",
+            func_name="failing_tool",
+            func_args={"data": "payload"},
+            available_functions=available_functions,
+        )
+
+        assert "Error executing tool" in result["result"]
+        cached = executor.tools_handler.cache.read(
+            tool="failing_tool", input='{"data": "payload"}'
+        )
+        assert cached == IDEMPOTENT_EXECUTION_SENTINEL
+
+    def test_non_idempotent_tool_no_preclaim(self) -> None:
+        """Non-idempotent tools should not write sentinel before execution."""
+
+        class NormalTool(BaseTool):
+            name: str = "normal_tool"
+            description: str = "Normal tool"
+
+            def _run(self, x: str) -> str:
+                raise RuntimeError("fail")
+
+        tool_instance = NormalTool()
+        executor = self._make_executor([tool_instance])
+
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+        _, available_functions, _ = convert_tools_to_openai_schema([tool_instance])
+
+        result = executor._execute_single_native_tool_call(
+            call_id="call_3",
+            func_name="normal_tool",
+            func_args={"x": "val"},
+            available_functions=available_functions,
+        )
+
+        assert "Error executing tool" in result["result"]
+        cached = executor.tools_handler.cache.read(
+            tool="normal_tool", input='{"x": "val"}'
+        )
+        assert cached is None

--- a/lib/crewai/tests/tools/test_base_tool.py
+++ b/lib/crewai/tests/tools/test_base_tool.py
@@ -447,3 +447,44 @@ class TestToolDecoratorArunValidation:
 
         with pytest.raises(ValueError, match="validation failed"):
             await async_execute.arun(wrong_arg="value")
+
+
+def test_idempotent_field_defaults_to_false():
+    class MyTool(BaseTool):
+        name: str = "my_tool"
+        description: str = "A tool"
+
+        def _run(self, question: str) -> str:
+            return question
+
+    assert MyTool().idempotent is False
+
+
+def test_idempotent_field_can_be_set_true():
+    class MyTool(BaseTool):
+        name: str = "my_tool"
+        description: str = "A tool"
+        idempotent: bool = True
+
+        def _run(self, question: str) -> str:
+            return question
+
+    assert MyTool().idempotent is True
+
+
+def test_idempotent_on_tool_decorator():
+    @tool("my_tool", idempotent=True)
+    def my_tool(question: str) -> str:
+        """A tool."""
+        return question
+
+    assert my_tool.idempotent is True
+
+
+def test_idempotent_defaults_false_on_tool_decorator():
+    @tool("my_tool")
+    def my_tool(question: str) -> str:
+        """A tool."""
+        return question
+
+    assert my_tool.idempotent is False


### PR DESCRIPTION
﻿Fixes #5802

When a task retries (e.g. after an LLM parsing failure or timeout), tools that already executed can get called again because:
- The cache write happens *after* execution — if the tool crashes mid-way (after the side effect), no cache entry exists
- _times_executed never resets between tasks, leaking the retry budget from task A into task B

This adds an opt-in idempotent=True field on BaseTool. When set, the tool's cache entry is written *before* execution (a "pre-claim"). If the tool then crashes after performing its side effect, the pre-claim stays in cache and prevents re-execution on retry. On success, the real result overwrites the pre-claim as normal.

Also fixes the retry counter leak — _times_executed now resets when a different task starts, without affecting the recursive retry logic for the same task.

**Usage:**
```python
class SendEmailTool(BaseTool):
    name = "send_email"
    description = "Send an email"
    idempotent = True

    def _run(self, to: str, body: str) -> str:
        ...

# or with the decorator
@tool("send_email", idempotent=True)
def send_email(to: str, body: str) -> str:
    """Send an email."""
    ...
```

Non-idempotent tools (the default) are completely unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent retry counts now reset per task so retries don’t accumulate across different tasks.

* **New Features**
  * Tools can be marked idempotent so identical calls return cached results on retry.
  * Idempotent tools pre-claim cache entries; observed pre-claims surface a sentinel response instead of re-executing.
  * Cache keys are canonicalized with deterministic serialization and support an atomic claim-if-absent flow for idempotent executions.

* **Tests**
  * Added tests for per-task retry reset and idempotent tool caching/pre-claim behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->