### PR TITLE
docs: update changelog and version for v1.14.5a6

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,28 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="15 مايو 2026">
+  ## v1.14.5a6
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a6)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - إصلاح استدعاءات الأدوات المتدفقة عندما تكون available_functions غائبة
+  - رفع اعتماد langsmith إلى الإصدار >=0.8.0 لمعالجة GHSA-3644-q5cj-c5c7
+  - حل مشاكل الأماكن الشاغرة لكتل التعليمات البرمجية غير المترجمة في وثائق البرتغالية البرازيلية
+
+  ### الوثائق
+  - إضافة وثائق لـ TavilyGetResearch
+  - تحديث سجل التغييرات والإصدار لـ v1.14.5a5
+
+  ## المساهمون
+
+  @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @manisrinivasan2k1
+
+</Update>
+
 <Update label="13 مايو 2026">
   ## v1.14.5a5
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,28 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="May 15, 2026">
+  ## v1.14.5a6
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a6)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Fix streamed tool calls when available_functions is absent
+  - Bump langsmith dependency to version >=0.8.0 to address GHSA-3644-q5cj-c5c7
+  - Resolve untranslated code block placeholders in Brazilian Portuguese documentation
+
+  ### Documentation
+  - Add documentation for TavilyGetResearch
+  - Update changelog and version for v1.14.5a5
+
+  ## Contributors
+
+  @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @manisrinivasan2k1
+
+</Update>
+
 <Update label="May 13, 2026">
   ## v1.14.5a5
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,28 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 5월 15일">
+  ## v1.14.5a6
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a6)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - available_functions가 없을 때 스트리밍 도구 호출 수정
+  - GHSA-3644-q5cj-c5c7 문제를 해결하기 위해 langsmith 의존성을 버전 >=0.8.0으로 업데이트
+  - 브라질 포르투갈어 문서에서 번역되지 않은 코드 블록 자리 표시자 해결
+
+  ### 문서
+  - TavilyGetResearch에 대한 문서 추가
+  - v1.14.5a5에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @manisrinivasan2k1
+
+</Update>
+
 <Update label="2026년 5월 13일">
   ## v1.14.5a5
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,28 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="15 mai 2026">
+  ## v1.14.5a6
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a6)
+
+  ## O que mudou
+
+  ### Correções de Bugs
+  - Corrigir chamadas de ferramentas transmitidas quando available_functions está ausente
+  - Atualizar a dependência langsmith para a versão >=0.8.0 para resolver GHSA-3644-q5cj-c5c7
+  - Resolver espaços reservados de blocos de código não traduzidos na documentação em português brasileiro
+
+  ### Documentação
+  - Adicionar documentação para TavilyGetResearch
+  - Atualizar changelog e versão para v1.14.5a5
+
+  ## Contributors
+
+  @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @manisrinivasan2k1
+
+</Update>
+
 <Update label="13 mai 2026">
   ## v1.14.5a5
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that add a new changelog entry and do not affect runtime behavior.
> 
> **Overview**
> Adds a new `v1.14.5a6` changelog entry (dated May 15, 2026) to the Arabic, English, Korean, and pt-BR docs, including links to the GitHub release, highlights for bug fixes (streamed tool calls when `available_functions` is missing, `langsmith >=0.8.0` security bump, and pt-BR placeholder cleanup), and a documentation note for `TavilyGetResearch` plus contributor list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6f5ffd361be438f328315ea63b777a209c4de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelogs across multiple languages (English, Arabic, Korean, Portuguese-BR) with the new v1.14.5a6 release entry dated May 15, 2026, including bug fixes, documentation improvements, and updated contributors list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5828)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->