### PR TITLE
fix: Remove response_model from agent executor to prevent tool-skipping on non-OpenAI LLMs

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1063,11 +1063,6 @@ class Agent(BaseAgent):
                 respect_context_window=self.respect_context_window,
                 request_within_rpm_limit=rpm_limit_fn,
                 callbacks=[TokenCalcHandler(self._token_process)],
-                response_model=(
-                    task.response_model or task.output_pydantic or task.output_json
-                )
-                if task
-                else None,
             )
 
     def _update_executor_parameters(
@@ -1103,12 +1098,6 @@ class Agent(BaseAgent):
             self.agent_executor.stop = stop_words
         self.agent_executor.tools_names = get_tool_names(tools)
         self.agent_executor.tools_description = render_text_description_and_args(tools)
-        self.agent_executor.response_model = (
-            (task.response_model or task.output_pydantic or task.output_json)
-            if task
-            else None
-        )
-
         self.agent_executor.tools_handler = self.tools_handler
         self.agent_executor.request_within_rpm_limit = rpm_limit_fn
 


### PR DESCRIPTION
## Description

Fixes #5472

When output_pydantic is set on a Task, CrewAI v1.9.0+ passes it as response_model into the agent executor, which passes it into every LLM call iteration as response_format. For LLMs served via vLLM (and likely other OpenAI-compatible servers), this causes the model to skip tool calls entirely and return structured JSON directly — tools never execute.

## Root Cause

In agent/core.py, create_agent_executor() and _update_executor_parameters() both set:
response_model = task.response_model or task.output_pydantic or task.output_json

This response_model is then passed to get_llm_response() on every iteration of the tool-calling loop. When the LLM returns a valid structured response, AgentFinish is returned immediately without checking for tool calls.

## Fix

Remove response_model from create_agent_executor() and _update_executor_parameters(). The structured output conversion is already correctly handled as a post-processing step in Task._export_output() via convert_to_model(), which runs after tools have executed.

## Testing

- Existing tests (test_output_pydantic_sequential, test_output_pydantic_hierarchical) use VCR cassettes and test the final output — this fix should not break them since the post-processing path is unchanged.
- The fix was verified against the reproduced scenario described in #5472.

## Related

- #5472: Original bug report with detailed root-cause analysis and proposed options
- Option A (implemented): Don't pass output_pydantic as response_model; keep it as post-processing only (pre-v1.9.0 behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified agent executor initialization by removing automatic response model assignment during task execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->