### PR TITLE
fix(tools): avoid double counting tool usage

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -378,36 +378,6 @@ class ToolUsage:
                     if self.agent and hasattr(self.agent, "tools_results"):
                         self.agent.tools_results.append(data)
 
-                    if available_tool and hasattr(
-                        available_tool, "_increment_usage_count"
-                    ):
-                        # Use _increment_usage_count to sync count to original tool
-                        available_tool._increment_usage_count()
-                        if (
-                            hasattr(available_tool, "max_usage_count")
-                            and available_tool.max_usage_count is not None
-                            and self.agent
-                            and self.agent.verbose
-                        ):
-                            PRINTER.print(
-                                content=f"Tool '{sanitize_tool_name(available_tool.name)}' usage: {available_tool.current_usage_count}/{available_tool.max_usage_count}",
-                                color="blue",
-                            )
-                    elif available_tool and hasattr(
-                        available_tool, "current_usage_count"
-                    ):
-                        available_tool.current_usage_count += 1
-                        if (
-                            hasattr(available_tool, "max_usage_count")
-                            and available_tool.max_usage_count is not None
-                            and self.agent
-                            and self.agent.verbose
-                        ):
-                            PRINTER.print(
-                                content=f"Tool '{sanitize_tool_name(available_tool.name)}' usage: {available_tool.current_usage_count}/{available_tool.max_usage_count}",
-                                color="blue",
-                            )
-
                 except Exception as e:
                     self.on_tool_error(tool=tool, tool_calling=calling, e=e)
                     error_event_emitted = True
@@ -610,36 +580,6 @@ class ToolUsage:
 
                     if self.agent and hasattr(self.agent, "tools_results"):
                         self.agent.tools_results.append(data)
-
-                    if available_tool and hasattr(
-                        available_tool, "_increment_usage_count"
-                    ):
-                        # Use _increment_usage_count to sync count to original tool
-                        available_tool._increment_usage_count()
-                        if (
-                            hasattr(available_tool, "max_usage_count")
-                            and available_tool.max_usage_count is not None
-                            and self.agent
-                            and self.agent.verbose
-                        ):
-                            PRINTER.print(
-                                content=f"Tool '{sanitize_tool_name(available_tool.name)}' usage: {available_tool.current_usage_count}/{available_tool.max_usage_count}",
-                                color="blue",
-                            )
-                    elif available_tool and hasattr(
-                        available_tool, "current_usage_count"
-                    ):
-                        available_tool.current_usage_count += 1
-                        if (
-                            hasattr(available_tool, "max_usage_count")
-                            and available_tool.max_usage_count is not None
-                            and self.agent
-                            and self.agent.verbose
-                        ):
-                            PRINTER.print(
-                                content=f"Tool '{sanitize_tool_name(available_tool.name)}' usage: {available_tool.current_usage_count}/{available_tool.max_usage_count}",
-                                color="blue",
-                            )
 
                 except Exception as e:
                     self.on_tool_error(tool=tool, tool_calling=calling, e=e)

--- a/lib/crewai/tests/tools/test_tool_usage_limit.py
+++ b/lib/crewai/tests/tools/test_tool_usage_limit.py
@@ -199,3 +199,53 @@ def test_tool_usage_increments_structured_tool_once_per_call():
     assert "has reached its usage limit of 2 times" in third_result
     assert structured_tool.current_usage_count == 2
     assert original_tool.current_usage_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_usage_increments_structured_tool_once_per_async_call():
+    """Test that async agent tool execution only consumes one usage per invocation."""
+
+    class LimitedTool(BaseTool):
+        name: str = "Limited Tool"
+        description: str = "A tool with usage limits for testing"
+        max_usage_count: int = 2
+
+        def _run(self, input_text: str) -> str:
+            return f"Processed {input_text}"
+
+    original_tool = LimitedTool()
+    structured_tool = original_tool.to_structured_tool()
+    llm = MagicMock()
+    llm.model = "gpt-4o-mini"
+    tool_usage = ToolUsage(
+        tools=[structured_tool],
+        agent=None,
+        task=None,
+        tools_handler=None,
+        function_calling_llm=llm,
+    )
+
+    first_result = await tool_usage.ause(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "first"}
+        ),
+        tool_string="",
+    )
+    second_result = await tool_usage.ause(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "second"}
+        ),
+        tool_string="",
+    )
+    third_result = await tool_usage.ause(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "third"}
+        ),
+        tool_string="",
+    )
+
+    assert first_result == "Processed first"
+    assert second_result == "Processed second"
+    assert "has reached its usage limit of 2 times" in third_result
+    assert structured_tool.current_usage_count == 2
+    assert original_tool.current_usage_count == 2

--- a/lib/crewai/tests/tools/test_tool_usage_limit.py
+++ b/lib/crewai/tests/tools/test_tool_usage_limit.py
@@ -181,12 +181,20 @@ def test_tool_usage_increments_structured_tool_once_per_call():
         ),
         tool_string="",
     )
+    assert first_result == "Processed first"
+    assert structured_tool.current_usage_count == 1
+    assert original_tool.current_usage_count == 1
+
     second_result = tool_usage.use(
         calling=ToolCalling(
             tool_name="Limited Tool", arguments={"input_text": "second"}
         ),
         tool_string="",
     )
+    assert second_result == "Processed second"
+    assert structured_tool.current_usage_count == 2
+    assert original_tool.current_usage_count == 2
+
     third_result = tool_usage.use(
         calling=ToolCalling(
             tool_name="Limited Tool", arguments={"input_text": "third"}
@@ -194,8 +202,6 @@ def test_tool_usage_increments_structured_tool_once_per_call():
         tool_string="",
     )
 
-    assert first_result == "Processed first"
-    assert second_result == "Processed second"
     assert "has reached its usage limit of 2 times" in third_result
     assert structured_tool.current_usage_count == 2
     assert original_tool.current_usage_count == 2
@@ -231,12 +237,20 @@ async def test_tool_usage_increments_structured_tool_once_per_async_call():
         ),
         tool_string="",
     )
+    assert first_result == "Processed first"
+    assert structured_tool.current_usage_count == 1
+    assert original_tool.current_usage_count == 1
+
     second_result = await tool_usage.ause(
         calling=ToolCalling(
             tool_name="Limited Tool", arguments={"input_text": "second"}
         ),
         tool_string="",
     )
+    assert second_result == "Processed second"
+    assert structured_tool.current_usage_count == 2
+    assert original_tool.current_usage_count == 2
+
     third_result = await tool_usage.ause(
         calling=ToolCalling(
             tool_name="Limited Tool", arguments={"input_text": "third"}
@@ -244,8 +258,6 @@ async def test_tool_usage_increments_structured_tool_once_per_async_call():
         tool_string="",
     )
 
-    assert first_result == "Processed first"
-    assert second_result == "Processed second"
     assert "has reached its usage limit of 2 times" in third_result
     assert structured_tool.current_usage_count == 2
     assert original_tool.current_usage_count == 2

--- a/lib/crewai/tests/tools/test_tool_usage_limit.py
+++ b/lib/crewai/tests/tools/test_tool_usage_limit.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from crewai.tools import BaseTool, tool
+from crewai.tools.tool_calling import ToolCalling
 from crewai.tools.tool_usage import ToolUsage
 
 
@@ -149,3 +150,52 @@ def test_tool_usage_with_toolusage_class():
     
     result3 = tool_usage._check_usage_limit(tool, "Limited Tool")
     assert "has reached its usage limit of 2 times" in result3
+
+
+def test_tool_usage_increments_structured_tool_once_per_call():
+    """Test that agent tool execution only consumes one usage per invocation."""
+
+    class LimitedTool(BaseTool):
+        name: str = "Limited Tool"
+        description: str = "A tool with usage limits for testing"
+        max_usage_count: int = 2
+
+        def _run(self, input_text: str) -> str:
+            return f"Processed {input_text}"
+
+    original_tool = LimitedTool()
+    structured_tool = original_tool.to_structured_tool()
+    llm = MagicMock()
+    llm.model = "gpt-4o-mini"
+    tool_usage = ToolUsage(
+        tools=[structured_tool],
+        agent=None,
+        task=None,
+        tools_handler=None,
+        function_calling_llm=llm,
+    )
+
+    first_result = tool_usage.use(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "first"}
+        ),
+        tool_string="",
+    )
+    second_result = tool_usage.use(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "second"}
+        ),
+        tool_string="",
+    )
+    third_result = tool_usage.use(
+        calling=ToolCalling(
+            tool_name="Limited Tool", arguments={"input_text": "third"}
+        ),
+        tool_string="",
+    )
+
+    assert first_result == "Processed first"
+    assert second_result == "Processed second"
+    assert "has reached its usage limit of 2 times" in third_result
+    assert structured_tool.current_usage_count == 2
+    assert original_tool.current_usage_count == 2


### PR DESCRIPTION
## Summary
- remove the extra ToolUsage-side usage-count increment after CrewStructuredTool invocation
- add a regression test that executes a limited structured tool through ToolUsage.use()

## Root cause
CrewStructuredTool.invoke() already increments current_usage_count and syncs the original BaseTool. ToolUsage._use() and _ause() then incremented the same structured tool again after successful execution, causing tools with max_usage_count=2 to be exhausted after one agent invocation.

## Validation
- uv run pytest lib/crewai/tests/tools/test_tool_usage_limit.py -q
- uv run ruff check lib/crewai/src/crewai/tools/tool_usage.py lib/crewai/tests/tools/test_tool_usage_limit.py
- uv run ruff format --check lib/crewai/src/crewai/tools/tool_usage.py lib/crewai/tests/tools/test_tool_usage_limit.py
- git diff --check

## Contributor note
This PR was AI-authored. I attempted to apply the required `llm-generated` label, but GitHub denied label permissions for the fork author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an inconsistency in how tool usage limits were tracked so usage counts remain consistent across different execution paths; normal invocation, caching, telemetry, error handling, and retries behave as before.

* **Tests**
  * Added sync and async tests to verify tool usage limits and that wrapped tools and originals stay synchronized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->