### PR TITLE
fix(tasks): preserve empty task json outputs

### DIFF
--- a/lib/crewai/src/crewai/tasks/task_output.py
+++ b/lib/crewai/src/crewai/tasks/task_output.py
@@ -90,15 +90,15 @@ class TaskOutput(BaseModel):
             over pydantic model dump if both are available.
         """
         output_dict = {}
-        if self.json_dict:
+        if self.json_dict is not None:
             output_dict.update(self.json_dict)
-        elif self.pydantic:
+        elif self.pydantic is not None:
             output_dict.update(self.pydantic.model_dump())
         return output_dict
 
     def __str__(self) -> str:
-        if self.pydantic:
+        if self.pydantic is not None:
             return str(self.pydantic)
-        if self.json_dict:
+        if self.json_dict is not None:
             return str(self.json_dict)
         return self.raw

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -1027,6 +1027,37 @@ def test_task_output_str_with_json_dict():
     assert str(task_output) == str(json_dict)
 
 
+def test_task_output_str_with_empty_json_dict():
+    from crewai.tasks.output_format import OutputFormat
+
+    task_output = TaskOutput(
+        description="Test task",
+        agent="Test Agent",
+        raw="Raw fallback",
+        json_dict={},
+        output_format=OutputFormat.JSON,
+    )
+
+    assert str(task_output) == "{}"
+
+
+def test_task_output_to_dict_prefers_empty_json_dict():
+    from crewai.tasks.output_format import OutputFormat
+
+    class ScoreOutput(BaseModel):
+        score: int
+
+    task_output = TaskOutput(
+        description="Test task",
+        agent="Test Agent",
+        pydantic=ScoreOutput(score=4),
+        json_dict={},
+        output_format=OutputFormat.JSON,
+    )
+
+    assert task_output.to_dict() == {}
+
+
 def test_task_output_str_with_raw():
     from crewai.tasks.output_format import OutputFormat
 


### PR DESCRIPTION
## Summary
- preserve an intentionally empty `TaskOutput.json_dict` when converting task output to a dict
- render empty JSON task output as `{}` instead of falling back to raw text
- add regression coverage for empty JSON task outputs

## Validation
- `uv run pytest lib/crewai/tests/test_task.py::test_task_output_str_with_json_dict lib/crewai/tests/test_task.py::test_task_output_str_with_empty_json_dict lib/crewai/tests/test_task.py::test_task_output_to_dict_prefers_empty_json_dict lib/crewai/tests/test_task.py::test_task_output_str_with_pydantic_and_json_dict -q`
- `uv run ruff check lib/crewai/src/crewai/tasks/task_output.py lib/crewai/tests/test_task.py`

## Contributor Note
This PR was authored with an AI coding assistant. The repository requires the `llm-generated` label for AI-authored contributions, but GitHub rejected applying that label from this fork with `AddLabelsToLabelable` permission denied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty-but-present JSON outputs are now preserved and included instead of being treated as absent, ensuring empty JSON objects are returned and displayed correctly.

* **Tests**
  * Added tests verifying behavior when JSON output is empty, confirming both string and dictionary representations reflect an empty JSON object.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->