### PR TITLE
chore(devtools): skip pinning crewai-files in file-processing extra

### DIFF
--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -3,6 +3,7 @@
 from collections.abc import Mapping
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -355,8 +356,19 @@ def update_pyproject_dependencies(
 
     workspace_packages = _DEFAULT_WORKSPACE_PACKAGES + (extra_packages or [])
 
+    current_extra: str | None = None
+    extra_header = re.compile(r"^\s*([A-Za-z0-9_-]+)\s*=\s*\[")
+
     for i, line in enumerate(lines):
+        match = extra_header.match(line)
+        if match:
+            current_extra = match.group(1)
+        elif line.strip().startswith("]"):
+            current_extra = None
+
         for pkg in workspace_packages:
+            if pkg == "crewai-files" and current_extra == "file-processing":
+                continue
             if f"{pkg}==" in line:
                 stripped = line.lstrip()
                 indent = line[: len(line) - len(stripped)]

--- a/lib/devtools/tests/test_toml_updates.py
+++ b/lib/devtools/tests/test_toml_updates.py
@@ -282,6 +282,25 @@ class TestUpdatePyprojectDependencies:
         assert '"crewai-files==2.0.0"' in result
         assert '"requests>=2.0"' in result
 
+    def test_skips_crewai_files_in_file_processing_extra(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            dedent("""\
+            [project.optional-dependencies]
+            file-processing = [
+                "crewai-files==1.0.0",
+            ]
+            other = [
+                "crewai-files==1.0.0",
+            ]
+        """)
+        )
+
+        update_pyproject_dependencies(pyproject, "2.0.0")
+        result = pyproject.read_text()
+        assert '"crewai-files==1.0.0"' in result
+        assert '"crewai-files==2.0.0"' in result
+
     def test_leaves_bare_crewai_pin_alone(self, tmp_path: Path) -> None:
         """`crewai==` must not collide with `crewai-core==` etc."""
         pyproject = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Summary
- Track current `[project.optional-dependencies]` extra in `update_pyproject_dependencies` and skip `crewai-files` when the surrounding extra is `file-processing`.
- All other workspace pinning behavior is unchanged.

## Test plan
- [x] `uv run pytest lib/devtools/tests/test_toml_updates.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes version-bump automation by adding context-sensitive parsing of `pyproject.toml` optional-dependency blocks, which could miss or misapply pins if the heuristic misidentifies list boundaries or extras.
> 
> **Overview**
> **Updates `update_pyproject_dependencies` to be extra-aware when rewriting pins.** The bump script now tracks the current `[project.optional-dependencies]` extra list while scanning `pyproject.toml` and **skips rewriting `crewai-files` when it appears under the `file-processing` extra**, while continuing to repin it elsewhere.
> 
> Adds a focused unit test to ensure `crewai-files` remains unchanged in the `file-processing` extra but is still updated in other extras.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea04d32d302f2ce3e42ff87f19c1e3252dc4ddf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed devtools dependency updater to correctly handle `crewai-files` package pins in the `file-processing` optional dependency section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->