### PR TITLE
fix: widen opentelemetry dependency range to resolve OpenLIT conflict (#5845)

### DIFF
--- a/lib/crewai-core/pyproject.toml
+++ b/lib/crewai-core/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "pyjwt>=2.9.0,<3",
     "pydantic>=2.11.9,<2.13",
     "rich>=13.7.1",
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.34.0,<2",
+    "opentelemetry-sdk>=1.34.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2",
     "tomli~=2.0.2",
 ]
 

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.34.0,<2",
+    "opentelemetry-sdk>=1.34.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers>=0.21,<1",


### PR DESCRIPTION
### Description

Fixes #5845 — dependency conflict between crewAI and openlit.

crewAI pins `opentelemetry-sdk~=1.34.0`, which restricts to `<1.35.0`.
openlit 1.41.2 requires `opentelemetry-sdk>=1.38.0`, making them
incompatible in the same project.

### Change

Widened the three opentelemetry dependency constraints from `~=1.34.0` to
`>=1.34.0,<2`, applied in both:
- `lib/crewai/pyproject.toml`
- `lib/crewai-core/pyproject.toml`

### Why this is safe
- The telemetry module only uses stable OpenTelemetry APIs:
  `TracerProvider`, `Resource`, `BatchSpanProcessor`, `Span`, `StatusCode`
- These APIs have not changed between 1.34 and 1.38
- openlit 1.41.2 works with this range
- Existing installations with 1.34.x continue to work unchanged

### Testing
Dependency resolution verified: `pip install crewai openlit` now resolves
successfully with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry dependency version constraints to allow compatibility with newer patch and minor releases while maintaining stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->