### PR TITLE
docs: update changelog and version for v1.14.5a7

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,25 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="18 مايو 2026">
+  ## v1.14.5a7
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a7)
+
+  ## ما الذي تغير
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار لـ v1.14.5a6
+
+  ### تغييرات كسرية
+  - إلغاء حقل function_calling_llm
+
+  ## المساهمون
+
+  @greysonlalonde, @heitorado
+
+</Update>
+
 <Update label="15 مايو 2026">
   ## v1.14.5a6
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,25 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="May 18, 2026">
+  ## v1.14.5a7
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a7)
+
+  ## What's Changed
+
+  ### Documentation
+  - Update changelog and version for v1.14.5a6
+
+  ### Breaking Changes
+  - Deprecate function_calling_llm field
+
+  ## Contributors
+
+  @greysonlalonde, @heitorado
+
+</Update>
+
 <Update label="May 15, 2026">
   ## v1.14.5a6
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,25 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 5월 18일">
+  ## v1.14.5a7
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a7)
+
+  ## 변경 사항
+
+  ### 문서
+  - v1.14.5a6의 변경 로그 및 버전 업데이트
+
+  ### 주요 변경 사항
+  - function_calling_llm 필드 사용 중단
+
+  ## 기여자
+
+  @greysonlalonde, @heitorado
+
+</Update>
+
 <Update label="2026년 5월 15일">
   ## v1.14.5a6
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,25 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="18 mai 2026">
+  ## v1.14.5a7
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.5a7)
+
+  ## O que Mudou
+
+  ### Documentação
+  - Atualizar changelog e versão para v1.14.5a6
+
+  ### Mudanças Quebradoras
+  - Depreciar o campo function_calling_llm
+
+  ## Contributors
+
+  @greysonlalonde, @heitorado
+
+</Update>
+
 <Update label="15 mai 2026">
   ## v1.14.5a6
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates changelog content across locales; no runtime code is modified.
> 
> **Overview**
> **Updates release notes for `v1.14.5a7`.**
> 
> Adds a new top entry to `docs/*/changelog.mdx` (EN/AR/KO/PT-BR) linking to the GitHub release, listing documentation updates, and calling out a **breaking change**: deprecation of the `function_calling_llm` field, along with updated contributor credits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde7c3f86c63c5e66fe07bc84f007e0fd7504200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v1.14.5a7 release notes to changelogs in English, Arabic, Korean, and Portuguese-Brazil.

* **Breaking Changes**
  * Deprecated the `function_calling_llm` field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->