### PR TITLE
fix: YoutubeChannelSearchTool fails for valid channel handles and URLs

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/rag/loaders/youtube_channel_loader.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/loaders/youtube_channel_loader.py
@@ -32,6 +32,10 @@ class YoutubeChannelLoader(BaseLoader):
 
         channel_url = source.source
 
+        # Normalize bare handles (e.g. "@krishnaik06") to full URLs
+        if channel_url.startswith("@"):
+            channel_url = f"https://www.youtube.com/{channel_url}"
+
         if not any(
             pattern in channel_url
             for pattern in [

--- a/lib/crewai-tools/src/crewai_tools/rag/loaders/youtube_channel_loader.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/loaders/youtube_channel_loader.py
@@ -30,7 +30,7 @@ class YoutubeChannelLoader(BaseLoader):
                 "YouTube channel support requires pytube. Install with: uv add pytube"
             ) from e
 
-        channel_url = source.source
+        channel_url = source.source.strip()
 
         # Normalize bare handles (e.g. "@krishnaik06") to full URLs
         if channel_url.startswith("@"):

--- a/lib/crewai-tools/src/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
@@ -42,7 +42,10 @@ class YoutubeChannelSearchTool(RagTool):
         self,
         youtube_channel_handle: str,
     ) -> None:
-        if not youtube_channel_handle.startswith("@"):
+        if youtube_channel_handle.startswith(("http://", "https://")):
+            # Already a full URL, pass through as-is
+            pass
+        elif not youtube_channel_handle.startswith("@"):
             youtube_channel_handle = f"@{youtube_channel_handle}"
         super().add(youtube_channel_handle, data_type=DataType.YOUTUBE_CHANNEL)
 

--- a/lib/crewai-tools/src/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
@@ -42,7 +42,8 @@ class YoutubeChannelSearchTool(RagTool):
         self,
         youtube_channel_handle: str,
     ) -> None:
-        if youtube_channel_handle.startswith(("http://", "https://")):
+        youtube_channel_handle = youtube_channel_handle.strip()
+        if youtube_channel_handle.lower().startswith(("http://", "https://")):
             # Already a full URL, pass through as-is
             pass
         elif not youtube_channel_handle.startswith("@"):


### PR DESCRIPTION
## Summary

Fix `YoutubeChannelSearchTool` to correctly handle both bare handles (e.g. `@krishnaik06`) and full URLs (e.g. `https://www.youtube.com/@krishnaik06`).

## Problem

Two bugs:

1. **`add()` method** — Unconditionally prepends `@` to any input not starting with `@`. When a user passes a full URL like `https://www.youtube.com/@krishnaik06`, it becomes `@https://www.youtube.com/@krishnaik06`, which is completely broken.

2. **`load()` validation** — Only accepts strings containing YouTube URL substrings (`youtube.com/channel/`, etc.). Bare handles like `@krishnaik06` never match and always raise `ValueError`.

## Changes

- `youtube_channel_search_tool.py`: Detect full URLs (starting with `http://` or `https://`) and pass them through unchanged. Only prepend `@` to bare handle strings.
- `youtube_channel_loader.py`: Normalize bare `@handle` inputs to `https://www.youtube.com/@handle` before validation.

## Test plan

- [x] Verified `@krishnaik06` → normalized to `https://www.youtube.com/@krishnaik06`
- [x] Verified `https://www.youtube.com/@krishnaik06` → passed through unchanged
- [x] Verified `krishnaik06` → `@krishnaik06` → normalized to full URL

Closes #5429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * YouTube channel inputs now accept and normalize multiple formats: bare handles (e.g., `@handle`) and full URLs.
  * Leading/trailing whitespace in channel inputs is trimmed before processing.
  * When a full URL is provided it is used as-is; non-URL inputs are normalized into handle/URL form.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->