### PR TITLE
fix(cli): add explicit encoding="utf-8" to text-mode open() calls

### DIFF
--- a/lib/cli/src/crewai_cli/create_crew.py
+++ b/lib/cli/src/crewai_cli/create_crew.py
@@ -23,7 +23,7 @@ def get_reserved_script_names() -> set[str]:
     package_dir = Path(__file__).parent
     template_path = package_dir / "templates" / "crew" / "pyproject.toml"
 
-    with open(template_path, "r") as f:
+    with open(template_path, "r", encoding="utf-8") as f:
         template_content = f.read()
 
     template_content = template_content.replace("{{folder_name}}", "_placeholder_")

--- a/lib/cli/src/crewai_cli/create_flow.py
+++ b/lib/cli/src/crewai_cli/create_flow.py
@@ -27,7 +27,7 @@ def create_flow(name: str) -> None:
     (project_root / "tests").mkdir(exist_ok=True)
 
     # Create .env file
-    with open(project_root / ".env", "w") as file:
+    with open(project_root / ".env", "w", encoding="utf-8") as file:
         file.write("OPENAI_API_KEY=YOUR_API_KEY")
 
     package_dir = Path(__file__).parent
@@ -62,7 +62,7 @@ def create_flow(name: str) -> None:
         content = content.replace("{{flow_name}}", class_name)
         content = content.replace("{{folder_name}}", folder_name)
 
-        with open(dst_file, "w") as file:
+        with open(dst_file, "w", encoding="utf-8") as file:
             file.write(content)
 
     # Copy and process root template files

--- a/lib/cli/src/crewai_cli/provider.py
+++ b/lib/cli/src/crewai_cli/provider.py
@@ -146,7 +146,7 @@ def read_cache_file(cache_file: Path) -> dict[str, Any] | None:
         The JSON content of the cache file or None if the JSON is invalid.
     """
     try:
-        with open(cache_file, "r") as f:
+        with open(cache_file, "r", encoding="utf-8") as f:
             data: dict[str, Any] = json.load(f)
             return data
     except json.JSONDecodeError:
@@ -168,7 +168,7 @@ def fetch_provider_data(cache_file: Path) -> dict[str, Any] | None:
         with httpx.stream("GET", JSON_URL, timeout=60, verify=ssl_config) as response:
             response.raise_for_status()
             data = download_data(response)
-            with open(cache_file, "w") as f:
+            with open(cache_file, "w", encoding="utf-8") as f:
                 json.dump(data, f)
             return data
     except httpx.HTTPError as e:

--- a/lib/cli/src/crewai_cli/utils.py
+++ b/lib/cli/src/crewai_cli/utils.py
@@ -44,14 +44,14 @@ def copy_template(
     src: Path, dst: Path, name: str, class_name: str, folder_name: str
 ) -> None:
     """Copy a file from src to dst."""
-    with open(src, "r") as file:
+    with open(src, "r", encoding="utf-8") as file:
         content = file.read()
 
     content = content.replace("{{name}}", name)
     content = content.replace("{{crew_name}}", class_name)
     content = content.replace("{{folder_name}}", folder_name)
 
-    with open(dst, "w") as file:
+    with open(dst, "w", encoding="utf-8") as file:
         file.write(content)
 
     click.secho(f"  - Created {dst}", fg="green")
@@ -60,7 +60,7 @@ def copy_template(
 def fetch_and_json_env_file(env_file_path: str = ".env") -> dict[str, Any]:
     """Fetch the environment variables from a .env file and return them as a dictionary."""
     try:
-        with open(env_file_path, "r") as f:
+        with open(env_file_path, "r", encoding="utf-8") as f:
             env_content = f.read()
 
         env_dict = {}
@@ -100,7 +100,7 @@ def tree_find_and_replace(directory: Path, find: str, replace: str) -> None:
 
             with open(filepath, "r", encoding="utf-8", errors="ignore") as file:
                 contents = file.read()
-            with open(filepath, "w") as file:
+            with open(filepath, "w", encoding="utf-8") as file:
                 file.write(contents.replace(find, replace))
 
             if find in filename:
@@ -121,7 +121,7 @@ def load_env_vars(folder_path: Path) -> dict[str, Any]:
     env_file_path = folder_path / ".env"
     env_vars = {}
     if env_file_path.exists():
-        with open(env_file_path, "r") as file:
+        with open(env_file_path, "r", encoding="utf-8") as file:
             for line in file:
                 key, _, value = line.strip().partition("=")
                 if key and value:
@@ -132,6 +132,6 @@ def load_env_vars(folder_path: Path) -> dict[str, Any]:
 def write_env_file(folder_path: Path, env_vars: dict[str, Any]) -> None:
     """Writes environment variables to a .env file in the specified folder."""
     env_file_path = folder_path / ".env"
-    with open(env_file_path, "w") as file:
+    with open(env_file_path, "w", encoding="utf-8") as file:
         for key, value in env_vars.items():
             file.write(f"{key.upper()}={value}\n")

--- a/lib/crewai-core/src/crewai_core/project.py
+++ b/lib/crewai-core/src/crewai_core/project.py
@@ -46,7 +46,7 @@ def _get_project_attribute(
     attribute = None
 
     try:
-        with open(pyproject_path, "r") as f:
+        with open(pyproject_path, "r", encoding="utf-8") as f:
             pyproject_content = parse_toml(f.read())
 
         dependencies = (


### PR DESCRIPTION
## What

Several text-mode `open()` calls in the CLI and `crewai_core` packages don't pass an explicit `encoding=` argument, so Python uses the platform default (`locale.getpreferredencoding()`). On Windows this is typically `cp1252`; on Linux/macOS it's `utf-8`. `.env` files, model-cache files, copied templates and `pyproject.toml` read/written through these paths can become unreadable when shared between platforms or written on a non-utf-8 locale.

## Why

- Reliability across Windows / Linux / macOS / Docker — `.env` files in particular are user-edited and frequently round-tripped between machines.
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behaviour change on systems where the default is already utf-8.

## Changes

Added `encoding="utf-8"` to text-mode `open()` calls in:

- `lib/cli/src/crewai_cli/create_crew.py` — template reader (1 site)
- `lib/cli/src/crewai_cli/create_flow.py` — `.env` writer and destination-file writer (2 sites)
- `lib/cli/src/crewai_cli/provider.py` — model provider cache (2 sites)
- `lib/cli/src/crewai_cli/utils.py` — `.env` and copy helpers (6 sites)
- `lib/crewai-core/src/crewai_core/project.py` — `pyproject.toml` reader (1 site)

Total: 12 sites across 5 files, +12/-12 lines. Scope intentionally limited to the CLI + core paths where encoding mismatch bites hardest; the experimental/tools text-mode opens can be a separate follow-up if you'd like.

## Testing

Pure keyword-argument addition to `open()` calls; no logic touched. Verified all 5 files parse cleanly with `python -m py_compile`. The files were already being read/written as utf-8 in practice on Linux/macOS CI — this just makes it explicit and portable to Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file encoding throughout the CLI and core modules to explicitly use UTF-8 standard. This ensures consistent handling of configuration files, environment settings, and project data across all operating systems, preventing encoding-related failures that could occur from platform-specific defaults and improving cross-platform reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->