### PR TITLE
feat(crewai-tools): add ScalekitTool for OAuth-based tool execution

### DIFF
--- a/docs/en/tools/automation/overview.mdx
+++ b/docs/en/tools/automation/overview.mdx
@@ -22,6 +22,10 @@ These tools enable your agents to automate workflows, integrate with external pl
     Automate browser interactions and web-based workflows.
   </Card>
 
+  <Card title="Scalekit Tool" icon="key" href="/en/tools/automation/scalekittool">
+    Execute OAuth-authenticated actions across 100+ connectors and 3,000+ tools via Scalekit.
+  </Card>
+
   <Card title="Zapier Actions Adapter" icon="bolt" href="/en/tools/automation/zapieractionstool">
     Expose Zapier Actions as CrewAI tools for automation across thousands of apps.
   </Card>

--- a/docs/en/tools/automation/scalekittool.mdx
+++ b/docs/en/tools/automation/scalekittool.mdx
@@ -1,0 +1,103 @@
+---
+title: Scalekit Tool
+description: Scalekit provides OAuth-based tool execution across 100+ connectors and 3,000+ tools for AI agents.
+icon: key
+mode: "wide"
+---
+
+# `ScalekitTool`
+
+## Description
+[Scalekit](https://scalekit.com) is an agent authentication platform that lets your AI agents call third-party APIs on behalf of authenticated users. Key features include:
+
+- **OAuth Lifecycle Management**: Handles token acquisition, refresh, and storage for 100+ connectors
+- **3,000+ Pre-built Tools**: Gmail, Slack, GitHub, Notion, Salesforce, and more
+- **User-scoped Execution**: Each tool call runs with the authenticated user's credentials
+
+## Installation
+
+To incorporate Scalekit tools into your project, follow the instructions below:
+
+```shell
+pip install scalekit-sdk-python
+pip install 'crewai[tools]'
+```
+
+After installation, set your Scalekit credentials as environment variables. Get these from [Scalekit Dashboard](https://app.scalekit.com) → **Developers** → **API Credentials**:
+
+```bash
+export SCALEKIT_ENV_URL="https://your-project.scalekit.cloud"
+export SCALEKIT_CLIENT_ID="skc_..."
+export SCALEKIT_CLIENT_SECRET="test_..."
+```
+
+## Example
+
+The following example demonstrates how to initialize the tool and execute Gmail actions:
+
+1. Create tools from a connection
+
+```python Code
+from crewai_tools import ScalekitTool
+from crewai import Agent, Task, Crew
+
+# Get all Gmail tools for a user
+tools = ScalekitTool.from_connection(
+    "gmail",
+    identifier="user@example.com",
+)
+```
+
+2. Or create a single specific tool
+
+```python Code
+draft_tool = ScalekitTool.from_tool(
+    tool_name="gmail_create_draft",
+    identifier="user@example.com",
+)
+```
+
+3. Define agent
+
+```python Code
+agent = Agent(
+    role="Email Assistant",
+    goal="Help manage emails and draft responses",
+    backstory=(
+        "You are an AI agent that helps users manage their email. "
+        "You can read, draft, and organize emails on behalf of users."
+    ),
+    verbose=True,
+    tools=tools,
+)
+```
+
+4. Execute task
+
+```python Code
+task = Task(
+    description="Draft a reply to the latest unread email",
+    agent=agent,
+    expected_output="Confirmation that the draft was created",
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+crew.kickoff()
+```
+
+### Multiple connections
+
+You can combine tools from multiple connections in a single call:
+
+```python Code
+tools = ScalekitTool.from_connection(
+    "gmail", "slack", "github-prod",
+    identifier="user@example.com",
+)
+```
+
+## Connected Accounts
+
+Before using ScalekitTool, ensure users have connected their accounts through Scalekit. Use the Scalekit Dashboard → **AgentKit** → **Connections** to set up OAuth connections for the providers your agents need.
+
+* More details at [Scalekit AgentKit Docs](https://docs.scalekit.com)

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -92,6 +92,9 @@ qdrant-client = [
 apify = [
     "langchain-apify>=0.1.2,<1.0.0",
 ]
+scalekit = [
+    "scalekit-sdk-python>=2.0.0",
+]
 
 databricks-sdk = [
     "databricks-sdk>=0.46.0",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -144,6 +144,7 @@ from crewai_tools.tools.qdrant_vector_search_tool.qdrant_search_tool import (
     QdrantVectorSearchTool,
 )
 from crewai_tools.tools.rag.rag_tool import RagTool
+from crewai_tools.tools.scalekit_tool.scalekit_tool import ScalekitTool
 from crewai_tools.tools.scrape_element_from_website.scrape_element_from_website import (
     ScrapeElementFromWebsiteTool,
 )
@@ -295,6 +296,7 @@ __all__ = [
     "RagTool",
     "S3ReaderTool",
     "S3WriterTool",
+    "ScalekitTool",
     "ScrapeElementFromWebsiteTool",
     "ScrapeWebsiteTool",
     "ScrapegraphScrapeTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/README.md
@@ -1,0 +1,94 @@
+# ScalekitTool Documentation
+
+## Description
+
+This tool is a wrapper around the [Scalekit](https://scalekit.com) AgentKit SDK and gives your agent access to OAuth-authenticated tools across 50+ providers (Gmail, Slack, GitHub, Notion, Salesforce, and more).
+
+Scalekit handles OAuth token management, refresh flows, and connected account lifecycle so your agents can focus on executing actions.
+
+## Installation
+
+To incorporate this tool into your project, follow the installation instructions below:
+
+```shell
+pip install scalekit-sdk-python
+pip install 'crewai[tools]'
+```
+
+After installation, set your Scalekit credentials as environment variables. Get these from [Scalekit Dashboard](https://app.scalekit.com) → **Developers** → **API Credentials**:
+
+```bash
+export SCALEKIT_ENV_URL="https://your-project.scalekit.cloud"
+export SCALEKIT_CLIENT_ID="skc_..."
+export SCALEKIT_CLIENT_SECRET="test_..."
+```
+
+## Example
+
+The following example demonstrates how to initialize the tool and execute Gmail actions:
+
+### 1. Create tools from a connection
+
+```python
+from crewai_tools import ScalekitTool
+from crewai import Agent, Task
+
+# Get all Gmail tools for a user
+tools = ScalekitTool.from_connection(
+    "gmail",
+    identifier="user@example.com",
+)
+```
+
+Or create a single specific tool:
+
+```python
+draft_tool = ScalekitTool.from_tool(
+    tool_name="gmail_create_draft",
+    identifier="user@example.com",
+)
+```
+
+### 2. Define agent
+
+```python
+agent = Agent(
+    role="Email Assistant",
+    goal="Help manage emails and draft responses",
+    backstory=(
+        "You are an AI agent that helps users manage their email. "
+        "You can read, draft, and organize emails on behalf of users."
+    ),
+    verbose=True,
+    tools=tools,
+)
+```
+
+### 3. Execute task
+
+```python
+task = Task(
+    description="Draft a reply to the latest unread email",
+    agent=agent,
+    expected_output="Confirmation that the draft was created",
+)
+
+task.execute()
+```
+
+### Multiple providers
+
+You can combine tools from multiple connections:
+
+```python
+tools = ScalekitTool.from_connection(
+    "gmail", "slack", "github-prod",
+    identifier="user@example.com",
+)
+```
+
+## Connected Accounts
+
+Before using ScalekitTool, ensure the user has connected their accounts through Scalekit. Use the Scalekit Dashboard → **AgentKit** → **Connections** to set up OAuth connections for providers your agents need.
+
+* More details at [Scalekit AgentKit Docs](https://docs.scalekit.com)

--- a/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This tool is a wrapper around the [Scalekit](https://scalekit.com) AgentKit SDK and gives your agent access to OAuth-authenticated tools across 50+ providers (Gmail, Slack, GitHub, Notion, Salesforce, and more).
+This tool is a wrapper around the [Scalekit](https://scalekit.com) AgentKit SDK and gives your agent access to OAuth-authenticated actions across 100+ connectors and 3,000+ tools (Gmail, Slack, GitHub, Notion, Salesforce, and more).
 
 Scalekit handles OAuth token management, refresh flows, and connected account lifecycle so your agents can focus on executing actions.
 

--- a/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
@@ -1,0 +1,283 @@
+"""Scalekit AgentKit tools wrapper for CrewAI.
+
+Scalekit provides OAuth-based tool execution for 50+ providers (Gmail,
+Slack, GitHub, Notion, Salesforce, etc.). This wrapper converts Scalekit
+tools into CrewAI ``BaseTool`` instances so agents can call third-party
+APIs on behalf of authenticated users.
+"""
+
+import os
+import typing as t
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel as PydanticBaseModel, Field, create_model
+import typing_extensions as te
+
+
+class ScalekitTool(BaseTool):
+    """Wrapper for Scalekit AgentKit tools."""
+
+    scalekit_action: t.Callable[..., t.Any]
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="SCALEKIT_ENV_URL",
+                description="Scalekit environment URL",
+                required=True,
+            ),
+            EnvVar(
+                name="SCALEKIT_CLIENT_ID",
+                description="Scalekit client ID",
+                required=True,
+            ),
+            EnvVar(
+                name="SCALEKIT_CLIENT_SECRET",
+                description="Scalekit client secret",
+                required=True,
+            ),
+        ]
+    )
+
+    def _run(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        """Run the Scalekit tool action with given arguments."""
+        return self.scalekit_action(**kwargs)
+
+    @staticmethod
+    def _get_client() -> t.Any:
+        """Create a ScalekitClient from environment variables."""
+        from scalekit import ScalekitClient
+
+        env_url = os.environ.get("SCALEKIT_ENV_URL")
+        client_id = os.environ.get("SCALEKIT_CLIENT_ID")
+        client_secret = os.environ.get("SCALEKIT_CLIENT_SECRET")
+
+        if not all([env_url, client_id, client_secret]):
+            raise ValueError(
+                "Missing Scalekit credentials. Set SCALEKIT_ENV_URL, "
+                "SCALEKIT_CLIENT_ID, and SCALEKIT_CLIENT_SECRET environment "
+                "variables. Get these from Scalekit Dashboard \u2192 Developers \u2192 "
+                "API Credentials."
+            )
+
+        return ScalekitClient(env_url, client_id, client_secret)
+
+    @classmethod
+    def from_tool(
+        cls,
+        tool_name: str,
+        identifier: str,
+        connected_account_id: t.Optional[str] = None,
+        connection_name: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> te.Self:
+        """Wrap a single Scalekit tool as a CrewAI tool.
+
+        Args:
+            tool_name: The Scalekit tool name, e.g. ``"gmail_create_draft"``.
+            identifier: The connected account identifier (e.g. user email or
+                an opaque user id).
+            connected_account_id: Optional connected account ID. When omitted,
+                the first matching account for the identifier is used.
+            connection_name: Optional connection name for account resolution.
+            **kwargs: Additional arguments forwarded to ``BaseTool``.
+
+        Returns:
+            A ``ScalekitTool`` instance ready for use with a CrewAI agent.
+        """
+        from scalekit.v1.tools.tools_pb2 import ScopedToolFilter
+        from scalekit.actions.frameworks.util import extract_tool_metadata
+
+        client = cls._get_client()
+
+        result_tuple = client.tools.list_scoped_tools(
+            identifier,
+            filter=ScopedToolFilter(tool_names=[tool_name]),
+        )
+        response = result_tuple[0]
+
+        target_tool = None
+        target_ca_id = connected_account_id
+        for scoped_tool in response.tools:
+            name, _, _ = extract_tool_metadata(scoped_tool.tool)
+            if name == tool_name:
+                target_tool = scoped_tool.tool
+                if not target_ca_id:
+                    target_ca_id = scoped_tool.connected_account_id
+                break
+
+        if target_tool is None:
+            available = [
+                extract_tool_metadata(st.tool)[0] for st in response.tools
+            ]
+            raise ValueError(
+                f"Tool '{tool_name}' not found for identifier "
+                f"'{identifier}'. Available: {available[:10]}"
+            )
+
+        name, description, definition_dict = extract_tool_metadata(target_tool)
+        input_schema = definition_dict.get("input_schema", {})
+        args_schema = _json_schema_to_pydantic(name, input_schema)
+
+        def execute(**arguments: t.Any) -> str:
+            resp = client.actions.execute_tool(
+                tool_input=arguments,
+                tool_name=name,
+                identifier=identifier,
+                connected_account_id=target_ca_id,
+                connection_name=connection_name,
+            )
+            result_data = resp.data if hasattr(resp, "data") else {}
+            result_dict = dict(result_data) if result_data else {}
+            execution_id = getattr(resp, "execution_id", None)
+            if execution_id:
+                result_dict["execution_id"] = execution_id
+            return (
+                str(result_dict)
+                if result_dict
+                else f"Tool {name} executed successfully"
+            )
+
+        execute.__name__ = name
+        execute.__doc__ = description
+
+        return cls(
+            name=name,
+            description=description,
+            args_schema=args_schema,
+            scalekit_action=execute,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_connection(
+        cls,
+        *connection_names: str,
+        identifier: str,
+        providers: t.Optional[list[str]] = None,
+        tool_names: t.Optional[list[str]] = None,
+        **kwargs: t.Any,
+    ) -> list[te.Self]:
+        """Create tools for all actions available on the given connections.
+
+        Args:
+            *connection_names: Connection names as shown in the Scalekit
+                dashboard (e.g. ``"gmail"``, ``"slack"``, ``"github-prod"``).
+            identifier: The connected account identifier.
+            providers: Optional provider name filter (e.g. ``["google"]``).
+            tool_names: Optional list of specific tool names to include.
+            **kwargs: Additional arguments forwarded to ``BaseTool``.
+
+        Returns:
+            A list of ``ScalekitTool`` instances, one per discovered tool.
+        """
+        if not connection_names and not providers and not tool_names:
+            raise ValueError(
+                "Provide at least one connection name, provider, or tool_names"
+            )
+
+        from scalekit.v1.tools.tools_pb2 import ScopedToolFilter
+        from scalekit.actions.frameworks.util import extract_tool_metadata
+
+        client = cls._get_client()
+
+        scoped_filter = ScopedToolFilter(
+            providers=list(providers or []),
+            tool_names=list(tool_names or []),
+            connection_names=list(connection_names),
+        )
+
+        result_tuple = client.tools.list_scoped_tools(
+            identifier, filter=scoped_filter
+        )
+        response = result_tuple[0]
+
+        tools: list[te.Self] = []
+        for scoped_tool in response.tools:
+            tool = scoped_tool.tool
+            ca_id = scoped_tool.connected_account_id
+
+            name, description, definition_dict = extract_tool_metadata(tool)
+            input_schema = definition_dict.get("input_schema", {})
+            args_schema = _json_schema_to_pydantic(name, input_schema)
+
+            def _make_executor(
+                t_name: str, t_ca_id: str, t_desc: str
+            ) -> t.Callable[..., str]:
+                def execute(**arguments: t.Any) -> str:
+                    resp = client.actions.execute_tool(
+                        tool_input=arguments,
+                        tool_name=t_name,
+                        identifier=identifier,
+                        connected_account_id=t_ca_id,
+                    )
+                    result_data = resp.data if hasattr(resp, "data") else {}
+                    result_dict = dict(result_data) if result_data else {}
+                    return (
+                        str(result_dict)
+                        if result_dict
+                        else f"Tool {t_name} executed successfully"
+                    )
+
+                execute.__name__ = t_name
+                execute.__doc__ = t_desc
+                return execute
+
+            tools.append(
+                cls(
+                    name=name,
+                    description=description,
+                    args_schema=args_schema,
+                    scalekit_action=_make_executor(name, ca_id, description),
+                    **kwargs,
+                )
+            )
+
+        return tools
+
+
+def _json_schema_to_pydantic(
+    tool_name: str, schema: dict[str, t.Any]
+) -> type[PydanticBaseModel]:
+    """Convert a JSON Schema dict to a Pydantic model for ``args_schema``."""
+    properties = schema.get("properties", {})
+    required_list = schema.get("required", [])
+    required = set(required_list) if isinstance(required_list, list) else set()
+
+    type_map: dict[str, type] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+    fields: dict[str, t.Any] = {}
+    for prop_name, prop_spec in properties.items():
+        if not isinstance(prop_spec, dict):
+            continue
+        prop_type = prop_spec.get("type", "string")
+        description = prop_spec.get("description", "")
+
+        # Handle union types like ["string", "null"]
+        if isinstance(prop_type, list):
+            prop_type = next((pt for pt in prop_type if pt != "null"), "string")
+
+        python_type = type_map.get(prop_type, t.Any)
+
+        if prop_name in required:
+            fields[prop_name] = (python_type, Field(description=description))
+        else:
+            fields[prop_name] = (
+                t.Optional[python_type],
+                Field(default=None, description=description),
+            )
+
+    safe_name = (
+        tool_name.replace(".", "_").replace("-", "_").title().replace("_", "")
+    )
+    return (
+        create_model(f"{safe_name}Schema", **fields)
+        if fields
+        else create_model(f"{safe_name}Schema")
+    )

--- a/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
@@ -218,6 +218,9 @@ class ScalekitTool(BaseTool):
                     )
                     result_data = resp.data if hasattr(resp, "data") else {}
                     result_dict = dict(result_data) if result_data else {}
+                    execution_id = getattr(resp, "execution_id", None)
+                    if execution_id:
+                        result_dict["execution_id"] = execution_id
                     return (
                         str(result_dict)
                         if result_dict

--- a/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py
@@ -1,9 +1,9 @@
 """Scalekit AgentKit tools wrapper for CrewAI.
 
-Scalekit provides OAuth-based tool execution for 50+ providers (Gmail,
-Slack, GitHub, Notion, Salesforce, etc.). This wrapper converts Scalekit
-tools into CrewAI ``BaseTool`` instances so agents can call third-party
-APIs on behalf of authenticated users.
+Scalekit provides OAuth-based tool execution across 100+ connectors and
+3,000+ tools (Gmail, Slack, GitHub, Notion, Salesforce, etc.). This
+wrapper converts Scalekit tools into CrewAI ``BaseTool`` instances so
+agents can call third-party APIs on behalf of authenticated users.
 """
 
 import os
@@ -89,10 +89,16 @@ class ScalekitTool(BaseTool):
 
         client = cls._get_client()
 
-        result_tuple = client.tools.list_scoped_tools(
-            identifier,
-            filter=ScopedToolFilter(tool_names=[tool_name]),
-        )
+        try:
+            result_tuple = client.tools.list_scoped_tools(
+                identifier,
+                filter=ScopedToolFilter(tool_names=[tool_name]),
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"Tool '{tool_name}' not found for identifier "
+                f"'{identifier}': {exc}"
+            ) from exc
         response = result_tuple[0]
 
         target_tool = None


### PR DESCRIPTION
## Summary

Adds `ScalekitTool` to `crewai-tools` — a wrapper around the [Scalekit](https://scalekit.com) AgentKit SDK that gives CrewAI agents access to OAuth-authenticated actions across 100+ connectors and 3,000+ tools (Gmail, Slack, GitHub, Notion, Salesforce, etc.).

Scalekit handles the full OAuth lifecycle (token acquisition, refresh, storage) so agents can call third-party APIs on behalf of authenticated users without any auth plumbing.

## What changed

### Code

- **`lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/scalekit_tool.py`**: New `ScalekitTool(BaseTool)` with two factory methods:
  - `from_tool(tool_name, identifier)` — wrap a single Scalekit tool by name
  - `from_connection(*connection_names, identifier)` — discover and wrap all tools from one or more OAuth connections
- **`lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/__init__.py`**: Empty init
- **`lib/crewai-tools/src/crewai_tools/tools/scalekit_tool/README.md`**: Usage docs with examples
- **`lib/crewai-tools/src/crewai_tools/__init__.py`**: Added `ScalekitTool` to exports
- **`lib/crewai-tools/pyproject.toml`**: Added `scalekit-sdk-python` as optional dependency

### Docs

- **`docs/en/tools/automation/scalekittool.mdx`**: New doc page following the existing tool page pattern
- **`docs/en/tools/automation/overview.mdx`**: Added Scalekit card to the Available Tools grid

### Note for maintainers

`docs/docs.json` needs a nav entry for `en/tools/automation/scalekittool` in the Automation group. The nav is repeated across 14 versions × 4 languages, so leaving that to your existing tooling.

## Design decisions

- **In-repo adapter** (same pattern as Apify, Firecrawl, Tavily, Exa, etc.) rather than a separate `scalekit-crewai` package. The SDK is an optional dependency, lazy-imported only when `ScalekitTool` is used.
- **`EnvVar` integration** for `SCALEKIT_ENV_URL`, `SCALEKIT_CLIENT_ID`, `SCALEKIT_CLIENT_SECRET`.
- **JSON Schema → Pydantic** conversion for `args_schema` so CrewAI agents get proper parameter validation and descriptions.
- Uses the SDK's own `extract_tool_metadata` util and `client.actions.execute_tool` (the `ActionClient` facade with modifier support).

## Testing

Validated against live Scalekit API. All 16 tests pass:

- **Class structure (4)** — BaseTool subclass, EnvVar wiring, factory methods, mock execution
- **JSON Schema edge cases (4)** — nullable types, empty schema, all JSON types, malformed property specs
- **Error handling (2)** — missing env vars → `ValueError`, no filters → `ValueError`
- **Live API discovery (4)** — `from_connection("gmail")` returns 10 tools, `from_tool("gmail_list_filters")` finds single tool, multi-connection (gmail + github) works, bad tool name → `ValueError`
- **Live API execution (2)** — `gmail_list_filters` and `gmail_get_vacation_settings` both returned real Gmail data via `tool.run()`

```
Results: 16 passed, 0 failed, 0 skipped (of 16)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Scalekit integration for OAuth-authenticated actions across 3,000+ tools and 100+ connectors; ScalekitTool is now available in the tools package and can wrap single or multiple connected tools.

* **Documentation**
  * Added comprehensive Scalekit docs and README with installation (optional scalekit extras), credential setup, configuration, and step‑by‑step usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->