### PR TITLE
feat(flow): log each flow method execution at INFO

### DIFF
--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -2633,6 +2633,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             the event_id of the MethodExecutionFinishedEvent, or None if events
             are suppressed.
         """
+        logger.info("Executing flow method: %s", method_name)
         try:
             dumped_params = {f"_{i}": arg for i, arg in enumerate(args)} | (
                 kwargs or {}


### PR DESCRIPTION
## Summary

Today the flow prints `Flow started with ID: …` and then nothing further until the next significant event. When a flow appears to hang, that makes it hard to tell which `@start`/`@listen` method is currently running.

This adds a single `logger.info("Executing flow method: %s", method_name)` at the entry of `_execute_method`. Both `@start` methods and listeners go through `_execute_method`, so one log line covers everything.

## Test plan
- [x] `pytest tests/test_flow.py` — 67/67 passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single additional `logger.info` call in `_execute_method` with no changes to control flow, state, or event emission; only potential impact is slightly noisier logs.
> 
> **Overview**
> Improves flow execution visibility by logging `Executing flow method: <method_name>` at INFO level at the start of `Flow._execute_method`, covering both `@start` and `@listen` (and router) method executions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2163cff4d1bfec3b0fab8ee198d0c43a8c6bf155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging to track execution flow initiation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->