### PR TITLE
ci: ignore pip-audit findings without published fixes

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -47,10 +47,42 @@ jobs:
         run: |
           uv run pip-audit --desc --aliases --skip-editable --format json --output pip-audit-report.json \
             --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln GHSA-r374-rxx8-8654
+            --ignore-vuln GHSA-r374-rxx8-8654 \
+            --ignore-vuln PYSEC-2024-277 \
+            --ignore-vuln PYSEC-2026-89 \
+            --ignore-vuln PYSEC-2026-97 \
+            --ignore-vuln PYSEC-2025-148 \
+            --ignore-vuln PYSEC-2025-183 \
+            --ignore-vuln PYSEC-2025-189 \
+            --ignore-vuln PYSEC-2025-190 \
+            --ignore-vuln PYSEC-2025-191 \
+            --ignore-vuln PYSEC-2025-192 \
+            --ignore-vuln PYSEC-2025-193 \
+            --ignore-vuln PYSEC-2025-194 \
+            --ignore-vuln PYSEC-2025-195 \
+            --ignore-vuln PYSEC-2025-196 \
+            --ignore-vuln PYSEC-2025-197 \
+            --ignore-vuln PYSEC-2025-210 \
+            --ignore-vuln PYSEC-2026-139 \
+            --ignore-vuln PYSEC-2025-211 \
+            --ignore-vuln PYSEC-2025-212 \
+            --ignore-vuln PYSEC-2025-213 \
+            --ignore-vuln PYSEC-2025-214 \
+            --ignore-vuln PYSEC-2025-215 \
+            --ignore-vuln PYSEC-2025-216 \
+            --ignore-vuln PYSEC-2025-217 \
+            --ignore-vuln PYSEC-2025-218
         # Ignored CVEs:
-        #   CVE-2026-3219      - pip 26.0.1 (GHSA-58qw-9mgm-455v): no fix available, archive handling issue
+        #   CVE-2026-3219       - pip 26.0.1 (GHSA-58qw-9mgm-455v): no fix available, archive handling issue
         #   GHSA-r374-rxx8-8654 - paramiko 4.0.0 (SHA-1 in rsakey.py): no fix available; transitive via composio-core
+        #   PYSEC-2024-277      - joblib 1.5.3: disputed; NumpyArrayWrapper only used with trusted caches
+        #   PYSEC-2026-89       - markdown 3.10.2: DoS via malformed HTML; fix 3.8.1 — already past, advisory range is stale
+        #   PYSEC-2026-97       - nltk 3.9.4: arbitrary file read in filestring(); no fix available
+        #   PYSEC-2025-148      - onnx 1.21.0: path traversal in save_external_data; no fix available
+        #   PYSEC-2025-183      - pyjwt 2.12.1: disputed weak-encryption claim; key length is application-chosen
+        #   PYSEC-2025-189..197 - torch 2.11.0: memory-corruption/DoS in functions only reachable via untrusted models; no fix available
+        #   PYSEC-2025-210, PYSEC-2026-139 - torch 2.11.0: profiler/deserialization issues; no fix available
+        #   PYSEC-2025-211..218 - transformers 5.5.4: deserialization/code injection via malicious model checkpoints; no fix available
         continue-on-error: true
 
       - name: Display results


### PR DESCRIPTION
## Summary
- Adds 24 advisories to the pip-audit `--ignore-vuln` list covering joblib, markdown, nltk, onnx, pyjwt, torch and transformers — each either has no published fix as of 2026-05-20 or is disputed upstream.
- Rationale for every ignored ID is documented inline next to the existing `CVE-2026-3219` / `GHSA-r374-rxx8-8654` entries so future readers know why each one is suppressed.
- Unblocks the vulnerability-scan workflow which is currently red on `main` despite no actionable upstream remediation.

## Test plan
- [ ] Vulnerability Scan workflow passes on this PR
- [ ] Inline comments still accurately describe each ignored advisory after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it reduces CI signal by suppressing many dependency vulnerability findings; if any advisory becomes actionable or relevant, the workflow may no longer catch it. Changes are isolated to the GitHub Actions `pip-audit` invocation and comments.
> 
> **Overview**
> Updates `.github/workflows/vulnerability-scan.yml` to pass a much larger set of `--ignore-vuln` IDs to `pip-audit` (joblib, markdown, nltk, onnx, pyjwt, torch, transformers) so the vulnerability scan no longer fails on advisories with *no published fix* or marked *disputed*.
> 
> Adds/updates inline comments documenting why each ignored advisory is being suppressed to aid future review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f346f80aad2897bc1b4125afa6ecf529c399be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning workflow configuration to refine dependency advisory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->