### PR TITLE
fix: harden RuntimeState serialization across entity fields

### DIFF
--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -127,6 +127,13 @@ def _validate_executor_ref(value: Any) -> Any:
     return value
 
 
+def _serialize_executor_ref(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    result: dict[str, Any] = value.model_dump(mode="json")
+    return result
+
+
 def _serialize_llm_ref(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
@@ -251,14 +258,13 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
     max_iter: int = Field(
         default=25, description="Maximum iterations for an agent to execute a task"
     )
-    agent_executor: SerializeAsAny[BaseAgentExecutor] | None = Field(
-        default=None, description="An instance of the CrewAgentExecutor class."
-    )
-
-    @field_validator("agent_executor", mode="before")
-    @classmethod
-    def _validate_agent_executor(cls, v: Any) -> Any:
-        return _validate_executor_ref(v)
+    agent_executor: Annotated[
+        SerializeAsAny[BaseAgentExecutor] | None,
+        BeforeValidator(_validate_executor_ref),
+        PlainSerializer(
+            _serialize_executor_ref, return_type=dict | None, when_used="json"
+        ),
+    ] = Field(default=None, description="An instance of the CrewAgentExecutor class.")
 
     llm: Annotated[
         str | BaseLLM | None,
@@ -326,7 +332,13 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
         default=None,
         description="List of MCP server references. Supports 'https://server.com/path' for external servers and bare slugs like 'notion' for connected MCP integrations. Use '#tool_name' suffix for specific tools.",
     )
-    memory: bool | Memory | MemoryScope | MemorySlice | None = Field(
+    memory: (
+        bool
+        | Annotated[
+            Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
+        ]
+        | None
+    ) = Field(
         default=None,
         description=(
             "Enable agent memory. Pass True for default Memory(), "

--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -410,7 +410,20 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
             self.agent_executor._resuming = True
         if self.checkpoint_kickoff_event_id is not None:
             self._kickoff_event_id = self.checkpoint_kickoff_event_id
+        self._rebind_memory_view()
         self._restore_event_scope(state)
+
+    def _rebind_memory_view(self) -> None:
+        """Reattach a fresh ``Memory`` to a restored ``MemoryScope``/``MemorySlice``.
+
+        Checkpoint JSON omits the live ``Memory`` dependency, so scoped
+        memory views raise ``RuntimeError`` on first use after restore.
+        """
+        if (
+            isinstance(self.memory, MemoryScope | MemorySlice)
+            and self.memory._memory is None
+        ):
+            self.memory.bind(Memory())
 
     def _restore_event_scope(self, state: RuntimeState) -> None:
         """Rebuild the event scope stack from the checkpoint's event record.

--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -31,7 +31,7 @@ from crewai.agents.tools_handler import ToolsHandler
 from crewai.events.base_events import set_emission_counter
 from crewai.events.event_bus import crewai_event_bus
 from crewai.events.event_context import restore_event_scope, set_last_event_id
-from crewai.knowledge.knowledge import Knowledge
+from crewai.knowledge.knowledge import Knowledge, _resolve_knowledge_sources
 from crewai.knowledge.knowledge_config import KnowledgeConfig
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
@@ -294,7 +294,10 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
     knowledge: Knowledge | None = Field(
         default=None, description="Knowledge for the agent."
     )
-    knowledge_sources: list[BaseKnowledgeSource] | None = Field(
+    knowledge_sources: Annotated[
+        list[BaseKnowledgeSource] | None,
+        BeforeValidator(_resolve_knowledge_sources),
+    ] = Field(
         default=None,
         description="Knowledge sources for the agent.",
     )

--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -37,7 +37,7 @@ from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
 from crewai.llms.base_llm import BaseLLM
 from crewai.mcp.config import MCPServerConfig
-from crewai.memory.memory_scope import MemoryScope, MemorySlice
+from crewai.memory.memory_scope import MemoryScope, MemorySlice, _ensure_memory_kind
 from crewai.memory.unified_memory import Memory
 from crewai.rag.embeddings.types import EmbedderConfig
 from crewai.security.security_config import SecurityConfig
@@ -332,13 +332,14 @@ class BaseAgent(BaseModel, ABC, metaclass=AgentMeta):
         default=None,
         description="List of MCP server references. Supports 'https://server.com/path' for external servers and bare slugs like 'notion' for connected MCP integrations. Use '#tool_name' suffix for specific tools.",
     )
-    memory: (
+    memory: Annotated[
         bool
         | Annotated[
             Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
         ]
-        | None
-    ) = Field(
+        | None,
+        BeforeValidator(_ensure_memory_kind),
+    ] = Field(
         default=None,
         description=(
             "Enable agent memory. Pass True for default Memory(), "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -93,7 +93,7 @@ from crewai.events.types.crew_events import (
     CrewTrainStartedEvent,
 )
 from crewai.flow.flow_trackable import FlowTrackable
-from crewai.knowledge.knowledge import Knowledge
+from crewai.knowledge.knowledge import Knowledge, _resolve_knowledge_sources
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.llm import LLM
 from crewai.llms.base_llm import BaseLLM
@@ -329,7 +329,10 @@ class Crew(FlowTrackable, BaseModel):
         default_factory=list,
         description="list of execution logs for tasks",
     )
-    knowledge_sources: list[BaseKnowledgeSource] | None = Field(
+    knowledge_sources: Annotated[
+        list[BaseKnowledgeSource] | None,
+        BeforeValidator(_resolve_knowledge_sources),
+    ] = Field(
         default=None,
         description=(
             "Knowledge sources for the crew. Add knowledge sources to the "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -492,23 +492,29 @@ class Crew(FlowTrackable, BaseModel):
 
         Checkpoint JSON omits the live ``Memory`` dependency on scope/slice
         views, so after restore they raise ``RuntimeError`` on first use.
-        Build a fresh ``Memory`` and bind it to any unbound views on the
-        crew and its agents.
+        Prefer the crew's restored ``Memory`` (from ``create_crew_memory``
+        or a ``Crew.memory=Memory(...)`` instance) so all views share one
+        backing store; fall back to a fresh ``Memory()`` only if nothing is
+        available.
         """
         from crewai.memory.memory_scope import MemoryScope, MemorySlice
         from crewai.memory.unified_memory import Memory
 
-        fresh: Memory | None = None
+        backing: Memory | None = None
+        if isinstance(self._memory, Memory):
+            backing = self._memory
+        elif isinstance(self.memory, Memory):
+            backing = self.memory
 
         def _ensure(view: Any) -> None:
-            nonlocal fresh
+            nonlocal backing
             if not isinstance(view, MemoryScope | MemorySlice):
                 return
             if view._memory is not None:
                 return
-            if fresh is None:
-                fresh = Memory()
-            view.bind(fresh)
+            if backing is None:
+                backing = Memory()
+            view.bind(backing)
 
         _ensure(self.memory)
         for agent in self.agents:

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -223,7 +223,13 @@ class Crew(FlowTrackable, BaseModel):
     ] = Field(default_factory=list)
     process: Process = Field(default=Process.sequential)
     verbose: bool = Field(default=False)
-    memory: bool | Memory | MemoryScope | MemorySlice | None = Field(
+    memory: (
+        bool
+        | Annotated[
+            Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
+        ]
+        | None
+    ) = Field(
         default=False,
         description=(
             "Enable crew memory. Pass True for default Memory(), "

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -484,7 +484,35 @@ class Crew(FlowTrackable, BaseModel):
         if self.checkpoint_train is not None:
             self._train = self.checkpoint_train
 
+        self._rebind_memory_views()
         self._restore_event_scope()
+
+    def _rebind_memory_views(self) -> None:
+        """Reattach a live ``Memory`` to restored ``MemoryScope``/``MemorySlice`` views.
+
+        Checkpoint JSON omits the live ``Memory`` dependency on scope/slice
+        views, so after restore they raise ``RuntimeError`` on first use.
+        Build a fresh ``Memory`` and bind it to any unbound views on the
+        crew and its agents.
+        """
+        from crewai.memory.memory_scope import MemoryScope, MemorySlice
+        from crewai.memory.unified_memory import Memory
+
+        fresh: Memory | None = None
+
+        def _ensure(view: Any) -> None:
+            nonlocal fresh
+            if not isinstance(view, MemoryScope | MemorySlice):
+                return
+            if view._memory is not None:
+                return
+            if fresh is None:
+                fresh = Memory()
+            view.bind(fresh)
+
+        _ensure(self.memory)
+        for agent in self.agents:
+            _ensure(agent.memory)
 
     def _restore_event_scope(self) -> None:
         """Rebuild the event scope stack from the checkpoint's event record."""

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -97,7 +97,7 @@ from crewai.knowledge.knowledge import Knowledge
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.llm import LLM
 from crewai.llms.base_llm import BaseLLM
-from crewai.memory.memory_scope import MemoryScope, MemorySlice
+from crewai.memory.memory_scope import MemoryScope, MemorySlice, _ensure_memory_kind
 from crewai.memory.unified_memory import Memory
 from crewai.process import Process
 from crewai.rag.embeddings.types import EmbedderConfig
@@ -223,13 +223,14 @@ class Crew(FlowTrackable, BaseModel):
     ] = Field(default_factory=list)
     process: Process = Field(default=Process.sequential)
     verbose: bool = Field(default=False)
-    memory: (
+    memory: Annotated[
         bool
         | Annotated[
             Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
         ]
-        | None
-    ) = Field(
+        | None,
+        BeforeValidator(_ensure_memory_kind),
+    ] = Field(
         default=False,
         description=(
             "Enable crew memory. Pass True for default Memory(), "

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -113,7 +113,7 @@ from crewai.flow.utils import (
     is_flow_method_name,
     is_simple_flow_condition,
 )
-from crewai.memory.memory_scope import MemoryScope, MemorySlice
+from crewai.memory.memory_scope import MemoryScope, MemorySlice, _ensure_memory_kind
 from crewai.memory.unified_memory import Memory
 from crewai.state.checkpoint_config import (
     CheckpointConfig,
@@ -164,7 +164,10 @@ def _serialize_persistence(value: Any) -> dict[str, Any] | None:
         return None
     if isinstance(value, FlowPersistence):
         return value.model_dump(mode="json")
-    return None
+    raise TypeError(
+        f"Cannot serialize Flow.persistence of type {type(value).__name__}: "
+        "expected FlowPersistence or None."
+    )
 
 
 def _validate_input_provider(value: Any) -> Any:
@@ -979,12 +982,13 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
     name: str | None = Field(default=None)
     tracing: bool | None = Field(default=None)
     stream: bool = Field(default=False)
-    memory: (
+    memory: Annotated[
         Annotated[
             Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
         ]
-        | None
-    ) = Field(default=None)
+        | None,
+        BeforeValidator(_ensure_memory_kind),
+    ] = Field(default=None)
     input_provider: Annotated[
         InputProvider | None,
         BeforeValidator(_validate_input_provider),

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -1098,6 +1098,11 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             }
         if self.checkpoint_state is not None:
             self._restore_state(self.checkpoint_state)
+        if (
+            isinstance(self.memory, MemoryScope | MemorySlice)
+            and self.memory._memory is None
+        ):
+            self.memory.bind(Memory())
         restore_event_scope(())
         reset_last_event_id()
 

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -120,7 +120,6 @@ from crewai.state.checkpoint_config import (
     _coerce_checkpoint,
     apply_checkpoint,
 )
-from crewai.types.callback import SerializableInstance
 
 
 if TYPE_CHECKING:
@@ -166,6 +165,28 @@ def _serialize_persistence(value: Any) -> dict[str, Any] | None:
     if isinstance(value, FlowPersistence):
         return value.model_dump(mode="json")
     return None
+
+
+def _validate_input_provider(value: Any) -> Any:
+    if value is None or isinstance(value, InputProvider):
+        return value
+    from crewai.types.callback import _dotted_path_to_instance
+
+    resolved = _dotted_path_to_instance(value)
+    if resolved is None or isinstance(resolved, InputProvider):
+        return resolved
+    raise ValueError(
+        f"Resolved input_provider {resolved!r} does not implement the "
+        "InputProvider protocol (missing request_input)."
+    )
+
+
+def _serialize_input_provider(value: Any) -> str | None:
+    if value is None:
+        return None
+    from crewai.types.callback import _instance_to_dotted_path
+
+    return _instance_to_dotted_path(value)
 
 
 _INITIAL_STATE_CLASS_MARKER = "__crewai_pydantic_class_schema__"
@@ -964,7 +985,13 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
         ]
         | None
     ) = Field(default=None)
-    input_provider: SerializableInstance | None = Field(default=None)
+    input_provider: Annotated[
+        InputProvider | None,
+        BeforeValidator(_validate_input_provider),
+        PlainSerializer(
+            _serialize_input_provider, return_type=str | None, when_used="json"
+        ),
+    ] = Field(default=None)
     suppress_flow_events: bool = Field(default=False)
     human_feedback_history: list[HumanFeedbackResult] = Field(default_factory=list)
     last_human_feedback: HumanFeedbackResult | None = Field(default=None)
@@ -3189,7 +3216,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
         from crewai.flow.flow_config import flow_config
 
         if self.input_provider is not None:
-            return cast(InputProvider, self.input_provider)
+            return self.input_provider
         if flow_config.input_provider is not None:
             return flow_config.input_provider
         return ConsoleProvider()

--- a/lib/crewai/src/crewai/flow/flow.py
+++ b/lib/crewai/src/crewai/flow/flow.py
@@ -120,6 +120,7 @@ from crewai.state.checkpoint_config import (
     _coerce_checkpoint,
     apply_checkpoint,
 )
+from crewai.types.callback import SerializableInstance
 
 
 if TYPE_CHECKING:
@@ -157,6 +158,14 @@ def _resolve_persistence(value: Any) -> Any:
         if cls is not None:
             return cls.model_validate(value)
     return value
+
+
+def _serialize_persistence(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, FlowPersistence):
+        return value.model_dump(mode="json")
+    return None
 
 
 _INITIAL_STATE_CLASS_MARKER = "__crewai_pydantic_class_schema__"
@@ -949,15 +958,23 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
     name: str | None = Field(default=None)
     tracing: bool | None = Field(default=None)
     stream: bool = Field(default=False)
-    memory: Memory | MemoryScope | MemorySlice | None = Field(default=None)
-    input_provider: InputProvider | None = Field(default=None)
+    memory: (
+        Annotated[
+            Memory | MemoryScope | MemorySlice, Field(discriminator="memory_kind")
+        ]
+        | None
+    ) = Field(default=None)
+    input_provider: SerializableInstance | None = Field(default=None)
     suppress_flow_events: bool = Field(default=False)
     human_feedback_history: list[HumanFeedbackResult] = Field(default_factory=list)
     last_human_feedback: HumanFeedbackResult | None = Field(default=None)
 
     persistence: Annotated[
-        SerializeAsAny[FlowPersistence] | Any,
+        SerializeAsAny[FlowPersistence] | None,
         BeforeValidator(lambda v, _: _resolve_persistence(v)),
+        PlainSerializer(
+            _serialize_persistence, return_type=dict | None, when_used="json"
+        ),
     ] = Field(default=None)
     max_method_calls: int = Field(default=100)
 
@@ -3172,7 +3189,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
         from crewai.flow.flow_config import flow_config
 
         if self.input_provider is not None:
-            return self.input_provider
+            return cast(InputProvider, self.input_provider)
         if flow_config.input_provider is not None:
             return flow_config.input_provider
         return ConsoleProvider()

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -83,7 +83,9 @@ def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
 def _validate_embedder_spec(value: Any) -> Any:
     """Resolve provider_class dotted-path dicts back to a class on restore."""
     if isinstance(value, dict) and set(value.keys()) == {"provider_class"}:
-        if not os.environ.get("CREWAI_DESERIALIZE_CALLBACKS"):
+        from crewai.types.callback import _trusted_deserialize
+
+        if not _trusted_deserialize():
             raise ValueError(
                 f"Refusing to resolve embedder provider_class "
                 f"{value['provider_class']!r}: set "

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -63,7 +63,10 @@ def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
         return {"provider_class": f"{value.__module__}.{value.__qualname__}"}
     if isinstance(value, dict):
         return value
-    return None
+    raise TypeError(
+        f"Cannot serialize embedder of type {type(value).__name__}: "
+        "expected ProviderSpec dict, BaseEmbeddingsProvider instance, or subclass."
+    )
 
 
 class Knowledge(BaseModel):

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -1,14 +1,69 @@
 import os
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, PlainSerializer
 
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
+from crewai.knowledge.source.crew_docling_source import CrewDoclingSource
+from crewai.knowledge.source.csv_knowledge_source import CSVKnowledgeSource
+from crewai.knowledge.source.excel_knowledge_source import ExcelKnowledgeSource
+from crewai.knowledge.source.json_knowledge_source import JSONKnowledgeSource
+from crewai.knowledge.source.pdf_knowledge_source import PDFKnowledgeSource
+from crewai.knowledge.source.string_knowledge_source import StringKnowledgeSource
+from crewai.knowledge.source.text_file_knowledge_source import (
+    TextFileKnowledgeSource,
+)
 from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
+from crewai.rag.core.base_embeddings_provider import BaseEmbeddingsProvider
 from crewai.rag.embeddings.types import EmbedderConfig
 from crewai.rag.types import SearchResult
 
 
+_KNOWN_SOURCES: dict[str, type[BaseKnowledgeSource]] = {
+    "string": StringKnowledgeSource,
+    "docling": CrewDoclingSource,
+    "csv": CSVKnowledgeSource,
+    "excel": ExcelKnowledgeSource,
+    "json": JSONKnowledgeSource,
+    "pdf": PDFKnowledgeSource,
+    "text_file": TextFileKnowledgeSource,
+}
+
+
+def _resolve_knowledge_sources(value: Any) -> Any:
+    """Coerce list of dicts into typed BaseKnowledgeSource subclasses via source_type.
+
+    Pass-through for anything else (existing instances, mocks).
+    """
+    if not isinstance(value, list):
+        return value
+    resolved: list[Any] = []
+    for item in value:
+        if isinstance(item, dict):
+            tag = item.get("source_type")
+            cls = _KNOWN_SOURCES.get(tag) if isinstance(tag, str) else None
+            if cls is None:
+                resolved.append(item)
+            else:
+                resolved.append(cls.model_validate(item))
+        else:
+            resolved.append(item)
+    return resolved
+
+
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # removes logging from fastembed
+
+
+def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, BaseEmbeddingsProvider):
+        return value.model_dump(mode="json")
+    if isinstance(value, type) and issubclass(value, BaseEmbeddingsProvider):
+        return {"provider_class": f"{value.__module__}.{value.__qualname__}"}
+    if isinstance(value, dict):
+        return value
+    return None
 
 
 class Knowledge(BaseModel):
@@ -20,10 +75,18 @@ class Knowledge(BaseModel):
         embedder: EmbedderConfig | None = None
     """
 
-    sources: list[BaseKnowledgeSource] = Field(default_factory=list)
+    sources: Annotated[
+        list[BaseKnowledgeSource],
+        BeforeValidator(_resolve_knowledge_sources),
+    ] = Field(default_factory=list)
     model_config = ConfigDict(arbitrary_types_allowed=True)
     storage: KnowledgeStorage | None = Field(default=None)
-    embedder: EmbedderConfig | None = None
+    embedder: Annotated[
+        EmbedderConfig | None,
+        PlainSerializer(
+            _serialize_embedder_spec, return_type=dict | None, when_used="json"
+        ),
+    ] = None
     collection_name: str | None = None
 
     def __init__(

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -38,14 +38,20 @@ def _resolve_knowledge_sources(value: Any) -> Any:
     if not isinstance(value, list):
         return value
     resolved: list[Any] = []
-    for item in value:
+    for idx, item in enumerate(value):
         if isinstance(item, dict):
             tag = item.get("source_type")
             cls = _KNOWN_SOURCES.get(tag) if isinstance(tag, str) else None
             if cls is None:
                 resolved.append(item)
             else:
-                resolved.append(cls.model_validate(item))
+                try:
+                    resolved.append(cls.model_validate(item))
+                except Exception as exc:
+                    raise ValueError(
+                        f"Failed to validate knowledge source at index {idx} "
+                        f"with source_type={tag!r}: {exc}"
+                    ) from exc
         else:
             resolved.append(item)
     return resolved

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -70,38 +70,18 @@ def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
         return None
     if isinstance(value, BaseEmbeddingsProvider):
         return value.model_dump(mode="json")
-    if isinstance(value, type) and issubclass(value, BaseEmbeddingsProvider):
-        return {"provider_class": f"{value.__module__}.{value.__qualname__}"}
     if isinstance(value, dict):
         return value
+    if isinstance(value, type) and issubclass(value, BaseEmbeddingsProvider):
+        raise TypeError(
+            f"Cannot checkpoint embedder class {value.__module__}.{value.__qualname__}: "
+            "build_embedder requires an instance or ProviderSpec dict, not a class. "
+            "Instantiate the provider before assigning it to Knowledge.embedder."
+        )
     raise TypeError(
         f"Cannot serialize embedder of type {type(value).__name__}: "
-        "expected ProviderSpec dict, BaseEmbeddingsProvider instance, or subclass."
+        "expected ProviderSpec dict or BaseEmbeddingsProvider instance."
     )
-
-
-def _validate_embedder_spec(value: Any) -> Any:
-    """Resolve provider_class dotted-path dicts back to a class on restore."""
-    if isinstance(value, dict) and set(value.keys()) == {"provider_class"}:
-        from crewai.types.callback import _trusted_deserialize
-
-        if not _trusted_deserialize():
-            raise ValueError(
-                f"Refusing to resolve embedder provider_class "
-                f"{value['provider_class']!r}: set "
-                "CREWAI_DESERIALIZE_CALLBACKS=1 to allow. Only enable this "
-                "for trusted checkpoint data."
-            )
-        from crewai.types.callback import _resolve_dotted_path
-
-        cls = _resolve_dotted_path(value["provider_class"])
-        if not isinstance(cls, type) or not issubclass(cls, BaseEmbeddingsProvider):
-            raise ValueError(
-                f"provider_class {value['provider_class']!r} did not resolve to a "
-                "BaseEmbeddingsProvider subclass."
-            )
-        return cls
-    return value
 
 
 class Knowledge(BaseModel):
@@ -121,7 +101,6 @@ class Knowledge(BaseModel):
     storage: KnowledgeStorage | None = Field(default=None)
     embedder: Annotated[
         EmbedderConfig | None,
-        BeforeValidator(_validate_embedder_spec),
         PlainSerializer(
             _serialize_embedder_spec, return_type=dict | None, when_used="json"
         ),

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -75,6 +75,21 @@ def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
     )
 
 
+def _validate_embedder_spec(value: Any) -> Any:
+    """Resolve provider_class dotted-path dicts back to a class on restore."""
+    if isinstance(value, dict) and set(value.keys()) == {"provider_class"}:
+        from crewai.types.callback import _resolve_dotted_path
+
+        cls = _resolve_dotted_path(value["provider_class"])
+        if not isinstance(cls, type) or not issubclass(cls, BaseEmbeddingsProvider):
+            raise ValueError(
+                f"provider_class {value['provider_class']!r} did not resolve to a "
+                "BaseEmbeddingsProvider subclass."
+            )
+        return cls
+    return value
+
+
 class Knowledge(BaseModel):
     """
     Knowledge is a collection of sources and setup for the vector store to save and query relevant context.
@@ -92,6 +107,7 @@ class Knowledge(BaseModel):
     storage: KnowledgeStorage | None = Field(default=None)
     embedder: Annotated[
         EmbedderConfig | None,
+        BeforeValidator(_validate_embedder_spec),
         PlainSerializer(
             _serialize_embedder_spec, return_type=dict | None, when_used="json"
         ),

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -41,17 +41,22 @@ def _resolve_knowledge_sources(value: Any) -> Any:
     for idx, item in enumerate(value):
         if isinstance(item, dict):
             tag = item.get("source_type")
-            cls = _KNOWN_SOURCES.get(tag) if isinstance(tag, str) else None
-            if cls is None:
+            if not isinstance(tag, str):
                 resolved.append(item)
-            else:
-                try:
-                    resolved.append(cls.model_validate(item))
-                except Exception as exc:
-                    raise ValueError(
-                        f"Failed to validate knowledge source at index {idx} "
-                        f"with source_type={tag!r}: {exc}"
-                    ) from exc
+                continue
+            cls = _KNOWN_SOURCES.get(tag)
+            if cls is None:
+                raise ValueError(
+                    f"Unknown source_type={tag!r} at index {idx}: "
+                    f"expected one of {sorted(_KNOWN_SOURCES)}"
+                )
+            try:
+                resolved.append(cls.model_validate(item))
+            except Exception as exc:
+                raise ValueError(
+                    f"Failed to validate knowledge source at index {idx} "
+                    f"with source_type={tag!r}: {exc}"
+                ) from exc
         else:
             resolved.append(item)
     return resolved
@@ -78,6 +83,13 @@ def _serialize_embedder_spec(value: Any) -> dict[str, Any] | None:
 def _validate_embedder_spec(value: Any) -> Any:
     """Resolve provider_class dotted-path dicts back to a class on restore."""
     if isinstance(value, dict) and set(value.keys()) == {"provider_class"}:
+        if not os.environ.get("CREWAI_DESERIALIZE_CALLBACKS"):
+            raise ValueError(
+                f"Refusing to resolve embedder provider_class "
+                f"{value['provider_class']!r}: set "
+                "CREWAI_DESERIALIZE_CALLBACKS=1 to allow. Only enable this "
+                "for trusted checkpoint data."
+            )
         from crewai.types.callback import _resolve_dotted_path
 
         cls = _resolve_dotted_path(value["provider_class"])

--- a/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
@@ -13,7 +13,9 @@ class BaseKnowledgeSource(BaseModel, ABC):
     chunk_size: int = 4000
     chunk_overlap: int = 200
     chunks: list[str] = Field(default_factory=list)
-    chunk_embeddings: list[np.ndarray[Any, np.dtype[Any]]] = Field(default_factory=list)
+    chunk_embeddings: list[np.ndarray[Any, np.dtype[Any]]] = Field(
+        default_factory=list, exclude=True
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     storage: KnowledgeStorage | None = Field(default=None)

--- a/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 
@@ -45,6 +45,7 @@ class CrewDoclingSource(BaseKnowledgeSource):
 
     _logger: Logger = Logger(verbose=True)
 
+    source_type: Literal["docling"] = "docling"
     file_path: list[Path | str] | None = Field(default=None)
     file_paths: list[Path | str] = Field(default_factory=list)
     chunks: list[str] = Field(default_factory=list)

--- a/lib/crewai/src/crewai/knowledge/source/csv_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/csv_knowledge_source.py
@@ -1,11 +1,14 @@
 import csv
 from pathlib import Path
+from typing import Literal
 
 from crewai.knowledge.source.base_file_knowledge_source import BaseFileKnowledgeSource
 
 
 class CSVKnowledgeSource(BaseFileKnowledgeSource):
     """A knowledge source that stores and queries CSV file content using embeddings."""
+
+    source_type: Literal["csv"] = "csv"
 
     def load_content(self) -> dict[Path, str]:
         """Load and preprocess CSV file content."""

--- a/lib/crewai/src/crewai/knowledge/source/excel_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/excel_knowledge_source.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field, field_validator
 
@@ -16,6 +16,7 @@ class ExcelKnowledgeSource(BaseKnowledgeSource):
 
     _logger: Logger = Logger(verbose=True)
 
+    source_type: Literal["excel"] = "excel"
     file_path: Path | list[Path] | str | list[str] | None = Field(
         default=None,
         description="[Deprecated] The path to the file. Use file_paths instead.",

--- a/lib/crewai/src/crewai/knowledge/source/json_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/json_knowledge_source.py
@@ -1,12 +1,14 @@
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from crewai.knowledge.source.base_file_knowledge_source import BaseFileKnowledgeSource
 
 
 class JSONKnowledgeSource(BaseFileKnowledgeSource):
     """A knowledge source that stores and queries JSON file content using embeddings."""
+
+    source_type: Literal["json"] = "json"
 
     def load_content(self) -> dict[Path, str]:
         """Load and preprocess JSON file content."""

--- a/lib/crewai/src/crewai/knowledge/source/pdf_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/pdf_knowledge_source.py
@@ -1,11 +1,14 @@
 from pathlib import Path
 from types import ModuleType
+from typing import Literal
 
 from crewai.knowledge.source.base_file_knowledge_source import BaseFileKnowledgeSource
 
 
 class PDFKnowledgeSource(BaseFileKnowledgeSource):
     """A knowledge source that stores and queries PDF file content using embeddings."""
+
+    source_type: Literal["pdf"] = "pdf"
 
     def load_content(self) -> dict[Path, str]:
         """Load and preprocess PDF file content."""

--- a/lib/crewai/src/crewai/knowledge/source/string_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/string_knowledge_source.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field
 
@@ -8,6 +8,7 @@ from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 class StringKnowledgeSource(BaseKnowledgeSource):
     """A knowledge source that stores and queries plain text content using embeddings."""
 
+    source_type: Literal["string"] = "string"
     content: str = Field(...)
     collection_name: str | None = Field(default=None)
 

--- a/lib/crewai/src/crewai/knowledge/source/text_file_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/text_file_knowledge_source.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from typing import Literal
 
 from crewai.knowledge.source.base_file_knowledge_source import BaseFileKnowledgeSource
 
 
 class TextFileKnowledgeSource(BaseFileKnowledgeSource):
     """A knowledge source that stores and queries text file content using embeddings."""
+
+    source_type: Literal["text_file"] = "text_file"
 
     def load_content(self) -> dict[Path, str]:
         """Load and preprocess text file content."""

--- a/lib/crewai/src/crewai/memory/memory_scope.py
+++ b/lib/crewai/src/crewai/memory/memory_scope.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from typing_extensions import Self
 
 from crewai.memory.types import (
     _RECALL_OVERSAMPLE_FACTOR,
@@ -36,16 +37,24 @@ class MemoryScope(BaseModel):
             return data
         if not isinstance(data, dict):
             raise ValueError(f"Expected dict or MemoryScope, got {type(data).__name__}")
-        if "memory" not in data:
-            raise ValueError("MemoryScope requires a 'memory' key")
-        memory = data.pop("memory")
+        memory = data.pop("memory", None)
         instance: MemoryScope = handler(data)
-        instance._memory = memory
+        if memory is not None:
+            instance._memory = memory
         root = instance.root_path.rstrip("/") or ""
         if root and not root.startswith("/"):
             root = "/" + root
         instance._root = root
         return instance
+
+    def bind(self, memory: Memory) -> Self:
+        """Rebind the runtime ``Memory`` dependency after restore.
+
+        Required after deserializing from a checkpoint, since the live
+        ``Memory`` cannot be serialized.
+        """
+        self._memory = memory
+        return self
 
     @property
     def read_only(self) -> bool:
@@ -209,13 +218,17 @@ class MemorySlice(BaseModel):
             return data
         if not isinstance(data, dict):
             raise ValueError(f"Expected dict or MemorySlice, got {type(data).__name__}")
-        if "memory" not in data:
-            raise ValueError("MemorySlice requires a 'memory' key")
-        memory = data.pop("memory")
+        memory = data.pop("memory", None)
         data["scopes"] = [s.rstrip("/") or "/" for s in data.get("scopes", [])]
         instance: MemorySlice = handler(data)
-        instance._memory = memory
+        if memory is not None:
+            instance._memory = memory
         return instance
+
+    def bind(self, memory: Memory) -> Self:
+        """Rebind the runtime ``Memory`` dependency after restore."""
+        self._memory = memory
+        return self
 
     def remember(
         self,

--- a/lib/crewai/src/crewai/memory/memory_scope.py
+++ b/lib/crewai/src/crewai/memory/memory_scope.py
@@ -21,6 +21,8 @@ class MemoryScope(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    memory_kind: Literal["scope"] = "scope"
+
     root_path: str = Field(default="/")
 
     _memory: Memory = PrivateAttr()
@@ -190,6 +192,8 @@ class MemorySlice(BaseModel):
     """View over multiple scopes: recall searches all, remember is a no-op when read_only."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    memory_kind: Literal["slice"] = "slice"
 
     scopes: list[str] = Field(default_factory=list)
     categories: list[str] | None = Field(default=None)

--- a/lib/crewai/src/crewai/memory/memory_scope.py
+++ b/lib/crewai/src/crewai/memory/memory_scope.py
@@ -17,6 +17,24 @@ from crewai.memory.types import (
 from crewai.memory.unified_memory import Memory
 
 
+def _ensure_memory_kind(value: Any) -> Any:
+    """Backfill ``memory_kind`` on legacy dicts that predate the discriminator.
+
+    Lets pre-1.14.6 configs/checkpoints flow into the discriminated
+    ``Memory | MemoryScope | MemorySlice`` union without crashing. Inference:
+    ``scopes`` key → ``slice``; ``root_path`` → ``scope``; else ``memory``.
+    Pass-through for non-dict values (instances, ``bool``, ``None``).
+    """
+    if isinstance(value, dict) and "memory_kind" not in value:
+        if "scopes" in value:
+            value["memory_kind"] = "slice"
+        elif "root_path" in value:
+            value["memory_kind"] = "scope"
+        else:
+            value["memory_kind"] = "memory"
+    return value
+
+
 class MemoryScope(BaseModel):
     """View of Memory restricted to a root path. All operations are scoped under that path."""
 
@@ -26,8 +44,8 @@ class MemoryScope(BaseModel):
 
     root_path: str = Field(default="/")
 
-    _memory: Memory = PrivateAttr()
-    _root: str = PrivateAttr()
+    _memory: Memory | None = PrivateAttr(default=None)
+    _root: str = PrivateAttr(default="")
 
     @model_validator(mode="wrap")
     @classmethod
@@ -56,10 +74,19 @@ class MemoryScope(BaseModel):
         self._memory = memory
         return self
 
+    def _require_memory(self) -> Memory:
+        """Return the bound ``Memory`` or raise a clear error if missing."""
+        if self._memory is None:
+            raise RuntimeError(
+                "MemoryScope is not bound to a Memory; call .bind(memory) "
+                "after restore."
+            )
+        return self._memory
+
     @property
     def read_only(self) -> bool:
         """Whether the underlying memory is read-only."""
-        return self._memory.read_only
+        return self._require_memory().read_only
 
     def _scope_path(self, scope: str | None) -> str:
         if not scope or scope == "/":
@@ -84,7 +111,7 @@ class MemoryScope(BaseModel):
     ) -> MemoryRecord | None:
         """Remember content; scope is relative to this scope's root."""
         path = self._scope_path(scope)
-        return self._memory.remember(
+        return self._require_memory().remember(
             content,
             scope=path,
             categories=categories,
@@ -107,7 +134,7 @@ class MemoryScope(BaseModel):
     ) -> list[MemoryRecord]:
         """Remember multiple items; scope is relative to this scope's root."""
         path = self._scope_path(scope)
-        return self._memory.remember_many(
+        return self._require_memory().remember_many(
             contents,
             scope=path,
             categories=categories,
@@ -130,7 +157,7 @@ class MemoryScope(BaseModel):
     ) -> list[MemoryMatch]:
         """Recall within this scope (root path and below)."""
         search_scope = self._scope_path(scope) if scope else (self._root or "/")
-        return self._memory.recall(
+        return self._require_memory().recall(
             query,
             scope=search_scope,
             categories=categories,
@@ -142,7 +169,7 @@ class MemoryScope(BaseModel):
 
     def extract_memories(self, content: str) -> list[str]:
         """Extract discrete memories from content; delegates to underlying Memory."""
-        return self._memory.extract_memories(content)
+        return self._require_memory().extract_memories(content)
 
     def forget(
         self,
@@ -154,7 +181,7 @@ class MemoryScope(BaseModel):
     ) -> int:
         """Forget within this scope."""
         prefix = self._scope_path(scope) if scope else (self._root or "/")
-        return self._memory.forget(
+        return self._require_memory().forget(
             scope=prefix,
             categories=categories,
             older_than=older_than,
@@ -165,27 +192,27 @@ class MemoryScope(BaseModel):
     def list_scopes(self, path: str = "/") -> list[str]:
         """List child scopes under path (relative to this scope's root)."""
         full = self._scope_path(path)
-        return self._memory.list_scopes(full)
+        return self._require_memory().list_scopes(full)
 
     def info(self, path: str = "/") -> ScopeInfo:
         """Info for path under this scope."""
         full = self._scope_path(path)
-        return self._memory.info(full)
+        return self._require_memory().info(full)
 
     def tree(self, path: str = "/", max_depth: int = 3) -> str:
         """Tree under path within this scope."""
         full = self._scope_path(path)
-        return self._memory.tree(full, max_depth=max_depth)
+        return self._require_memory().tree(full, max_depth=max_depth)
 
     def list_categories(self, path: str | None = None) -> dict[str, int]:
         """Categories in this scope; path None means this scope root."""
         full = self._scope_path(path) if path else (self._root or "/")
-        return self._memory.list_categories(full)
+        return self._require_memory().list_categories(full)
 
     def reset(self, scope: str | None = None) -> None:
         """Reset within this scope."""
         prefix = self._scope_path(scope) if scope else (self._root or "/")
-        self._memory.reset(scope=prefix)
+        self._require_memory().reset(scope=prefix)
 
     def subscope(self, path: str) -> MemoryScope:
         """Return a narrower scope under this scope."""
@@ -208,7 +235,7 @@ class MemorySlice(BaseModel):
     categories: list[str] | None = Field(default=None)
     read_only: bool = Field(default=True)
 
-    _memory: Memory = PrivateAttr()
+    _memory: Memory | None = PrivateAttr(default=None)
 
     @model_validator(mode="wrap")
     @classmethod
@@ -230,6 +257,15 @@ class MemorySlice(BaseModel):
         self._memory = memory
         return self
 
+    def _require_memory(self) -> Memory:
+        """Return the bound ``Memory`` or raise a clear error if missing."""
+        if self._memory is None:
+            raise RuntimeError(
+                "MemorySlice is not bound to a Memory; call .bind(memory) "
+                "after restore."
+            )
+        return self._memory
+
     def remember(
         self,
         content: str,
@@ -243,7 +279,7 @@ class MemorySlice(BaseModel):
         """Remember into an explicit scope. No-op when read_only=True."""
         if self.read_only:
             return None
-        return self._memory.remember(
+        return self._require_memory().remember(
             content,
             scope=scope,
             categories=categories,
@@ -267,7 +303,7 @@ class MemorySlice(BaseModel):
         cats = categories or self.categories
         all_matches: list[MemoryMatch] = []
         for sc in self.scopes:
-            matches = self._memory.recall(
+            matches = self._require_memory().recall(
                 query,
                 scope=sc,
                 categories=cats,
@@ -289,14 +325,14 @@ class MemorySlice(BaseModel):
 
     def extract_memories(self, content: str) -> list[str]:
         """Extract discrete memories from content; delegates to underlying Memory."""
-        return self._memory.extract_memories(content)
+        return self._require_memory().extract_memories(content)
 
     def list_scopes(self, path: str = "/") -> list[str]:
         """List scopes across all slice roots."""
         out: list[str] = []
         for sc in self.scopes:
             full = f"{sc.rstrip('/')}{path}" if sc != "/" else path
-            out.extend(self._memory.list_scopes(full))
+            out.extend(self._require_memory().list_scopes(full))
         return sorted(set(out))
 
     def info(self, path: str = "/") -> ScopeInfo:
@@ -308,7 +344,7 @@ class MemorySlice(BaseModel):
         children: list[str] = []
         for sc in self.scopes:
             full = f"{sc.rstrip('/')}{path}" if sc != "/" else path
-            inf = self._memory.info(full)
+            inf = self._require_memory().info(full)
             total_records += inf.record_count
             all_categories.update(inf.categories)
             if inf.oldest_record:
@@ -338,6 +374,6 @@ class MemorySlice(BaseModel):
         counts: dict[str, int] = {}
         for sc in self.scopes:
             full = (f"{sc.rstrip('/')}{path}" if sc != "/" else path) if path else sc
-            for k, v in self._memory.list_categories(full).items():
+            for k, v in self._require_memory().list_categories(full).items():
                 counts[k] = counts.get(k, 0) + v
         return counts

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -63,6 +63,8 @@ class Memory(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    memory_kind: Literal["memory"] = "memory"
+
     llm: Annotated[BaseLLM | str, PlainValidator(_passthrough)] = Field(
         default="gpt-4o-mini",
         description="LLM for analysis (model name or BaseLLM instance).",

--- a/lib/crewai/src/crewai/state/runtime.py
+++ b/lib/crewai/src/crewai/state/runtime.py
@@ -113,10 +113,46 @@ def _migrate(data: dict[str, Any]) -> dict[str, Any]:
         )
 
     # --- migrations in version order ---
-    # if stored < Version("X.Y.Z"):
-    #     data.setdefault("some_field", "default")
+    if stored < Version("1.14.6"):
+        for entity in data.get("entities") or []:
+            _backfill_discriminators(entity)
 
     return data
+
+
+def _backfill_memory_kind(value: Any) -> None:
+    """Infer ``memory_kind`` from structural fields on legacy memory dicts."""
+    if not isinstance(value, dict) or "memory_kind" in value:
+        return
+    if "scopes" in value:
+        value["memory_kind"] = "slice"
+    elif "root_path" in value:
+        value["memory_kind"] = "scope"
+    else:
+        value["memory_kind"] = "memory"
+
+
+def _backfill_source_type(source: Any) -> None:
+    """Infer ``source_type`` for legacy knowledge source dicts when possible."""
+    if not isinstance(source, dict) or "source_type" in source:
+        return
+    if "content" in source:
+        source["source_type"] = "string"
+
+
+def _backfill_discriminators(entity: Any) -> None:
+    """Walk an entity dict and backfill discriminator fields added in 1.14.6."""
+    if not isinstance(entity, dict):
+        return
+    _backfill_memory_kind(entity.get("memory"))
+    for agent in entity.get("agents") or []:
+        _backfill_memory_kind(agent.get("memory") if isinstance(agent, dict) else None)
+    for container in (entity.get("knowledge"), entity):
+        if isinstance(container, dict):
+            for src in (
+                container.get("sources") or container.get("knowledge_sources") or []
+            ):
+                _backfill_source_type(src)
 
 
 class RuntimeState(RootModel):  # type: ignore[type-arg]

--- a/lib/crewai/src/crewai/state/runtime.py
+++ b/lib/crewai/src/crewai/state/runtime.py
@@ -133,11 +133,22 @@ def _backfill_memory_kind(value: Any) -> None:
 
 
 def _backfill_source_type(source: Any) -> None:
-    """Infer ``source_type`` for legacy knowledge source dicts when possible."""
+    """Infer ``source_type`` for legacy knowledge source dicts when possible.
+
+    Only StringKnowledgeSource is reliably inferrable: it stores ``content``
+    as a plain string. File-based sources (CSV/PDF/Excel/JSON/docling) also
+    have a ``content`` field but populate it with dicts/lists, so we leave
+    those untagged and let downstream validation surface a clear error.
+    """
     if not isinstance(source, dict) or "source_type" in source:
         return
-    if "content" in source:
+    if isinstance(source.get("content"), str):
         source["source_type"] = "string"
+        return
+    raise ValueError(
+        "Legacy knowledge source is missing 'source_type' and could not be "
+        "inferred during migration. Re-checkpoint after upgrading to 1.14.6+."
+    )
 
 
 def _backfill_discriminators(entity: Any) -> None:

--- a/lib/crewai/src/crewai/state/runtime.py
+++ b/lib/crewai/src/crewai/state/runtime.py
@@ -151,19 +151,28 @@ def _backfill_source_type(source: Any) -> None:
     )
 
 
+def _backfill_sources_on(container: Any) -> None:
+    """Apply source_type backfill to ``sources`` and ``knowledge_sources`` lists."""
+    if not isinstance(container, dict):
+        return
+    for key in ("sources", "knowledge_sources"):
+        for src in container.get(key) or []:
+            _backfill_source_type(src)
+
+
 def _backfill_discriminators(entity: Any) -> None:
     """Walk an entity dict and backfill discriminator fields added in 1.14.6."""
     if not isinstance(entity, dict):
         return
     _backfill_memory_kind(entity.get("memory"))
+    _backfill_sources_on(entity)
+    _backfill_sources_on(entity.get("knowledge"))
     for agent in entity.get("agents") or []:
-        _backfill_memory_kind(agent.get("memory") if isinstance(agent, dict) else None)
-    for container in (entity.get("knowledge"), entity):
-        if isinstance(container, dict):
-            for src in (
-                container.get("sources") or container.get("knowledge_sources") or []
-            ):
-                _backfill_source_type(src)
+        if not isinstance(agent, dict):
+            continue
+        _backfill_memory_kind(agent.get("memory"))
+        _backfill_sources_on(agent)
+        _backfill_sources_on(agent.get("knowledge"))
 
 
 class RuntimeState(RootModel):  # type: ignore[type-arg]

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -150,3 +150,50 @@ SerializableCallable = Annotated[
     PlainSerializer(callable_to_string, return_type=str, when_used="json"),
     WithJsonSchema({"type": "string"}),
 ]
+
+
+def _instance_to_dotted_path(value: Any) -> str:
+    """Serialize an instance to a dotted path naming its class."""
+    cls = type(value)
+    module = getattr(cls, "__module__", None)
+    qualname = getattr(cls, "__qualname__", None)
+    if module is None or qualname is None:
+        raise ValueError(
+            f"Cannot serialize {value!r}: class missing __module__ or __qualname__. "
+            "Use a module-level class for checkpointable instances."
+        )
+    if qualname.endswith("<lambda>") or "<locals>" in qualname:
+        raise ValueError(
+            f"Cannot serialize {value!r}: class defined in <locals>. "
+            "Use a module-level class for checkpointable instances."
+        )
+    return f"{module}.{qualname}"
+
+
+def _dotted_path_to_instance(value: Any) -> Any:
+    """Resolve a dotted path to a class and instantiate it with no args.
+
+    If *value* is already a non-string object it is returned as-is.
+    """
+    if value is None or not isinstance(value, str):
+        return value
+    if "." not in value:
+        raise ValueError(
+            f"Invalid provider path {value!r}: expected 'module.name' format"
+        )
+    if not os.environ.get("CREWAI_DESERIALIZE_CALLBACKS"):
+        raise ValueError(
+            f"Refusing to resolve provider path {value!r}: "
+            "set CREWAI_DESERIALIZE_CALLBACKS=1 to allow. "
+            "Only enable this for trusted checkpoint data."
+        )
+    cls = _resolve_dotted_path(value)
+    return cls()
+
+
+SerializableInstance = Annotated[
+    Any,
+    BeforeValidator(_dotted_path_to_instance),
+    PlainSerializer(_instance_to_dotted_path, return_type=str, when_used="json"),
+    WithJsonSchema({"type": "string"}),
+]

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -186,7 +186,20 @@ def _dotted_path_to_instance(value: Any) -> Any:
 
     If *value* is already a non-string object it is returned as-is.
     """
-    if value is None or not isinstance(value, str):
+    if value is None:
+        return value
+    if not isinstance(value, str):
+        if inspect.isclass(value):
+            raise ValueError(
+                f"Expected an instance or dotted path string, got class "
+                f"{getattr(value, '__module__', '<unknown>')}."
+                f"{getattr(value, '__qualname__', getattr(value, '__name__', ''))}."
+            )
+        if type(value).__module__ == "builtins":
+            raise ValueError(
+                f"Expected an instance of a user-defined class or dotted "
+                f"path string, got builtin value {value!r}."
+            )
         return value
     if "." not in value:
         raise ValueError(

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -154,7 +154,16 @@ SerializableCallable = Annotated[
 
 def _instance_to_dotted_path(value: Any) -> str:
     """Serialize an instance to a dotted path naming its class."""
+    if inspect.isclass(value):
+        raise ValueError(
+            f"Expected an instance, got class {value.__module__}.{value.__qualname__}."
+        )
     cls = type(value)
+    if cls.__module__ == "builtins":
+        raise ValueError(
+            f"Cannot serialize {value!r}: builtin values are not "
+            "checkpointable instances."
+        )
     module = getattr(cls, "__module__", None)
     qualname = getattr(cls, "__qualname__", None)
     if module is None or qualname is None:
@@ -194,11 +203,3 @@ def _dotted_path_to_instance(value: Any) -> Any:
             f"{type(cls).__name__}"
         )
     return cls()
-
-
-SerializableInstance = Annotated[
-    Any,
-    BeforeValidator(_dotted_path_to_instance),
-    PlainSerializer(_instance_to_dotted_path, return_type=str, when_used="json"),
-    WithJsonSchema({"type": "string"}),
-]

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -155,9 +155,11 @@ SerializableCallable = Annotated[
 def _instance_to_dotted_path(value: Any) -> str:
     """Serialize an instance to a dotted path naming its class."""
     if inspect.isclass(value):
-        raise ValueError(
-            f"Expected an instance, got class {value.__module__}.{value.__qualname__}."
+        module = getattr(value, "__module__", "<unknown>")
+        qualname = getattr(
+            value, "__qualname__", getattr(value, "__name__", str(type(value)))
         )
+        raise ValueError(f"Expected an instance, got class {module}.{qualname}.")
     cls = type(value)
     if cls.__module__ == "builtins":
         raise ValueError(

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -188,6 +188,11 @@ def _dotted_path_to_instance(value: Any) -> Any:
             "Only enable this for trusted checkpoint data."
         )
     cls = _resolve_dotted_path(value)
+    if not inspect.isclass(cls):
+        raise ValueError(
+            f"Invalid provider path {value!r}: expected a class, got "
+            f"{type(cls).__name__}"
+        )
     return cls()
 
 

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -19,6 +19,15 @@ from pydantic import BeforeValidator, WithJsonSchema
 from pydantic.functional_serializers import PlainSerializer
 
 
+_TRUSTED_DESERIALIZE_VALUES = frozenset({"1", "true", "yes"})
+
+
+def _trusted_deserialize() -> bool:
+    """Return True only if ``CREWAI_DESERIALIZE_CALLBACKS`` is an explicit yes."""
+    raw = os.environ.get("CREWAI_DESERIALIZE_CALLBACKS", "")
+    return raw.strip().lower() in _TRUSTED_DESERIALIZE_VALUES
+
+
 def _is_non_roundtrippable(fn: object) -> bool:
     """Return ``True`` if *fn* cannot survive a serialize/deserialize round-trip.
 
@@ -76,7 +85,7 @@ def string_to_callable(value: Any) -> Callable[..., Any]:
         raise ValueError(
             f"Invalid callback path {value!r}: expected 'module.name' format"
         )
-    if not os.environ.get("CREWAI_DESERIALIZE_CALLBACKS"):
+    if not _trusted_deserialize():
         raise ValueError(
             f"Refusing to resolve callback path {value!r}: "
             "set CREWAI_DESERIALIZE_CALLBACKS=1 to allow. "
@@ -205,7 +214,7 @@ def _dotted_path_to_instance(value: Any) -> Any:
         raise ValueError(
             f"Invalid provider path {value!r}: expected 'module.name' format"
         )
-    if not os.environ.get("CREWAI_DESERIALIZE_CALLBACKS"):
+    if not _trusted_deserialize():
         raise ValueError(
             f"Refusing to resolve provider path {value!r}: "
             "set CREWAI_DESERIALIZE_CALLBACKS=1 to allow. "

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -204,4 +204,11 @@ def _dotted_path_to_instance(value: Any) -> Any:
             f"Invalid provider path {value!r}: expected a class, got "
             f"{type(cls).__name__}"
         )
-    return cls()
+    try:
+        return cls()
+    except TypeError as exc:
+        raise ValueError(
+            f"Cannot reinstantiate {value!r} with no arguments: {exc}. "
+            "Only no-arg constructors are checkpointable; rebuild the "
+            "instance manually and assign it after restore."
+        ) from exc

--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -25,7 +25,7 @@ def _reset_flow_memory(flow: Flow[Any]) -> None:
     try:
         if hasattr(mem, "reset"):
             mem.reset()
-        elif hasattr(mem, "_memory") and hasattr(mem._memory, "reset"):
+        elif hasattr(mem, "_memory") and mem._memory is not None:
             mem._memory.reset()
     except (FileNotFoundError, OSError):
         pass

--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -27,7 +27,7 @@ def _reset_flow_memory(flow: Flow[Any]) -> None:
             mem.reset()
         elif hasattr(mem, "_memory") and mem._memory is not None:
             mem._memory.reset()
-    except (FileNotFoundError, OSError):
+    except (FileNotFoundError, OSError, RuntimeError):
         pass
 
 

--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -27,8 +27,14 @@ def _reset_flow_memory(flow: Flow[Any]) -> None:
             mem.reset()
         elif hasattr(mem, "_memory") and mem._memory is not None:
             mem._memory.reset()
-    except (FileNotFoundError, OSError, RuntimeError):
+    except FileNotFoundError:
+        # Storage directory was never created — nothing to reset.
         pass
+    except OSError as exc:
+        click.echo(f"Memory reset skipped: storage I/O error ({exc}).", err=True)
+    except RuntimeError as exc:
+        # Restored MemoryScope/MemorySlice without a rebound Memory.
+        click.echo(f"Memory reset skipped: {exc}", err=True)
 
 
 def reset_memories_command(

--- a/lib/crewai/tests/test_flow_ask.py
+++ b/lib/crewai/tests/test_flow_ask.py
@@ -7,6 +7,7 @@ durability, input history tracking, and integration with flow machinery.
 
 from __future__ import annotations
 
+import copy
 import time
 from datetime import datetime
 from typing import Any
@@ -47,10 +48,15 @@ class _SaveStateRecorder:
         method_name: str,
         state_data: dict[str, Any] | BaseModel,
     ) -> None:
+        snapshot: dict[str, Any] | BaseModel
+        if isinstance(state_data, BaseModel):
+            snapshot = state_data.model_copy(deep=True)
+        else:
+            snapshot = copy.deepcopy(state_data)
         self.call_args_list.append(
-            _SaveCall((flow_uuid, method_name, state_data), {})
+            _SaveCall((flow_uuid, method_name, snapshot), {})
         )
-        self._owner._states[flow_uuid] = state_data
+        self._owner._states[flow_uuid] = snapshot
 
 
 class RecordingPersistence(FlowPersistence):
@@ -74,7 +80,12 @@ class RecordingPersistence(FlowPersistence):
         return None
 
     def load_state(self, flow_uuid: str) -> dict[str, Any] | None:
-        return None
+        snapshot = self._states.get(flow_uuid)
+        if snapshot is None:
+            return None
+        if isinstance(snapshot, BaseModel):
+            return snapshot.model_copy(deep=True).model_dump()
+        return copy.deepcopy(snapshot)
 
 
 class MockInputProvider:

--- a/lib/crewai/tests/test_flow_ask.py
+++ b/lib/crewai/tests/test_flow_ask.py
@@ -12,13 +12,69 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from pydantic import BaseModel
+
 from crewai.flow import Flow, flow_config, listen, start
 from crewai.flow.async_feedback.providers import ConsoleProvider
 from crewai.flow.flow import FlowState
 from crewai.flow.input_provider import InputProvider, InputResponse
+from crewai.flow.persistence.base import FlowPersistence
 
 
 # ── Test helpers ─────────────────────────────────────────────────
+
+
+class _SaveCall:
+    """Lightweight stand-in for ``MagicMock.call_args`` entries."""
+
+    __slots__ = ("args", "kwargs")
+
+    def __init__(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _SaveStateRecorder:
+    """Callable that records each ``save_state`` invocation."""
+
+    def __init__(self, owner: RecordingPersistence) -> None:
+        self._owner = owner
+        self.call_args_list: list[_SaveCall] = []
+
+    def __call__(
+        self,
+        flow_uuid: str,
+        method_name: str,
+        state_data: dict[str, Any] | BaseModel,
+    ) -> None:
+        self.call_args_list.append(
+            _SaveCall((flow_uuid, method_name, state_data), {})
+        )
+        self._owner._states[flow_uuid] = state_data
+
+
+class RecordingPersistence(FlowPersistence):
+    """In-memory FlowPersistence that records ``save_state`` invocations."""
+
+    persistence_type: str = "RecordingPersistence"
+
+    def model_post_init(self, _: Any) -> None:
+        object.__setattr__(self, "_states", {})
+        object.__setattr__(self, "save_state", _SaveStateRecorder(self))
+
+    def init_db(self) -> None:
+        return None
+
+    def save_state(  # type: ignore[no-redef]
+        self,
+        flow_uuid: str,
+        method_name: str,
+        state_data: dict[str, Any] | BaseModel,
+    ) -> None:
+        return None
+
+    def load_state(self, flow_uuid: str) -> dict[str, Any] | None:
+        return None
 
 
 class MockInputProvider:
@@ -436,8 +492,7 @@ class TestAskCheckpoint:
 
     def test_ask_checkpoints_state_before_waiting(self) -> None:
         """State is saved to persistence before waiting for input."""
-        mock_persistence = MagicMock()
-        mock_persistence.load_state.return_value = None
+        mock_persistence = RecordingPersistence()
 
         class TestFlow(Flow):
             input_provider = MockInputProvider(["answer"])
@@ -480,8 +535,7 @@ class TestAskCheckpoint:
         server crashes while waiting for input, previously gathered data
         is safe.
         """
-        mock_persistence = MagicMock()
-        mock_persistence.load_state.return_value = None
+        mock_persistence = RecordingPersistence()
 
         class GatherFlow(Flow):
             input_provider = MockInputProvider(["AI", "detailed"])
@@ -678,8 +732,7 @@ class TestAskIntegration:
 
     def test_ask_with_state_persistence_recovery(self) -> None:
         """Ask checkpoints state so previously gathered values survive."""
-        mock_persistence = MagicMock()
-        mock_persistence.load_state.return_value = None
+        mock_persistence = RecordingPersistence()
 
         class RecoverableFlow(Flow):
             input_provider = MockInputProvider(["AI", "detailed"])


### PR DESCRIPTION
## Summary

`RuntimeState.model_dump_json()` is the checkpoint contract, but several entity fields held live runtime objects (DB clients, sockets, executor state, callables) that would crash on dump, lose state silently, or restore to an ambiguous union member. This PR closes each gap using patterns already established in the repo (`_validate_X_ref` / `_serialize_X_ref` annotated pairs, `exclude=True` on runtime-only caches, discriminator fields on unions).

### Fixes

- **Flow.persistence** — added `_serialize_persistence`; dropped the `| Any` escape hatch so non-BaseModel objects can no longer slip through dump.
- **Flow.input_provider** — new `SerializableInstance` annotated alias in `types/callback.py` reuses the existing dotted-path machinery (`CREWAI_DESERIALIZE_CALLBACKS=1` gate). Only module-level provider classes round-trip; lambdas/local classes are rejected.
- **BaseAgent.agent_executor** — added matching `_serialize_executor_ref` (validator existed; serializer didn't). Validator moved off `@field_validator` onto the field's `Annotated` for symmetry with the `llm` field.
- **BaseAgent.tools_handler / cache_handler** — `exclude=True`. These wrap transient state (in-memory cache, RWLock, last-used tool); restore re-initializes empty handlers.
- **Memory / MemoryScope / MemorySlice** — added `memory_kind: Literal[…]` discriminator and switched `Crew.memory` / `Agent.memory` / `Flow.memory` to `Field(discriminator="memory_kind")`. Union resolution is no longer order-dependent.
- **Knowledge.storage** — `exclude=True` (live chromadb client). Rebuilt on restore via `KnowledgeStorage`'s existing `@model_validator(mode="after")`.
- **Knowledge.embedder** — new `_serialize_embedder_spec` serializer. Emits the dict form whether the value is a `BaseEmbeddingsProvider`, a class, or already a `ProviderSpec`.
- **BaseKnowledgeSource** + concrete subclasses — `source_type: Literal[…]` on each (`string`, `csv`, `excel`, `pdf`, `json`, `text_file`, `docling`). `Knowledge.sources` gets a `BeforeValidator` that resolves dicts by `source_type` to the right subclass while passing through existing instances (preserves Mock-based tests).
- **BaseKnowledgeSource.storage / chunk_embeddings** — `exclude=True` (live client; numpy arrays bloat checkpoints and are recomputed on `add()`).

## Test plan

- [x] `pytest tests/test_checkpoint.py tests/test_checkpoint_cli.py` — 89 pass
- [x] `pytest tests/memory/ tests/knowledge/` — 216 pass
- [x] `pytest tests/test_flow_persistence.py tests/test_flow_resumability_regression.py tests/test_flow_serializer.py tests/test_flow.py` — 173 pass
- [x] `pytest tests/agents tests/crew tests/task tests/test_crew.py` — 484 pass
- [x] `pytest tests/test_callback.py tests/test_guardrail_serialization.py tests/test_event_record.py tests/test_imports.py` — 153 pass
- [x] Manual round-trip smoke: Flow with `SQLiteFlowPersistence` and Knowledge with `StringKnowledgeSource` both restore with the correct subclass after `model_validate_json(model_dump_json())`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint serialization/deserialization across `Flow`, `Crew`, `Agent`, `Memory`, and `Knowledge`; mistakes could break backwards compatibility or resume behavior for existing saved checkpoints. Changes are mostly validation/serialization hardening with explicit migrations and rebinding logic to reduce runtime failures.
> 
> **Overview**
> Improves checkpoint robustness by **making `RuntimeState.model_dump_json()` reliably round-trippable** across `Flow`, `Crew`, and `Agent` entities.
> 
> Adds explicit validators/serializers for previously problematic runtime references (e.g. `Flow.persistence`, `Flow.input_provider`, `BaseAgent.agent_executor`, `Knowledge.embedder`) and introduces discriminators (`memory_kind`, `source_type`) to remove ambiguous union restores; legacy checkpoints are migrated via backfilling missing discriminator fields.
> 
> Fixes post-restore runtime issues by rebinding `MemoryScope`/`MemorySlice` views to a live `Memory` after checkpoint restore (in `Agent`, `Crew`, and `Flow`), excludes non-checkpointable/heavy runtime fields (e.g. numpy `chunk_embeddings`), and updates flow ask durability tests to use a real in-memory `FlowPersistence` recorder instead of mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9167dec33b86d42affa846162e9e06aa3d8e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-gated safe restore/serialization for checkpointable class-backed instances.

* **Improvements**
  * JSON-safe serialization for executors, embedders, input providers, and persistence.
  * Normalized, discriminated memory kinds with automatic rebinding of memory views on restore.
  * Explicit source-type identifiers for knowledge sources; internal chunk/embedding data excluded from serialization.
  * Clearer error reporting when resetting memories.

* **Bug Fixes / Migration**
  * Checkpoint backfills to restore missing discriminators from older checkpoints.

* **Tests**
  * Persistence tests switched to an in-memory recording persistence implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->