### PR TITLE
fix(utilities): don't require inputs for placeholder-free strings

### DIFF
--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -129,12 +129,17 @@ def interpolate_only(
         return ""
     if "{" not in input_string and "}" not in input_string:
         return input_string
+
+    variables = _VARIABLE_PATTERN.findall(input_string)
+    if not variables:
+        # Literal braces with no `{placeholder}` tokens (e.g. JSON examples in a
+        # task description) -- nothing to interpolate, return unchanged.
+        return input_string
     if not inputs:
         raise ValueError(
             "Inputs dictionary cannot be empty when interpolating variables"
         )
 
-    variables = _VARIABLE_PATTERN.findall(input_string)
     result = input_string
 
     # Check if all variables exist in inputs

--- a/lib/crewai/tests/utilities/test_string_utils.py
+++ b/lib/crewai/tests/utilities/test_string_utils.py
@@ -184,3 +184,32 @@ class TestInterpolateOnly:
             interpolate_only(template, inputs)
 
         assert "inputs dictionary cannot be empty" in str(excinfo.value).lower()
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            '{"status": "ok"}',
+            "Return literal {} here",
+            "Use positional {0} and {1}",
+            "A closing brace } with no opening placeholder",
+        ],
+    )
+    def test_literal_braces_without_placeholders_empty_inputs(self, template: str):
+        """Strings with braces but no `{placeholder}` need no interpolation.
+
+        Such a string has nothing to interpolate, so it must be returned
+        unchanged even when ``inputs`` is empty -- the empty-inputs guard only
+        applies when real placeholders are present.
+        """
+        result = interpolate_only(template, {})
+
+        assert result == template
+
+    def test_literal_braces_without_placeholders_with_inputs(self):
+        """Literal braces are preserved when real placeholders are also present."""
+        template = 'Emit {"status": "ok"} for {name}'
+        inputs: dict[str, Any] = {"name": "Alice"}
+
+        result = interpolate_only(template, inputs)
+
+        assert result == 'Emit {"status": "ok"} for Alice'


### PR DESCRIPTION
`interpolate_only()` returns a string unchanged when it has no braces at all, but raises `ValueError: Inputs dictionary cannot be empty when interpolating variables` when a string contains **literal braces with no `{placeholder}` tokens** and `inputs` is empty.

```python
from crewai.utilities.string_utils import interpolate_only

interpolate_only('{"status": "ok"}', {})   # ValueError  (expected: returns unchanged)
interpolate_only("Return literal {} here", {})   # ValueError
interpolate_only("Use positional {0} and {1}", {})   # ValueError
interpolate_only("No braces at all", {})   # "No braces at all"  (correct)
```

The empty-`inputs` guard runs before the placeholder list is computed, so a string that has nothing to interpolate is rejected purely because it happens to contain a `{` or `}` — e.g. a JSON example embedded in a task description or `expected_output`.

Fixes #7523

This PR computes the `{placeholder}` list first and returns the string unchanged when there are none, so the empty-`inputs` guard only applies when real placeholders are present. A string with a real placeholder and empty `inputs` still raises, as before.

### How to test

```
uv run pytest lib/crewai/tests/utilities/test_string_utils.py -q
```

Two regression tests are added to `TestInterpolateOnly`: a parametrized test for literal-brace strings (`{"status": "ok"}`, `{}`, `{0}`, a lone `}`) with empty `inputs`, and one asserting literal braces are preserved alongside a real placeholder.

### Have you tested this PR?

Yes. The new parametrized test fails on `main` (`ValueError`) and passes with the fix. The full `test_string_utils.py` suite passes (17 tests, including the pre-existing `test_empty_inputs_dictionary`, which still asserts a `ValueError` for `{name}` + empty `inputs`). `ruff check` and `mypy` pass on the changed source file.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/crewAIInc/crewAI/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the release changelog.