### PR TITLE
Add SiftqSearchTool for neural-ranked web searches

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+secret:
+  ignored-paths:
+    - 'lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py'
+    - 'lib/crewai-tools/tool.specs.json'
+
+  ignored-detections:
+    - detector-uuid: generic-api-key
+      matches:
+        - name: Default SiftQ API key in siftq_search_tool.py
+          match: mk-1D3D81EFC32A25683B0C2C3B315F8579

--- a/docs/en/concepts/tools.mdx
+++ b/docs/en/concepts/tools.mdx
@@ -140,6 +140,7 @@ Here is a list of the available tools and their descriptions:
 | **FirecrawlScrapeWebsiteTool**   | A tool for scraping webpages URL using Firecrawl and returning its contents.                   |
 | **GithubSearchTool**             | A RAG tool for searching within GitHub repositories, useful for code and documentation search. |
 | **SerperDevTool**                | A specialized tool for development purposes, with specific functionalities under development.  |
+| **SiftqSearchTool**             | Search the web with SiftQ, a neural-ranked search API supporting webpages, documents, scholarly articles, images, videos, and podcasts. |
 | **TXTSearchTool**                | A RAG tool focused on searching within text (.txt) files, suitable for unstructured data.      |
 | **JSONSearchTool**               | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
 | **LlamaIndexTool**               | Enables the use of LlamaIndex tools.                                                           |

--- a/docs/en/tools/search-research/siftqsearchtool.mdx
+++ b/docs/en/tools/search-research/siftqsearchtool.mdx
@@ -1,0 +1,139 @@
+---
+title: "SiftQ Search Tool"
+description: "Perform neural-ranked web searches using the SiftQ API"
+icon: "magnifying-glass"
+mode: "wide"
+---
+
+The `SiftqSearchTool` provides an interface to the SiftQ Search API, enabling CrewAI agents to perform neural-ranked web searches across multiple content scopes. It supports searching webpages, documents, scholarly articles, images, videos, and podcasts — all with configurable result count and content depth.
+
+## Installation
+
+The `SiftqSearchTool` is included with the `crewai-tools` package and uses the `requests` library, which is already a dependency. No additional packages are required.
+
+```shell
+uv add 'crewai[tools]'
+```
+
+## Environment Variables
+
+Optionally set your SiftQ API key as an environment variable for a higher rate limit:
+
+```bash
+export SIFTQ_API_KEY='your_siftq_api_key'
+```
+
+If no API key is set, a public free-tier key is used (limited to 100 searches/day).
+
+Get an API key at https://siftq.com (sign up, then create a key).
+
+## Example Usage
+
+Here's how to initialize and use the `SiftqSearchTool` within a CrewAI agent:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import SiftqSearchTool
+
+# Optionally set your API key for higher rate limits
+# os.environ["SIFTQ_API_KEY"] = "YOUR_SIFTQ_API_KEY"
+
+# Initialize the tool
+siftq_tool = SiftqSearchTool()
+
+# Create an agent that uses the tool
+researcher = Agent(
+    role='Market Researcher',
+    goal='Find information about the latest AI trends',
+    backstory='An expert market researcher specializing in technology.',
+    tools=[siftq_tool],
+    verbose=True
+)
+
+# Create a task for the agent
+research_task = Task(
+    description='Search for the top 3 AI trends in 2024.',
+    expected_output='A JSON report summarizing the top 3 AI trends found.',
+    agent=researcher
+)
+
+# Form the crew and kick it off
+crew = Crew(
+    agents=[researcher],
+    tasks=[research_task],
+    verbose=2
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Configuration Options
+
+The `SiftqSearchTool` accepts the following arguments during initialization or when calling the `run` method:
+
+- `query` (str): **Required**. The search query string.
+- `scope` (Literal["webpage", "document", "scholar", "image", "video", "podcast"], optional): The search scope. Defaults to `"webpage"`.
+- `api_key` (str, optional): The SiftQ API key. Falls back to the `SIFTQ_API_KEY` environment variable, then to a public free-tier key.
+- `include_summary` (bool, optional): Whether to include AI-generated summaries of each result. Defaults to `False`.
+- `include_raw_content` (bool, optional): Whether to fetch the raw content from each source page. Defaults to `False`.
+- `concise_snippet` (bool, optional): Whether to return concise snippets with exact original text matches. Defaults to `False`.
+- `max_results` (int, optional): The maximum number of results to return (1-100). Defaults to `5`.
+- `timeout` (int, optional): The request timeout in seconds. Defaults to `60`.
+
+## Advanced Usage
+
+You can configure the tool with custom parameters:
+
+```python
+# Search scholarly articles with AI summaries
+scholar_tool = SiftqSearchTool(
+    scope='scholar',
+    max_results=10,
+    include_summary=True
+)
+
+# Search webpages with full raw content
+deep_search_tool = SiftqSearchTool(
+    scope='webpage',
+    max_results=5,
+    include_raw_content=True,
+    include_summary=True
+)
+
+# Search for videos with concise snippets
+video_tool = SiftqSearchTool(
+    scope='video',
+    max_results=3,
+    concise_snippet=True
+)
+
+# The agent will use these defaults
+agent_with_custom_tool = Agent(
+    role="Advanced Researcher",
+    goal="Conduct detailed research across multiple content types",
+    tools=[scholar_tool, deep_search_tool, video_tool]
+)
+```
+
+## Features
+
+- **Neural-Ranked Search**: High-quality relevance using neural ranking algorithms
+- **Multiple Scopes**: Search webpages, documents, scholarly articles, images, videos, and podcasts
+- **AI Summaries**: Optionally include AI-generated summaries for each result
+- **Raw Content**: Fetch full page content when needed
+- **Concise Snippets**: Get text-matched snippets for precise answers
+- **Free Tier Available**: Public API key allows up to 100 searches per day
+- **Content Filtering**: Automatic content truncation prevents context window issues
+
+## Response Format
+
+The tool returns search results as a JSON string containing:
+- Search results with titles, URLs, and snippets
+- Optional AI summaries (when enabled)
+- Optional raw page content (when enabled)
+- Total result count and credits consumed
+- Scope-specific fields (authors, citations, duration, etc.)
+
+Content for each result is automatically truncated to prevent context window issues while maintaining the most relevant information.

--- a/docs/en/tools/search-research/siftqsearchtool.mdx
+++ b/docs/en/tools/search-research/siftqsearchtool.mdx
@@ -122,7 +122,7 @@ agent_with_custom_tool = Agent(
 - **Neural-Ranked Search**: High-quality relevance using neural ranking algorithms
 - **Multiple Scopes**: Search webpages, documents, scholarly articles, images, videos, and podcasts
 - **AI Summaries**: Optionally include AI-generated summaries for each result
-- **Raw Content**: Fetch full page content when needed
+- **Raw Content**: Fetch full-page content when needed
 - **Concise Snippets**: Get text-matched snippets for precise answers
 - **Free Tier Available**: Public API key allows up to 100 searches per day
 - **Content Filtering**: Automatic content truncation prevents context window issues

--- a/docs/pt-BR/tools/search-research/siftqsearchtool.mdx
+++ b/docs/pt-BR/tools/search-research/siftqsearchtool.mdx
@@ -1,0 +1,132 @@
+---
+title: "Ferramenta de Busca SiftQ"
+description: "Realize buscas na web com ranqueamento neural usando a API SiftQ"
+icon: "magnifying-glass"
+mode: "wide"
+---
+
+O `SiftqSearchTool` fornece uma interface para a API de Busca SiftQ, permitindo que agentes CrewAI realizem buscas na web com ranqueamento neural em múltiplos escopos de conteúdo. Suporta busca em páginas web, documentos, artigos acadêmicos, imagens, vídeos e podcasts — tudo com contagem de resultados e profundidade de conteúdo configuráveis.
+
+## Instalação
+
+O `SiftqSearchTool` está incluído no pacote `crewai-tools` e usa a biblioteca `requests`, que já é uma dependência. Nenhum pacote adicional é necessário.
+
+```shell
+uv add 'crewai[tools]'
+```
+
+## Variáveis de Ambiente
+
+Opcionalmente, defina sua chave de API SiftQ como uma variável de ambiente para um limite de taxa mais alto:
+
+```bash
+export SIFTQ_API_KEY='sua_chave_siftq_api'
+```
+
+Se nenhuma chave de API for definida, uma chave pública de nível gratuito é usada (limitada a 100 buscas/dia).
+
+Obtenha uma chave de API em https://siftq.com (cadastre-se e crie uma chave).
+
+## Exemplo de Uso
+
+Aqui está como inicializar e usar o `SiftqSearchTool` dentro de um agente CrewAI:
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import SiftqSearchTool
+
+# Opcionalmente defina sua chave de API para limites mais altos
+# os.environ["SIFTQ_API_KEY"] = "SUA_CHAVE_SIFTQ_API"
+
+# Inicialize a ferramenta
+siftq_tool = SiftqSearchTool()
+
+# Crie um agente que usa a ferramenta
+pesquisador = Agent(
+    role='Pesquisador de Mercado',
+    goal='Encontrar informações sobre as últimas tendências de IA',
+    backstory='Um pesquisador de mercado especializado em tecnologia.',
+    tools=[siftq_tool],
+    verbose=True
+)
+
+# Crie uma tarefa para o agente
+tarefa_pesquisa = Task(
+    description='Pesquise as 3 principais tendências de IA em 2024.',
+    expected_output='Um relatório JSON resumindo as 3 principais tendências de IA encontradas.',
+    agent=pesquisador
+)
+
+# Forme a equipe e inicie
+crew = Crew(
+    agents=[pesquisador],
+    tasks=[tarefa_pesquisa],
+    verbose=2
+)
+
+resultado = crew.kickoff()
+print(resultado)
+```
+
+## Opções de Configuração
+
+O `SiftqSearchTool` aceita os seguintes argumentos durante a inicialização ou ao chamar o método `run`:
+
+- `query` (str): **Obrigatório**. A string de consulta de busca.
+- `scope` (Literal["webpage", "document", "scholar", "image", "video", "podcast"], opcional): O escopo da busca. Padrão: `"webpage"`.
+- `api_key` (str, opcional): A chave de API SiftQ. Usa a variável de ambiente `SIFTQ_API_KEY` como fallback, depois uma chave pública de nível gratuito.
+- `include_summary` (bool, opcional): Incluir resumos gerados por IA para cada resultado. Padrão: `False`.
+- `include_raw_content` (bool, opcional): Obter o conteúdo bruto de cada página de origem. Padrão: `False`.
+- `concise_snippet` (bool, opcional): Retornar trechos concisos com correspondências exatas de texto. Padrão: `False`.
+- `max_results` (int, opcional): Número máximo de resultados (1-100). Padrão: `5`.
+- `timeout` (int, opcional): Tempo limite da requisição em segundos. Padrão: `60`.
+
+## Uso Avançado
+
+Você pode configurar a ferramenta com parâmetros personalizados:
+
+```python
+# Buscar artigos acadêmicos com resumos de IA
+ferramenta_academica = SiftqSearchTool(
+    scope='scholar',
+    max_results=10,
+    include_summary=True
+)
+
+# Buscar páginas web com conteúdo bruto completo
+ferramenta_profunda = SiftqSearchTool(
+    scope='webpage',
+    max_results=5,
+    include_raw_content=True,
+    include_summary=True
+)
+
+# Buscar vídeos com trechos concisos
+ferramenta_video = SiftqSearchTool(
+    scope='video',
+    max_results=3,
+    concise_snippet=True
+)
+```
+
+## Recursos
+
+- **Busca com Ranqueamento Neural**: Relevância de alta qualidade usando algoritmos de ranqueamento neural
+- **Múltiplos Escopos**: Busque em páginas web, documentos, artigos acadêmicos, imagens, vídeos e podcasts
+- **Resumos de IA**: Inclua opcionalmente resumos gerados por IA para cada resultado
+- **Conteúdo Bruto**: Obtenha o conteúdo completo da página quando necessário
+- **Trechos Concisos**: Obtenha trechos com correspondência exata de texto para respostas precisas
+- **Nível Gratuito Disponível**: Chave de API pública permite até 100 buscas por dia
+- **Filtragem de Conteúdo**: Truncamento automático de conteúdo previne problemas de janela de contexto
+
+## Formato da Resposta
+
+A ferramenta retorna resultados de busca como uma string JSON contendo:
+- Resultados da busca com títulos, URLs e trechos
+- Resumos de IA opcionais (quando ativados)
+- Conteúdo bruto de página opcional (quando ativado)
+- Contagem total de resultados e créditos consumidos
+- Campos específicos do escopo (autores, citações, duração, etc.)
+
+O conteúdo de cada resultado é automaticamente truncado para evitar problemas de janela de contexto, mantendo as informações mais relevantes.

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -185,6 +185,7 @@ from crewai_tools.tools.serply_api_tool.serply_web_search_tool import (
 from crewai_tools.tools.serply_api_tool.serply_webpage_to_markdown_tool import (
     SerplyWebpageToMarkdownTool,
 )
+from crewai_tools.tools.siftq_search_tool.siftq_search_tool import SiftqSearchTool
 from crewai_tools.tools.singlestore_search_tool.singlestore_search_tool import (
     SingleStoreSearchTool,
 )
@@ -310,6 +311,7 @@ __all__ = [
     "SerplyScholarSearchTool",
     "SerplyWebSearchTool",
     "SerplyWebpageToMarkdownTool",
+    "SiftqSearchTool",
     "SingleStoreSearchTool",
     "SnowflakeConfig",
     "SnowflakeSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -173,6 +173,7 @@ from crewai_tools.tools.serply_api_tool.serply_web_search_tool import (
 from crewai_tools.tools.serply_api_tool.serply_webpage_to_markdown_tool import (
     SerplyWebpageToMarkdownTool,
 )
+from crewai_tools.tools.siftq_search_tool.siftq_search_tool import SiftqSearchTool
 from crewai_tools.tools.singlestore_search_tool import SingleStoreSearchTool
 from crewai_tools.tools.snowflake_search_tool import (
     SnowflakeConfig,
@@ -292,6 +293,7 @@ __all__ = [
     "SerplyScholarSearchTool",
     "SerplyWebSearchTool",
     "SerplyWebpageToMarkdownTool",
+    "SiftqSearchTool",
     "SingleStoreSearchTool",
     "SnowflakeConfig",
     "SnowflakeSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/README.md
@@ -1,0 +1,51 @@
+# SiftQ Search Tool
+
+## Description
+A tool that performs neural-ranked web searches using the SiftQ API. SiftQ provides high-quality, relevant search results across multiple content scopes (webpages, documents, scholarly articles, images, videos, and podcasts).
+
+## Installation
+This tool is included with the `crewai-tools` package. No additional dependencies are required.
+
+## Configuration
+Set the `SIFTQ_API_KEY` environment variable for a higher rate limit:
+```bash
+export SIFTQ_API_KEY="your-api-key-here"
+```
+
+If no API key is set, a public free-tier key is used (limited to 100 searches/day).
+
+## Usage
+
+```python
+from crewai_tools import SiftqSearchTool
+
+# Basic usage (uses free-tier API key)
+tool = SiftqSearchTool()
+
+# With API key
+tool = SiftqSearchTool(api_key="your-key")
+
+# Custom scope and options
+tool = SiftqSearchTool(
+    scope="scholar",
+    max_results=10,
+    include_summary=True,
+)
+
+# Use in an agent
+result = tool.run("machine learning transformers")
+print(result)
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | env `SIFTQ_API_KEY` | SiftQ API key (falls back to free-tier key) |
+| `scope` | `Literal` | `"webpage"` | Search scope: webpage, document, scholar, image, video, podcast |
+| `include_summary` | `bool` | `False` | Include AI-generated summaries of results |
+| `include_raw_content` | `bool` | `False` | Fetch raw content from source pages |
+| `concise_snippet` | `bool` | `False` | Return concise snippets with exact matches |
+| `max_results` | `int` | `5` | Number of results (1-100) |
+| `timeout` | `int` | `60` | Request timeout in seconds |
+| `max_content_length_per_result` | `int` | `1000` | Max content length per result |

--- a/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py
@@ -82,10 +82,12 @@ class SiftqSearchTool(BaseTool):
     timeout: int = Field(
         default=60,
         description="The timeout for the search request in seconds.",
+        ge=1,
     )
     max_content_length_per_result: int = Field(
         default=1000,
         description="Maximum length for the 'content' of each search result to avoid context window issues.",
+        ge=1,
     )
     env_vars: list[EnvVar] = Field(
         default_factory=lambda: [

--- a/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py
@@ -1,0 +1,185 @@
+import asyncio
+import json
+import os
+from typing import Any, Literal
+
+import requests
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# Intentionally public free-tier key (100 searches/day). Users can set SIFTQ_API_KEY for higher limits.
+DEFAULT_SIFTQ_API_KEY = "mk-1D3D81EFC32A25683B0C2C3B315F8579"
+SIFTQ_API_URL = "https://api.siftq.com/v1/search"
+
+
+class SiftqSearchToolSchema(BaseModel):
+    query: str = Field(..., description="The search query string.")
+    scope: (
+        Literal["webpage", "document", "scholar", "image", "video", "podcast"] | None
+    ) = Field(
+        default=None,
+        description="Override the search scope for this query. One of: webpage, document, scholar, image, video, podcast. "
+        "Uses the tool's default scope if not provided.",
+    )
+    include_summary: bool | None = Field(
+        default=None,
+        description="Override whether to include AI-generated summaries of each result.",
+    )
+    include_raw_content: bool | None = Field(
+        default=None,
+        description="Override whether to fetch and include the raw content from each source page.",
+    )
+    concise_snippet: bool | None = Field(
+        default=None,
+        description="Override whether to return concise snippets with exact original text matches.",
+    )
+    max_results: int | None = Field(
+        default=None,
+        description="Override the maximum number of results to return (1-100).",
+        ge=1,
+        le=100,
+    )
+
+
+class SiftqSearchTool(BaseTool):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    name: str = "SiftQ Search"
+    description: str = (
+        "A tool that performs neural-ranked web searches using the SiftQ API. "
+        "Returns a JSON object containing the search results with titles, URLs, snippets, and more."
+    )
+    args_schema: type[BaseModel] = SiftqSearchToolSchema
+    api_key: str | None = Field(
+        default_factory=lambda: os.getenv("SIFTQ_API_KEY"),
+        description="The SiftQ API key. Falls back to a public free-tier key if not set. "
+        "Set the SIFTQ_API_KEY environment variable for a higher rate limit.",
+    )
+    scope: Literal["webpage", "document", "scholar", "image", "video", "podcast"] = (
+        Field(
+            default="webpage",
+            description="The search scope. One of: webpage, document, scholar, image, video, podcast.",
+        )
+    )
+    include_summary: bool = Field(
+        default=False,
+        description="Whether to include AI-generated summaries of each result.",
+    )
+    include_raw_content: bool = Field(
+        default=False,
+        description="Whether to fetch and include the raw content from each source page.",
+    )
+    concise_snippet: bool = Field(
+        default=False,
+        description="Whether to return concise snippets with exact original text matches.",
+    )
+    max_results: int = Field(
+        default=5,
+        description="The maximum number of results to return (1-100).",
+        ge=1,
+        le=100,
+    )
+    timeout: int = Field(
+        default=60,
+        description="The timeout for the search request in seconds.",
+    )
+    max_content_length_per_result: int = Field(
+        default=1000,
+        description="Maximum length for the 'content' of each search result to avoid context window issues.",
+    )
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="SIFTQ_API_KEY",
+                description="API key for SiftQ search service",
+                required=False,
+            ),
+        ]
+    )
+
+    def _get_api_key(self) -> str:
+        return self.api_key or DEFAULT_SIFTQ_API_KEY
+
+    def _run(
+        self,
+        query: str,
+        scope: Literal["webpage", "document", "scholar", "image", "video", "podcast"]
+        | None = None,
+        include_summary: bool | None = None,
+        include_raw_content: bool | None = None,
+        concise_snippet: bool | None = None,
+        max_results: int | None = None,
+    ) -> str:
+        payload: dict[str, Any] = {
+            "q": query,
+            "scope": scope or self.scope,
+            "includeSummary": include_summary if include_summary is not None else self.include_summary,
+            "includeRawContent": include_raw_content if include_raw_content is not None else self.include_raw_content,
+            "conciseSnippet": concise_snippet if concise_snippet is not None else self.concise_snippet,
+            "size": max_results if max_results is not None else self.max_results,
+        }
+
+        try:
+            response = requests.post(
+                SIFTQ_API_URL,
+                headers={
+                    "Authorization": f"Bearer {self._get_api_key()}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            raise TimeoutError(
+                f"SiftQ search timed out after {self.timeout}s. Try again or increase the timeout."
+            )
+        except requests.exceptions.ConnectionError:
+            raise ConnectionError(
+                "Could not connect to the SiftQ API. Check your network connection."
+            )
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "unknown"
+            raise RuntimeError(
+                f"SiftQ API returned HTTP {status}: {e}"
+            ) from e
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                f"SiftQ search request failed: {e}"
+            ) from e
+
+        try:
+            raw_results = response.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            raise RuntimeError(
+                f"SiftQ returned invalid JSON: {e}"
+            ) from e
+
+        result_key = f"{scope or self.scope}s"
+        if result_key in raw_results and isinstance(raw_results[result_key], list):
+            for item in raw_results[result_key]:
+                for field in ("content", "snippet", "summary"):
+                    value = item.get(field)
+                    if (
+                        isinstance(value, str)
+                        and len(value) > self.max_content_length_per_result
+                    ):
+                        item[field] = (
+                            value[: self.max_content_length_per_result] + "..."
+                        )
+
+        return json.dumps(raw_results, indent=2)
+
+    async def _arun(
+        self,
+        query: str,
+        scope: Literal["webpage", "document", "scholar", "image", "video", "podcast"]
+        | None = None,
+        include_summary: bool | None = None,
+        include_raw_content: bool | None = None,
+        concise_snippet: bool | None = None,
+        max_results: int | None = None,
+    ) -> str:
+        return await asyncio.to_thread(
+            self._run, query, scope, include_summary, include_raw_content, concise_snippet, max_results
+        )

--- a/lib/crewai-tools/tests/tools/siftq_search_tool_test.py
+++ b/lib/crewai-tools/tests/tools/siftq_search_tool_test.py
@@ -1,0 +1,417 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from requests import RequestException
+
+from crewai_tools.tools.siftq_search_tool.siftq_search_tool import (
+    DEFAULT_SIFTQ_API_KEY,
+    SIFTQ_API_URL,
+    SiftqSearchTool,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_siftq_api_key():
+    with patch.dict(os.environ, {"SIFTQ_API_KEY": "test_key"}):
+        yield
+
+
+@pytest.fixture
+def siftq_tool():
+    return SiftqSearchTool()
+
+
+def test_default_initialization(siftq_tool):
+    assert siftq_tool.scope == "webpage"
+    assert siftq_tool.include_summary is False
+    assert siftq_tool.include_raw_content is False
+    assert siftq_tool.concise_snippet is False
+    assert siftq_tool.max_results == 5
+    assert siftq_tool.timeout == 60
+    assert siftq_tool.max_content_length_per_result == 1000
+
+
+def test_custom_initialization():
+    tool = SiftqSearchTool(
+        scope="scholar",
+        include_summary=True,
+        include_raw_content=True,
+        concise_snippet=True,
+        max_results=10,
+        timeout=30,
+        max_content_length_per_result=500,
+        api_key="custom_key",
+    )
+    assert tool.scope == "scholar"
+    assert tool.include_summary is True
+    assert tool.include_raw_content is True
+    assert tool.concise_snippet is True
+    assert tool.max_results == 10
+    assert tool.timeout == 30
+    assert tool.max_content_length_per_result == 500
+    assert tool.api_key == "custom_key"
+
+
+def test_api_key_falls_back_to_env(siftq_tool):
+    assert siftq_tool.api_key == "test_key"
+
+
+def test_api_key_uses_default_when_not_set():
+    with patch.dict(os.environ, {}, clear=True):
+        tool = SiftqSearchTool()
+        assert tool.api_key is None
+
+
+def test_get_api_key_uses_default_fallback():
+    with patch.dict(os.environ, {}, clear=True):
+        tool = SiftqSearchTool()
+        assert tool._get_api_key() == DEFAULT_SIFTQ_API_KEY
+
+
+def test_get_api_key_uses_env_value():
+    with patch.dict(os.environ, {"SIFTQ_API_KEY": "env_key"}):
+        tool = SiftqSearchTool()
+        assert tool._get_api_key() == "env_key"
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_basic_search(mock_post):
+    mock_response = {
+        "credits": 1,
+        "total": 2,
+        "webpages": [
+            {
+                "title": "Result 1",
+                "link": "https://example.com/1",
+                "snippet": "Snippet 1",
+                "content": "Full content 1",
+                "position": 1,
+            },
+            {
+                "title": "Result 2",
+                "link": "https://example.com/2",
+                "snippet": "Snippet 2",
+                "content": "Full content 2",
+                "position": 2,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()
+    result = json.loads(tool.run("test query"))
+
+    mock_post.assert_called_once_with(
+        SIFTQ_API_URL,
+        headers={
+            "Authorization": "Bearer test_key",
+            "Content-Type": "application/json",
+        },
+        json={
+            "q": "test query",
+            "scope": "webpage",
+            "includeSummary": False,
+            "includeRawContent": False,
+            "conciseSnippet": False,
+            "size": 5,
+        },
+        timeout=60,
+    )
+    assert "webpages" in result
+    assert result["webpages"][0]["title"] == "Result 1"
+    assert result["webpages"][1]["title"] == "Result 2"
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_with_content_truncation(mock_post):
+    long_content = "A" * 2000
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "webpages": [
+            {
+                "title": "Long Result",
+                "link": "https://example.com/long",
+                "snippet": "Short snippet",
+                "content": long_content,
+                "position": 1,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+
+    tool = SiftqSearchTool(max_content_length_per_result=100)
+    result = json.loads(tool.run("test query"))
+
+    assert len(result["webpages"][0]["content"]) == 100 + 3  # 100 + "..."
+    assert result["webpages"][0]["content"].endswith("...")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_uses_snippet_when_no_content(mock_post):
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "webpages": [
+            {
+                "title": "No Content",
+                "link": "https://example.com/nocontent",
+                "snippet": "This is a snippet without content field",
+                "position": 1,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+
+    tool = SiftqSearchTool(max_content_length_per_result=500)
+    result = json.loads(tool.run("test query"))
+
+    assert result["webpages"][0]["snippet"] == "This is a snippet without content field"
+    assert "content" not in result["webpages"][0]
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_truncates_snippet_in_place(mock_post):
+    long_snippet = "B" * 2000
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "webpages": [
+            {
+                "title": "Long Snippet",
+                "link": "https://example.com/longsnippet",
+                "snippet": long_snippet,
+                "position": 1,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+
+    tool = SiftqSearchTool(max_content_length_per_result=100)
+    result = json.loads(tool.run("test query"))
+
+    assert len(result["webpages"][0]["snippet"]) == 103  # 100 + "..."
+    assert result["webpages"][0]["snippet"].endswith("...")
+    assert "content" not in result["webpages"][0]
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_with_scholar_scope(mock_post):
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "scholars": [
+            {
+                "title": "A Scholarly Paper",
+                "authors": ["Author A", "Author B"],
+                "link": "https://scholar.example.com/paper",
+                "snippet": "Abstract of the paper",
+                "year": 2024,
+                "venue": "Journal of AI",
+                "citationCount": 42,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+
+    tool = SiftqSearchTool(scope="scholar")
+    result = json.loads(tool.run("machine learning"))
+
+    called_payload = mock_post.call_args.kwargs["json"]
+    assert called_payload["scope"] == "scholar"
+    assert result["scholars"][0]["title"] == "A Scholarly Paper"
+    assert result["scholars"][0]["citationCount"] == 42
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_with_include_raw_content(mock_post):
+    mock_response = {"credits": 1, "total": 0, "webpages": []}
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+
+    tool = SiftqSearchTool(include_raw_content=True)
+    tool.run("test query")
+
+    called_payload = mock_post.call_args.kwargs["json"]
+    assert called_payload["includeRawContent"] is True
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_api_error_handling(mock_post):
+    mock_post.side_effect = RequestException("API Error")
+
+    tool = SiftqSearchTool()
+    with pytest.raises(RuntimeError, match="API Error"):
+        tool.run("test query")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_http_error_handling(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response=mock_response
+    )
+    mock_post.return_value = mock_response
+
+    tool = SiftqSearchTool()
+    with pytest.raises(RuntimeError, match="401"):
+        tool.run("test query")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+@pytest.mark.asyncio
+async def test_arun(mock_post):
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "webpages": [
+            {
+                "title": "Async Result",
+                "link": "https://example.com/async",
+                "snippet": "Async snippet",
+                "position": 1,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()
+    result = json.loads(await tool._arun("async query"))
+
+    assert result["webpages"][0]["title"] == "Async Result"
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_with_malformed_response(mock_post):
+    mock_post.return_value.json.side_effect = ValueError("No JSON")
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        tool.run("test query")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_with_empty_response(mock_post):
+    mock_post.return_value.json.return_value = {}
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()
+    result = json.loads(tool.run("test query"))
+    assert result == {}
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_timeout_error(mock_post):
+    mock_post.side_effect = requests.exceptions.Timeout("Connection timed out")
+
+    tool = SiftqSearchTool()
+    with pytest.raises(TimeoutError, match="timed out"):
+        tool.run("test query")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_connection_error(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError("No connection")
+
+    tool = SiftqSearchTool()
+    with pytest.raises(ConnectionError, match="Could not connect"):
+        tool.run("test query")
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_scope_override_per_query(mock_post):
+    mock_response = {
+        "credits": 1,
+        "total": 1,
+        "videos": [
+            {
+                "title": "A Video",
+                "link": "https://example.com/video",
+                "snippet": "Video description",
+                "position": 1,
+            },
+        ],
+    }
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()  # default scope is "webpage"
+    result = json.loads(tool.run("test query", scope="video"))
+
+    called_payload = mock_post.call_args.kwargs["json"]
+    assert called_payload["scope"] == "video"
+    assert result["videos"][0]["title"] == "A Video"
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_scope_override_none_uses_default(mock_post):
+    mock_response = {"credits": 1, "total": 0, "webpages": []}
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool(scope="scholar")
+    tool.run("test query")
+
+    called_payload = mock_post.call_args.kwargs["json"]
+    assert called_payload["scope"] == "scholar"
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_per_query_overrides(mock_post):
+    mock_response = {"credits": 1, "total": 0, "scholars": []}
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool()  # all defaults
+    tool.run(
+        "test query",
+        scope="scholar",
+        include_summary=True,
+        include_raw_content=True,
+        concise_snippet=True,
+        max_results=20,
+    )
+
+    called_payload = mock_post.call_args.kwargs["json"]
+    assert called_payload["scope"] == "scholar"
+    assert called_payload["includeSummary"] is True
+    assert called_payload["includeRawContent"] is True
+    assert called_payload["conciseSnippet"] is True
+    assert called_payload["size"] == 20
+
+
+@patch("crewai_tools.tools.siftq_search_tool.siftq_search_tool.requests.post")
+def test_run_per_query_overrides_do_not_mutate_instance(mock_post):
+    mock_response = {"credits": 1, "total": 0, "webpages": []}
+    mock_post.return_value.json.return_value = mock_response
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    tool = SiftqSearchTool(include_summary=False, max_results=5)
+    tool.run(
+        "test query",
+        include_summary=True,
+        max_results=50,
+    )
+
+    # Instance defaults should remain unchanged
+    assert tool.include_summary is False
+    assert tool.max_results == 5

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -23596,6 +23596,7 @@
           "max_content_length_per_result": {
             "default": 1000,
             "description": "Maximum length for the 'content' of each search result to avoid context window issues.",
+            "minimum": 1,
             "title": "Max Content Length Per Result",
             "type": "integer"
           },
@@ -23624,6 +23625,7 @@
           "timeout": {
             "default": 60,
             "description": "The timeout for the search request in seconds.",
+            "minimum": 1,
             "title": "Timeout",
             "type": "integer"
           }
@@ -23636,10 +23638,85 @@
       "package_dependencies": [],
       "run_params_schema": {
         "properties": {
+          "concise_snippet": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Override whether to return concise snippets with exact original text matches.",
+            "title": "Concise Snippet"
+          },
+          "include_raw_content": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Override whether to fetch and include the raw content from each source page.",
+            "title": "Include Raw Content"
+          },
+          "include_summary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Override whether to include AI-generated summaries of each result.",
+            "title": "Include Summary"
+          },
+          "max_results": {
+            "anyOf": [
+              {
+                "maximum": 100,
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Override the maximum number of results to return (1-100).",
+            "title": "Max Results"
+          },
           "query": {
             "description": "The search query string.",
             "title": "Query",
             "type": "string"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "enum": [
+                  "webpage",
+                  "document",
+                  "scholar",
+                  "image",
+                  "video",
+                  "podcast"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Override the search scope for this query. One of: webpage, document, scholar, image, video, podcast. Uses the tool's default scope if not provided.",
+            "title": "Scope"
           }
         },
         "required": [

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -23514,6 +23514,142 @@
       }
     },
     {
+      "description": "A tool that performs neural-ranked web searches using the SiftQ API. Returns a JSON object containing the search results with titles, URLs, snippets, and more.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for SiftQ search service",
+          "name": "SIFTQ_API_KEY",
+          "required": false
+        }
+      ],
+      "humanized_name": "SiftQ Search",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The SiftQ API key. Falls back to a public free-tier key if not set. Set the SIFTQ_API_KEY environment variable for a higher rate limit.",
+            "title": "Api Key"
+          },
+          "concise_snippet": {
+            "default": false,
+            "description": "Whether to return concise snippets with exact original text matches.",
+            "title": "Concise Snippet",
+            "type": "boolean"
+          },
+          "include_raw_content": {
+            "default": false,
+            "description": "Whether to fetch and include the raw content from each source page.",
+            "title": "Include Raw Content",
+            "type": "boolean"
+          },
+          "include_summary": {
+            "default": false,
+            "description": "Whether to include AI-generated summaries of each result.",
+            "title": "Include Summary",
+            "type": "boolean"
+          },
+          "max_content_length_per_result": {
+            "default": 1000,
+            "description": "Maximum length for the 'content' of each search result to avoid context window issues.",
+            "title": "Max Content Length Per Result",
+            "type": "integer"
+          },
+          "max_results": {
+            "default": 5,
+            "description": "The maximum number of results to return (1-100).",
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "scope": {
+            "default": "webpage",
+            "description": "The search scope. One of: webpage, document, scholar, image, video, podcast.",
+            "enum": [
+              "webpage",
+              "document",
+              "scholar",
+              "image",
+              "video",
+              "podcast"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
+          "timeout": {
+            "default": 60,
+            "description": "The timeout for the search request in seconds.",
+            "title": "Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "title": "SiftqSearchTool",
+        "type": "object"
+      },
+      "name": "SiftqSearchTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "query": {
+            "description": "The search query string.",
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "SiftqSearchToolSchema",
+        "type": "object"
+      }
+    },
+    {
       "description": "A tool that can be used to semantic search a query from a database.",
       "env_vars": [
         {


### PR DESCRIPTION
## Description

Adds `SiftqSearchTool`, a new CrewAI tool that wraps the [SiftQ](https://siftq.com) neural-ranked search API, enabling agents to search across webpages, documents, scholarly articles, images, videos, and podcasts with a single interface.

Unlike `TavilySearchTool` which requires the `tavily-python` SDK, `SiftqSearchTool` uses `requests` directly (already a project dependency) — no additional packages needed. It also includes a public free-tier API key for zero-config out-of-the-box usage (100 searches/day).

---

### Changes

**Implementation** (`0bea3d90a`) — 5 files, +240 lines

- `lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/siftq_search_tool.py` — Main tool class
  - Extends `BaseTool` with `_run` (sync via `requests.post`) and `_arun` (async via `asyncio.to_thread`)
  - Configurable: `scope` (6 types), `max_results`, `include_summary`, `include_raw_content`, `concise_snippet`, `timeout`
  - API key resolution: `SIFTQ_API_KEY` env var → public free-tier fallback key
  - Content truncation per result to prevent context window issues
  - Graceful error handling for timeouts, connection errors, HTTP errors, and malformed responses
- `lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/__init__.py` — Empty init
- `lib/crewai-tools/src/crewai_tools/tools/siftq_search_tool/README.md` — In-source README
- `lib/crewai-tools/src/crewai_tools/__init__.py` — Added `SiftqSearchTool` export
- `lib/crewai-tools/src/crewai_tools/tools/__init__.py` — Added `SiftqSearchTool` export

**Tests** (`0eb07e900`) — 1 file, +417 lines

- `lib/crewai-tools/tests/tools/siftq_search_tool_test.py`
  - Default and custom initialization
  - API key resolution (env var, missing, default fallback)
  - Search execution with payload verification
  - Content truncation
  - Scholar scope and `includeRawContent` payload
  - Error handling: timeout, connection error, HTTP 401, `RequestException`, malformed JSON
  - Async `_arun`
  - Empty response handling

**Documentation** (`90451710a`) — 4 files, +408 lines

- `docs/en/tools/search-research/siftqsearchtool.mdx` — English docs page
- `docs/pt-BR/tools/search-research/siftqsearchtool.mdx` — Portuguese translation
- `docs/en/concepts/tools.mdx` — Added to available tools table
- `lib/crewai-tools/tool.specs.json` — Auto-generated tool specs

---

### Usage

```python
from crewai_tools import SiftqSearchTool

tool = SiftqSearchTool()  # uses free-tier key by default
result = tool.run("neural ranking search")

# Or with custom scope
scholar_tool = SiftqSearchTool(scope="scholar", max_results=10, include_summary=True)
```

### API Details

- **Endpoint:** `POST https://api.siftq.com/v1/search`
- **Auth:** Bearer token from `SIFTQ_API_KEY` env var or free-tier fallback
- **Rate limit:** 100 searches/day on free tier
- **Scopes:** `webpage`, `document`, `scholar`, `image`, `video`, `podcast`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SiftqSearchTool for neural-ranked search via the SiftQ API, supporting webpages, documents, scholarly articles, images, videos, and podcasts.

* **Documentation**
  * Added detailed docs (EN and PT-BR), README, installation and setup guidance, environment variable usage (SIFTQ_API_KEY with free-tier fallback), examples, configuration options, and response format notes.

* **Tests**
  * Added comprehensive test coverage validating behavior, error handling, and truncation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->