### PR TITLE
fix(tools): correct mongdb typo to pymongo in package_dependencies

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
@@ -103,7 +103,7 @@ class MongoDBVectorSearchTool(BaseTool):
             ),
         ]
     )
-    package_dependencies: list[str] = Field(default_factory=lambda: ["mongdb"])
+    package_dependencies: list[str] = Field(default_factory=lambda: ["pymongo"])
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -14633,7 +14633,7 @@
       },
       "name": "MongoDBVectorSearchTool",
       "package_dependencies": [
-        "mongdb"
+        "pymongo"
       ],
       "run_params_schema": {
         "description": "Input for MongoDBTool.",


### PR DESCRIPTION
## Summary

- `MongoDBVectorSearchTool.package_dependencies` listed `"mongdb"` — a non-existent PyPI package name (missing the `py` prefix).
- The file imports and uses `pymongo` throughout, so the correct value is `"pymongo"`.
- Single-character-range fix; no logic changed.

## Test plan

- [ ] Verify the `package_dependencies` field now returns `["pymongo"]` when inspecting a `MongoDBVectorSearchTool` instance.
- [ ] Confirm that any tooling that reads `package_dependencies` to auto-install dependencies will correctly resolve `pymongo` from PyPI.
- [ ] Run existing tests for `MongoDBVectorSearchTool` to ensure no regressions (`pytest` or equivalent in the tools library).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: fixes an incorrect dependency name used for auto-install/metadata, with no runtime logic changes beyond dependency resolution.
> 
> **Overview**
> Fixes `MongoDBVectorSearchTool` dependency metadata by replacing the misspelled/nonexistent `mongdb` entry with `pymongo` in both the tool definition (`vector_search.py`) and the generated `tool.specs.json`, ensuring dependency auto-install/validation resolves correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115aa6f26b9a0074b29ea47a83ddedb47075b0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected an incorrect package dependency declaration in the MongoDB Vector Search tool, ensuring proper dependency management and installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->