### PR TITLE
feat(tools): declare env_vars on DatabricksQueryTool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/databricks_query_tool/databricks_query_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/databricks_query_tool/databricks_query_tool.py
@@ -4,7 +4,7 @@ import os
 import time
 from typing import TYPE_CHECKING, Any, TypeGuard, TypedDict
 
-from crewai.tools import BaseTool
+from crewai.tools import BaseTool, EnvVar
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -99,6 +99,25 @@ class DatabricksQueryTool(BaseTool):
 
     _workspace_client: WorkspaceClient | None = None
     package_dependencies: list[str] = Field(default_factory=lambda: ["databricks-sdk"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="DATABRICKS_HOST",
+                description="Databricks workspace URL (use with DATABRICKS_TOKEN, or set DATABRICKS_CONFIG_PROFILE instead).",
+                required=False,
+            ),
+            EnvVar(
+                name="DATABRICKS_TOKEN",
+                description="Databricks personal access token (pair with DATABRICKS_HOST).",
+                required=False,
+            ),
+            EnvVar(
+                name="DATABRICKS_CONFIG_PROFILE",
+                description="Databricks CLI profile name (alternative to DATABRICKS_HOST/TOKEN).",
+                required=False,
+            ),
+        ]
+    )
 
     def __init__(
         self,

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -6821,7 +6821,26 @@
     },
     {
       "description": "Execute SQL queries against Databricks workspace tables and return the results. Provide a 'query' parameter with the SQL query to execute.",
-      "env_vars": [],
+      "env_vars": [
+        {
+          "default": null,
+          "description": "Databricks workspace URL (use with DATABRICKS_TOKEN, or set DATABRICKS_CONFIG_PROFILE instead).",
+          "name": "DATABRICKS_HOST",
+          "required": false
+        },
+        {
+          "default": null,
+          "description": "Databricks personal access token (pair with DATABRICKS_HOST).",
+          "name": "DATABRICKS_TOKEN",
+          "required": false
+        },
+        {
+          "default": null,
+          "description": "Databricks CLI profile name (alternative to DATABRICKS_HOST/TOKEN).",
+          "name": "DATABRICKS_CONFIG_PROFILE",
+          "required": false
+        }
+      ],
       "humanized_name": "Databricks SQL Query",
       "init_params_schema": {
         "$defs": {


### PR DESCRIPTION
## Summary

- Added `EnvVar` to the existing `from crewai.tools import BaseTool, EnvVar` import in `databricks_query_tool.py`
- Added `env_vars: list[EnvVar]` field immediately after `package_dependencies` on the `DatabricksQueryTool` class
- Declares all three Databricks auth env vars (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_CONFIG_PROFILE`) with `required=False`, since auth is satisfied by either DATABRICKS_HOST+TOKEN or DATABRICKS_CONFIG_PROFILE alone

## Test plan

- [ ] Verify `DatabricksQueryTool().env_vars` returns a list of three `EnvVar` objects
- [ ] Confirm `EnvVar` names match what `_validate_credentials()` checks: `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_CONFIG_PROFILE`
- [ ] Confirm all three entries have `required=False`
- [ ] Check host UI correctly renders the env var hints when configuring a DatabricksQueryTool
- [ ] Ensure no other files were modified (untracked files `FLOWS_V2_MVP_HANDOFF.md`, `flows_v2_mvp_examples/`, `flows_v2_mvp_reference.py` excluded)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change that exposes env var requirements for the Databricks tool without altering query execution or credential validation logic.
> 
> **Overview**
> **Adds explicit env var metadata for Databricks auth.** `DatabricksQueryTool` now declares `env_vars` entries for `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, and `DATABRICKS_CONFIG_PROFILE` (all optional individually to support either auth path).
> 
> Updates the generated `tool.specs.json` so tooling/host UIs can surface these environment variable hints when configuring the Databricks query tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdad0d57c88c9e1c78b8409270c5af0ff06cc32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Databricks query tool now explicitly declares required environment variables (host, token, and config profile) so credential inputs are discoverable in configuration.
  * Tool metadata updated to surface these connection settings, improving clarity when configuring Databricks access and reducing guesswork for required credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->