### PR TITLE
fix(crew): only report real template variables in fetch_inputs

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -7,7 +7,6 @@ from copy import copy as shallow_copy
 from hashlib import md5
 import json
 from pathlib import Path
-import re
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -142,7 +141,10 @@ from crewai.utilities.streaming import (
     signal_end,
     signal_error,
 )
-from crewai.utilities.string_utils import sanitize_tool_name
+from crewai.utilities.string_utils import (
+    TEMPLATE_VARIABLE_PATTERN,
+    sanitize_tool_name,
+)
 from crewai.utilities.task_output_storage_handler import TaskOutputStorageHandler
 from crewai.utilities.training_handler import CrewTrainingHandler
 
@@ -1971,21 +1973,25 @@ class Crew(FlowTrackable, BaseModel):
         'role', 'goal', and 'backstory'.
 
         Returns a set of all discovered placeholder names.
+
+        Only valid template variables are reported — the same pattern used by
+        ``interpolate_only`` to substitute them. Literal braces (e.g. embedded
+        JSON examples or output schemas) are not interpolated, so they are not
+        treated as required inputs.
         """
-        placeholder_pattern = re.compile(r"\{(.+?)}")
         required_inputs: set[str] = set()
 
         # Scan tasks for inputs
         for task in self.tasks:
             # description and expected_output might contain e.g. {topic}, {user_name}
             text = f"{task.description or ''} {task.expected_output or ''}"
-            required_inputs.update(placeholder_pattern.findall(text))
+            required_inputs.update(TEMPLATE_VARIABLE_PATTERN.findall(text))
 
         # Scan agents for inputs
         for agent in self.agents:
             # role, goal, backstory might have placeholders like {role_detail}, etc.
             text = f"{agent.role or ''} {agent.goal or ''} {agent.backstory or ''}"
-            required_inputs.update(placeholder_pattern.findall(text))
+            required_inputs.update(TEMPLATE_VARIABLE_PATTERN.findall(text))
 
         return required_inputs
 

--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -9,7 +9,9 @@ from typing import Any, Final
 import unicodedata
 
 
-_VARIABLE_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{([A-Za-z_][A-Za-z0-9_\-]*)}")
+TEMPLATE_VARIABLE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\{([A-Za-z_][A-Za-z0-9_\-]*)}"
+)
 _QUOTE_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\'\"]+")
 _CAMEL_LOWER_UPPER: Final[re.Pattern[str]] = re.compile(r"([a-z])([A-Z])")
 _CAMEL_UPPER_LOWER: Final[re.Pattern[str]] = re.compile(r"([A-Z]+)([A-Z][a-z])")
@@ -134,7 +136,7 @@ def interpolate_only(
             "Inputs dictionary cannot be empty when interpolating variables"
         )
 
-    variables = _VARIABLE_PATTERN.findall(input_string)
+    variables = TEMPLATE_VARIABLE_PATTERN.findall(input_string)
     result = input_string
 
     # Check if all variables exist in inputs

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -3966,6 +3966,33 @@ def test_fetch_inputs():
     )
 
 
+def test_fetch_inputs_ignores_literal_braces():
+    """fetch_inputs must only report real template variables.
+
+    Literal braces (embedded JSON examples, output schemas) and non-identifier
+    braces are not interpolated by ``interpolate_only``, so they must not be
+    reported as required inputs. Otherwise ``kickoff`` accepts inputs that are
+    silently ignored, while ``fetch_inputs`` advertises placeholders that can
+    never be filled.
+    """
+    agent = Agent(
+        role="Researcher",
+        goal="Research on {topic}.",
+        backstory='Reply as JSON like {"name": "value"}.',
+    )
+
+    task = Task(
+        description='Analyze {topic} and return {"result": [1, 2, 3]}.',
+        expected_output="Summary of {topic}. Ignore {123} markers.",
+        agent=agent,
+    )
+
+    crew = Crew(agents=[agent], tasks=[task])
+
+    # Only the genuine identifier placeholder should be reported.
+    assert crew.fetch_inputs() == {"topic"}
+
+
 @pytest.mark.vcr()
 def test_task_tools_preserve_code_execution_tools():
     """


### PR DESCRIPTION
## Problem

`Crew.fetch_inputs()` is meant to return the placeholder names a crew expects so callers know what to pass to `kickoff()`. It scans task descriptions / expected outputs and agent role/goal/backstory with the regex `\{(.+?)}`, which matches **any** content between braces.

That regex does not match what actually gets interpolated. `interpolate_only()` (the function that performs the substitution) only replaces valid identifiers via `\{([A-Za-z_][A-Za-z0-9_\-]*)}`. As a result, literal braces that are common in prompts — embedded JSON examples, output schemas, etc. — are reported as required inputs even though they are never substituted.

Example:

```python
agent = Agent(
    role="Researcher",
    goal="Research on {topic}.",
    backstory='Reply as JSON like {"name": "value"}.',
)
task = Task(
    description='Analyze {topic} and return {"result": [1, 2, 3]}.',
    expected_output="Summary of {topic}.",
    agent=agent,
)
crew = Crew(agents=[agent], tasks=[task])

crew.fetch_inputs()
# before: {'topic', '"name": "value"', '"result": [1, 2, 3]'}
# after:  {'topic'}
```

The bogus entries are not real variables, so any value passed for them via `kickoff(inputs=...)` is silently ignored, and tools that build UIs/prompts from `fetch_inputs()` surface placeholders that can never be filled.

## Fix

Reuse the canonical template-variable pattern that `interpolate_only` already uses, so input discovery and input substitution share a single source of truth and cannot drift. The pattern is promoted to a public `TEMPLATE_VARIABLE_PATTERN` in `string_utils` and imported by `crew.py`. The now-unused `re` import in `crew.py` is removed.

## Testing

- Added `test_fetch_inputs_ignores_literal_braces`, which fails on `main` (returns the JSON fragments as inputs) and passes with this change.
- Existing `test_fetch_inputs` and the task/crew interpolation tests still pass.
- `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

---

Developed with AI coding assistance; reviewed and submitted by the author.

_Per CONTRIBUTING.md, this PR should carry the `llm-generated` label — I do not have permission to apply labels as an external contributor, so could a maintainer please add it._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template variable detection to correctly ignore literal braces in strings (e.g., JSON objects).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->