### PR TITLE
fix: use running loop in async paths

### DIFF
--- a/lib/crewai/src/crewai/rag/chromadb/client.py
+++ b/lib/crewai/src/crewai/rag/chromadb/client.py
@@ -86,7 +86,7 @@ class ChromaDBClient(BaseClient):
             yield
             return
         lock_cm = store_lock(self._lock_name)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, lock_cm.__enter__)
         try:
             yield

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -279,7 +279,7 @@ class CrewStructuredTool(BaseModel):
             # Run sync functions in a thread pool
             import asyncio
 
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.func(**parsed_args, **kwargs)
             )
         except Exception:

--- a/lib/crewai/src/crewai/utilities/streaming.py
+++ b/lib/crewai/src/crewai/utilities/streaming.py
@@ -206,7 +206,7 @@ def create_streaming_state(
 
     if use_async:
         async_queue = asyncio.Queue()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
     stream_id = str(uuid.uuid4())
 


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in async execution paths
- Cover tool executor, streaming state setup, and ChromaDB async lock code paths

## Problem
`asyncio.get_event_loop()` is legacy behavior in modern Python and can warn or behave differently when no loop is set on the current thread. These call sites are already inside async execution paths, so the running event loop is the loop they need.

## Before / After
Before, async code asked asyncio for the current event loop policy result with `get_event_loop()`.

After, the code explicitly uses the active running loop with `get_running_loop()`, matching the async context these functions run in.

## Verification
- `python -m compileall -q lib\crewai\src\crewai\tools\structured_tool.py lib\crewai\src\crewai\utilities\streaming.py lib\crewai\src\crewai\rag\chromadb\client.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of async operations throughout the framework by fixing event loop context handling in RAG operations, structured tool execution, and streaming functionality for better stability in concurrent scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->