### PR TITLE
feat(llms): add NEAR AI Cloud provider

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -342,6 +342,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "cerebras",
     "dashscope",
     "snowflake",
+    "nearai",
 ]
 
 
@@ -431,6 +432,7 @@ class LLM(BaseLLM):
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
                 "snowflake": "snowflake",
+                "nearai": "nearai",
             }
 
             canonical_provider = provider_mapping.get(prefix.lower())
@@ -553,6 +555,10 @@ class LLM(BaseLLM):
         if provider == "snowflake":
             return True
 
+        if provider == "nearai":
+            # NEAR AI Cloud publishes a dynamic model catalog and accepts provider/model IDs.
+            return True
+
         return False
 
     @classmethod
@@ -664,6 +670,7 @@ class LLM(BaseLLM):
             "hosted_vllm",
             "cerebras",
             "dashscope",
+            "nearai",
         }
         if provider in openai_compatible_providers:
             from crewai.llms.providers.openai_compatible.completion import (

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -2,7 +2,7 @@
 
 This module provides a thin subclass of OpenAICompletion that supports
 various OpenAI-compatible APIs like OpenRouter, DeepSeek, Ollama, vLLM,
-Cerebras, and Dashscope (Alibaba/Qwen).
+Cerebras, Dashscope (Alibaba/Qwen), and NEAR AI Cloud.
 
 Usage:
     llm = LLM(model="deepseek/deepseek-chat")  # Uses DeepSeek API
@@ -32,6 +32,11 @@ class ProviderConfig:
         default_headers: HTTP headers to include in all requests.
         api_key_required: Whether an API key is required for this provider.
         default_api_key: Default API key to use if none is provided and not required.
+        use_max_tokens_for_completion_tokens: Whether to send max_completion_tokens
+            as max_tokens for providers that do not support the newer OpenAI field.
+        supports_reasoning_effort: Whether reasoning_effort can be sent.
+        supports_strict_tool_schema: Whether strict tool schema mode can be sent.
+        unsupported_params: Request parameters to remove before sending.
     """
 
     base_url: str
@@ -40,6 +45,10 @@ class ProviderConfig:
     default_headers: dict[str, str] = field(default_factory=dict)
     api_key_required: bool = True
     default_api_key: str | None = None
+    use_max_tokens_for_completion_tokens: bool = False
+    supports_reasoning_effort: bool = True
+    supports_strict_tool_schema: bool = True
+    unsupported_params: tuple[str, ...] = ()
 
 
 OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
@@ -89,6 +98,16 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         base_url_env="DASHSCOPE_BASE_URL",
         api_key_required=True,
     ),
+    "nearai": ProviderConfig(
+        base_url="https://cloud-api.near.ai/v1",
+        api_key_env="NEARAI_API_KEY",
+        base_url_env="NEARAI_BASE_URL",
+        api_key_required=True,
+        use_max_tokens_for_completion_tokens=True,
+        supports_reasoning_effort=False,
+        supports_strict_tool_schema=False,
+        unsupported_params=("store",),
+    ),
 }
 
 
@@ -125,6 +144,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         - hosted_vllm: vLLM server (https://github.com/vllm-project/vllm)
         - cerebras: Cerebras (https://cerebras.ai)
         - dashscope: Alibaba Dashscope/Qwen (https://dashscope.aliyun.com)
+        - nearai: NEAR AI Cloud TEE inference (https://cloud.near.ai)
 
     Example:
         # Using provider prefix
@@ -249,6 +269,51 @@ class OpenAICompatibleCompletion(OpenAICompletion):
             merged.update(headers)
 
         return merged if merged else None
+
+    def _get_provider_config(self) -> ProviderConfig | None:
+        """Return the configuration for this provider."""
+        return OPENAI_COMPATIBLE_PROVIDERS.get(self.provider)
+
+    def _prepare_completion_params(
+        self,
+        messages: list[Any],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Prepare chat completion parameters with provider-specific compatibility."""
+        params = super()._prepare_completion_params(messages=messages, tools=tools)
+        config = self._get_provider_config()
+        if config is None:
+            return params
+
+        if (
+            config.use_max_tokens_for_completion_tokens
+            and "max_completion_tokens" in params
+        ):
+            params["max_tokens"] = params.pop("max_completion_tokens")
+
+        if not config.supports_reasoning_effort:
+            params.pop("reasoning_effort", None)
+
+        for param in config.unsupported_params:
+            params.pop(param, None)
+
+        return params
+
+    def _convert_tools_for_interference(
+        self, tools: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Convert tools while honoring provider-specific schema support."""
+        converted_tools = super()._convert_tools_for_interference(tools)
+        config = self._get_provider_config()
+        if config is None or config.supports_strict_tool_schema:
+            return converted_tools
+
+        for tool in converted_tools:
+            function = tool.get("function")
+            if isinstance(function, dict):
+                function.pop("strict", None)
+
+        return converted_tools
 
     def supports_function_calling(self) -> bool:
         """Check if the provider supports function calling.

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -36,6 +36,10 @@ class TestProviderConfig:
         assert config.default_headers == {}
         assert config.api_key_required is True
         assert config.default_api_key is None
+        assert config.use_max_tokens_for_completion_tokens is False
+        assert config.supports_reasoning_effort is True
+        assert config.supports_strict_tool_schema is True
+        assert config.unsupported_params == ()
 
 
 class TestProviderRegistry:
@@ -94,6 +98,18 @@ class TestProviderRegistry:
         assert config.base_url == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
         assert config.api_key_env == "DASHSCOPE_API_KEY"
         assert config.api_key_required is True
+
+    def test_nearai_config(self):
+        """Test NEAR AI Cloud provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["nearai"]
+        assert config.base_url == "https://cloud-api.near.ai/v1"
+        assert config.api_key_env == "NEARAI_API_KEY"
+        assert config.base_url_env == "NEARAI_BASE_URL"
+        assert config.api_key_required is True
+        assert config.use_max_tokens_for_completion_tokens is True
+        assert config.supports_reasoning_effort is False
+        assert config.supports_strict_tool_schema is False
+        assert config.unsupported_params == ("store",)
 
 
 class TestNormalizeOllamaBaseUrl:
@@ -223,6 +239,57 @@ class TestOpenAICompatibleCompletion:
         completion = OpenAICompatibleCompletion(model="llama3", provider="ollama")
         assert completion.supports_function_calling() is True
 
+    def test_nearai_remaps_max_completion_tokens(self):
+        """Test NEAR AI Cloud receives max_tokens instead of max_completion_tokens."""
+        with patch.dict(os.environ, {"NEARAI_API_KEY": "test-key"}):
+            completion = OpenAICompatibleCompletion(
+                model="anthropic/claude-haiku-4-5",
+                provider="nearai",
+                max_completion_tokens=100,
+            )
+            params = completion._prepare_completion_params(
+                messages=[{"role": "user", "content": "Hello"}]
+            )
+            assert params["max_tokens"] == 100
+            assert "max_completion_tokens" not in params
+
+    def test_nearai_drops_unsupported_params(self):
+        """Test NEAR AI Cloud does not receive unsupported OpenAI-only params."""
+        with patch.dict(os.environ, {"NEARAI_API_KEY": "test-key"}):
+            completion = OpenAICompatibleCompletion(
+                model="openai/o1",
+                provider="nearai",
+                reasoning_effort="low",
+                additional_params={"store": True},
+            )
+            params = completion._prepare_completion_params(
+                messages=[{"role": "user", "content": "Hello"}]
+            )
+            assert "reasoning_effort" not in params
+            assert "store" not in params
+
+    def test_nearai_removes_strict_from_tool_schema(self):
+        """Test NEAR AI Cloud tool schemas do not include strict mode."""
+        with patch.dict(os.environ, {"NEARAI_API_KEY": "test-key"}):
+            completion = OpenAICompatibleCompletion(
+                model="anthropic/claude-haiku-4-5", provider="nearai"
+            )
+            tools = [
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather for a location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                }
+            ]
+
+            converted_tools = completion._convert_tools_for_interference(tools)
+
+            assert "strict" not in converted_tools[0]["function"]
+
 
 class TestLLMIntegration:
     """Tests for LLM factory integration with OpenAI-compatible providers."""
@@ -270,6 +337,37 @@ class TestLLMIntegration:
             llm = LLM(model="dashscope/qwen-turbo")
             assert isinstance(llm, OpenAICompatibleCompletion)
             assert llm.provider == "dashscope"
+
+    def test_llm_creates_openai_compatible_for_nearai(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for NEAR AI Cloud."""
+        with patch.dict(os.environ, {"NEARAI_API_KEY": "test-key"}):
+            llm = LLM(model="nearai/anthropic/claude-haiku-4-5")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "nearai"
+            assert llm.model == "anthropic/claude-haiku-4-5"
+            assert llm.base_url == "https://cloud-api.near.ai/v1"
+
+    def test_llm_creates_openai_compatible_for_nearai_with_explicit_provider(self):
+        """Test LLM factory routes to NEAR AI Cloud with explicit provider."""
+        with patch.dict(os.environ, {"NEARAI_API_KEY": "test-key"}):
+            llm = LLM(model="anthropic/claude-haiku-4-5", provider="nearai")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "nearai"
+            assert llm.model == "anthropic/claude-haiku-4-5"
+
+    def test_nearai_base_url_env_override(self):
+        """Test NEARAI_BASE_URL env var overrides default base URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "NEARAI_API_KEY": "test-key",
+                "NEARAI_BASE_URL": "https://staging.cloud-api.near.ai/v1",
+            },
+        ):
+            completion = OpenAICompatibleCompletion(
+                model="anthropic/claude-haiku-4-5", provider="nearai"
+            )
+            assert completion.base_url == "https://staging.cloud-api.near.ai/v1"
 
     def test_llm_with_explicit_provider(self):
         """Test LLM with explicit provider parameter."""


### PR DESCRIPTION
## Summary
Adds NEAR AI Cloud as a native OpenAI-compatible LLM provider. It can be used with the nearai/ model prefix or by passing provider="nearai".

## Implementation notes
- Registers nearai with https://cloud-api.near.ai/v1, NEARAI_API_KEY, and optional NEARAI_BASE_URL.
- Reuses the existing OpenAICompatibleCompletion path instead of adding a separate provider class.
- Handles NEAR AI Cloud compatibility by sending max_tokens instead of max_completion_tokens, dropping unsupported store and reasoning_effort parameters, and omitting strict tool schema mode.

## Testing
- uv run pytest lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py -q
- uv run ruff check lib/crewai/src/crewai/llm.py lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
- uv run ruff format --check lib/crewai/src/crewai/llm.py lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
- uv run mypy lib/crewai/src/crewai/llm.py lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py

I could not run a live NEAR AI Cloud smoke test because NEARAI_API_KEY was not set locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NEAR AI Cloud is now a supported provider with configurable base URL via environment variable.
  * Requests to NEAR AI are normalized automatically (token param remapping, unsupported params removed).
  * Tool schema compatibility is handled automatically (strict mode removed when unsupported).
  * Provider capability flags control parameter/feature compatibility per provider.

* **Tests**
  * Added coverage for NEAR AI behavior, routing, and environment-based base URL override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->