### PR TITLE
fix(experimental): allow AgentExecutor restore from checkpoint

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1411,6 +1411,7 @@ class Agent(BaseAgent):
 
         if _is_resuming_agent_executor(self.agent_executor):
             executor = self.agent_executor
+            executor.llm = cast(BaseLLM, self.llm)
             executor.tools = parsed_tools
             executor.tools_names = get_tool_names(parsed_tools)
             executor.tools_description = render_text_description_and_args(parsed_tools)

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1109,9 +1109,14 @@ class Agent(BaseAgent):
         """
         if self.agent_executor is None:
             raise RuntimeError("Agent executor is not initialized.")
+        if not isinstance(self.llm, BaseLLM):
+            raise RuntimeError(
+                "LLM must be resolved before updating agent executor parameters."
+            )
 
         if task is not None:
             self.agent_executor.task = task
+        self.agent_executor.llm = self.llm
         self.agent_executor.tools = tools
         self.agent_executor.original_tools = raw_tools
         self.agent_executor.prompt = prompt
@@ -1411,7 +1416,11 @@ class Agent(BaseAgent):
 
         if _is_resuming_agent_executor(self.agent_executor):
             executor = self.agent_executor
-            executor.llm = cast(BaseLLM, self.llm)
+            if not isinstance(self.llm, BaseLLM):
+                raise RuntimeError(
+                    "LLM must be resolved before resuming agent executor."
+                )
+            executor.llm = self.llm
             executor.tools = parsed_tools
             executor.tools_names = get_tool_names(parsed_tools)
             executor.tools_description = render_text_description_and_args(parsed_tools)

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -173,8 +173,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
     executor_type: Literal["experimental"] = "experimental"
     suppress_flow_events: bool = True  # always suppress for executor
-    llm: BaseLLM = Field(exclude=True)
-    prompt: SystemPromptResult | StandardPromptResult = Field(exclude=True)
+    llm: BaseLLM | None = Field(default=None, exclude=True)
+    prompt: SystemPromptResult | StandardPromptResult | None = Field(
+        default=None, exclude=True
+    )
     max_iter: int = Field(default=25, exclude=True)
     tools: list[CrewStructuredTool] = Field(default_factory=list, exclude=True)
     tools_names: str = Field(default="", exclude=True)
@@ -2585,6 +2587,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._kickoff_input = inputs.get("input", "")
 
+            if self.prompt is None:
+                raise RuntimeError(
+                    "AgentExecutor.prompt is unset; the executor was not "
+                    "fully restored or initialized before execution."
+                )
             if "system" in self.prompt:
                 from crewai.llms.cache import mark_cache_breakpoint
 
@@ -2686,6 +2693,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._kickoff_input = inputs.get("input", "")
 
+            if self.prompt is None:
+                raise RuntimeError(
+                    "AgentExecutor.prompt is unset; the executor was not "
+                    "fully restored or initialized before execution."
+                )
             if "system" in self.prompt:
                 from crewai.llms.cache import mark_cache_breakpoint
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2587,10 +2587,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._kickoff_input = inputs.get("input", "")
 
-            if self.prompt is None:
+            if self.llm is None or self.prompt is None:
                 raise RuntimeError(
-                    "AgentExecutor.prompt is unset; the executor was not "
-                    "fully restored or initialized before execution."
+                    "AgentExecutor.llm or .prompt is unset; the executor was "
+                    "not fully restored or initialized before execution."
                 )
             if "system" in self.prompt:
                 from crewai.llms.cache import mark_cache_breakpoint
@@ -2693,10 +2693,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._kickoff_input = inputs.get("input", "")
 
-            if self.prompt is None:
+            if self.llm is None or self.prompt is None:
                 raise RuntimeError(
-                    "AgentExecutor.prompt is unset; the executor was not "
-                    "fully restored or initialized before execution."
+                    "AgentExecutor.llm or .prompt is unset; the executor was "
+                    "not fully restored or initialized before execution."
                 )
             if "system" in self.prompt:
                 from crewai.llms.cache import mark_cache_breakpoint


### PR DESCRIPTION
## Summary
- `experimental.AgentExecutor.llm` and `prompt` were declared required with `exclude=True`, so the model can't be restored from its own serialized output — the excluded fields are missing on `model_validate`.
- Reproduces today: `crewai checkpoint` → select a checkpoint → Fork → `ValidationError: Field required` on `llm` / `prompt`.
- Mirror the `CrewAgentExecutor` pattern: make both fields nullable with `default=None`, keep `exclude=True`.
- Re-attach `executor.llm = self.llm` on the resume path in `Agent._setup_agent_executor` (was attaching `prompt`, tools, callbacks, etc., but had silently dropped `llm`).
- Guard the two `self.prompt[...]` deref sites so the looser type doesn't break runtime.

## Test plan
- [x] `RuntimeState.from_checkpoint(...)` on a checkpoint that previously raised — restore now succeeds.
- [x] mypy + ruff clean.
- [ ] CI green.
- [ ] End-to-end: fork via `crewai checkpoint` TUI, kick off the forked crew.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent execution/resume paths and loosens executor field requirements, which can affect runtime behavior if `llm`/`prompt` are not properly reattached; mitigated by new explicit runtime guards.
> 
> **Overview**
> Fixes experimental executor checkpoint restore by making `AgentExecutor.llm` and `prompt` nullable (still excluded from serialization) so `model_validate` can succeed when restoring from saved state.
> 
> Ensures resumed executors are fully rehydrated by reattaching the resolved `llm` during both parameter updates and the checkpoint resume path, and adds explicit runtime checks in `invoke`/`invoke_async` to fail fast if `llm`/`prompt` were not set before execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1938f19619e6c3a58c08a216329c7092706f7412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation when resuming or updating agents to ensure the configured language model is valid before continuing.
  * Agent executor now tolerates partially-restored state but checks for a configured prompt at runtime and raises a clear error if execution is attempted before full initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->