### PR TITLE
chore(deps): force starlette>=1.0.1 for PYSEC-2026-161

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ exclude-newer = "3 days"
 # authlib <1.6.11 has GHSA-jj8c-mmj3-mmgv (CSRF bypass in cache-based state storage).
 # pip <26.1.1 has GHSA-58qw-9mgm-455v (archive handling); OSV considers 26.1.1 unaffected.
 # paramiko <5.0.0 has GHSA-r374-rxx8-8654 (SHA-1 in rsakey.py); OSV considers 5.0.0 unaffected. Transitive via composio-core.
+# starlette <1.0.1 has PYSEC-2026-161 (missing Host header validation poisons request.url.path, bypassing path-based auth). Transitive via fastapi.
 # litellm 1.83.8+ hard-pins openai==2.24.0, missing openai.types.responses used by crewai;
 # override to >=2.30.0 (the version litellm 1.83.7 used) until upstream relaxes the pin.
 override-dependencies = [
@@ -209,6 +210,7 @@ override-dependencies = [
     "authlib>=1.6.11",
     "pip>=26.1.1",
     "paramiko>=5.0.0",
+    "starlette>=1.0.1",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-17T14:20:01.778505Z"
+exclude-newer = "2026-05-19T15:27:50.647689Z"
 exclude-newer-span = "P3D"
+
+[options.exclude-newer-package]
+starlette = "2026-05-22T16:00:00Z"
 
 [manifest]
 members = [
@@ -40,6 +43,7 @@ overrides = [
     { name = "pypdf", specifier = ">=6.10.2,<7" },
     { name = "python-multipart", specifier = ">=0.0.27,<1" },
     { name = "rich", specifier = ">=13.7.1" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "transformers", marker = "python_full_version >= '3.10'", specifier = ">=5.4.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uv", specifier = ">=0.11.6,<1" },
@@ -8528,15 +8532,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- pip-audit flagged starlette 1.0.0 for [PYSEC-2026-161](https://github.com/advisories/PYSEC-2026-161): missing Host header validation poisons `request.url.path`, allowing attackers to bypass path-based security checks.
- Pulled in transitively via fastapi.
- Add `starlette>=1.0.1` to the existing `[tool.uv] override-dependencies` block (same pattern used for prior advisories) and regenerate the lock.

## Test plan
- [x] `grep starlette uv.lock` → 1.0.1.
- [ ] pip-audit clean on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency update that only adjusts resolution/lock state; main risk is potential incompatibility from the Starlette patch-level bump in FastAPI’s dependency tree.
> 
> **Overview**
> Forces `starlette>=1.0.1` via `[tool.uv] override-dependencies` to remediate *PYSEC-2026-161* (Host header validation issue affecting path-based auth checks).
> 
> Regenerates `uv.lock` to apply the override, bumping `starlette` from `1.0.0` to `1.0.1` and adding a per-package `exclude-newer` entry to ensure the resolver can select the patched release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3734c36fc96ceba283c62e67a03920bc0bcb5024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version requirements to address a security vulnerability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->