### PR TITLE
docs(llms): add Auxen provider configuration example

### DIFF
--- a/docs/en/concepts/llms.mdx
+++ b/docs/en/concepts/llms.mdx
@@ -1189,6 +1189,43 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Auxen">
+    [Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) with an OpenAI-compatible `/v1/chat/completions` API. Each instance is a dedicated GPU billed per-minute of runtime — no token charges, no monthly minimums.
+
+    Provision an instance from the [Auxen dashboard](https://auxen.ai) to obtain a per-instance base URL (`https://api.auxen.ai/v1/inst_xxx/v1`) and `auxk_*` API key. Set the following environment variables in your `.env` file:
+    ```toml Code
+    AUXEN_API_BASE=https://api.auxen.ai/v1/inst_xxx/v1
+    AUXEN_API_KEY=auxk_...
+    ```
+
+    Example usage in your CrewAI project — Auxen instances are OpenAI-wire-compatible, so configure via the `openai/` LiteLLM prefix with a custom base URL:
+    ```python Code
+    import os
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/llama-3.1-8b",  # or qwen2.5-14b, mistral-nemo-12b, etc.
+        api_key=os.environ["AUXEN_API_KEY"],
+        base_url=os.environ["AUXEN_API_BASE"],
+        temperature=0.7,
+    )
+    ```
+
+    <Info>
+      Auxen features:
+      - Dedicated GPU per instance (no shared inference fleet)
+      - OpenAI-compatible API (drop-in replacement)
+      - Per-minute billing, not per-token
+      - Open-source model catalog (Llama, Qwen, Mistral, Gemma, Mixtral, Phi, Command R)
+      - MCP server with OAuth 2.1 + PKCE for agent workloads
+    </Info>
+
+    **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses


### PR DESCRIPTION
Adds an Auxen accordion to the Provider Configuration Examples section on \`docs/en/concepts/llms.mdx\`, following the same shape as the existing Fireworks AI / Nebius AI Studio entries.

[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) with an OpenAI-compatible \`/v1/chat/completions\` API. Each instance is a dedicated GPU billed per-minute of runtime — no token charges, no monthly minimums.

Because Auxen instances are OpenAI-wire-compatible, the example uses LiteLLM's \`openai/\` model prefix with a custom \`base_url\` — works with the current CrewAI install.

## Companion PRs (Auxen distribution series)

- [BerriAI/litellm#28532](https://github.com/BerriAI/litellm/pull/28532) — LiteLLM provider (once merged, CrewAI users can also use the \`auxen/\` LiteLLM prefix directly)
- [vercel/ai#15536](https://github.com/vercel/ai/pull/15536) — Vercel AI SDK community provider
- [langchain-ai/docs#4146](https://github.com/langchain-ai/docs/pull/4146) — LangChain docs (Python + JS)
- [run-llama/llama_index#21764](https://github.com/run-llama/llama_index/pull/21764) — LlamaIndex Python
- [continuedev/continue#12473](https://github.com/continuedev/continue/pull/12473) — Continue.dev provider
- [cline/cline#10988](https://github.com/cline/cline/pull/10988) — Cline OpenAI-compatible quickstart
- [Helicone/helicone#5685](https://github.com/Helicone/helicone/pull/5685) — Helicone gateway
- [langfuse/langfuse-docs#2990](https://github.com/langfuse/langfuse-docs/pull/2990) — Langfuse provider page
- npm: [\`@auxen/ai-sdk-provider\`](https://www.npmjs.com/package/@auxen/ai-sdk-provider) (live)

AI agent (Claude) assisted in drafting this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Auxen provider documentation with setup instructions, required environment configuration, and integration examples for using Auxen as an LLM provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->