### PR TITLE
fix(checkpoint): drop unroundtrippable callbacks and adapter state

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
@@ -103,16 +103,16 @@ class Adapter(BaseModel, ABC):
 
 
 def _resolve_adapter(value: Any) -> Any:
-    """Validate the ``adapter`` field, returning a placeholder for dict input.
+    """Validate the ``adapter`` field, returning a placeholder for dict/None input.
 
     Adapter state is not round-tripped; the ``_ensure_adapter`` post-validator
     rebuilds a fresh adapter from the tool's ``config``.
     """
     if isinstance(value, Adapter):
         return value
-    if not isinstance(value, dict):
-        return value
-    return RagTool._AdapterPlaceholder()
+    if value is None or isinstance(value, dict):
+        return RagTool._AdapterPlaceholder()
+    return value
 
 
 def _serialize_adapter(adapter: Any, info: Any) -> Any:
@@ -148,7 +148,7 @@ class RagTool(BaseTool):
     adapter: Annotated[
         Adapter,
         BeforeValidator(_resolve_adapter),
-        PlainSerializer(_serialize_adapter),
+        PlainSerializer(_serialize_adapter, when_used="json"),
     ] = Field(default_factory=_AdapterPlaceholder)
     config: RagToolConfig = Field(
         default_factory=RagToolConfig,

--- a/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
@@ -14,6 +14,7 @@ from pydantic import (
     PlainSerializer,
     TypeAdapter,
     ValidationError,
+    WithJsonSchema,
     field_validator,
     model_validator,
 )
@@ -149,6 +150,7 @@ class RagTool(BaseTool):
         Adapter,
         BeforeValidator(_resolve_adapter),
         PlainSerializer(_serialize_adapter, when_used="json"),
+        WithJsonSchema({"type": ["object", "null"]}),
     ] = Field(default_factory=_AdapterPlaceholder)
     config: RagToolConfig = Field(
         default_factory=RagToolConfig,

--- a/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import os
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
 from crewai.rag.core.base_embeddings_callable import EmbeddingFunction
 from crewai.rag.embeddings.factory import build_embedder
@@ -8,8 +8,10 @@ from crewai.rag.embeddings.types import ProviderSpec
 from crewai.tools import BaseTool
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
+    PlainSerializer,
     TypeAdapter,
     ValidationError,
     field_validator,
@@ -100,6 +102,26 @@ class Adapter(BaseModel, ABC):
         """Add content to the knowledge base."""
 
 
+def _resolve_adapter(value: Any) -> Any:
+    """Validate the ``adapter`` field, returning a placeholder for dict input.
+
+    Adapter state is not round-tripped; the ``_ensure_adapter`` post-validator
+    rebuilds a fresh adapter from the tool's ``config``.
+    """
+    if isinstance(value, Adapter):
+        return value
+    if not isinstance(value, dict):
+        return value
+    return RagTool._AdapterPlaceholder()
+
+
+def _serialize_adapter(adapter: Any, info: Any) -> Any:
+    """Serialize the ``adapter`` field, dropping runtime state from the payload."""
+    if not isinstance(adapter, Adapter):
+        return adapter
+    return None
+
+
 class RagTool(BaseTool):
     class _AdapterPlaceholder(Adapter):
         def query(
@@ -123,7 +145,11 @@ class RagTool(BaseTool):
     similarity_threshold: float = 0.6
     limit: int = 5
     collection_name: str = "rag_tool_collection"
-    adapter: Adapter = Field(default_factory=_AdapterPlaceholder)
+    adapter: Annotated[
+        Adapter,
+        BeforeValidator(_resolve_adapter),
+        PlainSerializer(_serialize_adapter),
+    ] = Field(default_factory=_AdapterPlaceholder)
     config: RagToolConfig = Field(
         default_factory=RagToolConfig,
         description="Configuration format accepted by RagTool.",

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -2912,12 +2912,6 @@
       "humanized_name": "Search a CSV's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -3902,9 +3896,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -3964,12 +3956,6 @@
       "humanized_name": "Search a Code Docs content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -4954,9 +4940,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -5641,12 +5625,6 @@
       "humanized_name": "Search a DOCX's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -6631,9 +6609,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -7926,12 +7902,6 @@
       "humanized_name": "Search a directory's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -8916,9 +8886,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -10762,12 +10730,6 @@
       "humanized_name": "Search a github repo's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -11752,9 +11714,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -12041,12 +12001,6 @@
       "humanized_name": "Search a JSON's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -13031,9 +12985,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -13316,12 +13268,6 @@
       "humanized_name": "Search a MDX's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -14306,9 +14252,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -14774,12 +14718,6 @@
       "humanized_name": "Search a database's table content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -15764,9 +15702,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -15965,21 +15901,6 @@
               "description"
             ],
             "title": "EnvVar",
-            "type": "object"
-          },
-          "JsonResponseFormat": {
-            "description": "Response format requesting raw JSON output (e.g. ``{\"type\": \"json_object\"}``).",
-            "properties": {
-              "type": {
-                "const": "json_object",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": [
-              "type"
-            ],
-            "title": "JsonResponseFormat",
             "type": "object"
           },
           "LLM": {
@@ -16210,16 +16131,6 @@
                 "title": "Reasoning Effort"
               },
               "response_format": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/JsonResponseFormat"
-                  },
-                  {},
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
                 "title": "Response Format"
               },
               "seed": {
@@ -17207,12 +17118,6 @@
       "humanized_name": "Search a PDF's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -18197,9 +18102,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -18906,12 +18809,6 @@
       "humanized_name": "Knowledge base",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -19896,9 +19793,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -20994,12 +20889,6 @@
       "humanized_name": "Job Search",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -21984,9 +21873,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -22462,12 +22349,6 @@
       "humanized_name": "Webpage to Markdown",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -23452,9 +23333,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -24307,12 +24186,6 @@
       "humanized_name": "Search a txt's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -25297,9 +25170,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -26227,12 +26098,6 @@
       "humanized_name": "Search in a specific website",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -27217,9 +27082,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -27279,12 +27142,6 @@
       "humanized_name": "Search a XML's content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -28269,9 +28126,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -28331,12 +28186,6 @@
       "humanized_name": "Search a Youtube Channels content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -29321,9 +29170,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -29383,12 +29230,6 @@
       "humanized_name": "Search a Youtube Video content",
       "init_params_schema": {
         "$defs": {
-          "Adapter": {
-            "description": "Abstract base class for RAG adapters.",
-            "properties": {},
-            "title": "Adapter",
-            "type": "object"
-          },
           "AzureProviderConfig": {
             "description": "Configuration for Azure provider.",
             "properties": {
@@ -30373,9 +30214,7 @@
           }
         },
         "properties": {
-          "adapter": {
-            "$ref": "#/$defs/Adapter"
-          },
+          "adapter": {},
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -3896,7 +3896,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -4940,7 +4945,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -6609,7 +6619,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -8886,7 +8901,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -11714,7 +11734,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -12985,7 +13010,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -14252,7 +14282,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -15702,7 +15737,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -18102,7 +18142,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -19793,7 +19838,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -21873,7 +21923,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -23333,7 +23388,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -25170,7 +25230,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -27082,7 +27147,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -28126,7 +28196,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -29170,7 +29245,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",
@@ -30214,7 +30294,12 @@
           }
         },
         "properties": {
-          "adapter": {},
+          "adapter": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "collection_name": {
             "default": "rag_tool_collection",
             "title": "Collection Name",

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -382,6 +382,15 @@ class Crew(FlowTrackable, BaseModel):
     checkpoint_train: bool | None = Field(default=None)
     checkpoint_kickoff_event_id: str | None = Field(default=None)
 
+    @field_validator(
+        "before_kickoff_callbacks", "after_kickoff_callbacks", mode="before"
+    )
+    @classmethod
+    def _drop_unresolvable_callbacks(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            return [v for v in value if v is not None]
+        return value
+
     @classmethod
     def from_checkpoint(cls, config: CheckpointConfig) -> Crew:
         """Restore a Crew from a checkpoint, ready to resume via kickoff().

--- a/lib/crewai/src/crewai/state/event_record.py
+++ b/lib/crewai/src/crewai/state/event_record.py
@@ -67,7 +67,11 @@ class EventNode(BaseModel):
     event: Annotated[
         BaseEvent,
         BeforeValidator(_resolve_event),
-        PlainSerializer(lambda v: v.model_dump()),
+        PlainSerializer(
+            lambda v, info: (
+                v.model_dump(mode="json") if info.mode == "json" else v.model_dump()
+            ),
+        ),
     ]
     edges: dict[EdgeType, list[str]] = Field(default_factory=dict)
 

--- a/lib/crewai/src/crewai/types/callback.py
+++ b/lib/crewai/src/crewai/types/callback.py
@@ -130,18 +130,15 @@ def _resolve_dotted_path(path: str) -> Callable[..., Any]:
     raise ValueError(f"Cannot resolve callback {path!r}")
 
 
-def callable_to_string(fn: Callable[..., Any]) -> str:
-    """Serialize a callable to its dotted-path string representation.
-
-    Uses ``fn.__module__`` and ``fn.__qualname__`` to produce a string such
-    as ``"builtins.print"``.  Lambdas and closures produce paths that contain
-    ``<locals>`` and cannot be round-tripped via :func:`string_to_callable`.
+def callable_to_string(fn: Callable[..., Any]) -> str | None:
+    """Serialize a module-level callable as a ``"module.qualname"`` string.
 
     Args:
         fn: The callable to serialize.
 
     Returns:
-        A dotted string of the form ``"module.qualname"``.
+        The dotted path, or ``None`` for lambdas and closures (not
+        resolvable by :func:`string_to_callable`).
     """
     module = getattr(fn, "__module__", None)
     qualname = getattr(fn, "__qualname__", None)
@@ -150,6 +147,8 @@ def callable_to_string(fn: Callable[..., Any]) -> str:
             f"Cannot serialize {fn!r}: missing __module__ or __qualname__. "
             "Use a module-level named function for checkpointable callbacks."
         )
+    if "<locals>" in qualname or qualname == "<lambda>":
+        return None
     return f"{module}.{qualname}"
 
 

--- a/lib/crewai/tests/test_callback.py
+++ b/lib/crewai/tests/test_callback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import os
+from collections.abc import Callable
 from typing import Any
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -93,10 +94,18 @@ class TestCallableToString:
         result = callable_to_string(print)
         assert result == "builtins.print"
 
-    def test_lambda_produces_locals_path(self) -> None:
+    def test_lambda_returns_none(self) -> None:
         fn = lambda: None  # noqa: E731
-        result = callable_to_string(fn)
-        assert "<lambda>" in result
+        assert callable_to_string(fn) is None
+
+    def test_closure_returns_none(self) -> None:
+        def outer() -> Callable[[], None]:
+            def inner() -> None:
+                return None
+
+            return inner
+
+        assert callable_to_string(outer()) is None
 
     def test_missing_qualname_raises(self) -> None:
         obj = type("NoQual", (), {"__module__": "test"})()


### PR DESCRIPTION
## Summary

- \`callable_to_string\` returns \`None\` for lambdas and closures instead of emitting an unresolvable \`<locals>\` path. \`Crew\` filters \`None\` out of \`before_kickoff_callbacks\` / \`after_kickoff_callbacks\` on restore.
- \`EventNode.event\` serializer threads \`info.mode\`, so \`mode=\"json\"\` dumps recurse correctly into nested event payloads.
- \`RagTool.adapter\` serializes to \`None\`; the \`_ensure_adapter\` post-validator rebuilds a fresh adapter from \`self.config\` on restore. Concrete adapters hold runtime resources (DB clients, embedding fns) that can't be round-tripped.

## Test plan
- [ ] Checkpoint a crew with a lambda callback → resume cleanly with the callback dropped.
- [ ] Checkpoint a crew using \`RagTool\` → adapter rebuilt on restore.
- [ ] Event record \`mode=\"json\"\` dump round-trips through Pydantic without nested serialization errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect checkpoint save/restore for crews, RAG tools, and event records—resume behavior differs for lambda callbacks (dropped) and RAG adapters (rebuilt from config).
> 
> **Overview**
> Checkpoint restore no longer breaks on **non-roundtrippable** runtime objects. **`callable_to_string`** now returns **`None`** for lambdas and closures instead of bogus `<locals>` paths; **`Crew`** strips **`None`** entries from **`before_kickoff_callbacks`** / **`after_kickoff_callbacks`** when loading checkpoint JSON so those hooks are silently dropped on resume.
> 
> **`RagTool.adapter`** is treated as ephemeral: JSON serialization writes **`null`**, dict/`None` inputs map to a placeholder, and **`_ensure_adapter`** still builds a live adapter from **`config`**. Generated **`tool.specs.json`** drops the abstract **`Adapter`** def and types **`adapter`** as object|null (plus unrelated LLM schema tightening).
> 
> **`EventNode.event`** JSON serialization uses **`model_dump(mode="json")`** so nested event payloads serialize correctly in checkpoint/event records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aef015c6eee9714c6f4cf869da855a5dd45d75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crew initialization now reliably filters out empty callback entries.
  * Event node serialization yields the correct shape when exported as JSON.

* **Refactor**
  * Adapter handling improved: validation and JSON serialization behavior made more robust.
  * Tool schemas simplified to accept a generic adapter shape (object or null).
  * Callable serialization refined to return null for lambdas/locals instead of a dotted path.

* **Tests**
  * Updated tests to cover callable serialization edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->