### PR TITLE
fix: use timezone-aware memory timestamps

### DIFF
--- a/lib/crewai/src/crewai/memory/encoding_flow.py
+++ b/lib/crewai/src/crewai/memory/encoding_flow.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import math
 from typing import Any
@@ -421,7 +421,7 @@ class EncodingFlow(Flow[EncodingState]):
         conflicts from two operations targeting the same record.
         """
         items = list(self.state.items)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # --- Deduplicate actions across all items ---
         # Multiple items may reference the same existing record (because their

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -164,8 +164,8 @@ class LanceDBStorage:
                 "categories_str": "[]",
                 "metadata_str": "{}",
                 "importance": 0.5,
-                "created_at": datetime.utcnow().isoformat(),
-                "last_accessed": datetime.utcnow().isoformat(),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_accessed": datetime.now(timezone.utc).isoformat(),
                 "source": "",
                 "private": False,
                 "vector": [0.0] * vector_dim,
@@ -267,7 +267,7 @@ class LanceDBStorage:
     def _row_to_record(self, row: dict[str, Any]) -> MemoryRecord:
         def _parse_dt(val: Any) -> datetime:
             if val is None:
-                return datetime.utcnow()
+                return datetime.now(timezone.utc)
             if isinstance(val, datetime):
                 return val
             s = str(val)
@@ -337,7 +337,7 @@ class LanceDBStorage:
         if not record_ids or self._table is None:
             return
         with store_lock(self._lock_name):
-            now = datetime.utcnow().isoformat()
+            now = datetime.now(timezone.utc).isoformat()
             safe_ids = [str(rid).replace("'", "''") for rid in record_ids]
             ids_expr = ", ".join(f"'{rid}'" for rid in safe_ids)
             self._do_write(

--- a/lib/crewai/src/crewai/memory/types.py
+++ b/lib/crewai/src/crewai/memory/types.py
@@ -349,6 +349,12 @@ def embed_texts(embedder: Any, texts: list[str]) -> list[list[float]]:
     return embeddings
 
 
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def compute_composite_score(
     record: MemoryRecord,
     semantic_score: float,
@@ -368,7 +374,7 @@ def compute_composite_score(
         Tuple of (composite_score, match_reasons). match_reasons includes
         "semantic" always; "recency" if decay > 0.5; "importance" if record.importance > 0.5.
     """
-    age_seconds = (datetime.now(timezone.utc) - record.created_at).total_seconds()
+    age_seconds = (datetime.now(timezone.utc) - _as_utc(record.created_at)).total_seconds()
     age_days = max(age_seconds / 86400.0, 0.0)
     decay = 0.5 ** (age_days / config.recency_half_life_days)
 

--- a/lib/crewai/src/crewai/memory/types.py
+++ b/lib/crewai/src/crewai/memory/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -368,7 +368,7 @@ def compute_composite_score(
         Tuple of (composite_score, match_reasons). match_reasons includes
         "semantic" always; "recency" if decay > 0.5; "importance" if record.importance > 0.5.
     """
-    age_seconds = (datetime.utcnow() - record.created_at).total_seconds()
+    age_seconds = (datetime.now(timezone.utc) - record.created_at).total_seconds()
     age_days = max(age_seconds / 86400.0, 0.0)
     decay = 0.5 ** (age_days / config.recency_half_life_days)
 

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 import threading
 import time
 from typing import TYPE_CHECKING, Annotated, Any, Literal
@@ -845,7 +845,7 @@ class Memory(BaseModel):
         existing = self._storage.get_record(record_id)
         if existing is None:
             raise ValueError(f"Record not found: {record_id}")
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         updates: dict[str, Any] = {"last_accessed": now}
         if content is not None:
             updates["content"] = content

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -493,6 +493,21 @@ def test_composite_score_old_memory_decayed() -> None:
     assert "recency" not in reasons  # decay 0.25 is not > 0.5
 
 
+def test_composite_score_accepts_legacy_naive_datetime() -> None:
+    """Legacy records with naive UTC datetimes still score without type errors."""
+    config = MemoryConfig()
+    record = MemoryRecord(
+        content="legacy",
+        scope="/",
+        created_at=datetime.utcnow(),
+    )
+
+    score, reasons = compute_composite_score(record, 0.7, config)
+
+    assert score > 0
+    assert "semantic" in reasons
+
+
 def test_composite_score_reranks_results(
     tmp_path: Path, mock_embedder: MagicMock
 ) -> None:

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -468,7 +468,7 @@ def test_composite_score_brand_new_memory() -> None:
         content="test",
         scope="/",
         importance=0.7,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     score, reasons = compute_composite_score(record, 0.8, config)
     assert 0.82 <= score <= 0.86
@@ -480,7 +480,7 @@ def test_composite_score_brand_new_memory() -> None:
 def test_composite_score_old_memory_decayed() -> None:
     """Memory 60 days old (2 half-lives) has decay = 0.25; composite ~ 0.575."""
     config = MemoryConfig(recency_half_life_days=30)
-    old_date = datetime.utcnow() - timedelta(days=60)
+    old_date = datetime.now(timezone.utc) - timedelta(days=60)
     record = MemoryRecord(
         content="old",
         scope="/",
@@ -516,7 +516,7 @@ def test_composite_score_reranks_results(
         embedding=emb,
     )
     mem._storage.save([record_high])
-    old = datetime.utcnow() - timedelta(days=90)
+    old = datetime.now(timezone.utc) - timedelta(days=90)
     record_low = MemoryRecord(
         content="Old trivial note",
         scope="/",
@@ -538,7 +538,7 @@ def test_composite_score_match_reasons_populated() -> None:
     fresh_high = MemoryRecord(
         content="x",
         importance=0.9,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     score1, reasons1 = compute_composite_score(fresh_high, 0.5, config)
     assert "semantic" in reasons1
@@ -548,7 +548,7 @@ def test_composite_score_match_reasons_populated() -> None:
     old_low = MemoryRecord(
         content="y",
         importance=0.1,
-        created_at=datetime.utcnow() - timedelta(days=60),
+        created_at=datetime.now(timezone.utc) - timedelta(days=60),
     )
     score2, reasons2 = compute_composite_score(old_low, 0.5, config)
     assert "semantic" in reasons2
@@ -566,7 +566,7 @@ def test_composite_score_custom_config() -> None:
     record = MemoryRecord(
         content="any",
         importance=0.9,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     score, reasons = compute_composite_score(record, 0.73, config)
     assert score == pytest.approx(0.73, rel=1e-5)


### PR DESCRIPTION
## Summary
- replace remaining naive `datetime.utcnow()` calls in the unified memory runtime with timezone-aware UTC timestamps
- update the matching memory tests to construct timezone-aware UTC datetimes

## Before / after
Before, memory records and LanceDB rows could be created or scored with naive UTC datetimes from `datetime.utcnow()`.
After, these code paths use `datetime.now(timezone.utc)`, preserving explicit UTC offsets in serialized timestamps.

## Verification
- `python -m py_compile lib/crewai/src/crewai/memory/unified_memory.py lib/crewai/src/crewai/memory/types.py lib/crewai/src/crewai/memory/encoding_flow.py lib/crewai/src/crewai/memory/storage/lancedb_storage.py lib/crewai/tests/memory/test_unified_memory.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized timestamps to use timezone-aware UTC across memory operations, improving accuracy and consistency of time-based behavior and scoring; maintains compatibility with legacy naive timestamps.

* **Tests**
  * Updated memory test suite to reflect timezone-aware timestamp handling and added a test ensuring legacy naive datetimes remain supported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->