### PR TITLE
docs: add pip alternative to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,21 @@ Ensure you have Python >=3.10 <3.14 installed on your system. CrewAI uses [UV](h
 First, install CrewAI:
 
 ```shell
+# Using uv (recommended)
 uv pip install crewai
+
+# Using pip
+pip install crewai
 ```
 
 If you want to install the 'crewai' package along with its optional features that include additional tools for agents, you can do so by using the following command:
 
 ```shell
+# Using uv (recommended)
 uv pip install 'crewai[tools]'
+
+# Using pip
+pip install 'crewai[tools]'
 ```
 
 The command above installs the basic package and also adds extra components which require more dependencies to function.
@@ -717,13 +725,21 @@ A: CrewAI is a standalone, lean, and fast Python framework built specifically fo
 A: Install CrewAI using pip:
 
 ```shell
+# Using uv (recommended)
 uv pip install crewai
+
+# Using pip
+pip install crewai
 ```
 
 For additional tools, use:
 
 ```shell
+# Using uv (recommended)
 uv pip install 'crewai[tools]'
+
+# Using pip
+pip install 'crewai[tools]'
 ```
 
 ### Q: Does CrewAI depend on LangChain?


### PR DESCRIPTION
## What this changes
Adds `pip install` as an alternative to `uv pip install` in the 
installation section and FAQ.

## Why
Many beginners don't have `uv` installed and get confused when 
the only installation method shown is `uv pip install`. 
Adding `pip install` as an alternative makes the docs more 
accessible for new users.

## Changes
- Installation section: added pip alternative
- crewai[tools] section: added pip alternative  
- FAQ installation answer: added pip alternative


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Installation instructions updated to feature `uv` as the recommended package manager for installing CrewAI, with traditional `pip` available as an alternative.
* Optional tools installation guidance similarly updated to promote `uv` as the preferred option.
* FAQ section enhanced with consistent and updated installation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->