### PR TITLE
Skip lock acquisition in CrewTrainingHandler.load when file is missing

### DIFF
--- a/lib/crewai/src/crewai/utilities/file_handler.py
+++ b/lib/crewai/src/crewai/utilities/file_handler.py
@@ -167,17 +167,12 @@ class PickleHandler:
         Returns:
             The data loaded from the file.
         """
-        with store_lock(f"file:{os.path.realpath(self.file_path)}"):
-            if (
-                not os.path.exists(self.file_path)
-                or os.path.getsize(self.file_path) == 0
-            ):
-                return {}
+        if not os.path.exists(self.file_path):
+            return {}
 
-            with open(self.file_path, "rb") as file:
-                try:
+        with store_lock(f"file:{os.path.realpath(self.file_path)}"):
+            try:
+                with open(self.file_path, "rb") as file:
                     return pickle.load(file)  # noqa: S301
-                except EOFError:
-                    return {}
-                except Exception:
-                    raise
+            except (FileNotFoundError, EOFError):
+                return {}

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1083,6 +1083,21 @@ def test_agent_use_trained_data_honors_env_var(crew_training_handler, monkeypatc
     )
 
 
+def test_agent_use_trained_data_skips_load_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "CREWAI_TRAINED_AGENTS_FILE", str(tmp_path / "does_not_exist.pkl")
+    )
+    agent = Agent(role="researcher", goal="test goal", backstory="test backstory")
+
+    with patch(
+        "crewai.utilities.file_handler.store_lock",
+        side_effect=AssertionError("kickoff acquired lock with no trained-agents file"),
+    ):
+        result = agent._use_trained_data(task_prompt="What is 1 + 1?")
+
+    assert result == "What is 1 + 1?"
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",

--- a/lib/crewai/tests/utilities/test_training_handler.py
+++ b/lib/crewai/tests/utilities/test_training_handler.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from crewai.utilities.training_handler import CrewTrainingHandler
 
@@ -53,3 +54,23 @@ class InternalCrewTrainingHandler(unittest.TestCase):
         # Assert that the new agent and data are appended correctly
         data = self.handler.load()
         assert data[agent_id][train_iteration] == new_data
+
+    def test_load_missing_file_does_not_acquire_lock(self):
+        handler = CrewTrainingHandler(self.temp_file.name + ".missing")
+
+        with patch(
+            "crewai.utilities.file_handler.store_lock",
+            side_effect=AssertionError("load() acquired lock for missing file"),
+        ):
+            assert handler.load() == {}
+
+    def test_load_acquires_lock_for_zero_size_file(self):
+        # Empty file mimics a concurrent save() mid-truncation (open "wb").
+        assert os.path.getsize(self.temp_file.name) == 0
+
+        with patch(
+            "crewai.utilities.file_handler.store_lock",
+            side_effect=AssertionError("load() short-circuited on size 0"),
+        ):
+            with self.assertRaises(AssertionError):
+                self.handler.load()


### PR DESCRIPTION
#4827 wrapped `CrewTrainingHandler.load()` in `store_lock` (Redis-backed via `portalocker.RedisLock` when `REDIS_URL` is set, file-based otherwise). `Agent._use_trained_data` runs on every kickoff and unconditionally calls `CrewTrainingHandler(trained_file).load()`, so since that PR every kickoff acquires the cross-process lock — including on deployments that never train and have no trained-agents file on disk. Under concurrency this serializes kickoffs on a single global lock; `lock()` blocks up to 120s before raising.

Before #4827, `load()` was an unlocked pickle read and parallel kickoffs without a training file did not contend.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to training pickle I/O with tests; no auth or core execution path changes beyond reducing lock contention on kickoff.
> 
> **Overview**
> **`PickleHandler.load()`** no longer acquires `store_lock` when the pickle path does not exist—it returns `{}` immediately. That restores pre-#4827 behavior for deployments that never create a trained-agents file, so every kickoff via `Agent._use_trained_data` no longer contends on a global Redis/file lock.
> 
> When the file **does** exist, load still runs under the lock. The prior early exit for **zero-byte** files before locking was removed, so an empty file (e.g. mid-`save()` truncation) still takes the lock and pickle read; `EOFError` / `FileNotFoundError` during read return `{}` instead of treating empty size as unlocked no-op.
> 
> Regression tests assert missing-file paths never call `store_lock`, while a zero-size file must still enter the lock path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2dd6b894fef1f67105c28f18a86125890ae534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File loading now detects missing or empty training-data files before attempting file locks, preventing unnecessary lock attempts and improving robustness when training data is absent or corrupted.

* **Tests**
  * Added regression and unit tests to verify that missing or empty training-data files are handled safely (returning empty results) without acquiring file locks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->