### PR TITLE
chore(crewai-core): drop self-explanatory comments

### DIFF
--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -186,8 +186,6 @@ class Telemetry:
 
         self._safe_telemetry_procedure(_operation)
 
-    # --- CLI-facing spans ---------------------------------------------------
-
     def deploy_signup_error_span(self) -> None:
         """Records when an error occurs during the deployment signup process."""
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only edit in telemetry with no logic or export path changes.
> 
> **Overview**
> Removes a decorative section divider comment (`# --- CLI-facing spans ---`) from `crewai_core/telemetry.py` above the CLI-related span helpers. **No runtime or telemetry behavior changes**—documentation-only cleanup aligned with dropping self-explanatory comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ff6f34a923b030a468c2af529437ad689bec7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comment from telemetry module with no functional impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->