### PR TITLE
chore(devtools): drop self-explanatory comments

### DIFF
--- a/lib/devtools/src/crewai_devtools/docs_check.py
+++ b/lib/devtools/src/crewai_devtools/docs_check.py
@@ -34,9 +34,6 @@ _LANGUAGE_NAMES: Final[dict[DocLang, str]] = {
 }
 
 
-# --- Structured output models ---
-
-
 class DocAction(BaseModel):
     """A single documentation action to take."""
 
@@ -65,8 +62,6 @@ class DocsAnalysis(BaseModel):
         description="List of documentation actions to take.",
     )
 
-
-# --- Prompts ---
 
 _ANALYZE_SYSTEM: Final[str] = """\
 You are a documentation analyst for the CrewAI open-source framework.

--- a/lib/devtools/tests/test_toml_updates.py
+++ b/lib/devtools/tests/test_toml_updates.py
@@ -13,9 +13,6 @@ from crewai_devtools.cli import (
 )
 
 
-# --- update_pyproject_version ---
-
-
 class TestUpdatePyprojectVersion:
     def test_updates_version(self, tmp_path: Path) -> None:
         pyproject = tmp_path / "pyproject.toml"
@@ -80,9 +77,6 @@ class TestUpdatePyprojectVersion:
 
         assert "# This is important" in result
         assert 'description = "A package"' in result
-
-
-# --- _pin_crewai_deps ---
 
 
 class TestPinCrewaiDeps:
@@ -195,9 +189,6 @@ class TestPinCrewaiDeps:
         assert "==" not in result
 
 
-# --- _repin_crewai_install ---
-
-
 class TestRepinCrewaiInstall:
     def test_repins_a2a_extra(self) -> None:
         result = _repin_crewai_install('uv pip install "crewai[a2a]==1.14.0"', "2.0.0")
@@ -226,9 +217,6 @@ class TestRepinCrewaiInstall:
     def test_no_version_specifier_unchanged(self) -> None:
         cmd = 'pip install "crewai[tools]>=1.0"'
         assert _repin_crewai_install(cmd, "2.0.0") == cmd
-
-
-# --- update_pyproject_dependencies ---
 
 
 class TestUpdatePyprojectDependencies:
@@ -318,9 +306,6 @@ class TestUpdatePyprojectDependencies:
         result = pyproject.read_text()
         assert '"crewai==2.0.0"' in result
         assert '"crewai-core==2.0.0"' in result
-
-
-# --- update_template_dependencies ---
 
 
 class TestUpdateTemplateDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only edits with no runtime or test logic impact.
> 
> **Overview**
> Removes **section divider comments** (e.g. `# --- Structured output models ---`, `# --- update_pyproject_version ---`) from `docs_check.py` and `test_toml_updates.py` in **crewai_devtools**. No code, tests, or behavior changes—only comment cleanup aligned with treating those headers as self-explanatory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8ee9b67b0dec0c40d8d1caba3b81b0dd096c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal comment blocks from code files for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->