### PR TITLE
fix(a2a): verify AgentCard signatures and avoid pickle cache

### DIFF
--- a/lib/crewai/src/crewai/a2a/utils/agent_card.py
+++ b/lib/crewai/src/crewai/a2a/utils/agent_card.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 import concurrent.futures
 import contextvars
 from functools import lru_cache
+import json
 import ssl
 import time
 from types import MethodType
@@ -15,7 +16,7 @@ from typing import TYPE_CHECKING
 from a2a.client.errors import A2AClientHTTPError
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill
 from aiocache import cached  # type: ignore[import-untyped]
-from aiocache.serializers import PickleSerializer  # type: ignore[import-untyped]
+from aiocache.serializers import BaseSerializer  # type: ignore[import-untyped]
 import httpx
 
 from crewai.a2a.auth.client_schemes import APIKeyAuth, HTTPDigestAuth
@@ -25,6 +26,7 @@ from crewai.a2a.auth.utils import (
     retry_on_401,
 )
 from crewai.a2a.config import A2AServerConfig
+from crewai.a2a.utils.agent_card_signing import verify_agent_card_signature
 from crewai.crew import Crew
 from crewai.events.event_bus import crewai_event_bus
 from crewai.events.types.a2a_events import (
@@ -38,6 +40,21 @@ if TYPE_CHECKING:
     from crewai.a2a.auth.client_schemes import ClientAuthScheme
     from crewai.agent import Agent
     from crewai.task import Task
+
+
+class _AgentCardCacheSerializer(BaseSerializer):
+    """JSON serializer for cached AgentCard responses.
+
+    Agent cards are untrusted network inputs and may also be cached in external
+    backends (e.g. redis). Using pickle here can execute arbitrary code if a
+    cached value is attacker-controlled.
+    """
+
+    def dumps(self, value: AgentCard) -> str:
+        return json.dumps(value.model_dump(exclude_none=True), sort_keys=True)
+
+    def loads(self, value: str) -> AgentCard:
+        return AgentCard.model_validate(json.loads(value))
 
 
 def _get_tls_verify(auth: ClientAuthScheme | None) -> ssl.SSLContext | bool | str:
@@ -100,12 +117,37 @@ def _get_server_config(agent: Agent) -> A2AServerConfig | None:
     return None
 
 
+def _normalize_signature_algorithms(
+    signature_algorithms: Sequence[str] | None,
+) -> tuple[str, ...] | None:
+    return tuple(signature_algorithms) if signature_algorithms is not None else None
+
+
+def _verify_agent_card_signatures(
+    agent_card: AgentCard,
+    signature_public_key: str | bytes | None,
+    signature_algorithms: tuple[str, ...] | None,
+) -> None:
+    if signature_public_key is None:
+        return
+
+    signatures = agent_card.signatures or []
+    algorithms = list(signature_algorithms) if signature_algorithms is not None else None
+    if not signatures or not any(
+        verify_agent_card_signature(agent_card, sig, signature_public_key, algorithms)
+        for sig in signatures
+    ):
+        raise A2AClientHTTPError(422, "AgentCard signature verification failed")
+
+
 def fetch_agent_card(
     endpoint: str,
     auth: ClientAuthScheme | None = None,
     timeout: int = 30,
     use_cache: bool = True,
     cache_ttl: int = 300,
+    signature_public_key: str | bytes | None = None,
+    signature_algorithms: Sequence[str] | None = None,
 ) -> AgentCard:
     """Fetch AgentCard from an A2A endpoint with optional caching.
 
@@ -123,6 +165,7 @@ def fetch_agent_card(
         httpx.HTTPStatusError: If the request fails.
         A2AClientHTTPError: If authentication fails.
     """
+    signature_algorithms_key = _normalize_signature_algorithms(signature_algorithms)
     if use_cache:
         if auth:
             auth_data = auth.model_dump_json(
@@ -138,9 +181,27 @@ def fetch_agent_card(
             auth_hash = _auth_store.compute_key("none", "")
         _auth_store.set(auth_hash, auth)
         ttl_hash = int(time.time() // cache_ttl)
-        return _fetch_agent_card_cached(endpoint, auth_hash, timeout, ttl_hash)
+        agent_card = _fetch_agent_card_cached(
+            endpoint,
+            auth_hash,
+            timeout,
+            ttl_hash,
+            signature_public_key,
+            signature_algorithms_key,
+        )
+        _verify_agent_card_signatures(
+            agent_card, signature_public_key, signature_algorithms_key
+        )
+        return agent_card
 
-    coro = afetch_agent_card(endpoint=endpoint, auth=auth, timeout=timeout)
+    coro = afetch_agent_card(
+        endpoint=endpoint,
+        auth=auth,
+        timeout=timeout,
+        use_cache=False,
+        signature_public_key=signature_public_key,
+        signature_algorithms=signature_algorithms_key,
+    )
     try:
         asyncio.get_running_loop()
         has_running_loop = True
@@ -159,6 +220,8 @@ async def afetch_agent_card(
     auth: ClientAuthScheme | None = None,
     timeout: int = 30,
     use_cache: bool = True,
+    signature_public_key: str | bytes | None = None,
+    signature_algorithms: Sequence[str] | None = None,
 ) -> AgentCard:
     """Fetch AgentCard from an A2A endpoint asynchronously.
 
@@ -177,6 +240,7 @@ async def afetch_agent_card(
         httpx.HTTPStatusError: If the request fails.
         A2AClientHTTPError: If authentication fails.
     """
+    signature_algorithms_key = _normalize_signature_algorithms(signature_algorithms)
     if use_cache:
         if auth:
             auth_data = auth.model_dump_json(
@@ -192,11 +256,24 @@ async def afetch_agent_card(
             auth_hash = _auth_store.compute_key("none", "")
         _auth_store.set(auth_hash, auth)
         agent_card: AgentCard = await _afetch_agent_card_cached(
-            endpoint, auth_hash, timeout
+            endpoint,
+            auth_hash,
+            timeout,
+            signature_public_key,
+            signature_algorithms_key,
+        )
+        _verify_agent_card_signatures(
+            agent_card, signature_public_key, signature_algorithms_key
         )
         return agent_card
 
-    return await _afetch_agent_card_impl(endpoint=endpoint, auth=auth, timeout=timeout)
+    return await _afetch_agent_card_impl(
+        endpoint=endpoint,
+        auth=auth,
+        timeout=timeout,
+        signature_public_key=signature_public_key,
+        signature_algorithms=signature_algorithms_key,
+    )
 
 
 @lru_cache()
@@ -205,11 +282,19 @@ def _fetch_agent_card_cached(
     auth_hash: str,
     timeout: int,
     _ttl_hash: int,
+    signature_public_key: str | bytes | None,
+    signature_algorithms: tuple[str, ...] | None,
 ) -> AgentCard:
     """Cached sync version of fetch_agent_card."""
     auth = _auth_store.get(auth_hash)
 
-    coro = _afetch_agent_card_impl(endpoint=endpoint, auth=auth, timeout=timeout)
+    coro = _afetch_agent_card_impl(
+        endpoint=endpoint,
+        auth=auth,
+        timeout=timeout,
+        signature_public_key=signature_public_key,
+        signature_algorithms=signature_algorithms,
+    )
     try:
         asyncio.get_running_loop()
         has_running_loop = True
@@ -223,21 +308,31 @@ def _fetch_agent_card_cached(
     return asyncio.run(coro)
 
 
-@cached(ttl=300, serializer=PickleSerializer())  # type: ignore[untyped-decorator]
+@cached(ttl=300, serializer=_AgentCardCacheSerializer())  # type: ignore[untyped-decorator]
 async def _afetch_agent_card_cached(
     endpoint: str,
     auth_hash: str,
     timeout: int,
+    signature_public_key: str | bytes | None,
+    signature_algorithms: tuple[str, ...] | None,
 ) -> AgentCard:
     """Cached async implementation of AgentCard fetching."""
     auth = _auth_store.get(auth_hash)
-    return await _afetch_agent_card_impl(endpoint=endpoint, auth=auth, timeout=timeout)
+    return await _afetch_agent_card_impl(
+        endpoint=endpoint,
+        auth=auth,
+        timeout=timeout,
+        signature_public_key=signature_public_key,
+        signature_algorithms=signature_algorithms,
+    )
 
 
 async def _afetch_agent_card_impl(
     endpoint: str,
     auth: ClientAuthScheme | None,
     timeout: int,
+    signature_public_key: str | bytes | None = None,
+    signature_algorithms: tuple[str, ...] | None = None,
 ) -> AgentCard:
     """Internal async implementation of AgentCard fetching."""
     start_time = time.perf_counter()
@@ -278,6 +373,9 @@ async def _afetch_agent_card_impl(
             response.raise_for_status()
 
             agent_card = AgentCard.model_validate(response.json())
+            _verify_agent_card_signatures(
+                agent_card, signature_public_key, signature_algorithms
+            )
             fetch_time_ms = (time.perf_counter() - start_time) * 1000
             agent_card_dict = agent_card.model_dump(exclude_none=True)
 

--- a/lib/crewai/tests/a2a/utils/test_agent_card_fetch_signature_verification.py
+++ b/lib/crewai/tests/a2a/utils/test_agent_card_fetch_signature_verification.py
@@ -1,0 +1,112 @@
+"""Tests for AgentCard signature verification during fetch."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a2a.client.errors import A2AClientHTTPError
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import httpx
+import pytest
+
+from crewai.a2a.utils.agent_card import afetch_agent_card
+from crewai.a2a.utils.agent_card_signing import sign_agent_card
+
+
+def _generate_rsa_keypair() -> tuple[bytes, bytes]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _make_agent_card() -> AgentCard:
+    return AgentCard(
+        name="Test Agent",
+        description="Test description",
+        url="http://example.com",
+        version="1.0.0",
+        capabilities=AgentCapabilities(streaming=True, push_notifications=True),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[
+            AgentSkill(
+                id="test-skill",
+                name="Test Skill",
+                description="Test skill description",
+                tags=["test"],
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_afetch_agent_card_verifies_signature_when_key_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, public_pem = _generate_rsa_keypair()
+    card = _make_agent_card()
+    signature = sign_agent_card(card, private_pem, algorithm="RS256")
+    signed_card = card.model_copy(update={"signatures": [signature]})
+
+    async def _fake_get(self, url: str, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN001
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            json=signed_card.model_dump(exclude_none=True),
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get, raising=True)
+
+    result = await afetch_agent_card(
+        endpoint="http://example.com/.well-known/agent-card.json",
+        use_cache=False,
+        signature_public_key=public_pem,
+        signature_algorithms=["RS256"],
+    )
+
+    assert result.name == signed_card.name
+
+
+@pytest.mark.asyncio
+async def test_afetch_agent_card_rejects_invalid_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, public_pem = _generate_rsa_keypair()
+    other_private_pem, _other_public_pem = _generate_rsa_keypair()
+    card = _make_agent_card()
+
+    # Sign with a different key than the one we will verify with.
+    signature = sign_agent_card(card, other_private_pem, algorithm="RS256")
+    signed_card = card.model_copy(update={"signatures": [signature]})
+
+    async def _fake_get(self, url: str, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN001
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            json=signed_card.model_dump(exclude_none=True),
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get, raising=True)
+
+    with pytest.raises(A2AClientHTTPError) as excinfo:
+        await afetch_agent_card(
+            endpoint="http://example.com/.well-known/agent-card.json",
+            use_cache=False,
+            signature_public_key=public_pem,
+            signature_algorithms=["RS256"],
+        )
+
+    assert excinfo.value.status_code == 422
+    assert "signature verification failed" in excinfo.value.message.lower()


### PR DESCRIPTION
## What

This PR hardens A2A AgentCard fetching:

1. Adds opt-in signature verification for `fetch_agent_card` / `afetch_agent_card` via two new optional parameters:
   - `signature_public_key`: PEM public key (str/bytes). If provided, the fetched AgentCard must contain at least one valid signature.
   - `signature_algorithms`: optional allowlist of JWS algorithms.

2. Replaces the async AgentCard cache serializer from `PickleSerializer` to a small JSON serializer for `AgentCard`.

3. Fixes a small bug where `fetch_agent_card(use_cache=False)` still called `afetch_agent_card` with the default `use_cache=True`.

Default behavior is unchanged when `signature_public_key` is not provided.

## Why

- AgentCards are network inputs. Enabling clients to verify a signed AgentCard makes it possible to pin trust to a key when using A2A endpoints.
- Using `pickle` for cached network responses is risky when caches are configured to use external backends (e.g. redis/memcached) or restored from lower-trust storage.

## Verification

- `uv run ruff check lib/crewai/src/crewai/a2a/utils/agent_card.py lib/crewai/tests/a2a/utils/test_agent_card_fetch_signature_verification.py`
- `uv run --extra a2a pytest -q lib/crewai/tests/a2a/utils/test_agent_card_fetch_signature_verification.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent card fetching now supports optional cryptographic signature verification using configurable public keys and signature algorithms
  * Fetched agent cards are validated before being returned to callers

* **Updates**
  * Agent card caching implementation has been updated

* **Tests**
  * Added comprehensive test coverage for agent card signature verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->