### PR TITLE
fix: don't inject cache_breakpoint for non-Anthropic LLMs

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -164,6 +164,11 @@ class CrewAgentExecutor(BaseAgentExecutor):
             self.llm.supports_stop_words() if isinstance(self.llm, BaseLLM) else False
         )
 
+    def _llm_is_anthropic(self) -> bool:
+        """Return True if the configured LLM is an Anthropic model."""
+        model: str = getattr(getattr(self, "llm", None), "model", "") or ""
+        return model.startswith("claude") or "anthropic" in model
+
     def _setup_messages(self, inputs: dict[str, Any]) -> None:
         """Set up messages for the agent execution.
 
@@ -176,6 +181,11 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         from crewai.llms.cache import mark_cache_breakpoint
 
+        # cache_breakpoint is an Anthropic-only feature; injecting it for other
+        # providers (Groq, OpenAI-compatible APIs, etc.) causes a hard
+        # validation error on the provider side.
+        _mark = mark_cache_breakpoint if self._llm_is_anthropic() else (lambda m: m)
+
         if self.prompt is not None and "system" in self.prompt:
             system_prompt = self._format_prompt(
                 cast(str, self.prompt.get("system", "")), inputs
@@ -183,22 +193,11 @@ class CrewAgentExecutor(BaseAgentExecutor):
             user_prompt = self._format_prompt(
                 cast(str, self.prompt.get("user", "")), inputs
             )
-            # Cache breakpoints: end-of-system caches the per-agent stable
-            # prefix; end-of-user caches the per-task stable prefix across
-            # ReAct-loop iterations.
-            self.messages.append(
-                mark_cache_breakpoint(
-                    format_message_for_llm(system_prompt, role="system")
-                )
-            )
-            self.messages.append(
-                mark_cache_breakpoint(format_message_for_llm(user_prompt))
-            )
+            self.messages.append(_mark(format_message_for_llm(system_prompt, role="system")))
+            self.messages.append(_mark(format_message_for_llm(user_prompt)))
         elif self.prompt is not None:
             user_prompt = self._format_prompt(self.prompt.get("prompt", ""), inputs)
-            self.messages.append(
-                mark_cache_breakpoint(format_message_for_llm(user_prompt))
-            )
+            self.messages.append(_mark(format_message_for_llm(user_prompt)))
 
         provider.post_setup_messages(cast(ExecutorContext, cast(object, self)))
 


### PR DESCRIPTION
## Problem

`_setup_messages` unconditionally calls `mark_cache_breakpoint()` on every message regardless of the configured LLM provider. `cache_breakpoint` is an Anthropic-only extension — Groq, OpenAI-compatible endpoints, and other providers reject messages containing this key with a hard validation error:

```
BadRequestError: {"error":{"message":"Invalid request: extra fields not permitted"}}
```

This breaks crewAI for any non-Anthropic provider once the cache-breakpoint code path is triggered.

## Fix

Added `_llm_is_anthropic()` that checks the model name, and gated `mark_cache_breakpoint` on that check. For every other provider the messages pass through unchanged — no behavior change for existing Anthropic users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved LLM provider compatibility by fixing validation errors that occurred with non-Anthropic providers. Caching functionality now works reliably across different LLM services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->