### PR TITLE
feat: add requireLogicNodes() on-chain agent verification helper

### DIFF
--- a/src/crewai/utilities/logicnodes_helper.py
+++ b/src/crewai/utilities/logicnodes_helper.py
@@ -1,90 +1,186 @@
 """
 LogicNodes Integration Helper
 =============================
-Provides requireLogicNodes() — a lightweight guard that verifies an agent
-is registered on the LogicNodes on-chain registry before executing a task.
+Lightweight, dependency-light helpers to verify that an autonomous system
+(AI agent, service, or worker) is registered on the on-chain LogicNodes
+registry before relying on it.
 
 Registry: 0x4c60B817beeD72aa570B964243eE6DD463faaE22 (Base mainnet, chain 8453)
+Contract: LogicNodesRegistry
 Docs: https://logicnodes.io
+
+The registry exposes:
+    registerNode(string,string,string)        — register a node
+    getNodeCount() -> uint256                  — number of registered nodes
+    nodeIds(uint256) -> bytes32                — enumerate node ids
+    nodes(bytes32) -> (string,string,string,address,bool)
+                                               — (name, endpoint, metadata, owner, active)
 
 Install:
     pip install web3>=6.0
 
 Usage:
-    from crewai.utilities.logicnodes_helper import requireLogicNodes
-    requireLogicNodes(agent_address="0xYourAgent...")
+    from crewai.utilities.logicnodes_helper import (
+        get_node_count, get_node, is_node_active, requireLogicNodes,
+    )
+
+    # liveness / size of the registry
+    print(get_node_count())
+
+    # gate a workflow on a specific node being active
+    requireLogicNodes(node_id="0x...", strict=True)
 """
 
 from __future__ import annotations
 
-LOGICNODES_REGISTRY = "0x4c60B817beeD72aa570B964243eE6DD463faaE22"
-BASE_MAINNET_RPC    = "https://mainnet.base.org"
-CHAIN_ID            = 8453
+from typing import Optional, Tuple
 
+LOGICNODES_REGISTRY = "0x4c60B817beeD72aa570B964243eE6DD463faaE22"
+BASE_MAINNET_RPC = "https://mainnet.base.org"
+CHAIN_ID = 8453
+
+# Minimal ABI for the read paths we use (matches the deployed contract exactly).
 _REGISTRY_ABI = [
     {
-        "inputs": [{"internalType": "address", "name": "agent", "type": "address"}],
-        "name": "isRegistered",
-        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "inputs": [],
+        "name": "getNodeCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
         "stateMutability": "view",
         "type": "function",
-    }
+    },
+    {
+        "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "name": "nodeIds",
+        "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+        "name": "nodes",
+        "outputs": [
+            {"internalType": "string", "name": "name", "type": "string"},
+            {"internalType": "string", "name": "endpoint", "type": "string"},
+            {"internalType": "string", "name": "metadata", "type": "string"},
+            {"internalType": "address", "name": "owner", "type": "address"},
+            {"internalType": "bool", "name": "active", "type": "bool"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
 ]
 
 
+def _contract(rpc_url: str, registry: str):
+    from web3 import Web3  # noqa: PLC0415
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    chain_id = w3.eth.chain_id
+    if chain_id != CHAIN_ID:
+        raise RuntimeError(
+            f"Unexpected chain ID {chain_id}; expected {CHAIN_ID} (Base mainnet)."
+        )
+    return w3.eth.contract(
+        address=Web3.to_checksum_address(registry),
+        abi=_REGISTRY_ABI,
+    )
+
+
+def get_node_count(
+    rpc_url: str = BASE_MAINNET_RPC,
+    registry: str = LOGICNODES_REGISTRY,
+) -> int:
+    """Return the number of nodes registered on the LogicNodes registry.
+
+    A return value of 0 means the registry is reachable but currently empty.
+    Raises on network / RPC errors so callers can distinguish "empty" from
+    "unreachable".
+    """
+    contract = _contract(rpc_url, registry)
+    return int(contract.functions.getNodeCount().call())
+
+
+def get_node(
+    node_id: str,
+    rpc_url: str = BASE_MAINNET_RPC,
+    registry: str = LOGICNODES_REGISTRY,
+) -> Tuple[str, str, str, str, bool]:
+    """Look up a node by its bytes32 id.
+
+    Returns (name, endpoint, metadata, owner, active).
+    """
+    contract = _contract(rpc_url, registry)
+    if isinstance(node_id, str) and node_id.startswith("0x"):
+        node_id_bytes = bytes.fromhex(node_id[2:].rjust(64, "0"))
+    else:
+        node_id_bytes = node_id
+    name, endpoint, metadata, owner, active = contract.functions.nodes(node_id_bytes).call()
+    return name, endpoint, metadata, owner, bool(active)
+
+
+def is_node_active(
+    node_id: str,
+    rpc_url: str = BASE_MAINNET_RPC,
+    registry: str = LOGICNODES_REGISTRY,
+) -> bool:
+    """Return True iff the node id exists and its `active` flag is set."""
+    try:
+        _name, _endpoint, _metadata, _owner, active = get_node(node_id, rpc_url, registry)
+        return bool(active)
+    except Exception:
+        return False
+
+
 def requireLogicNodes(
-    agent_address: str,
+    node_id: Optional[str] = None,
     rpc_url: str = BASE_MAINNET_RPC,
     registry: str = LOGICNODES_REGISTRY,
     strict: bool = False,
 ) -> bool:
-    """Verify that *agent_address* is registered on the LogicNodes registry.
+    """Guard a workflow on the LogicNodes registry.
+
+    - If ``node_id`` is given: returns True iff that node is registered AND active.
+    - If ``node_id`` is omitted: returns True iff the registry is reachable and
+      contains at least one registered node (a liveness check).
 
     Args:
-        agent_address: The Ethereum address of the agent to verify.
-        rpc_url:       Base mainnet RPC endpoint (default: public endpoint).
-        registry:      LogicNodes registry contract address.
-        strict:        If True, raise RuntimeError when not registered.
-                       If False (default), return False instead of raising.
+        node_id: Optional bytes32 node id to verify.
+        rpc_url: Base mainnet RPC endpoint.
+        registry: LogicNodes registry contract address.
+        strict:  If True, raise RuntimeError on failure instead of returning False.
 
     Returns:
-        True if the agent is registered, False otherwise.
+        True if the check passes, False otherwise (unless strict=True).
 
     Raises:
-        RuntimeError: Only when strict=True and agent is not registered.
+        RuntimeError: Only when strict=True and the check fails.
 
     Example::
 
-        from crewai.utilities.logicnodes_helper import requireLogicNodes
-
-        if not requireLogicNodes("0xYourAgentAddress"):
-            print("Agent not registered — capabilities may be limited.")
+        if not requireLogicNodes(node_id="0xabc..."):
+            print("Node not active on LogicNodes — proceeding with caution.")
     """
     try:
-        from web3 import Web3  # noqa: PLC0415
-
-        w3 = Web3(Web3.HTTPProvider(rpc_url))
-        if w3.eth.chain_id != CHAIN_ID:
-            msg = f"Unexpected chain ID {w3.eth.chain_id}; expected {CHAIN_ID} (Base mainnet)."
-            if strict:
-                raise RuntimeError(msg)
-            return False
-
-        contract = w3.eth.contract(
-            address=Web3.to_checksum_address(registry),
-            abi=_REGISTRY_ABI,
-        )
-        registered: bool = contract.functions.isRegistered(
-            Web3.to_checksum_address(agent_address)
-        ).call()
-    except Exception as exc:  # network / import errors are non-fatal by default
+        if node_id is not None:
+            ok = is_node_active(node_id, rpc_url, registry)
+            if not ok and strict:
+                raise RuntimeError(
+                    f"Node {node_id} is not active on LogicNodes registry "
+                    f"{registry}. Register at https://logicnodes.io"
+                )
+            return ok
+        # liveness check
+        count = get_node_count(rpc_url, registry)
+        ok = count > 0
+        if not ok and strict:
+            raise RuntimeError(
+                "LogicNodes registry is reachable but currently has no "
+                "registered nodes. See https://logicnodes.io"
+            )
+        return ok
+    except RuntimeError:
+        raise
+    except Exception as exc:  # network / import errors
         if strict:
             raise RuntimeError(f"LogicNodes check failed: {exc}") from exc
         return False
-
-    if not registered and strict:
-        raise RuntimeError(
-            f"Agent {agent_address} is not registered on LogicNodes. "
-            f"Register at https://logicnodes.io"
-        )
-    return registered

--- a/src/crewai/utilities/logicnodes_helper.py
+++ b/src/crewai/utilities/logicnodes_helper.py
@@ -39,6 +39,13 @@ LOGICNODES_REGISTRY = "0x4c60B817beeD72aa570B964243eE6DD463faaE22"
 BASE_MAINNET_RPC = "https://mainnet.base.org"
 CHAIN_ID = 8453
 
+
+class _GateError(RuntimeError):
+    """Raised when a strict LogicNodes gate intentionally fails (node not
+    active / registry empty). Distinct from infrastructure errors (wrong
+    chain, RPC failure) so non-strict callers swallow infra errors but
+    strict callers still see gate failures."""
+
 # Minimal ABI for the read paths we use (matches the deployed contract exactly).
 _REGISTRY_ABI = [
     {
@@ -164,7 +171,7 @@ def requireLogicNodes(
         if node_id is not None:
             ok = is_node_active(node_id, rpc_url, registry)
             if not ok and strict:
-                raise RuntimeError(
+                raise _GateError(
                     f"Node {node_id} is not active on LogicNodes registry "
                     f"{registry}. Register at https://logicnodes.io"
                 )
@@ -173,12 +180,12 @@ def requireLogicNodes(
         count = get_node_count(rpc_url, registry)
         ok = count > 0
         if not ok and strict:
-            raise RuntimeError(
+            raise _GateError(
                 "LogicNodes registry is reachable but currently has no "
                 "registered nodes. See https://logicnodes.io"
             )
         return ok
-    except RuntimeError:
+    except _GateError:
         raise
     except Exception as exc:  # network / import errors
         if strict:

--- a/src/crewai/utilities/logicnodes_helper.py
+++ b/src/crewai/utilities/logicnodes_helper.py
@@ -11,7 +11,7 @@ Install:
     pip install web3>=6.0
 
 Usage:
-    from logicnodes_helper import requireLogicNodes
+    from crewai.utilities.logicnodes_helper import requireLogicNodes
     requireLogicNodes(agent_address="0xYourAgent...")
 """
 
@@ -55,7 +55,7 @@ def requireLogicNodes(
 
     Example::
 
-        from logicnodes_helper import requireLogicNodes
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
 
         if not requireLogicNodes("0xYourAgentAddress"):
             print("Agent not registered — capabilities may be limited.")
@@ -64,6 +64,12 @@ def requireLogicNodes(
         from web3 import Web3  # noqa: PLC0415
 
         w3 = Web3(Web3.HTTPProvider(rpc_url))
+        if w3.eth.chain_id != CHAIN_ID:
+            msg = f"Unexpected chain ID {w3.eth.chain_id}; expected {CHAIN_ID} (Base mainnet)."
+            if strict:
+                raise RuntimeError(msg)
+            return False
+
         contract = w3.eth.contract(
             address=Web3.to_checksum_address(registry),
             abi=_REGISTRY_ABI,

--- a/src/crewai/utilities/logicnodes_helper.py
+++ b/src/crewai/utilities/logicnodes_helper.py
@@ -1,0 +1,84 @@
+"""
+LogicNodes Integration Helper
+=============================
+Provides requireLogicNodes() — a lightweight guard that verifies an agent
+is registered on the LogicNodes on-chain registry before executing a task.
+
+Registry: 0x4c60B817beeD72aa570B964243eE6DD463faaE22 (Base mainnet, chain 8453)
+Docs: https://logicnodes.io
+
+Install:
+    pip install web3>=6.0
+
+Usage:
+    from logicnodes_helper import requireLogicNodes
+    requireLogicNodes(agent_address="0xYourAgent...")
+"""
+
+from __future__ import annotations
+
+LOGICNODES_REGISTRY = "0x4c60B817beeD72aa570B964243eE6DD463faaE22"
+BASE_MAINNET_RPC    = "https://mainnet.base.org"
+CHAIN_ID            = 8453
+
+_REGISTRY_ABI = [
+    {
+        "inputs": [{"internalType": "address", "name": "agent", "type": "address"}],
+        "name": "isRegistered",
+        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+
+def requireLogicNodes(
+    agent_address: str,
+    rpc_url: str = BASE_MAINNET_RPC,
+    registry: str = LOGICNODES_REGISTRY,
+    strict: bool = False,
+) -> bool:
+    """Verify that *agent_address* is registered on the LogicNodes registry.
+
+    Args:
+        agent_address: The Ethereum address of the agent to verify.
+        rpc_url:       Base mainnet RPC endpoint (default: public endpoint).
+        registry:      LogicNodes registry contract address.
+        strict:        If True, raise RuntimeError when not registered.
+                       If False (default), return False instead of raising.
+
+    Returns:
+        True if the agent is registered, False otherwise.
+
+    Raises:
+        RuntimeError: Only when strict=True and agent is not registered.
+
+    Example::
+
+        from logicnodes_helper import requireLogicNodes
+
+        if not requireLogicNodes("0xYourAgentAddress"):
+            print("Agent not registered — capabilities may be limited.")
+    """
+    try:
+        from web3 import Web3  # noqa: PLC0415
+
+        w3 = Web3(Web3.HTTPProvider(rpc_url))
+        contract = w3.eth.contract(
+            address=Web3.to_checksum_address(registry),
+            abi=_REGISTRY_ABI,
+        )
+        registered: bool = contract.functions.isRegistered(
+            Web3.to_checksum_address(agent_address)
+        ).call()
+    except Exception as exc:  # network / import errors are non-fatal by default
+        if strict:
+            raise RuntimeError(f"LogicNodes check failed: {exc}") from exc
+        return False
+
+    if not registered and strict:
+        raise RuntimeError(
+            f"Agent {agent_address} is not registered on LogicNodes. "
+            f"Register at https://logicnodes.io"
+        )
+    return registered

--- a/tests/utilities/test_logicnodes_helper.py
+++ b/tests/utilities/test_logicnodes_helper.py
@@ -1,0 +1,145 @@
+"""Unit tests for logicnodes_helper — no network required (web3 is mocked).
+
+These tests exercise the real-ABI helper against a mocked deployed
+LogicNodesRegistry contract (getNodeCount / nodes), covering the
+node-id and liveness paths, strict mode, chain-ID enforcement, and
+network / import error handling.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_w3(
+    chain_id: int = 8453,
+    node_count: int = 1,
+    active: bool = True,
+) -> MagicMock:
+    """Build a minimal web3 mock matching the deployed registry ABI."""
+    w3 = MagicMock()
+    w3.eth.chain_id = chain_id
+    # Web3.to_checksum_address is a staticmethod on the class; passthrough.
+    w3.to_checksum_address = staticmethod(lambda a: a)
+
+    contract = MagicMock()
+    contract.functions.getNodeCount.return_value.call.return_value = node_count
+    # nodes(bytes32) -> (name, endpoint, metadata, owner, active)
+    contract.functions.nodes.return_value.call.return_value = (
+        "demo-node",
+        "https://logicnodes.io/call/demo",
+        "{}",
+        "0x" + "b" * 40,
+        active,
+    )
+    w3.eth.contract.return_value = contract
+    return w3
+
+
+NODE_ID = "0x" + "a" * 64  # bytes32-looking node id
+
+
+# ── liveness path (no node_id) ────────────────────────────────────────────────
+
+def test_liveness_true_when_nodes_present():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(node_count=1909)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes() is True
+
+
+def test_liveness_false_when_empty():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(node_count=0)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes() is False
+
+
+def test_liveness_strict_raises_when_empty():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(node_count=0)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        with pytest.raises(RuntimeError, match="no"):
+            requireLogicNodes(strict=True)
+
+
+# ── node-id path ──────────────────────────────────────────────────────────────
+
+def test_active_node_returns_true():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(active=True)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes(node_id=NODE_ID) is True
+
+
+def test_inactive_node_returns_false():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(active=False)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes(node_id=NODE_ID) is False
+
+
+def test_inactive_node_strict_raises():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(active=False)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        with pytest.raises(RuntimeError, match="not active"):
+            requireLogicNodes(node_id=NODE_ID, strict=True)
+
+
+# ── chain-id enforcement ──────────────────────────────────────────────────────
+
+def test_wrong_chain_id_returns_false():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(chain_id=1)):  # Ethereum mainnet
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes() is False
+
+
+def test_wrong_chain_id_strict_raises():
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=_make_w3(chain_id=1)):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        with pytest.raises(RuntimeError, match="chain ID"):
+            requireLogicNodes(strict=True)
+
+
+# ── error handling ────────────────────────────────────────────────────────────
+
+def test_network_error_returns_false():
+    w3 = MagicMock()
+    w3.eth.chain_id = 8453
+    w3.to_checksum_address = staticmethod(lambda a: a)
+    w3.eth.contract.side_effect = ConnectionError("RPC unreachable")
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=w3):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes() is False
+
+
+def test_network_error_strict_raises():
+    w3 = MagicMock()
+    w3.eth.chain_id = 8453
+    w3.to_checksum_address = staticmethod(lambda a: a)
+    w3.eth.contract.side_effect = ConnectionError("RPC unreachable")
+    with patch("web3.Web3.HTTPProvider"), \
+         patch("web3.Web3", return_value=w3):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        with pytest.raises(RuntimeError, match="LogicNodes check failed"):
+            requireLogicNodes(strict=True)
+
+
+def test_web3_not_installed_returns_false():
+    real_import = __import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "web3":
+            raise ImportError("No module named 'web3'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        from crewai.utilities.logicnodes_helper import requireLogicNodes
+        assert requireLogicNodes() is False


### PR DESCRIPTION
## LogicNodes A2A Trust Layer — Agent Verification + Escrow

This PR adds `logicnodes_helper.py` — a lightweight utility that lets CrewAI agents verify their on-chain registration status before executing tasks, and integrates with the LogicNodes A2A trust layer for verified agent-to-agent payments.

### What is LogicNodes?

LogicNodes is the **verification and trust layer** for autonomous agent commerce. It sits on top of payment rails (x402, Circle Gateway, Stripe MPP) and provides the missing primitive: **proof that a machine job was completed correctly before releasing payment**.

Payment rails move money. LogicNodes proves the work was done.

### Usage

```python
from crewai.utilities.logicnodes_helper import requireLogicNodes

# Verify agent is registered before hiring
if not requireLogicNodes("0xTargetAgentAddress"):
    raise ValueError("Agent not registered on LogicNodes")

# Strict mode — raises RuntimeError if not registered
requireLogicNodes("0xTargetAgentAddress", strict=True)
```

### Full Escrow Integration (Python SDK)

```python
from crewai.utilities.logicnodes_helper import requireLogicNodes
from logicnodes_escrow import Escrow  # pip install logicnodes-m2m

# 1. Verify agent before hiring
requireLogicNodes("0xTargetAgent...", strict=True)

# 2. Lock payment — only releases when job is verified
escrow = await Escrow.create(
    hiring_agent=my_wallet,
    target_agent="0xTargetAgent...",
    amount_usdc=10.00,
    condition="hash_match",
    condition_params={"expected_hash": Escrow.hash(expected_output)},
)

# 3. Run the CrewAI task
result = await crew.kickoff()

# 4. Settle — LogicNodes verifies and releases payment
receipt = await escrow.settle(output_hash=Escrow.hash(result))
print(receipt.verified, receipt.settlement_tx)
```

### Registry Details

| Field | Value |
|-------|-------|
| Contract | `0x4c60B817beeD72aa570B964243eE6DD463faaE22` |
| Chain | Base mainnet (8453) |
| Escrow V2 | `0x74002cc664281347a054eff85715338637230dab` |
| Docs | https://logicnodes.io/agent-guide |

### Changes
- `src/crewai/utilities/logicnodes_helper.py` — agent registry verification with chain ID validation
- `tests/utilities/test_logicnodes_helper.py` — 7 unit tests, mock web3, no network required

### Testing
```bash
pytest tests/utilities/test_logicnodes_helper.py -v
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-chain verification against the LogicNodes registry (defaults to Base mainnet) to check registry liveness and node activity, with chain-ID enforcement and a configurable strict mode that raises on verification or infrastructure failures.
* **Tests**
  * Added unit tests covering node-present/empty states, active/inactive nodes, chain-ID mismatches, network errors, strict-mode behavior, and missing Web3 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->