### PR TITLE
docs: update changelog and version for v1.14.6a2

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,39 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="27 مايو 2026">
+  ## v1.14.6a2
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6a2)
+
+  ## ما الذي تغير
+
+  ### الميزات
+  - تحسين `StdioTransport` لمنع تسرب متغيرات البيئة
+  - تحسين تكوين التخطيط ومعالجة المراقبة
+  - إعلان `env_vars` على `DatabricksQueryTool`
+  - إضافة وثائق خطة التحكم بالوكيل
+
+  ### إصلاحات الأخطاء
+  - إصلاح تسرب المخرجات المنظمة في حلقات استدعاء الأدوات
+  - حذف الاستدعاءات غير القابلة للعودة وحالة المحول في نقاط التحقق
+  - تسلسل حقول `type[BaseModel]` كـ JSON schema في نقاط التحقق
+  - تجنب `task_started` اليتيمة عند استعادة نطاق الاستئناف
+  - السماح لـ `AgentExecutor` بالاستعادة من نقطة تحقق
+  - تصحيح خطأ مطبعي في MongoDB إلى `pymongo` في تبعيات الحزمة
+
+  ### الوثائق
+  - إعادة هيكلة صفحة نقاط التحقق
+  - توثيق خطوة تثبيت حزمة الإدارة لمرة واحدة
+  - نقل Secrets Manager / Workload Identity من replicated-config
+  - إزالة إدخال Skills Repository من سجل التغييرات
+
+  ## المساهمون
+
+  @github-actions[bot], @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @lucasgomide, @mattatcha, @thiagomoretto, @vinibrsl
+
+</Update>
+
 <Update label="21 مايو 2026">
   ## v1.14.6a1
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,39 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="May 27, 2026">
+  ## v1.14.6a2
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6a2)
+
+  ## What's Changed
+
+  ### Features
+  - Enhance `StdioTransport` to prevent environment variable leakage
+  - Enhance planning configuration and observation handling
+  - Declare `env_vars` on `DatabricksQueryTool`
+  - Add Agent Control Plane documentation
+
+  ### Bug Fixes
+  - Fix structured output leaks in tool-calling loops
+  - Drop unroundtrippable callbacks and adapter state in checkpointing
+  - Serialize `type[BaseModel]` fields as JSON schema in checkpointing
+  - Avoid orphan `task_started` on resume scope restore
+  - Allow `AgentExecutor` to restore from checkpoint
+  - Correct MongoDB typo to `pymongo` in package dependencies
+
+  ### Documentation
+  - Restructure checkpointing page
+  - Document one-time admin package install step
+  - Migrate Secrets Manager / Workload Identity from replicated-config
+  - Remove Skills Repository entry from changelog
+
+  ## Contributors
+
+  @github-actions[bot], @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @lucasgomide, @mattatcha, @thiagomoretto, @vinibrsl
+
+</Update>
+
 <Update label="May 21, 2026">
   ## v1.14.6a1
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,39 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 5월 27일">
+  ## v1.14.6a2
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6a2)
+
+  ## 변경 사항
+
+  ### 기능
+  - 환경 변수 유출을 방지하기 위해 `StdioTransport` 개선
+  - 계획 구성 및 관찰 처리 개선
+  - `DatabricksQueryTool`에서 `env_vars` 선언
+  - 에이전트 제어 평면 문서 추가
+
+  ### 버그 수정
+  - 도구 호출 루프에서 구조화된 출력 유출 수정
+  - 체크포인팅에서 원형으로 돌아갈 수 없는 콜백 및 어댑터 상태 제거
+  - 체크포인팅에서 `type[BaseModel]` 필드를 JSON 스키마로 직렬화
+  - 복원 범위 복원 시 고아 `task_started` 방지
+  - `AgentExecutor`가 체크포인트에서 복원할 수 있도록 허용
+  - 패키지 종속성에서 MongoDB 오타를 `pymongo`로 수정
+
+  ### 문서
+  - 체크포인팅 페이지 구조 재편성
+  - 일회성 관리자 패키지 설치 단계 문서화
+  - 복제된 구성에서 비밀 관리자 / 작업 부하 ID 마이그레이션
+  - 변경 로그에서 기술 리포지토리 항목 제거
+
+  ## 기여자
+
+  @github-actions[bot], @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @lucasgomide, @mattatcha, @thiagomoretto, @vinibrsl
+
+</Update>
+
 <Update label="2026년 5월 21일">
   ## v1.14.6a1
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,39 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="27 mai 2026">
+  ## v1.14.6a2
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6a2)
+
+  ## O que Mudou
+
+  ### Recursos
+  - Aprimorar `StdioTransport` para evitar vazamento de variáveis de ambiente
+  - Aprimorar a configuração de planejamento e o manuseio de observações
+  - Declarar `env_vars` em `DatabricksQueryTool`
+  - Adicionar documentação do Controle de Agentes
+
+  ### Correções de Bugs
+  - Corrigir vazamentos de saída estruturada em loops de chamada de ferramentas
+  - Remover callbacks e estado de adaptadores que não podem ser revertidos em checkpoints
+  - Serializar campos `type[BaseModel]` como esquema JSON em checkpoints
+  - Evitar `task_started` órfão na restauração do escopo de retomar
+  - Permitir que `AgentExecutor` restaure a partir de checkpoints
+  - Corrigir erro de digitação do MongoDB para `pymongo` nas dependências do pacote
+
+  ### Documentação
+  - Reestruturar a página de checkpoints
+  - Documentar o passo de instalação do pacote administrativo único
+  - Migrar Secrets Manager / Workload Identity de replicated-config
+  - Remover a entrada do Repositório de Habilidades do changelog
+
+  ## Contribuidores
+
+  @github-actions[bot], @greysonlalonde, @heitorado, @iris-clawd, @lorenzejay, @lucasgomide, @mattatcha, @thiagomoretto, @vinibrsl
+
+</Update>
+
 <Update label="21 mai 2026">
   ## v1.14.6a1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog inserts with no runtime or API changes in this diff.
> 
> **Overview**
> Adds a new **v1.14.6a2** release block at the top of the product changelog in **English**, **Arabic**, **Korean**, and **pt-BR**, each dated May 27, 2026, with a link to the GitHub release.
> 
> The new entry documents shipped work from that tag: **StdioTransport** env isolation, planning/observation tweaks, **`env_vars`** on **`DatabricksQueryTool`**, Agent Control Plane docs, checkpointing/resume fixes (**`AgentExecutor`**, structured output in tool loops, **`type[BaseModel]`** serialization), **`pymongo`** dependency typo fix, and doc moves (checkpointing page, admin install, Secrets Manager / Workload Identity). It also drops a stale Skills Repository changelog line and lists contributors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f74583bcbda2efe6cc34d4e2661e1174faa9af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog documentation across multiple language versions (English, Arabic, Korean, and Portuguese-Brazilian) with v1.14.6a2 release information, including categorized features, bug fixes, documentation updates, and contributor credits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->