### PR TITLE
docs: add ACP (Beta) docs navigation block to Agent Control Plane pages

### DIFF
--- a/docs/ar/enterprise/features/agent-control-plane/monitoring.mdx
+++ b/docs/ar/enterprise/features/agent-control-plane/monitoring.mdx
@@ -6,6 +6,14 @@ icon: "gauge"
 mode: "wide"
 ---
 
+<Info>
+  **تنقل وثائق ACP (إصدار تجريبي)**
+
+  - [نظرة عامة](/ar/enterprise/features/agent-control-plane/overview)
+  - **المراقبة** *(أنت هنا)*
+  - [القواعد](/ar/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## نظرة عامة
 
 تبويب **Automations** هو عرض العمليات للقراءة فقط في [Agent Control Plane](/ar/enterprise/features/agent-control-plane/overview). يجمع بين بطاقتَي مقاييس و sankey تفاعلي وجدولين فرعيين — **Automations** و **Consumption** — يمكنك البحث والتصفية والفرز فيهما.

--- a/docs/ar/enterprise/features/agent-control-plane/overview.mdx
+++ b/docs/ar/enterprise/features/agent-control-plane/overview.mdx
@@ -5,6 +5,14 @@ sidebarTitle: نظرة عامة
 icon: "book-open"
 ---
 
+<Info>
+  **تنقل وثائق ACP (إصدار تجريبي)**
+
+  - **نظرة عامة** *(أنت هنا)*
+  - [المراقبة](/ar/enterprise/features/agent-control-plane/monitoring)
+  - [القواعد](/ar/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## نظرة عامة
 
 **Agent Control Plane** (ACP) هو مركز العمليات لكل ما يعمل لديك على CrewAI AMP. إنها شاشة واحدة — مقسّمة إلى تبويبَي **Automations** و **Rules** — تمنح فريقك القدرة على:

--- a/docs/ar/enterprise/features/agent-control-plane/rules.mdx
+++ b/docs/ar/enterprise/features/agent-control-plane/rules.mdx
@@ -6,6 +6,14 @@ icon: "shield-check"
 mode: "wide"
 ---
 
+<Info>
+  **تنقل وثائق ACP (إصدار تجريبي)**
+
+  - [نظرة عامة](/ar/enterprise/features/agent-control-plane/overview)
+  - [المراقبة](/ar/enterprise/features/agent-control-plane/monitoring)
+  - **القواعد** *(أنت هنا)*
+</Info>
+
 ## نظرة عامة
 
 تتيح لك القواعد تطبيق سياسات — اليوم: **PII Redaction** — عبر العديد من الأتمتات دفعة واحدة، بدلاً من ضبط كل deployment على حدة. افتح تبويب **Rules** في [Agent Control Plane](/ar/enterprise/features/agent-control-plane/overview) لإدارتها.

--- a/docs/en/enterprise/features/agent-control-plane/monitoring.mdx
+++ b/docs/en/enterprise/features/agent-control-plane/monitoring.mdx
@@ -6,6 +6,14 @@ icon: "gauge"
 mode: "wide"
 ---
 
+<Info>
+  **ACP (Beta) Docs Navigation**
+
+  - [Overview](/en/enterprise/features/agent-control-plane/overview)
+  - **Monitoring** *(you are here)*
+  - [Rules](/en/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## Overview
 
 The **Automations** tab is the read-only operations view of the [Agent Control Plane](/en/enterprise/features/agent-control-plane/overview). It combines two metric cards, an interactive sankey, and two sub-tables — **Automations** and **Consumption** — that you can search, filter, and sort.

--- a/docs/en/enterprise/features/agent-control-plane/overview.mdx
+++ b/docs/en/enterprise/features/agent-control-plane/overview.mdx
@@ -5,6 +5,14 @@ sidebarTitle: Overview
 icon: "book-open"
 ---
 
+<Info>
+  **ACP (Beta) Docs Navigation**
+
+  - **Overview** *(you are here)*
+  - [Monitoring](/en/enterprise/features/agent-control-plane/monitoring)
+  - [Rules](/en/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## Overview
 
 The **Agent Control Plane** (ACP) is the operations hub for everything you have running on CrewAI AMP. It is a single screen — split into **Automations** and **Rules** tabs — that lets your team:

--- a/docs/en/enterprise/features/agent-control-plane/rules.mdx
+++ b/docs/en/enterprise/features/agent-control-plane/rules.mdx
@@ -6,6 +6,14 @@ icon: "shield-check"
 mode: "wide"
 ---
 
+<Info>
+  **ACP (Beta) Docs Navigation**
+
+  - [Overview](/en/enterprise/features/agent-control-plane/overview)
+  - [Monitoring](/en/enterprise/features/agent-control-plane/monitoring)
+  - **Rules** *(you are here)*
+</Info>
+
 ## Overview
 
 Rules let you apply policies — today: **PII Redaction** — across many automations at once, instead of configuring each deployment individually. Open the **Rules** tab in the [Agent Control Plane](/en/enterprise/features/agent-control-plane/overview) to manage them.

--- a/docs/ko/enterprise/features/agent-control-plane/monitoring.mdx
+++ b/docs/ko/enterprise/features/agent-control-plane/monitoring.mdx
@@ -6,6 +6,14 @@ icon: "gauge"
 mode: "wide"
 ---
 
+<Info>
+  **ACP (베타) 문서 내비게이션**
+
+  - [개요](/ko/enterprise/features/agent-control-plane/overview)
+  - **모니터링** *(현재 페이지)*
+  - [규칙](/ko/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## 개요
 
 **Automations** 탭은 [Agent Control Plane](/ko/enterprise/features/agent-control-plane/overview)의 읽기 전용 운영 뷰입니다. 두 개의 메트릭 카드, 인터랙티브 sankey, 그리고 **Automations**와 **Consumption** 두 개의 서브 테이블을 결합해 검색·필터·정렬을 지원합니다.

--- a/docs/ko/enterprise/features/agent-control-plane/overview.mdx
+++ b/docs/ko/enterprise/features/agent-control-plane/overview.mdx
@@ -5,6 +5,14 @@ sidebarTitle: 개요
 icon: "book-open"
 ---
 
+<Info>
+  **ACP (베타) 문서 내비게이션**
+
+  - **개요** *(현재 페이지)*
+  - [모니터링](/ko/enterprise/features/agent-control-plane/monitoring)
+  - [규칙](/ko/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## 개요
 
 **Agent Control Plane**(ACP)은 CrewAI AMP에서 실행 중인 모든 워크로드를 위한 운영 허브입니다. **Automations**와 **Rules** 두 개의 탭으로 구성된 단일 화면에서 다음 작업을 할 수 있습니다:

--- a/docs/ko/enterprise/features/agent-control-plane/rules.mdx
+++ b/docs/ko/enterprise/features/agent-control-plane/rules.mdx
@@ -6,6 +6,14 @@ icon: "shield-check"
 mode: "wide"
 ---
 
+<Info>
+  **ACP (베타) 문서 내비게이션**
+
+  - [개요](/ko/enterprise/features/agent-control-plane/overview)
+  - [모니터링](/ko/enterprise/features/agent-control-plane/monitoring)
+  - **규칙** *(현재 페이지)*
+</Info>
+
 ## 개요
 
 규칙(Rules)은 각 deployment를 개별 설정하는 대신, 정책 — 현재: **PII Redaction** — 을 한 번에 여러 자동화에 적용할 수 있게 해줍니다. 관리하려면 [Agent Control Plane](/ko/enterprise/features/agent-control-plane/overview)에서 **Rules** 탭을 엽니다.

--- a/docs/pt-BR/enterprise/features/agent-control-plane/monitoring.mdx
+++ b/docs/pt-BR/enterprise/features/agent-control-plane/monitoring.mdx
@@ -6,6 +6,14 @@ icon: "gauge"
 mode: "wide"
 ---
 
+<Info>
+  **Navegação da Documentação do ACP (Beta)**
+
+  - [Visão Geral](/pt-BR/enterprise/features/agent-control-plane/overview)
+  - **Monitoramento** *(você está aqui)*
+  - [Regras](/pt-BR/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## Visão Geral
 
 A aba **Automações** é a visão de operações somente leitura do [Agent Control Plane](/pt-BR/enterprise/features/agent-control-plane/overview). Ela combina dois cards de métricas, um sankey interativo e duas sub-tabelas — **Automações** e **Consumo** — nas quais você pode buscar, filtrar e ordenar.

--- a/docs/pt-BR/enterprise/features/agent-control-plane/overview.mdx
+++ b/docs/pt-BR/enterprise/features/agent-control-plane/overview.mdx
@@ -5,6 +5,14 @@ sidebarTitle: Visão Geral
 icon: "book-open"
 ---
 
+<Info>
+  **Navegação da Documentação do ACP (Beta)**
+
+  - **Visão Geral** *(você está aqui)*
+  - [Monitoramento](/pt-BR/enterprise/features/agent-control-plane/monitoring)
+  - [Regras](/pt-BR/enterprise/features/agent-control-plane/rules)
+</Info>
+
 ## Visão Geral
 
 O **Agent Control Plane** (ACP) é o hub de operações para tudo que você tem rodando no CrewAI AMP. É uma tela única — dividida nas abas **Automações** e **Regras** — que permite à sua equipe:

--- a/docs/pt-BR/enterprise/features/agent-control-plane/rules.mdx
+++ b/docs/pt-BR/enterprise/features/agent-control-plane/rules.mdx
@@ -6,6 +6,14 @@ icon: "shield-check"
 mode: "wide"
 ---
 
+<Info>
+  **Navegação da Documentação do ACP (Beta)**
+
+  - [Visão Geral](/pt-BR/enterprise/features/agent-control-plane/overview)
+  - [Monitoramento](/pt-BR/enterprise/features/agent-control-plane/monitoring)
+  - **Regras** *(você está aqui)*
+</Info>
+
 ## Visão Geral
 
 As Regras permitem aplicar políticas — hoje: **PII Redaction** — em muitas automações de uma só vez, em vez de configurar cada deployment individualmente. Abra a aba **Regras** no [Agent Control Plane](/pt-BR/enterprise/features/agent-control-plane/overview) para gerenciá-las.


### PR DESCRIPTION
- Adds an <Info> "ACP (Beta) Docs Navigation" block at the top of every Agent Control Plane page so readers can jump between Overview, Monitoring, and Rules without scrolling to the bottom-of-page Related cards.


https://github.com/user-attachments/assets/920e9c6f-4c89-497d-90c9-1f64c7f87dd9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX additions with internal links; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds a top-of-page **ACP (Beta) Docs Navigation** `<Info>` block on every Agent Control Plane doc page (**Overview**, **Monitoring**, **Rules**) so readers can jump between the three guides without scrolling to the bottom **Related** cards.
> 
> The change is applied consistently across **en**, **ar**, **ko**, and **pt-BR** under `docs/*/enterprise/features/agent-control-plane/`. Each page highlights the current section and links to the other two with locale-prefixed paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c202371dcb82259491e336a8b6e2bca6daba7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added navigation blocks across Agent Control Plane (ACP) documentation pages (Overview, Monitoring, and Rules) in English, Arabic, Korean, and Portuguese-Brazilian languages, enabling users to easily navigate between related sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->