### PR TITLE
fix: inject TextFile content as text on non-multimodal models

### DIFF
--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -47,7 +47,7 @@ from crewai.utilities.pydantic_schema_utils import serialize_model_class
 
 
 try:
-    from crewai_files import format_multimodal_content
+    from crewai_files import TextFile, format_multimodal_content
 
     HAS_CREWAI_FILES = True
 except ImportError:
@@ -739,12 +739,26 @@ class BaseLLM(BaseModel, ABC):
             return messages
 
         if not self.supports_multimodal():
-            if any(msg.get("files") for msg in messages):
-                raise ValueError(
-                    f"Model '{self.model}' does not support multimodal input, "
-                    "but files were provided via 'input_files'. "
-                    "Use a vision-capable model or remove the file inputs."
-                )
+            for msg in messages:
+                files: list[Any] = msg.get("files") or []
+                if not files:
+                    continue
+                text_files = [f for f in files if isinstance(f, TextFile)]
+                non_text_files = [f for f in files if not isinstance(f, TextFile)]
+                if non_text_files:
+                    raise ValueError(
+                        f"Model '{self.model}' does not support multimodal input, "
+                        "but files were provided via 'input_files'. "
+                        "Use a vision-capable model or remove the file inputs."
+                    )
+                # Inject text-file contents directly into the message body so
+                # non-vision models can still read text attachments.
+                if text_files:
+                    injected = "\n\n".join(f.read_text() for f in text_files)
+                    existing = msg.get("content", "")
+                    if isinstance(existing, str):
+                        msg["content"] = f"{existing}\n\n{injected}".strip()
+                    msg.pop("files", None)
             return messages
 
         provider = getattr(self, "provider", None) or getattr(self, "model", "openai")

--- a/lib/crewai/tests/llms/test_multimodal.py
+++ b/lib/crewai/tests/llms/test_multimodal.py
@@ -371,3 +371,77 @@ class TestMultipleFilesFormatting:
         result = format_multimodal_content({}, llm.model)
 
         assert result == []
+
+
+class TestTextFileNonMultimodalInjection:
+    """Tests for TextFile handling on non-vision models.
+
+    Regression tests for https://github.com/crewAIInc/crewAI/issues/5137
+
+    Before the fix, passing *any* file (including text-only TextFile) to a
+    non-multimodal model raised a ValueError.  Text files should instead be
+    read as plain text and injected into the message content so that
+    text-only models can still process them.
+    """
+
+    def _make_non_vision_llm(self) -> LLM:
+        return LLM(model="gpt-3.5-turbo", is_litellm=True)
+
+    def test_text_file_injected_into_message_content(self) -> None:
+        """TextFile content is appended to the message body for non-vision models."""
+        llm = self._make_non_vision_llm()
+        msg: dict = {"role": "user", "content": "Summarise this:", "files": [TextFile(source=b"line one\nline two")]}
+
+        result = llm._process_message_files([msg])
+
+        assert len(result) == 1
+        assert "files" not in result[0], "files key must be stripped after injection"
+        assert "line one" in result[0]["content"]
+        assert "line two" in result[0]["content"]
+        assert "Summarise this:" in result[0]["content"]
+
+    def test_multiple_text_files_all_injected(self) -> None:
+        """All TextFile instances are injected when there are several."""
+        llm = self._make_non_vision_llm()
+        msg: dict = {
+            "role": "user",
+            "content": "Context:",
+            "files": [
+                TextFile(source=b"file A"),
+                TextFile(source=b"file B"),
+            ],
+        }
+
+        result = llm._process_message_files([msg])
+
+        assert "file A" in result[0]["content"]
+        assert "file B" in result[0]["content"]
+
+    def test_image_file_on_non_multimodal_still_raises(self) -> None:
+        """ImageFile on a non-vision model must still raise ValueError."""
+        llm = self._make_non_vision_llm()
+        msg: dict = {"role": "user", "content": "Look at this", "files": [ImageFile(source=MINIMAL_PNG)]}
+
+        with pytest.raises(ValueError, match="does not support multimodal"):
+            llm._process_message_files([msg])
+
+    def test_mixed_text_and_image_raises(self) -> None:
+        """A mix of TextFile and ImageFile raises because of the ImageFile."""
+        llm = self._make_non_vision_llm()
+        msg: dict = {
+            "role": "user",
+            "content": "Mixed",
+            "files": [TextFile(source=b"some text"), ImageFile(source=MINIMAL_PNG)],
+        }
+
+        with pytest.raises(ValueError, match="does not support multimodal"):
+            llm._process_message_files([msg])
+
+    def test_no_files_returns_messages_unchanged(self) -> None:
+        """Messages without files pass through unmodified."""
+        llm = self._make_non_vision_llm()
+        msg: dict = {"role": "user", "content": "plain message"}
+
+        result = llm._process_message_files([msg])
+
+        assert result[0]["content"] == "plain message"


### PR DESCRIPTION
## Summary

Fixes #5137

`_process_message_files()` previously raised a `ValueError` for *any* file attached to a non-vision model, including `TextFile` objects whose content is pure text requiring no visual understanding.

## Root cause

The guard was a blunt `any(msg.get("files")...)` check that did not distinguish between file types.

## Fix

Separate `TextFile` instances from genuinely visual inputs (`ImageFile`, `PDFFile`, `AudioFile`, `VideoFile`):

- **`TextFile` on a non-multimodal model** → call `read_text()` and append the decoded content to the message `content` field, then strip the `files` key. The model receives plain text with no binary blobs.
- **Any other file type on a non-multimodal model** → keep raising `ValueError` with the original message directing the user to a vision-capable model.

`TextFile` is already exported from `crewai_files`; it is added alongside the existing `format_multimodal_content` import inside the `try/except ImportError` guard so the overall feature-flag logic is unchanged.

## Tests

Five new regression tests in `TestTextFileNonMultimodalInjection`:

- text file content injected into message body
- multiple text files all injected
- `ImageFile` on non-multimodal still raises
- mixed `TextFile` + `ImageFile` still raises (because of the image)
- messages without files pass through unmodified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text files can now be used with text-only language models—their contents are automatically extracted and integrated into messages
  * Image files and other non-text attachments continue to be properly rejected for non-multimodal models
  * Mixed text and image file attachments are now correctly handled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->