### PR TITLE
fix: guard cache_breakpoint marking behind is_anthropic check

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -174,7 +174,18 @@ class CrewAgentExecutor(BaseAgentExecutor):
         if provider.setup_messages(cast(ExecutorContext, cast(object, self))):
             return
 
-        from crewai.llms.cache import mark_cache_breakpoint
+        use_cache_breakpoint = (
+            hasattr(self, "llm")
+            and self.llm is not None
+            and getattr(self.llm, "is_anthropic", False)
+        )
+        if use_cache_breakpoint:
+            from crewai.llms.cache import mark_cache_breakpoint
+            def _maybe_mark(msg):
+                return mark_cache_breakpoint(msg)
+        else:
+            def _maybe_mark(msg):
+                return msg
 
         if self.prompt is not None and "system" in self.prompt:
             system_prompt = self._format_prompt(
@@ -187,17 +198,17 @@ class CrewAgentExecutor(BaseAgentExecutor):
             # prefix; end-of-user caches the per-task stable prefix across
             # ReAct-loop iterations.
             self.messages.append(
-                mark_cache_breakpoint(
+                _maybe_mark(
                     format_message_for_llm(system_prompt, role="system")
                 )
             )
             self.messages.append(
-                mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                _maybe_mark(format_message_for_llm(user_prompt))
             )
         elif self.prompt is not None:
             user_prompt = self._format_prompt(self.prompt.get("prompt", ""), inputs)
             self.messages.append(
-                mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                _maybe_mark(format_message_for_llm(user_prompt))
             )
 
         provider.post_setup_messages(cast(ExecutorContext, cast(object, self)))

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2643,26 +2643,30 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     "AgentExecutor.llm or .prompt is unset; the executor was "
                     "not fully restored or initialized before execution."
                 )
-            if "system" in self.prompt:
+            use_cache_breakpoint = getattr(self.llm, "is_anthropic", False)
+            if use_cache_breakpoint:
                 from crewai.llms.cache import mark_cache_breakpoint
-
+                def _maybe_mark(msg):
+                    return mark_cache_breakpoint(msg)
+            else:
+                def _maybe_mark(msg):
+                    return msg
+            if "system" in self.prompt:
                 prompt = cast("SystemPromptResult", self.prompt)
                 system_prompt = self._format_prompt(prompt["system"], inputs)
                 user_prompt = self._format_prompt(prompt["user"], inputs)
                 self.state.messages.append(
-                    mark_cache_breakpoint(
+                    _maybe_mark(
                         format_message_for_llm(system_prompt, role="system")
                     )
                 )
                 self.state.messages.append(
-                    mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                    _maybe_mark(format_message_for_llm(user_prompt))
                 )
             else:
-                from crewai.llms.cache import mark_cache_breakpoint
-
                 user_prompt = self._format_prompt(self.prompt["prompt"], inputs)
                 self.state.messages.append(
-                    mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                    _maybe_mark(format_message_for_llm(user_prompt))
                 )
 
             self._inject_files_from_inputs(inputs)
@@ -2749,26 +2753,30 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     "AgentExecutor.llm or .prompt is unset; the executor was "
                     "not fully restored or initialized before execution."
                 )
-            if "system" in self.prompt:
+            use_cache_breakpoint = getattr(self.llm, "is_anthropic", False)
+            if use_cache_breakpoint:
                 from crewai.llms.cache import mark_cache_breakpoint
-
+                def _maybe_mark(msg):
+                    return mark_cache_breakpoint(msg)
+            else:
+                def _maybe_mark(msg):
+                    return msg
+            if "system" in self.prompt:
                 prompt = cast("SystemPromptResult", self.prompt)
                 system_prompt = self._format_prompt(prompt["system"], inputs)
                 user_prompt = self._format_prompt(prompt["user"], inputs)
                 self.state.messages.append(
-                    mark_cache_breakpoint(
+                    _maybe_mark(
                         format_message_for_llm(system_prompt, role="system")
                     )
                 )
                 self.state.messages.append(
-                    mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                    _maybe_mark(format_message_for_llm(user_prompt))
                 )
             else:
-                from crewai.llms.cache import mark_cache_breakpoint
-
                 user_prompt = self._format_prompt(self.prompt["prompt"], inputs)
                 self.state.messages.append(
-                    mark_cache_breakpoint(format_message_for_llm(user_prompt))
+                    _maybe_mark(format_message_for_llm(user_prompt))
                 )
 
             self._inject_files_from_inputs(inputs)


### PR DESCRIPTION
Fixes #5886

## Problem

`mark_cache_breakpoint()` is called unconditionally in `crew_agent_executor.py` for every LLM provider. The `cache_breakpoint` flag is a CrewAI-internal marker that only the Anthropic provider adapter knows how to translate and strip before the API call.

Every other provider — Groq, OpenAI-compatible endpoints, Bedrock, Gemini, LiteLLM — receives `cache_breakpoint: True` in the raw message dict and rejects the request with `400 Bad Request`.

## Root cause

`mark_cache_breakpoint()` was imported and called unconditionally. Only `llms/providers/anthropic/completion.py` strips this flag — no other provider does.

## Fix

Added `use_cache_breakpoint` guard that checks `self.llm.is_anthropic` before calling `mark_cache_breakpoint()`. When `False`, a no-op `_maybe_mark()` is used instead.

Applied to both:
- `agents/crew_agent_executor.py`
- `experimental/agent_executor.py`

## Result

- Anthropic: behaviour unchanged, prompt caching still works
- Groq, OpenAI-compatible, Bedrock, Gemini: no longer receive unknown `cache_breakpoint` field, requests succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LLM compatibility by optimizing cache handling logic to properly support multiple LLM providers, improving performance with non-Anthropic implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crewAIInc/crewAI/pull/5971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->