### PR TITLE
Document Tuning Engines OpenAI-compatible configuration

### DIFF
--- a/docs/v1.13.0/en/learn/llm-connections.mdx
+++ b/docs/v1.13.0/en/learn/llm-connections.mdx
@@ -177,6 +177,17 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
             agent = Agent(llm=llm, ...)
             ```
         </CodeGroup>
+
+        <Note>
+        Configuring an OpenAI-compatible gateway changes the model-call path only.
+        CrewAI continues to own agent, task, tool, and workflow behavior; the
+        gateway can handle model routing, policy checks, audit/usage logging, and
+        approval requirements. Use a tenant-scoped gateway key rather than a
+        direct provider key. If the gateway is unavailable, the LLM call fails as
+        a provider error; CrewAI does not automatically fall back to a direct
+        provider unless you explicitly configure that behavior in your
+        application.
+        </Note>
     </Tab>
 </Tabs>
 

--- a/docs/v1.13.0/en/learn/llm-connections.mdx
+++ b/docs/v1.13.0/en/learn/llm-connections.mdx
@@ -156,6 +156,17 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
             agent = Agent(llm=llm, ...)
             ```
 
+            ```python Tuning Engines
+            # Governed OpenAI-compatible endpoint for model routing,
+            # policy controls, audit logs, traces, approvals, and cost visibility.
+            llm = LLM(
+                model="gpt-4o-mini",
+                api_key="your-tuning-engines-key",
+                base_url="https://api.tuningengines.com/v1"
+            )
+            agent = Agent(llm=llm, ...)
+            ```
+
             ```python Google
             # Example using Gemini's OpenAI-compatible API
             llm = LLM(

--- a/docs/v1.13.0/en/learn/llm-connections.mdx
+++ b/docs/v1.13.0/en/learn/llm-connections.mdx
@@ -157,10 +157,10 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
             ```
 
             ```python Tuning Engines
-            # Governed OpenAI-compatible endpoint for model routing,
-            # policy controls, audit logs, traces, approvals, and cost visibility.
+            # Example using Tuning Engines OpenAI-compatible endpoint.
+            # Use a model alias from your Tuning Engines catalog.
             llm = LLM(
-                model="gpt-4o-mini",
+                model="your-model-alias",
                 api_key="your-tuning-engines-key",
                 base_url="https://api.tuningengines.com/v1"
             )


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Using LLM Class Attributes” section with a new “Tuning Engines” code example for connecting to an OpenAI-compatible endpoint (including model, API key, and base URL) and wiring it into an Agent.
  * Added a note clarifying how OpenAI-compatible gateway settings affect only the model-call path, and that the call fails with a provider error if the gateway is unavailable (no automatic fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->