### PR TITLE
fix(cli): prevent traceback when reset-memories finds no crews or flows

### DIFF
--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -64,7 +64,8 @@ def reset_memories_command(
         flows = get_flows()
 
         if not crews and not flows:
-            raise ValueError("No crew or flow found.")
+            click.echo("No crew or flow found.")
+            return
 
         for crew in crews:
             if all:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when resetting memories without an active crew or flow. Users now receive a clear message instead of an exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->