### PR TITLE
fix(llm): strip trailing/leading whitespace from API keys across all …

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -256,6 +256,8 @@ class AnthropicCompletion(BaseLLM):
             self.api_key = os.getenv("ANTHROPIC_API_KEY")
             if self.api_key is None:
                 raise ValueError("ANTHROPIC_API_KEY is required")
+        if isinstance(self.api_key, str):
+            self.api_key = self.api_key.strip()
 
         client_params = {
             "api_key": self.api_key,

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -118,7 +118,11 @@ class AzureCompletion(BaseLLM):
                 "Interceptors are currently supported for OpenAI and Anthropic providers only."
             )
 
-        data["api_key"] = data.get("api_key") or os.getenv("AZURE_API_KEY")
+        api_key = data.get("api_key") or os.getenv("AZURE_API_KEY")
+        if isinstance(api_key, str):
+            api_key = api_key.strip()
+        data["api_key"] = api_key
+
         data["endpoint"] = (
             data.get("endpoint")
             or os.getenv("AZURE_ENDPOINT")
@@ -268,6 +272,8 @@ class AzureCompletion(BaseLLM):
         # module import before deployment env vars were injected).
         if not self.api_key:
             self.api_key = os.getenv("AZURE_API_KEY")
+        if isinstance(self.api_key, str):
+            self.api_key = self.api_key.strip()
         if not self.endpoint:
             endpoint = (
                 os.getenv("AZURE_ENDPOINT")

--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -79,11 +79,15 @@ class GeminiCompletion(BaseLLM):
             seqs = [seqs]
         data["stop"] = seqs
 
-        data["api_key"] = (
+        api_key = (
             data.get("api_key")
             or os.getenv("GOOGLE_API_KEY")
             or os.getenv("GEMINI_API_KEY")
         )
+        if isinstance(api_key, str):
+            api_key = api_key.strip()
+        data["api_key"] = api_key
+
         data["project"] = data.get("project") or os.getenv("GOOGLE_CLOUD_PROJECT")
         data["location"] = (
             data.get("location") or os.getenv("GOOGLE_CLOUD_LOCATION") or "us-central1"
@@ -133,6 +137,8 @@ class GeminiCompletion(BaseLLM):
                 self.api_key = os.getenv("GOOGLE_API_KEY") or os.getenv(
                     "GEMINI_API_KEY"
                 )
+            if isinstance(self.api_key, str):
+                self.api_key = self.api_key.strip()
             if not self.project:
                 self.project = os.getenv("GOOGLE_CLOUD_PROJECT")
             self._client = self._initialize_client(self.use_vertexai)

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -246,7 +246,10 @@ class OpenAICompletion(BaseLLM):
             return data
         if not data.get("provider"):
             data["provider"] = "openai"
-        data["api_key"] = data.get("api_key") or os.getenv("OPENAI_API_KEY")
+        api_key = data.get("api_key") or os.getenv("OPENAI_API_KEY")
+        if isinstance(api_key, str):
+            api_key = api_key.strip()
+        data["api_key"] = api_key
         if "api_base" not in data:
             data["api_base"] = None
         model = data.get("model", "gpt-4o")
@@ -363,6 +366,8 @@ class OpenAICompletion(BaseLLM):
             self.api_key = os.getenv("OPENAI_API_KEY")
             if self.api_key is None:
                 raise ValueError("OPENAI_API_KEY is required")
+        if isinstance(self.api_key, str):
+            self.api_key = self.api_key.strip()
 
         base_params = {
             "api_key": self.api_key,

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -184,11 +184,11 @@ class OpenAICompatibleCompletion(OpenAICompletion):
             ValueError: If API key is required but not found.
         """
         if api_key:
-            return api_key
+            return api_key.strip()
 
         env_key = os.getenv(config.api_key_env)
         if env_key:
-            return env_key
+            return env_key.strip()
 
         if config.api_key_required:
             raise ValueError(


### PR DESCRIPTION
Description
This PR resolves issue #5622 where valid API keys read from `.env` files or environment variables fail with 401 invalid_api_key errors due to trailing or leading whitespace, newlines, or tabs.

Changes
Automatically formats API keys by calling `.strip()` across all native LLM providers (OpenAI, Anthropic, Gemini, Azure, and OpenAI-compatible).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved API key handling across all LLM providers (Anthropic, Azure, Gemini, OpenAI, and OpenAI-compatible) by automatically trimming leading and trailing whitespace from API credentials, ensuring authentication works reliably even if keys contain accidental whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->