### PR TITLE
chore: widen click dependency to >=8.1.7,<9

### DIFF
--- a/lib/cli/pyproject.toml
+++ b/lib/cli/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "crewai-core==1.14.6",
-    "click~=8.1.7",
+    "click>=8.1.7,<9",
     "pydantic>=2.11.9,<2.13",
     "pydantic-settings~=2.10.1",
     "appdirs~=1.4.4",

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "python-dotenv>=1.2.2,<2",
     "pyjwt>=2.9.0,<3",
     # Configuration and Utils
-    "click~=8.1.7",
+    "click>=8.1.7,<9",
     "appdirs~=1.4.4",
     "jsonref~=1.1.0",
     "json-repair~=0.25.2",

--- a/lib/devtools/pyproject.toml
+++ b/lib/devtools/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10, <3.14"
 classifiers = ["Private :: Do Not Upload"]
 private = true
 dependencies = [
-    "click~=8.1.7",
+    "click>=8.1.7,<9",
     "tomlkit~=0.13.2",
     "openai>=1.83.0,<3",
     "python-dotenv>=1.2.2,<2",


### PR DESCRIPTION
## Summary

Relaxes the `click` pin from `~=8.1.7` (which caps at `<8.2.0`) to `>=8.1.7,<9`.

## Motivation

Enterprise customers (e.g. Genpact) have InfoSec requirements pinning `click==8.3.3`. The current `~=8.1.7` constraint blocks dependency resolution when they attempt to install CrewAI alongside their required click version.

## Changes

Updated in 3 files:
- `lib/crewai/pyproject.toml`
- `lib/cli/pyproject.toml`  
- `lib/devtools/pyproject.toml`

`click~=8.1.7` → `click>=8.1.7,<9`

## Risk

Low — Click 8.1.x → 8.3.x are minor version bumps with no breaking changes affecting our usage (CLI decorators, argument/option parsing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `click` dependency constraints across the project from compatible-release specification to explicit version bounds, ensuring compatibility with versions 8.1.7 and above while preventing upgrades to version 9.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->