### PR TITLE
fix(devtools): point template bumper at lib/cli templates dir

### DIFF
--- a/lib/cli/src/crewai_cli/templates/crew/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/crew/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.5a2"
+    "crewai[tools]==1.14.6"
 ]
 
 [project.scripts]

--- a/lib/cli/src/crewai_cli/templates/flow/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.5a2"
+    "crewai[tools]==1.14.6"
 ]
 
 [project.scripts]

--- a/lib/cli/src/crewai_cli/templates/tool/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.5a2"
+    "crewai[tools]==1.14.6"
 ]
 
 [tool.crewai]

--- a/lib/devtools/src/crewai_devtools/cli.py
+++ b/lib/devtools/src/crewai_devtools/cli.py
@@ -918,7 +918,7 @@ def _update_all_versions(
             "[yellow]Warning:[/yellow] No __version__ attributes found to update"
         )
 
-    templates_dir = lib_dir / "crewai" / "src" / "crewai" / "cli" / "templates"
+    templates_dir = lib_dir / "cli" / "src" / "crewai_cli" / "templates"
     if templates_dir.exists():
         if dry_run:
             for tpl in templates_dir.rglob("pyproject.toml"):


### PR DESCRIPTION
## Summary
- `_update_all_versions` in `crewai_devtools.cli` was looking for templates at the pre-split path `lib/crewai/src/crewai/cli/templates`, which no longer exists, so the release tooling silently skipped bumping the CLI templates' `crewai[tools]` pin.
- Repoint it at the current location (`lib/cli/src/crewai_cli/templates`) and bring the three template `pyproject.toml` files in sync with the current release (1.14.6).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/devtools path fix and template dependency pin updates only; no runtime product behavior change.
> 
> **Overview**
> Release tooling in **`crewai_devtools`** now resolves CLI scaffold templates under **`lib/cli/src/crewai_cli/templates`** instead of the obsolete **`lib/crewai/src/crewai/cli/templates`**, so version bumps during release actually update the **`crewai[tools]`** pin in crew, flow, and tool template **`pyproject.toml`** files again.
> 
> Those three templates are aligned to **`crewai[tools]==1.14.6`** (from **`1.14.5a2`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c26a9ef7ba58ee58782cf8ca982bf0cdbaf7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project template dependencies to the latest stable version
  * Corrected the path reference used by the CLI to locate project template files during version management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->