### PR TITLE
fix: handle reasoning_content in OpenRouter thinking model responses

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -1661,7 +1661,11 @@ class OpenAICompletion(BaseLLM):
                 if result is not None:
                     return result
 
-            content = message.content or ""
+            content = message.content if isinstance(message.content, str) else None
+            if content is None:
+                reasoning = getattr(message, "reasoning_content", None)
+                content = reasoning if isinstance(reasoning, str) else None
+            content = content or ""
 
             if self.response_format and isinstance(self.response_format, type):
                 try:
@@ -1898,10 +1902,17 @@ class OpenAICompletion(BaseLLM):
             choice = completion_chunk.choices[0]
             chunk_delta: ChoiceDelta = choice.delta
 
-            if chunk_delta.content:
-                full_response += chunk_delta.content
+            delta_text: str | None = None
+            if isinstance(chunk_delta.content, str):
+                delta_text = chunk_delta.content
+            elif isinstance(
+                getattr(chunk_delta, "reasoning_content", None), str
+            ):
+                delta_text = chunk_delta.reasoning_content
+            if delta_text:
+                full_response += delta_text
                 self._emit_stream_chunk_event(
-                    chunk=chunk_delta.content,
+                    chunk=delta_text,
                     from_task=from_task,
                     from_agent=from_agent,
                     response_id=response_id_stream,
@@ -2051,7 +2062,11 @@ class OpenAICompletion(BaseLLM):
                 if result is not None:
                     return result
 
-            content = message.content or ""
+            content = message.content if isinstance(message.content, str) else None
+            if content is None:
+                reasoning = getattr(message, "reasoning_content", None)
+                content = reasoning if isinstance(reasoning, str) else None
+            content = content or ""
 
             if self.response_format and isinstance(self.response_format, type):
                 try:
@@ -2199,10 +2214,17 @@ class OpenAICompletion(BaseLLM):
             choice = chunk.choices[0]
             chunk_delta: ChoiceDelta = choice.delta
 
-            if chunk_delta.content:
-                full_response += chunk_delta.content
+            delta_text: str | None = None
+            if isinstance(chunk_delta.content, str):
+                delta_text = chunk_delta.content
+            elif isinstance(
+                getattr(chunk_delta, "reasoning_content", None), str
+            ):
+                delta_text = chunk_delta.reasoning_content
+            if delta_text:
+                full_response += delta_text
                 self._emit_stream_chunk_event(
-                    chunk=chunk_delta.content,
+                    chunk=delta_text,
                     from_task=from_task,
                     from_agent=from_agent,
                     response_id=response_id_stream,


### PR DESCRIPTION
## Summary
When using OpenRouter with thinking models (Anthropic Claude, Google Gemini), the API returns a reasoning_content field alongside content in streaming deltas and response messages. The OpenAI completion handlers were only checking the content field, causing empty responses and ValueError: Invalid response from LLM call - None or empty.

## Changes
- Streaming path (sync and async): Check reasoning_content as fallback when content is not a string in delta chunks
- Non-streaming path (sync and async): Check reasoning_content as fallback when message.content is not a string

## Testing
All 121 existing tests pass (OpenAI completions and OpenAI-compatible providers).

Fixes #5537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI chat completion handling to support models that emit alternative response formats, with fallback mechanisms for both streaming and non-streaming requests. Enhanced compatibility and reliability across different model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->