### PR TITLE
perf(knowledge): lazy-load docling imports to speed up crewai import

### DIFF
--- a/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from collections.abc import Iterator
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Self, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from urllib.parse import urlparse
 
 from pydantic import Field, model_validator
+from typing_extensions import Self
 
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.utilities.constants import KNOWLEDGE_DIRECTORY

--- a/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
@@ -1,30 +1,81 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Self, cast
 from urllib.parse import urlparse
 
-
-try:
-    from docling.datamodel.base_models import InputFormat
-    from docling.document_converter import DocumentConverter
-    from docling.exceptions import ConversionError
-    from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
-    from docling_core.types.doc.document import DoclingDocument
-
-    DOCLING_AVAILABLE = True
-except ImportError:
-    DOCLING_AVAILABLE = False
-    if TYPE_CHECKING:
-        from docling.document_converter import DocumentConverter
-        from docling_core.types.doc.document import DoclingDocument
-
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
 from crewai.utilities.constants import KNOWLEDGE_DIRECTORY
 from crewai.utilities.logger import Logger
+
+
+if TYPE_CHECKING:
+    from docling.document_converter import DocumentConverter
+    from docling_core.types.doc.document import DoclingDocument
+
+
+_DOCLING_IMPORT_ERROR = (
+    "The docling package is required to use CrewDoclingSource. "
+    "Please install it using: uv add docling"
+)
+
+
+class _DoclingModules(NamedTuple):
+    """Lazily-imported docling symbols used by ``CrewDoclingSource``."""
+
+    input_format: Any
+    document_converter: Any
+    conversion_error: type[BaseException]
+    hierarchical_chunker: Any
+
+
+@cache
+def _import_docling() -> _DoclingModules:
+    """Import docling submodules lazily and cache the result.
+
+    Raises:
+        ImportError: If the docling package is not installed.
+    """
+    try:
+        from docling.datamodel.base_models import InputFormat
+        from docling.document_converter import DocumentConverter
+        from docling.exceptions import ConversionError
+        from docling_core.transforms.chunker.hierarchical_chunker import (
+            HierarchicalChunker,
+        )
+    except ImportError as e:
+        raise ImportError(_DOCLING_IMPORT_ERROR) from e
+    return _DoclingModules(
+        input_format=InputFormat,
+        document_converter=DocumentConverter,
+        conversion_error=ConversionError,
+        hierarchical_chunker=HierarchicalChunker,
+    )
+
+
+def _build_default_document_converter() -> DocumentConverter:
+    """Construct the default ``DocumentConverter`` with crewAI's allowed formats."""
+    docling = _import_docling()
+    input_format = docling.input_format
+    return cast(
+        DocumentConverter,
+        docling.document_converter(
+            allowed_formats=[
+                input_format.MD,
+                input_format.ASCIIDOC,
+                input_format.PDF,
+                input_format.DOCX,
+                input_format.HTML,
+                input_format.IMAGE,
+                input_format.XLSX,
+                input_format.PPTX,
+            ]
+        ),
+    )
 
 
 class CrewDoclingSource(BaseKnowledgeSource):
@@ -34,13 +85,11 @@ class CrewDoclingSource(BaseKnowledgeSource):
     any additional dependencies and follows the docling package as the source of truth.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        if not DOCLING_AVAILABLE:
-            raise ImportError(
-                "The docling package is required to use CrewDoclingSource. "
-                "Please install it using: uv add docling"
-            )
-        super().__init__(*args, **kwargs)
+    @model_validator(mode="before")
+    @classmethod
+    def _ensure_docling_available(cls, data: Any) -> Any:
+        _import_docling()
+        return data
 
     _logger: Logger = Logger(verbose=True)
 
@@ -49,23 +98,11 @@ class CrewDoclingSource(BaseKnowledgeSource):
     file_paths: list[Path | str] = Field(default_factory=list)
     chunks: list[str] = Field(default_factory=list)
     safe_file_paths: list[Path | str] = Field(default_factory=list)
-    content: list[DoclingDocument] = Field(default_factory=list)
-    document_converter: DocumentConverter = Field(
-        default_factory=lambda: DocumentConverter(
-            allowed_formats=[
-                InputFormat.MD,
-                InputFormat.ASCIIDOC,
-                InputFormat.PDF,
-                InputFormat.DOCX,
-                InputFormat.HTML,
-                InputFormat.IMAGE,
-                InputFormat.XLSX,
-                InputFormat.PPTX,
-            ]
-        )
-    )
+    content: list[Any] = Field(default_factory=list)
+    document_converter: Any = Field(default_factory=_build_default_document_converter)
 
-    def model_post_init(self, _: Any) -> None:
+    @model_validator(mode="after")
+    def _load_sources(self) -> Self:
         if self.file_path:
             self._logger.log(
                 "warning",
@@ -75,11 +112,13 @@ class CrewDoclingSource(BaseKnowledgeSource):
             self.file_paths = self.file_path
         self.safe_file_paths = self.validate_content()
         self.content = self._load_content()
+        return self
 
     def _load_content(self) -> list[DoclingDocument]:
+        conversion_error = _import_docling().conversion_error
         try:
             return self._convert_source_to_docling_documents()
-        except ConversionError as e:
+        except conversion_error as e:
             self._logger.log(
                 "error",
                 f"Error loading content: {e}. Supported formats: {self.document_converter.allowed_formats}",
@@ -112,7 +151,7 @@ class CrewDoclingSource(BaseKnowledgeSource):
         return [result.document for result in conv_results_iter]
 
     def _chunk_doc(self, doc: DoclingDocument) -> Iterator[str]:
-        chunker = HierarchicalChunker()
+        chunker = _import_docling().hierarchical_chunker()
         for chunk in chunker.chunk(doc):
             yield chunk.text
 

--- a/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/crew_docling_source.py
@@ -62,7 +62,7 @@ def _build_default_document_converter() -> DocumentConverter:
     docling = _import_docling()
     input_format = docling.input_format
     return cast(
-        DocumentConverter,
+        "DocumentConverter",
         docling.document_converter(
             allowed_formats=[
                 input_format.MD,


### PR DESCRIPTION
Defer docling/docling_core imports until CrewDoclingSource is actually used, so they no longer load on every `import crewai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of import timing and Pydantic validators only; behavior for users who instantiate CrewDoclingSource should match prior docling-required semantics.
> 
> **Overview**
> **Defers loading `docling` / `docling_core`** so importing `crewai` (and loading `CrewDoclingSource`’s module) no longer pulls those heavy dependencies until someone actually constructs a `CrewDoclingSource`.
> 
> The module-level `try`/`except` import and `DOCLING_AVAILABLE` flag are replaced with a cached `_import_docling()` helper and a before-validator that fails fast with the same install message when the class is instantiated without docling. Default `DocumentConverter` setup and chunking/error handling now go through that lazy path; post-init loading moves into an after-validator (`_load_sources`) instead of `model_post_init` / `__init__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450eb062a985190048370453f0905622ad31b11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to lazy loading of the document-processing backend to avoid startup overhead.
  * Document format handling now limits supported input formats to those validated by the backend.
  * Availability checks for the backend run earlier in validation to surface missing dependencies sooner.
  * Document conversion and loading logic streamlined for more robust and predictable initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->