### PR TITLE
fix(deps): relax opentelemetry-sdk dependency for OpenLIT compatibility (#5845)

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.34.0",
-    "opentelemetry-sdk~=1.34.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.34.0",
+    "opentelemetry-api>=1.34.0,<2.0.0",
+    "opentelemetry-sdk>=1.34.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2.0.0",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers>=0.21,<1",


### PR DESCRIPTION
## Summary

`crewai` pins OpenTelemetry dependencies to `~=1.34.0`, which prevents installation alongside `openlit>=1.41.2` because OpenLIT requires `opentelemetry-sdk>=1.38.0`.

## Changes

Relaxes the following dependency constraints in `lib/crewai/pyproject.toml` from `~=1.34.0` to `>=1.34.0,<2.0.0`:
- `opentelemetry-api`
- `opentelemetry-sdk`
- `opentelemetry-exporter-otlp-proto-http`

This keeps the minimum supported version while allowing newer minor releases that OpenLIT and other observability tools depend on.

## Fixes

Fixes #5845

## Tests

- Verified that `pip check` passes after the change with the latest compatible versions.
- Existing telemetry tests remain unchanged; no breaking API changes are expected within the 1.x line of `opentelemetry-python`.

## Checklist

- [x] I have read the contributing guide.
- [x] My changes are limited to dependency constraints.
- [x] I used a conventional commit (`fix(deps):`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry dependency specifications to ensure improved version compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->