### PR TITLE
docs: update changelog and version for v1.14.7a1

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,38 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="3 يونيو 2026">
+  ## v1.14.7a1
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a1)
+
+  ## ما الذي تغير
+
+  ### الميزات
+  - إضافة دعم ملفات الوكلاء المدربين
+  - إضافة مزود LLM الأصلي لـ Snowflake Cortex
+  - إضافة دليل تكامل Databricks
+  - إضافة دليل تكامل Snowflake
+
+  ### إصلاحات الأخطاء
+  - إصلاح CLI عن طريق استعادة `[project.scripts]` في حزمة crewai لتثبيت أداة UV
+  - حل مشكلات موثوقية إدخال الملفات
+  - إصلاح تاريخ نتائج الأدوات غير المكتملة في Snowflake Claude
+  - التعامل مع استدعاءات الأدوات الممثلة كسلاسل لـ Snowflake Claude
+  - إعادة تفعيل مستمعي `or_` متعدد المصادر عبر دورات مدفوعة بالموجه
+
+  ### الأداء
+  - تحسين سرعة استيراد crewai عن طريق تحميل استيرادات docling بشكل كسول
+
+  ### إعادة هيكلة
+  - تقسيم `flow.py` إلى DSL، تعريف، وتشغيل
+
+  ## المساهمون
+
+  @Luzk, @alex-clawd, @devin-ai-integration[bot], @greysonlalonde, @jessemiller, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="28 مايو 2026">
   ## v1.14.6
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,38 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Jun 03, 2026">
+  ## v1.14.7a1
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a1)
+
+  ## What's Changed
+
+  ### Features
+  - Add crew trained agents file support
+  - Add native Snowflake Cortex LLM provider
+  - Add Databricks integration guide
+  - Add Snowflake integration guide
+
+  ### Bug Fixes
+  - Fix CLI by restoring `[project.scripts]` in crewai package for UV tool install
+  - Resolve file input reliability issues
+  - Fix incomplete tool result histories in Snowflake Claude
+  - Handle stringified tool calls for Snowflake Claude
+  - Re-arm multi-source `or_` listeners across router-driven cycles
+
+  ### Performance
+  - Improve crewai import speed by lazy-loading docling imports
+
+  ### Refactoring
+  - Split `flow.py` into DSL, definition, and runtime
+
+  ## Contributors
+
+  @Luzk, @alex-clawd, @devin-ai-integration[bot], @greysonlalonde, @jessemiller, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="May 28, 2026">
   ## v1.14.6
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,38 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 6월 3일">
+  ## v1.14.7a1
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a1)
+
+  ## 변경 사항
+
+  ### 기능
+  - 승무원 교육을 받은 에이전트 파일 지원 추가
+  - 네이티브 Snowflake Cortex LLM 공급자 추가
+  - Databricks 통합 가이드 추가
+  - Snowflake 통합 가이드 추가
+
+  ### 버그 수정
+  - UV 도구 설치를 위한 crewai 패키지에서 `[project.scripts]` 복원하여 CLI 수정
+  - 파일 입력 신뢰성 문제 해결
+  - Snowflake Claude에서 불완전한 도구 결과 기록 수정
+  - Snowflake Claude를 위한 문자열화된 도구 호출 처리
+  - 라우터 주도 사이클 전반에 걸쳐 다중 소스 `or_` 리스너 재장착
+
+  ### 성능
+  - docling 가져오기를 지연 로딩하여 crewai 가져오기 속도 개선
+
+  ### 리팩토링
+  - `flow.py`를 DSL, 정의 및 런타임으로 분할
+
+  ## 기여자
+
+  @Luzk, @alex-clawd, @devin-ai-integration[bot], @greysonlalonde, @jessemiller, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="2026년 5월 28일">
   ## v1.14.6
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,38 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="03 jun 2026">
+  ## v1.14.7a1
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a1)
+
+  ## O Que Mudou
+
+  ### Funcionalidades
+  - Adicionar suporte a arquivos de agentes treinados da equipe
+  - Adicionar provedor nativo Snowflake Cortex LLM
+  - Adicionar guia de integração com Databricks
+  - Adicionar guia de integração com Snowflake
+
+  ### Correções de Bugs
+  - Corrigir CLI restaurando `[project.scripts]` no pacote crewai para instalação da ferramenta UV
+  - Resolver problemas de confiabilidade na entrada de arquivos
+  - Corrigir históricos de resultados de ferramentas incompletos no Snowflake Claude
+  - Lidar com chamadas de ferramentas em formato de string para Snowflake Claude
+  - Re-armar ouvintes `or_` de múltiplas fontes em ciclos controlados por roteadores
+
+  ### Desempenho
+  - Melhorar a velocidade de importação do crewai através do carregamento preguiçoso de importações do docling
+
+  ### Refatoração
+  - Dividir `flow.py` em DSL, definição e tempo de execução
+
+  ## Contributors
+
+  @Luzk, @alex-clawd, @devin-ai-integration[bot], @greysonlalonde, @jessemiller, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="28 mai 2026">
   ## v1.14.6
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or configuration changes.
> 
> **Overview**
> Adds a new **v1.14.7a1** release section at the top of the changelog in **English, Arabic, Korean, and Brazilian Portuguese** (`docs/*/changelog.mdx`), dated Jun 03, 2026, with a link to the GitHub release.
> 
> The new entry documents the release notes for that alpha: trained-agents file support, Snowflake Cortex LLM and integration guides (Databricks/Snowflake), CLI/UV and file-input fixes, Snowflake Claude tool-history handling, `or_` listener re-arming, lazy docling imports for faster imports, and splitting `flow.py` into DSL/definition/runtime, plus contributors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4bea48117129ba937ab8b73c38a7e6e8f4cc509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->