### PR TITLE
Revalidate templated task output paths

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -142,7 +142,7 @@ def _validate_output_file_path(
         return value
 
     if value.startswith("/") and not preserve_absolute:
-        return value[1:]
+        return value.lstrip("/")
     return value
 
 
@@ -1041,7 +1041,9 @@ Follow these guidelines:
                 self.output_file = _validate_output_file_path(
                     interpolated_output_file,
                     allow_templates=False,
-                    preserve_absolute=Path(str(self._original_output_file)).is_absolute(),
+                    preserve_absolute=Path(
+                        str(self._original_output_file)
+                    ).is_absolute(),
                 )
             except (KeyError, ValueError) as e:
                 raise ValueError(f"Error interpolating output_file path: {e!s}") from e

--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -111,6 +111,41 @@ def _deserialize_model_class(v: Any) -> type[BaseModel] | None:
     return None
 
 
+def _validate_output_file_path(
+    value: str | None,
+    *,
+    allow_templates: bool = True,
+    preserve_absolute: bool = False,
+) -> str | None:
+    """Validate an output file path before it is written."""
+    if value is None:
+        return None
+
+    if ".." in value:
+        raise ValueError("Path traversal attempts are not allowed in output_file paths")
+
+    if value.startswith(("~", "$")):
+        raise ValueError(
+            "Shell expansion characters are not allowed in output_file paths"
+        )
+
+    if any(char in value for char in ["|", ">", "<", "&", ";"]):
+        raise ValueError(
+            "Shell special characters are not allowed in output_file paths"
+        )
+
+    if allow_templates and ("{" in value or "}" in value):
+        template_vars = [part.split("}")[0] for part in value.split("{")[1:]]
+        for var in template_vars:
+            if not var.isidentifier():
+                raise ValueError(f"Invalid template variable name: {var}")
+        return value
+
+    if value.startswith("/") and not preserve_absolute:
+        return value[1:]
+    return value
+
+
 class Task(BaseModel):
     """Class that represents a task to be executed.
 
@@ -501,34 +536,7 @@ class Task(BaseModel):
             ValueError: If the path contains invalid characters, path traversal attempts,
                       or other security concerns.
         """
-        if value is None:
-            return None
-
-        if ".." in value:
-            raise ValueError(
-                "Path traversal attempts are not allowed in output_file paths"
-            )
-
-        if value.startswith(("~", "$")):
-            raise ValueError(
-                "Shell expansion characters are not allowed in output_file paths"
-            )
-
-        if any(char in value for char in ["|", ">", "<", "&", ";"]):
-            raise ValueError(
-                "Shell special characters are not allowed in output_file paths"
-            )
-
-        if "{" in value or "}" in value:
-            template_vars = [part.split("}")[0] for part in value.split("{")[1:]]
-            for var in template_vars:
-                if not var.isidentifier():
-                    raise ValueError(f"Invalid template variable name: {var}")
-            return value
-
-        if value.startswith("/"):
-            return value[1:]
-        return value
+        return _validate_output_file_path(value)
 
     @model_validator(mode="after")
     def set_attributes_based_on_config(self) -> Task:
@@ -1027,8 +1035,13 @@ Follow these guidelines:
 
         if self.output_file is not None:
             try:
-                self.output_file = interpolate_only(
+                interpolated_output_file = interpolate_only(
                     input_string=self._original_output_file, inputs=inputs
+                )
+                self.output_file = _validate_output_file_path(
+                    interpolated_output_file,
+                    allow_templates=False,
+                    preserve_absolute=Path(str(self._original_output_file)).is_absolute(),
                 )
             except (KeyError, ValueError) as e:
                 raise ValueError(f"Error interpolating output_file path: {e!s}") from e

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -1152,6 +1152,19 @@ def test_output_file_validation(tmp_path):
         )
 
 
+def test_output_file_template_interpolation_revalidates_path():
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        output_file="{tenant}/output.txt",
+    )
+
+    with pytest.raises(ValueError, match="Path traversal"):
+        task.interpolate_inputs_and_add_conversation_history(
+            inputs={"tenant": "../escape"}
+        )
+
+
 def test_create_directory_true():
     """Test that directories are created when create_directory=True."""
     from pathlib import Path

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -1164,6 +1164,14 @@ def test_output_file_template_interpolation_revalidates_path():
             inputs={"tenant": "../escape"}
         )
 
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        output_file="{tenant}/output.txt",
+    )
+    task.interpolate_inputs_and_add_conversation_history(inputs={"tenant": "//tmp"})
+    assert task.output_file == "tmp/output.txt"
+
 
 def test_create_directory_true():
     """Test that directories are created when create_directory=True."""


### PR DESCRIPTION
## Summary

- share `output_file` path validation between initial model validation and interpolation
- revalidate the resolved `output_file` after template inputs are applied
- add regression coverage for a template input that resolves to path traversal

## Rationale

`Task.output_file` allows template variables such as `{tenant}/output.txt`, which is useful because the concrete value is not available at model validation time. After interpolation, though, the resolved path needs the same validation as a literal `output_file` value.

This PR reuses the existing validation checks after interpolation so a value like `{"tenant": "../escape"}` is rejected before the task writes an output file.

## Tests

- `uv run pytest lib/crewai/tests/test_task.py -q`
- `uv run ruff check lib/crewai/src/crewai/task.py lib/crewai/tests/test_task.py`
- `uv run python -m py_compile lib/crewai/src/crewai/task.py lib/crewai/tests/test_task.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of output file paths to block path traversal, shell expansion and special-character injection.
  * Re-validates output file paths after template variable interpolation to prevent injected or escaped paths from being used.

* **Tests**
  * Added tests verifying interpolation re-validation and correct normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->