### PR TITLE
fix: add ToolFileReference system to bypass LLM context for binary data

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -870,6 +870,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
         if parse_error is not None:
             return parse_error
 
+        args_dict = self._resolve_file_references(args_dict)
+
         if original_tool is None:
             for tool in self.original_tools or []:
                 if sanitize_tool_name(tool.name) == func_name:
@@ -977,9 +979,20 @@ class CrewAgentExecutor(BaseAgentExecutor):
                             tool=func_name, input=input_str, output=raw_result
                         )
 
-                result = (
-                    str(raw_result) if not isinstance(raw_result, str) else raw_result
+                from crewai.tools.tool_file_reference import (
+                    ToolFileReference,
+                    auto_store_if_binary,
                 )
+
+                raw_result = auto_store_if_binary(raw_result)
+                if isinstance(raw_result, ToolFileReference):
+                    result = raw_result.placeholder()
+                else:
+                    result = (
+                        str(raw_result)
+                        if not isinstance(raw_result, str)
+                        else raw_result
+                    )
             except Exception as e:
                 result = f"Error executing tool: {e}"
                 if self.task:
@@ -1042,6 +1055,27 @@ class CrewAgentExecutor(BaseAgentExecutor):
             "from_cache": from_cache,
             "original_tool": original_tool,
         }
+
+    @staticmethod
+    def _resolve_file_references(args: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Replace file reference IDs in tool arguments with base64-encoded data."""
+        if not args:
+            return args
+
+        import base64
+
+        from crewai.tools.tool_file_reference import _UUID_RE, tool_file_store
+
+        resolved = {}
+        for key, value in args.items():
+            if isinstance(value, str):
+                match = _UUID_RE.fullmatch(value.strip())
+                if match and tool_file_store.has(match.group()):
+                    data = tool_file_store.resolve(match.group())
+                    resolved[key] = base64.b64encode(data).decode("ascii")
+                    continue
+            resolved[key] = value
+        return resolved
 
     def _append_tool_result_and_check_finality(
         self, execution_result: dict[str, Any]

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1047,6 +1047,9 @@ class Crew(FlowTrackable, BaseModel):
             if self._memory is not None and hasattr(self._memory, "drain_writes"):
                 self._memory.drain_writes()
             clear_files(self.id)
+            from crewai.tools.tool_file_reference import tool_file_store
+
+            tool_file_store.clear()
             detach(token)
 
     def _post_kickoff(self, result: CrewOutput) -> CrewOutput:
@@ -1255,6 +1258,9 @@ class Crew(FlowTrackable, BaseModel):
             raise
         finally:
             clear_files(self.id)
+            from crewai.tools.tool_file_reference import tool_file_store
+
+            tool_file_store.clear()
             detach(token)
 
     async def akickoff_for_each(

--- a/lib/crewai/src/crewai/tools/__init__.py
+++ b/lib/crewai/src/crewai/tools/__init__.py
@@ -1,8 +1,11 @@
 from crewai.tools.base_tool import BaseTool, EnvVar, tool
+from crewai.tools.tool_file_reference import ToolFileReference, tool_file_store
 
 
 __all__ = [
     "BaseTool",
     "EnvVar",
+    "ToolFileReference",
     "tool",
+    "tool_file_store",
 ]

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -36,6 +36,7 @@ from crewai.tools.structured_tool import (
     _serialize_schema,
     build_schema_hint,
 )
+from crewai.tools.tool_file_reference import ToolFileReference, tool_file_store
 from crewai.types.callback import SerializableCallable, _resolve_dotted_path
 from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.string_utils import sanitize_tool_name

--- a/lib/crewai/src/crewai/tools/tool_file_reference.py
+++ b/lib/crewai/src/crewai/tools/tool_file_reference.py
@@ -1,0 +1,117 @@
+"""Sideband file reference system for binary data between tool calls.
+
+Binary file data (e.g. base64-encoded content) that exceeds a size threshold
+is stored here instead of passing through the LLM context window, preventing
+token-by-token corruption.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import threading
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+
+@dataclass
+class ToolFileReference:
+    """A reference to binary data stored in the sideband file store."""
+
+    ref_id: str = field(default_factory=lambda: str(uuid4()))
+    filename: str = ""
+    content_type: str = "application/octet-stream"
+    size_bytes: int = 0
+    data: bytes = b""
+
+    def placeholder(self) -> str:
+        return f"[File: {self.filename}, {_human_size(self.size_bytes)}, ref={self.ref_id}]"
+
+
+class ToolFileStore:
+    """Thread-safe in-memory store for binary data between tool calls."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._store: dict[str, ToolFileReference] = {}
+
+    def store(
+        self,
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "application/octet-stream",
+    ) -> ToolFileReference:
+        ref = ToolFileReference(
+            filename=filename,
+            content_type=content_type,
+            size_bytes=len(data),
+            data=data,
+        )
+        with self._lock:
+            self._store[ref.ref_id] = ref
+        return ref
+
+    def resolve(self, ref_id: str) -> bytes:
+        with self._lock:
+            ref = self._store.get(ref_id)
+        if ref is None:
+            raise KeyError(f"File reference not found: {ref_id}")
+        return ref.data
+
+    def resolve_reference(self, ref_id: str) -> ToolFileReference:
+        with self._lock:
+            ref = self._store.get(ref_id)
+        if ref is None:
+            raise KeyError(f"File reference not found: {ref_id}")
+        return ref
+
+    def has(self, ref_id: str) -> bool:
+        with self._lock:
+            return ref_id in self._store
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+tool_file_store = ToolFileStore()
+
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/\n\r]+=*$")
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+)
+
+
+def is_large_base64(text: str, threshold: int = 4096) -> bool:
+    """Check if text looks like base64-encoded data above threshold bytes."""
+    stripped = text.strip()
+    if len(stripped) < threshold:
+        return False
+    if not _BASE64_RE.match(stripped):
+        return False
+    try:
+        decoded = base64.b64decode(stripped, validate=True)
+        return len(decoded) >= threshold
+    except Exception:
+        return False
+
+
+def auto_store_if_binary(result: object, threshold: int = 4096) -> object:
+    """If result is a large base64 string, store it and return a ToolFileReference."""
+    if isinstance(result, ToolFileReference):
+        return result
+    if isinstance(result, str) and is_large_base64(result, threshold):
+        data = base64.b64decode(result.strip())
+        return tool_file_store.store(data, filename="tool_output.bin")
+    return result
+
+
+def _human_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -680,8 +680,18 @@ class ToolUsage:
         return result
 
     def _format_result(self, result: Any) -> str:
+        from crewai.tools.tool_file_reference import (
+            ToolFileReference,
+            auto_store_if_binary,
+        )
+
         if self.task:
             self.task.used_tools += 1
+
+        result = auto_store_if_binary(result)
+        if isinstance(result, ToolFileReference):
+            result = result.placeholder()
+
         if self._should_remember_format():
             result = self._remember_format(result=result)
         return str(result)

--- a/lib/crewai/tests/tools/test_tool_file_reference.py
+++ b/lib/crewai/tests/tools/test_tool_file_reference.py
@@ -1,0 +1,154 @@
+"""Tests for the ToolFileReference sideband file store system."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from crewai.tools.tool_file_reference import (
+    ToolFileReference,
+    ToolFileStore,
+    auto_store_if_binary,
+    is_large_base64,
+    tool_file_store,
+)
+
+
+class TestToolFileStore:
+    def setup_method(self) -> None:
+        self.store = ToolFileStore()
+
+    def test_store_and_resolve(self) -> None:
+        data = b"hello world"
+        ref = self.store.store(data, filename="test.txt", content_type="text/plain")
+        assert ref.filename == "test.txt"
+        assert ref.content_type == "text/plain"
+        assert ref.size_bytes == len(data)
+        assert self.store.resolve(ref.ref_id) == data
+
+    def test_resolve_reference(self) -> None:
+        data = b"\x00\x01\x02"
+        ref = self.store.store(data, filename="bin.dat")
+        resolved = self.store.resolve_reference(ref.ref_id)
+        assert resolved is ref
+        assert resolved.data == data
+
+    def test_resolve_missing_raises(self) -> None:
+        with pytest.raises(KeyError, match="File reference not found"):
+            self.store.resolve("nonexistent-id")
+
+    def test_resolve_reference_missing_raises(self) -> None:
+        with pytest.raises(KeyError, match="File reference not found"):
+            self.store.resolve_reference("nonexistent-id")
+
+    def test_has(self) -> None:
+        ref = self.store.store(b"data")
+        assert self.store.has(ref.ref_id)
+        assert not self.store.has("fake-id")
+
+    def test_clear(self) -> None:
+        ref = self.store.store(b"data")
+        self.store.clear()
+        assert not self.store.has(ref.ref_id)
+
+    def test_placeholder_format(self) -> None:
+        ref = ToolFileReference(
+            ref_id="abc-123",
+            filename="report.pdf",
+            size_bytes=46080,
+            data=b"x" * 46080,
+        )
+        assert ref.placeholder() == "[File: report.pdf, 45.0 KB, ref=abc-123]"
+
+
+class TestIsLargeBase64:
+    def test_small_string_returns_false(self) -> None:
+        assert is_large_base64("aGVsbG8=") is False
+
+    def test_non_base64_returns_false(self) -> None:
+        assert is_large_base64("not base64 at all! @#$" * 500) is False
+
+    def test_large_base64_returns_true(self) -> None:
+        data = base64.b64encode(b"\x00" * 5000).decode()
+        assert is_large_base64(data) is True
+
+    def test_custom_threshold(self) -> None:
+        data = base64.b64encode(b"\x00" * 100).decode()
+        assert is_large_base64(data, threshold=50) is True
+        assert is_large_base64(data, threshold=200) is False
+
+
+class TestAutoStoreIfBinary:
+    def setup_method(self) -> None:
+        tool_file_store.clear()
+
+    def test_passthrough_for_short_strings(self) -> None:
+        result = auto_store_if_binary("hello world")
+        assert result == "hello world"
+
+    def test_passthrough_for_non_string(self) -> None:
+        result = auto_store_if_binary(42)
+        assert result == 42
+
+    def test_passthrough_for_existing_reference(self) -> None:
+        ref = ToolFileReference(filename="x.bin", data=b"data")
+        result = auto_store_if_binary(ref)
+        assert result is ref
+
+    def test_stores_large_base64(self) -> None:
+        raw = b"\x00" * 5000
+        b64_str = base64.b64encode(raw).decode()
+        result = auto_store_if_binary(b64_str)
+        assert isinstance(result, ToolFileReference)
+        assert result.size_bytes == 5000
+        assert tool_file_store.resolve(result.ref_id) == raw
+
+
+class TestResolveFileReferences:
+    """Test the _resolve_file_references static method on CrewAgentExecutor."""
+
+    def setup_method(self) -> None:
+        tool_file_store.clear()
+
+    def test_resolves_ref_id_in_args(self) -> None:
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+        data = b"binary content here"
+        ref = tool_file_store.store(data, filename="upload.bin")
+
+        args = {"file_content": ref.ref_id, "name": "test.bin"}
+        resolved = CrewAgentExecutor._resolve_file_references(args)
+
+        assert resolved is not None
+        assert resolved["file_content"] == base64.b64encode(data).decode("ascii")
+        assert resolved["name"] == "test.bin"
+
+    def test_passthrough_non_ref_args(self) -> None:
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+        args = {"query": "hello", "count": "5"}
+        resolved = CrewAgentExecutor._resolve_file_references(args)
+        assert resolved == args
+
+    def test_none_args(self) -> None:
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+        assert CrewAgentExecutor._resolve_file_references(None) is None
+
+    def test_empty_args(self) -> None:
+        from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
+        assert CrewAgentExecutor._resolve_file_references({}) == {}
+
+
+class TestModuleSingleton:
+    def test_singleton_is_shared(self) -> None:
+        from crewai.tools.tool_file_reference import (
+            tool_file_store as store1,
+        )
+        from crewai.tools.tool_file_reference import (
+            tool_file_store as store2,
+        )
+
+        assert store1 is store2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools can now efficiently handle large binary payloads through automatic file referencing and external storage mechanisms
  * Large binary outputs are automatically detected and externalized, with reference placeholders substituted in subsequent tool communications

* **Improvements**
  * Temporary tool file references are automatically cleared after each crew execution to prevent residual storage buildup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->