### PR TITLE
feat: add tool execution idempotency guard to prevent duplicate side effects on task retry

### DIFF
--- a/lib/crewai/src/crewai/agents/tools_handler.py
+++ b/lib/crewai/src/crewai/agents/tools_handler.py
@@ -68,11 +68,24 @@ class ToolsHandler(BaseModel):
     ) -> str | None:
         """Atomically try to claim the execution slot for this tool call.
 
-        Returns the stored result if already completed, or ``None`` if the
-        caller should proceed with execution (the claim has been recorded).
+        There are three possible outcomes based on the backend's ``claim()``
+        return value:
 
-        Two concurrent callers for the same key will never both receive
-        ``None`` — one will get the result and the other will get ``None``.
+        * **(claimed, result) == (True, None)** — the caller owns the claim
+          and **must** execute the tool, then call :meth:`set_idempotent_result`
+          to publish the result.  This method returns ``None``.
+        * **(claimed, result) == (False, <value>)** — another caller already
+          completed this key; *result* is the final output.  This method
+          returns the stored result so the caller can skip execution.
+        * **(claimed, result) == (False, None)** — another caller has claimed
+          the key but has not yet published a result (still in progress).
+          This method returns ``None`` so the caller falls through to normal
+          execution; the race window is narrowed to a brief in-progress
+          interval.
+
+        Returns:
+            The previously stored result if this tool call already completed,
+            or ``None`` if the caller should proceed with execution.
         """
         key = self._idempotency_key(tool_name, arguments)
         claimed, result = self._get_backend().claim(key)
@@ -123,9 +136,7 @@ class ToolsHandler(BaseModel):
                 if isinstance(calling.arguments, dict)
                 else {}
             )
-            self.set_idempotent_result(
-                sanitize_tool_name(calling.tool_name), arguments, output
-            )
+            self.set_idempotent_result(calling.tool_name, arguments, output)
 
         if self.cache and should_cache and calling.tool_name != CacheTools().name:
             input_str = ""

--- a/lib/crewai/src/crewai/agents/tools_handler.py
+++ b/lib/crewai/src/crewai/agents/tools_handler.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.tools.cache_tools.cache_tools import CacheTools
 from crewai.tools.tool_calling import InstructorToolCalling, ToolCalling
+from crewai.utilities.string_utils import sanitize_tool_name
+
+if TYPE_CHECKING:
+    from crewai.utilities.idempotency_backend import IdempotencyBackend
 
 
 class ToolsHandler(BaseModel):
@@ -24,29 +28,68 @@ class ToolsHandler(BaseModel):
     cache: CacheHandler | None = Field(default=None)
     last_used_tool: ToolCalling | InstructorToolCalling | None = Field(default=None)
 
-    # Idempotency store — prevents duplicate tool execution on task retry.
-    # Scoped to the handler's lifetime (typically one agent lifetime).
-    _idempotency_store: dict[str, str] = {}
+    # ------------------------------------------------------------------
+    # Idempotency — prevents duplicate tool side effects on task retry.
+    # Uses a pluggable backend (default: MemoryIdempotencyBackend).
+    # Inject a persistent backend for cross-process / cross-worker safety.
+    # ------------------------------------------------------------------
+    _idempotency_backend: IdempotencyBackend | None = PrivateAttr(default=None)
+
+    def _get_backend(self) -> IdempotencyBackend:
+        """Lazily initialise the default in-memory backend."""
+        if self._idempotency_backend is None:
+            from crewai.utilities.idempotency_backend import MemoryIdempotencyBackend
+
+            self._idempotency_backend = MemoryIdempotencyBackend()
+        return self._idempotency_backend
+
+    def set_idempotency_backend(self, backend: IdempotencyBackend) -> None:
+        """Replace the idempotency backend (e.g. with a Redis-backed one).
+
+        Call once before any tool execution.
+        """
+        self._idempotency_backend = backend
 
     def _idempotency_key(self, tool_name: str, arguments: dict[str, object]) -> str:
-        """Build a stable key from tool name and serialised arguments."""
+        """Build a stable key from sanitised tool name and serialised arguments."""
         args_json = json.dumps(arguments, sort_keys=True, default=str)
         args_hash = hashlib.sha256(args_json.encode()).hexdigest()
-        return f"{tool_name}:{args_hash}"
+        return f"{sanitize_tool_name(tool_name)}:{args_hash}"
 
     def get_idempotent_result(
         self, tool_name: str, arguments: dict[str, object]
     ) -> str | None:
         """Return a previously stored result if this tool call already completed."""
         key = self._idempotency_key(tool_name, arguments)
-        return self._idempotency_store.get(key)
+        return self._get_backend().get(key)
+
+    def claim_idempotent_result(
+        self, tool_name: str, arguments: dict[str, object]
+    ) -> str | None:
+        """Atomically try to claim the execution slot for this tool call.
+
+        Returns the stored result if already completed, or ``None`` if the
+        caller should proceed with execution (the claim has been recorded).
+
+        Two concurrent callers for the same key will never both receive
+        ``None`` — one will get the result and the other will get ``None``.
+        """
+        key = self._idempotency_key(tool_name, arguments)
+        claimed, result = self._get_backend().claim(key)
+        if claimed:
+            return None  # caller must execute
+        # Not claimed: either completed (result is the output) or in-progress
+        # (result is None).  In the in-progress case we return None so the
+        # caller falls through to normal execution — the race window is
+        # narrowed to a brief in-progress interval.
+        return result
 
     def set_idempotent_result(
         self, tool_name: str, arguments: dict[str, object], result: str
     ) -> None:
         """Store a tool result so that future retries can reuse it."""
         key = self._idempotency_key(tool_name, arguments)
-        self._idempotency_store[key] = result
+        self._get_backend().set(key, result)
 
     def reset_idempotency_store(self) -> None:
         """Clear the idempotency store.
@@ -54,7 +97,8 @@ class ToolsHandler(BaseModel):
         Call this at the start of a fresh task execution to avoid stale
         entries from a previous unrelated task.
         """
-        self._idempotency_store.clear()
+        if self._idempotency_backend is not None:
+            self._idempotency_backend.clear()
 
     def on_tool_use(
         self,
@@ -71,14 +115,17 @@ class ToolsHandler(BaseModel):
         """
         self.last_used_tool = calling
 
-        # Store in idempotency store (independent of cache config)
-        if calling.arguments:
+        # Store in idempotency store (independent of cache config).
+        # Use the same sanitised name as the read path for consistency.
+        if calling.arguments is not None:
             arguments: dict[str, object] = (
                 calling.arguments
                 if isinstance(calling.arguments, dict)
                 else {}
             )
-            self.set_idempotent_result(calling.tool_name, arguments, output)
+            self.set_idempotent_result(
+                sanitize_tool_name(calling.tool_name), arguments, output
+            )
 
         if self.cache and should_cache and calling.tool_name != CacheTools().name:
             input_str = ""
@@ -89,7 +136,7 @@ class ToolsHandler(BaseModel):
                     input_str = str(calling.arguments)
 
             self.cache.add(
-                tool=calling.tool_name,
+                tool=sanitize_tool_name(calling.tool_name),
                 input=input_str,
                 output=output,
             )

--- a/lib/crewai/src/crewai/agents/tools_handler.py
+++ b/lib/crewai/src/crewai/agents/tools_handler.py
@@ -1,7 +1,8 @@
-"""Tools handler for managing tool execution and caching."""
+"""Tools handler for managing tool execution, caching, and idempotency."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any
 
@@ -23,6 +24,38 @@ class ToolsHandler(BaseModel):
     cache: CacheHandler | None = Field(default=None)
     last_used_tool: ToolCalling | InstructorToolCalling | None = Field(default=None)
 
+    # Idempotency store — prevents duplicate tool execution on task retry.
+    # Scoped to the handler's lifetime (typically one agent lifetime).
+    _idempotency_store: dict[str, str] = {}
+
+    def _idempotency_key(self, tool_name: str, arguments: dict[str, object]) -> str:
+        """Build a stable key from tool name and serialised arguments."""
+        args_json = json.dumps(arguments, sort_keys=True, default=str)
+        args_hash = hashlib.sha256(args_json.encode()).hexdigest()
+        return f"{tool_name}:{args_hash}"
+
+    def get_idempotent_result(
+        self, tool_name: str, arguments: dict[str, object]
+    ) -> str | None:
+        """Return a previously stored result if this tool call already completed."""
+        key = self._idempotency_key(tool_name, arguments)
+        return self._idempotency_store.get(key)
+
+    def set_idempotent_result(
+        self, tool_name: str, arguments: dict[str, object], result: str
+    ) -> None:
+        """Store a tool result so that future retries can reuse it."""
+        key = self._idempotency_key(tool_name, arguments)
+        self._idempotency_store[key] = result
+
+    def reset_idempotency_store(self) -> None:
+        """Clear the idempotency store.
+
+        Call this at the start of a fresh task execution to avoid stale
+        entries from a previous unrelated task.
+        """
+        self._idempotency_store.clear()
+
     def on_tool_use(
         self,
         calling: ToolCalling | InstructorToolCalling,
@@ -37,6 +70,16 @@ class ToolsHandler(BaseModel):
             should_cache: Whether to cache the tool output.
         """
         self.last_used_tool = calling
+
+        # Store in idempotency store (independent of cache config)
+        if calling.arguments:
+            arguments: dict[str, object] = (
+                calling.arguments
+                if isinstance(calling.arguments, dict)
+                else {}
+            )
+            self.set_idempotent_result(calling.tool_name, arguments, output)
+
         if self.cache and should_cache and calling.tool_name != CacheTools().name:
             input_str = ""
             if calling.arguments:

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -298,7 +298,20 @@ class ToolUsage:
         error_event_emitted = False
 
         try:
-            if self.tools_handler and self.tools_handler.cache:
+            # Check cross-retry idempotency store (independent of cache config)
+            if self.tools_handler and calling.arguments:
+                idem_args: dict[str, object] = (
+                    calling.arguments
+                    if isinstance(calling.arguments, dict)
+                    else {}
+                )
+                result = self.tools_handler.get_idempotent_result(
+                    sanitize_tool_name(calling.tool_name), idem_args
+                )
+                from_cache = result is not None
+
+            # Fall back to cache handler if configured
+            if result is None and self.tools_handler and self.tools_handler.cache:
                 input_str = ""
                 if calling.arguments:
                     if isinstance(calling.arguments, dict):
@@ -549,7 +562,20 @@ class ToolUsage:
         error_event_emitted = False
 
         try:
-            if self.tools_handler and self.tools_handler.cache:
+            # Check cross-retry idempotency store (independent of cache config)
+            if self.tools_handler and calling.arguments:
+                idem_args: dict[str, object] = (
+                    calling.arguments
+                    if isinstance(calling.arguments, dict)
+                    else {}
+                )
+                result = self.tools_handler.get_idempotent_result(
+                    sanitize_tool_name(calling.tool_name), idem_args
+                )
+                from_cache = result is not None
+
+            # Fall back to cache handler if configured
+            if result is None and self.tools_handler and self.tools_handler.cache:
                 input_str = ""
                 if calling.arguments:
                     if isinstance(calling.arguments, dict):

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -308,7 +308,7 @@ class ToolUsage:
                     else {}
                 )
                 result = self.tools_handler.claim_idempotent_result(
-                    sanitize_tool_name(calling.tool_name), idem_args
+                    calling.tool_name, idem_args
                 )
                 from_cache = result is not None
 
@@ -574,7 +574,7 @@ class ToolUsage:
                     else {}
                 )
                 result = self.tools_handler.claim_idempotent_result(
-                    sanitize_tool_name(calling.tool_name), idem_args
+                    calling.tool_name, idem_args
                 )
                 from_cache = result is not None
 

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -298,14 +298,16 @@ class ToolUsage:
         error_event_emitted = False
 
         try:
-            # Check cross-retry idempotency store (independent of cache config)
-            if self.tools_handler and calling.arguments:
+            # Check cross-retry idempotency store (independent of cache config).
+            # Use claim_idempotent_result for an atomic check-and-claim to
+            # prevent duplicate execution from overlapping retries.
+            if self.tools_handler and calling.arguments is not None:
                 idem_args: dict[str, object] = (
                     calling.arguments
                     if isinstance(calling.arguments, dict)
                     else {}
                 )
-                result = self.tools_handler.get_idempotent_result(
+                result = self.tools_handler.claim_idempotent_result(
                     sanitize_tool_name(calling.tool_name), idem_args
                 )
                 from_cache = result is not None
@@ -562,14 +564,16 @@ class ToolUsage:
         error_event_emitted = False
 
         try:
-            # Check cross-retry idempotency store (independent of cache config)
-            if self.tools_handler and calling.arguments:
+            # Check cross-retry idempotency store (independent of cache config).
+            # Use claim_idempotent_result for an atomic check-and-claim to
+            # prevent duplicate execution from overlapping retries.
+            if self.tools_handler and calling.arguments is not None:
                 idem_args: dict[str, object] = (
                     calling.arguments
                     if isinstance(calling.arguments, dict)
                     else {}
                 )
-                result = self.tools_handler.get_idempotent_result(
+                result = self.tools_handler.claim_idempotent_result(
                     sanitize_tool_name(calling.tool_name), idem_args
                 )
                 from_cache = result is not None

--- a/lib/crewai/src/crewai/utilities/idempotency_backend.py
+++ b/lib/crewai/src/crewai/utilities/idempotency_backend.py
@@ -1,0 +1,104 @@
+"""Pluggable idempotency backends for tool execution deduplication.
+
+Provides an abstract interface and a default in-memory implementation.
+Users requiring cross-process / cross-worker durability can inject a
+custom backend (e.g. Redis, database) via :meth:`ToolsHandler.set_idempotency_backend`.
+
+The in-memory default is *process-local* — it will NOT prevent duplicate
+tool side effects when a retry is dispatched to a different worker process.
+For multi-worker deployments, use a persistent backend.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from threading import Lock
+from typing import Final
+
+
+# Sentinel stored by claim() to mark an in-progress execution.
+_IN_PROGRESS: Final[str] = "__idempotency_in_progress__"
+
+
+class IdempotencyBackend(ABC):
+    """Abstract interface for an idempotency store.
+
+    Implementations must be thread-safe.  Cross-process safety is
+    implementation-dependent — the default :class:`MemoryIdempotencyBackend`
+    is process-local only.
+    """
+
+    @abstractmethod
+    def get(self, key: str) -> str | None:
+        """Return a previously stored result, or None."""
+        ...
+
+    @abstractmethod
+    def set(self, key: str, value: str) -> None:
+        """Store a result for the given key."""
+        ...
+
+    @abstractmethod
+    def claim(self, key: str) -> tuple[bool, str | None]:
+        """Atomically try to claim execution rights for *key*.
+
+        Returns a ``(claimed, result)`` tuple:
+
+        * ``(True, None)`` — the caller owns the claim and **must** execute
+          the tool, then call :meth:`set` to publish the result.
+        * ``(False, result)`` — another caller already claimed or completed
+          this key.  If *result* is not ``None`` it is the final result that
+          can be returned immediately.  If *result* is ``None`` the other
+          caller is still in progress; the current caller should wait/retry
+          or fall back to normal execution.
+        """
+        ...
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all stored entries (e.g. at the start of a fresh task)."""
+        ...
+
+
+class MemoryIdempotencyBackend(IdempotencyBackend):
+    """In-memory idempotency store (process-local, thread-safe).
+
+    .. warning::
+        This backend lives in the process memory of a single worker.
+        It **will not** deduplicate tool executions across worker
+        processes or restarts.  For multi-worker deployments, inject a
+        persistent :class:`IdempotencyBackend` backed by Redis or a database.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+        self._lock = Lock()
+
+    def get(self, key: str) -> str | None:
+        with self._lock:
+            value = self._store.get(key)
+            if value == _IN_PROGRESS:
+                return None  # treat in-progress as "not yet available"
+            return value
+
+    def set(self, key: str, value: str) -> None:
+        with self._lock:
+            self._store[key] = value
+
+    def claim(self, key: str) -> tuple[bool, str | None]:
+        with self._lock:
+            existing = self._store.get(key)
+            if existing is not None:
+                if existing == _IN_PROGRESS:
+                    # Another caller is still executing — tell caller to
+                    # wait or proceed normally.
+                    return (False, None)
+                # Already completed — return the stored result.
+                return (False, existing)
+            # We own the claim.
+            self._store[key] = _IN_PROGRESS
+            return (True, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()

--- a/lib/crewai/src/crewai/utilities/idempotency_backend.py
+++ b/lib/crewai/src/crewai/utilities/idempotency_backend.py
@@ -55,6 +55,16 @@ class IdempotencyBackend(ABC):
         ...
 
     @abstractmethod
+    def release(self, key: str) -> None:
+        """Release an in-progress claim without publishing a result.
+
+        Call this when the caller that won the claim fails before calling
+        :meth:`set`, so that subsequent callers are not blocked by a stale
+        in-progress marker.
+        """
+        ...
+
+    @abstractmethod
     def clear(self) -> None:
         """Remove all stored entries (e.g. at the start of a fresh task)."""
         ...
@@ -102,3 +112,13 @@ class MemoryIdempotencyBackend(IdempotencyBackend):
     def clear(self) -> None:
         with self._lock:
             self._store.clear()
+
+    def release(self, key: str) -> None:
+        """Remove the in-progress marker for *key* without storing a result.
+
+        Only clears the entry if it is currently ``_IN_PROGRESS`` — completed
+        results are left untouched to preserve idempotency.
+        """
+        with self._lock:
+            if self._store.get(key) == _IN_PROGRESS:
+                del self._store[key]

--- a/lib/crewai/tests/tools/test_tool_idempotency.py
+++ b/lib/crewai/tests/tools/test_tool_idempotency.py
@@ -1,13 +1,74 @@
 """Tests for tool execution idempotency on task retry."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from crewai.agents.tools_handler import ToolsHandler
-from crewai.tools.structured_tool import CrewStructuredTool
 from crewai.tools.tool_usage import ToolUsage
+from crewai.utilities.idempotency_backend import (
+    IdempotencyBackend,
+    MemoryIdempotencyBackend,
+)
+
+
+class TestMemoryIdempotencyBackend:
+    """Unit tests for MemoryIdempotencyBackend."""
+
+    def test_set_and_get(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        backend.set("key1", "value1")
+        assert backend.get("key1") == "value1"
+
+    def test_get_missing_returns_none(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        assert backend.get("missing") is None
+
+    def test_claim_succeeds_when_key_absent(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        claimed, result = backend.claim("key1")
+        assert claimed is True
+        assert result is None
+
+    def test_claim_returns_result_when_key_exists(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        backend.set("key1", "value1")
+        claimed, result = backend.claim("key1")
+        assert claimed is False
+        assert result == "value1"
+
+    def test_claim_blocks_second_caller_on_in_progress(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        # First caller claims
+        claimed1, result1 = backend.claim("key1")
+        assert claimed1 is True
+        assert result1 is None
+        # Second caller sees in-progress
+        claimed2, result2 = backend.claim("key1")
+        assert claimed2 is False
+        assert result2 is None  # in-progress, not yet completed
+
+    def test_claim_then_set_makes_result_available(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        backend.claim("key1")  # claim
+        backend.set("key1", "final_value")  # publish result
+        claimed, result = backend.claim("key1")
+        assert claimed is False
+        assert result == "final_value"
+
+    def test_get_returns_none_for_in_progress(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        backend.claim("key1")
+        assert backend.get("key1") is None  # in-progress treated as not available
+
+    def test_clear_removes_all(self) -> None:
+        backend = MemoryIdempotencyBackend()
+        backend.set("key1", "value1")
+        backend.set("key2", "value2")
+        backend.clear()
+        assert backend.get("key1") is None
+        assert backend.get("key2") is None
 
 
 class TestToolsHandlerIdempotency:
@@ -43,6 +104,95 @@ class TestToolsHandlerIdempotency:
         handler.on_tool_use(calling, "payment-sent", should_cache=False)
         assert handler.get_idempotent_result("pay", {"amount": 10}) == "payment-sent"
 
+    def test_on_tool_use_with_empty_dict_arguments_stores_result(self) -> None:
+        """No-argument tool calls (arguments={}) must be stored for idempotency."""
+        handler = ToolsHandler()
+        from crewai.tools.tool_calling import ToolCalling
+
+        calling = ToolCalling(tool_name="noop", arguments={})
+        handler.on_tool_use(calling, "done", should_cache=False)
+        assert handler.get_idempotent_result("noop", {}) == "done"
+
+    def test_on_tool_use_with_none_arguments_skips_store(self) -> None:
+        """None arguments should skip idempotency storage (no key to build)."""
+        handler = ToolsHandler()
+        from crewai.tools.tool_calling import ToolCalling
+
+        calling = ToolCalling(tool_name="noop", arguments=None)
+        handler.on_tool_use(calling, "done", should_cache=False)
+        # Should not have stored anything
+        assert handler.get_idempotent_result("noop", {}) is None
+
+    def test_claim_idempotent_result_returns_stored_result(self) -> None:
+        handler = ToolsHandler()
+        handler.set_idempotent_result("add", {"x": 1}, "42")
+        result = handler.claim_idempotent_result("add", {"x": 1})
+        assert result == "42"
+
+    def test_claim_idempotent_result_returns_none_when_not_stored(self) -> None:
+        handler = ToolsHandler()
+        result = handler.claim_idempotent_result("add", {"x": 1})
+        assert result is None  # claim succeeded, caller must execute
+
+    def test_claim_idempotent_prevents_double_claim(self) -> None:
+        handler = ToolsHandler()
+        # First claim succeeds
+        result1 = handler.claim_idempotent_result("add", {"x": 1})
+        assert result1 is None
+        # Second claim sees in-progress, returns None (falls through)
+        result2 = handler.claim_idempotent_result("add", {"x": 1})
+        assert result2 is None  # not yet completed
+
+    def test_tool_name_sanitization_consistency(self) -> None:
+        """Write and read paths must use the same sanitised tool name."""
+        handler = ToolsHandler()
+        from crewai.tools.tool_calling import ToolCalling
+
+        # Tool name with spaces and mixed case — should be normalized
+        calling = ToolCalling(
+            tool_name="My Tool !", arguments={"x": 1}
+        )
+        handler.on_tool_use(calling, "result", should_cache=False)
+        # Read back with the same raw name — sanitization must match
+        assert (
+            handler.get_idempotent_result("My Tool !", {"x": 1}) == "result"
+        )
+
+    def test_custom_backend_injection(self) -> None:
+        """Users can inject a custom IdempotencyBackend."""
+        handler = ToolsHandler()
+
+        class CountingBackend(IdempotencyBackend):
+            def __init__(self) -> None:
+                self.gets = 0
+                self.sets = 0
+                self._store: dict[str, str] = {}
+
+            def get(self, key: str) -> str | None:
+                self.gets += 1
+                return self._store.get(key)
+
+            def set(self, key: str, value: str) -> None:
+                self.sets += 1
+                self._store[key] = value
+
+            def claim(self, key: str) -> tuple[bool, str | None]:
+                existing = self._store.get(key)
+                if existing is not None:
+                    return (False, existing)
+                self._store[key] = "claimed"
+                return (True, None)
+
+            def clear(self) -> None:
+                self._store.clear()
+
+        backend = CountingBackend()
+        handler.set_idempotency_backend(backend)
+        handler.set_idempotent_result("tool", {}, "result")
+        assert backend.sets == 1
+        assert handler.get_idempotent_result("tool", {}) == "result"
+        assert backend.gets == 1
+
 
 class TestToolUsageIdempotency:
     """Integration tests: ToolUsage checks idempotency before executing."""
@@ -53,9 +203,12 @@ class TestToolUsageIdempotency:
         handler = ToolsHandler()
         handler.set_idempotent_result("add", {"x": 1, "y": 2}, "3")
 
-        tool = MagicMock(spec=CrewStructuredTool)
+        tool = MagicMock()
         tool.name = "add"
         tool.description = "Add numbers"
+        tool.max_usage_count = None
+        tool.current_usage_count = 0
+        tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
         }
@@ -82,13 +235,16 @@ class TestToolUsageIdempotency:
         """If no idempotent result, tool should execute normally."""
         handler = ToolsHandler()
 
-        tool = MagicMock(spec=CrewStructuredTool)
+        tool = MagicMock()
         tool.name = "add"
         tool.description = "Add numbers"
+        tool.max_usage_count = None
+        tool.current_usage_count = 0
+        tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
         }
-        tool.ainvoke.return_value = 3
+        tool.ainvoke = AsyncMock(return_value=3)
 
         from crewai.tools.tool_calling import ToolCalling
         calling = ToolCalling(tool_name="add", arguments={"x": 1, "y": 2})
@@ -111,9 +267,12 @@ class TestToolUsageIdempotency:
         handler = ToolsHandler()
         handler.set_idempotent_result("add", {"x": 1, "y": 2}, "3")
 
-        tool = MagicMock(spec=CrewStructuredTool)
+        tool = MagicMock()
         tool.name = "add"
         tool.description = "Add numbers"
+        tool.max_usage_count = None
+        tool.current_usage_count = 0
+        tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
         }
@@ -134,3 +293,67 @@ class TestToolUsageIdempotency:
         result = tool_usage._use(tool_string="", tool=tool, calling=calling)
         assert result == "3"
         tool.invoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ause_with_no_args_tool(self) -> None:
+        """No-argument tool calls (arguments={}) must go through idempotency check."""
+        handler = ToolsHandler()
+        # Pre-store a result for a no-arg tool call
+        handler.set_idempotent_result("noop", {}, "done")
+
+        tool = MagicMock()
+        tool.name = "noop"
+        tool.description = "No-op tool"
+        tool.max_usage_count = None
+        tool.current_usage_count = 0
+        tool.args_schema = MagicMock()
+        tool.args_schema.model_json_schema.return_value = {"properties": {}}
+
+        from crewai.tools.tool_calling import ToolCalling
+        calling = ToolCalling(tool_name="noop", arguments={})
+
+        tool_usage = ToolUsage(
+            tools_handler=handler,
+            tools=[tool],
+            task=None,
+            function_calling_llm=MagicMock(),
+        )
+        tool_usage.action = MagicMock()
+        tool_usage.action.tool = "noop"
+        tool_usage.action.tool_input = {}
+
+        result = await tool_usage._ause(tool_string="", tool=tool, calling=calling)
+        assert result == "done"
+        tool.ainvoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ause_with_none_arguments_skips_idempotency(self) -> None:
+        """None arguments should skip idempotency check entirely."""
+        handler = ToolsHandler()
+        handler.set_idempotent_result("noop", {}, "stale")
+
+        tool = MagicMock()
+        tool.name = "noop"
+        tool.description = "No-op tool"
+        tool.max_usage_count = None
+        tool.current_usage_count = 0
+        tool.args_schema = MagicMock()
+        tool.args_schema.model_json_schema.return_value = {"properties": {}}
+        tool.ainvoke = AsyncMock(return_value="fresh")
+
+        from crewai.tools.tool_calling import ToolCalling
+        calling = ToolCalling(tool_name="noop", arguments=None)
+
+        tool_usage = ToolUsage(
+            tools_handler=handler,
+            tools=[tool],
+            task=None,
+            function_calling_llm=MagicMock(),
+        )
+        tool_usage.action = MagicMock()
+        tool_usage.action.tool = "noop"
+        tool_usage.action.tool_input = None
+
+        result = await tool_usage._ause(tool_string="", tool=tool, calling=calling)
+        assert result == "fresh"  # executed fresh, not from idempotency
+        tool.ainvoke.assert_called_once()

--- a/lib/crewai/tests/tools/test_tool_idempotency.py
+++ b/lib/crewai/tests/tools/test_tool_idempotency.py
@@ -1,0 +1,136 @@
+"""Tests for tool execution idempotency on task retry."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from crewai.agents.tools_handler import ToolsHandler
+from crewai.tools.structured_tool import CrewStructuredTool
+from crewai.tools.tool_usage import ToolUsage
+
+
+class TestToolsHandlerIdempotency:
+    """Unit tests for ToolsHandler idempotency store."""
+
+    def test_store_and_retrieve(self) -> None:
+        handler = ToolsHandler()
+        handler.set_idempotent_result("pay", {"amount": 10}, "payment-sent")
+        assert handler.get_idempotent_result("pay", {"amount": 10}) == "payment-sent"
+
+    def test_different_args_different_keys(self) -> None:
+        handler = ToolsHandler()
+        handler.set_idempotent_result("pay", {"amount": 10}, "result-10")
+        handler.set_idempotent_result("pay", {"amount": 20}, "result-20")
+        assert handler.get_idempotent_result("pay", {"amount": 10}) == "result-10"
+        assert handler.get_idempotent_result("pay", {"amount": 20}) == "result-20"
+
+    def test_missing_key_returns_none(self) -> None:
+        handler = ToolsHandler()
+        assert handler.get_idempotent_result("pay", {"amount": 10}) is None
+
+    def test_reset_clears_store(self) -> None:
+        handler = ToolsHandler()
+        handler.set_idempotent_result("pay", {"amount": 10}, "sent")
+        handler.reset_idempotency_store()
+        assert handler.get_idempotent_result("pay", {"amount": 10}) is None
+
+    def test_on_tool_use_stores_idempotent_result(self) -> None:
+        handler = ToolsHandler()
+        from crewai.tools.tool_calling import ToolCalling
+
+        calling = ToolCalling(tool_name="pay", arguments={"amount": 10})
+        handler.on_tool_use(calling, "payment-sent", should_cache=False)
+        assert handler.get_idempotent_result("pay", {"amount": 10}) == "payment-sent"
+
+
+class TestToolUsageIdempotency:
+    """Integration tests: ToolUsage checks idempotency before executing."""
+
+    @pytest.mark.asyncio
+    async def test_ause_skips_execution_when_idempotent_result_exists(self) -> None:
+        """If ToolsHandler already has an idempotent result, tool should not be invoked again."""
+        handler = ToolsHandler()
+        handler.set_idempotent_result("add", {"x": 1, "y": 2}, "3")
+
+        tool = MagicMock(spec=CrewStructuredTool)
+        tool.name = "add"
+        tool.description = "Add numbers"
+        tool.args_schema.model_json_schema.return_value = {
+            "properties": {"x": {}, "y": {}}
+        }
+
+        from crewai.tools.tool_calling import ToolCalling
+        calling = ToolCalling(tool_name="add", arguments={"x": 1, "y": 2})
+
+        tool_usage = ToolUsage(
+            tools_handler=handler,
+            tools=[tool],
+            task=None,
+            function_calling_llm=MagicMock(),
+        )
+        tool_usage.action = MagicMock()
+        tool_usage.action.tool = "add"
+        tool_usage.action.tool_input = {"x": 1, "y": 2}
+
+        result = await tool_usage._ause(tool_string="", tool=tool, calling=calling)
+        assert result == "3"
+        tool.ainvoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ause_executes_when_no_idempotent_result(self) -> None:
+        """If no idempotent result, tool should execute normally."""
+        handler = ToolsHandler()
+
+        tool = MagicMock(spec=CrewStructuredTool)
+        tool.name = "add"
+        tool.description = "Add numbers"
+        tool.args_schema.model_json_schema.return_value = {
+            "properties": {"x": {}, "y": {}}
+        }
+        tool.ainvoke.return_value = 3
+
+        from crewai.tools.tool_calling import ToolCalling
+        calling = ToolCalling(tool_name="add", arguments={"x": 1, "y": 2})
+
+        tool_usage = ToolUsage(
+            tools_handler=handler,
+            tools=[tool],
+            task=None,
+            function_calling_llm=MagicMock(),
+        )
+        tool_usage.action = MagicMock()
+        tool_usage.action.tool = "add"
+        tool_usage.action.tool_input = {"x": 1, "y": 2}
+
+        await tool_usage._ause(tool_string="", tool=tool, calling=calling)
+        tool.ainvoke.assert_called_once()
+
+    def test_use_skips_execution_when_idempotent_result_exists(self) -> None:
+        """Sync path also skips execution when idempotent result exists."""
+        handler = ToolsHandler()
+        handler.set_idempotent_result("add", {"x": 1, "y": 2}, "3")
+
+        tool = MagicMock(spec=CrewStructuredTool)
+        tool.name = "add"
+        tool.description = "Add numbers"
+        tool.args_schema.model_json_schema.return_value = {
+            "properties": {"x": {}, "y": {}}
+        }
+
+        from crewai.tools.tool_calling import ToolCalling
+        calling = ToolCalling(tool_name="add", arguments={"x": 1, "y": 2})
+
+        tool_usage = ToolUsage(
+            tools_handler=handler,
+            tools=[tool],
+            task=None,
+            function_calling_llm=MagicMock(),
+        )
+        tool_usage.action = MagicMock()
+        tool_usage.action.tool = "add"
+        tool_usage.action.tool_input = {"x": 1, "y": 2}
+
+        result = tool_usage._use(tool_string="", tool=tool, calling=calling)
+        assert result == "3"
+        tool.invoke.assert_not_called()

--- a/lib/crewai/tests/tools/test_tool_idempotency.py
+++ b/lib/crewai/tests/tools/test_tool_idempotency.py
@@ -134,12 +134,14 @@ class TestToolsHandlerIdempotency:
         result = handler.claim_idempotent_result("add", {"x": 1})
         assert result is None  # claim succeeded, caller must execute
 
-    def test_claim_idempotent_prevents_double_claim(self) -> None:
+    def test_claim_idempotent_narrows_race_window(self) -> None:
         handler = ToolsHandler()
-        # First claim succeeds
+        # First claim succeeds (caller must execute)
         result1 = handler.claim_idempotent_result("add", {"x": 1})
         assert result1 is None
-        # Second claim sees in-progress, returns None (falls through)
+        # Second claim sees in-progress, returns None (falls through to execution).
+        # This narrows the race window rather than strictly preventing double
+        # execution — both callers receive None so both may execute.
         result2 = handler.claim_idempotent_result("add", {"x": 1})
         assert result2 is None  # not yet completed
 
@@ -186,6 +188,9 @@ class TestToolsHandlerIdempotency:
             def clear(self) -> None:
                 self._store.clear()
 
+            def release(self, key: str) -> None:
+                self._store.pop(key, None)
+
         backend = CountingBackend()
         handler.set_idempotency_backend(backend)
         handler.set_idempotent_result("tool", {}, "result")
@@ -208,6 +213,7 @@ class TestToolUsageIdempotency:
         tool.description = "Add numbers"
         tool.max_usage_count = None
         tool.current_usage_count = 0
+        tool.format_output_for_agent.side_effect = str
         tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
@@ -240,6 +246,7 @@ class TestToolUsageIdempotency:
         tool.description = "Add numbers"
         tool.max_usage_count = None
         tool.current_usage_count = 0
+        tool.format_output_for_agent.side_effect = str
         tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
@@ -272,6 +279,7 @@ class TestToolUsageIdempotency:
         tool.description = "Add numbers"
         tool.max_usage_count = None
         tool.current_usage_count = 0
+        tool.format_output_for_agent.side_effect = str
         tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {
             "properties": {"x": {}, "y": {}}
@@ -306,6 +314,7 @@ class TestToolUsageIdempotency:
         tool.description = "No-op tool"
         tool.max_usage_count = None
         tool.current_usage_count = 0
+        tool.format_output_for_agent.side_effect = str
         tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {"properties": {}}
 
@@ -337,6 +346,7 @@ class TestToolUsageIdempotency:
         tool.description = "No-op tool"
         tool.max_usage_count = None
         tool.current_usage_count = 0
+        tool.format_output_for_agent.side_effect = str
         tool.args_schema = MagicMock()
         tool.args_schema.model_json_schema.return_value = {"properties": {}}
         tool.ainvoke = AsyncMock(return_value="fresh")


### PR DESCRIPTION
## Summary

When a CrewAI task fails and is retried via `max_retry_limit`, `@tool`-decorated functions that already executed successfully can fire again, causing duplicate side effects (payments, emails, trades, etc.).

This adds a cross-retry **idempotency store** to `ToolsHandler` that persists across task retries within the same agent lifecycle.

## Changes

1. **`ToolsHandler`** — adds `get_idempotent_result()`, `set_idempotent_result()`, `reset_idempotency_store()`, and `_idempotency_key()` methods backed by a SHA256-keyed dict
2. **`ToolUsage._ause()` / `_use()`** — checks the idempotency store before executing a tool, independent of the `CacheHandler` config. After successful execution, results are stored via `on_tool_use()`
3. **Tests** — 8 tests covering store/retrieve, different-arg keys, missing keys, reset, `on_tool_use` integration, async skip-execution, sync skip-execution, and normal execution path

## Design decisions

- **Independent of CacheHandler** — the idempotency store works regardless of whether caching is configured
- **Opt-out via `reset_idempotency_store()`** — call this at the start of a fresh task to clear stale entries
- **SHA256-based key** — deterministic across JSON key ordering via `sort_keys=True`
- **Zero config** — existing users get protection automatically; no migration needed

Fixes #5802

## Test plan

- `make format` — passed
- `make lint` — passed
- New test file `test_tool_idempotency.py` with 8 cases covering the full surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable idempotency for tool execution with a default in-memory backend; supports atomic claim, store, retrieve, release, and clear operations to avoid duplicate tool runs.
  * Tool outputs are recorded into the idempotency store when call arguments are present; tool-name sanitization improved for consistent keys.
  * API to inject/replace custom idempotency backends.

* **Tests**
  * Comprehensive tests covering backend behavior, claim/release semantics, integration with tool execution (sync/async), argument handling, and store clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->