### PR TITLE
fix: add 'anthropic/' prefix to model pattern matching

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -455,7 +455,8 @@ class LLM(BaseLLM):
 
         if provider == "anthropic" or provider == "claude":
             return any(
-                model_lower.startswith(prefix) for prefix in ["claude-", "anthropic."]
+                model_lower.startswith(prefix)
+                for prefix in ["claude-", "anthropic.", "anthropic/"]
             )
 
         if provider == "gemini" or provider == "google":


### PR DESCRIPTION
## Problem

Users with self-deployed Anthropic models use naming conventions like `anthropic/claude-...` (the standard LiteLLM routing format). The existing `_matches_provider_pattern` only recognized `claude-` and `anthropic.` prefixes, causing these models to be incorrectly filtered out when explicitly setting `provider='anthropic'`.

Fixes #5893

## Fix

Added `anthropic/` to the recognized prefix list for the anthropic provider in `_matches_provider_pattern`:

```python
# Before
["claude-", "anthropic."]

# After
["claude-", "anthropic.", "anthropic/"]
```

This is backwards-compatible and handles the common LiteLLM model naming convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anthropic model provider detection now supports the `anthropic/` model name prefix format, in addition to existing naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->