### PR TITLE
fix: skip unsupported response_format for Deepseek provider

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -261,3 +261,14 @@ class OpenAICompatibleCompletion(OpenAICompletion):
             Whether the model supports function calling.
         """
         return super().supports_function_calling()
+
+    def _prepare_completion_params(self, *args, **kwargs) -> dict[str, Any]:
+        """Prepare parameters for OpenAI chat completion.
+
+        Skips ``response_format`` for providers that do not support it
+        (e.g. DeepSeek), avoiding a 400 error from the API.
+        """
+        params = super()._prepare_completion_params(*args, **kwargs)
+        if self.provider == "deepseek" or "deepseek" in self.model.lower():
+            params.pop("response_format", None)
+        return params

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -291,6 +291,42 @@ class TestLLMIntegration:
             assert llm.max_tokens == 1000
 
 
+class TestDeepseekResponseFormat:
+    """Tests for skipping response_format on DeepSeek."""
+
+    def test_response_format_omitted_for_deepseek_provider(self):
+        """Test that response_format is removed from params for Deepseek provider."""
+        completion = OpenAICompatibleCompletion(
+            model="deepseek-chat",
+            provider="deepseek",
+            api_key="test-key",
+            response_format={"type": "json_object"},
+        )
+        params = completion._prepare_completion_params([{"role": "user", "content": "hi"}])
+        assert "response_format" not in params
+
+    def test_response_format_omitted_for_deepseek_model(self):
+        """Test that response_format is removed when model name contains deepseek."""
+        completion = OpenAICompatibleCompletion(
+            model="openrouter/deepseek/deepseek-chat",
+            provider="openrouter",
+            api_key="test-key",
+            response_format={"type": "json_object"},
+        )
+        params = completion._prepare_completion_params([{"role": "user", "content": "hi"}])
+        assert "response_format" not in params
+
+    def test_response_format_kept_for_other_providers(self):
+        """Test that response_format is kept for non-Deepseek providers."""
+        completion = OpenAICompatibleCompletion(
+            model="llama3",
+            provider="ollama",
+            response_format={"type": "json_object"},
+        )
+        params = completion._prepare_completion_params([{"role": "user", "content": "hi"}])
+        assert "response_format" in params
+
+
 class TestCallMocking:
     """Tests for mocking the call method."""
 


### PR DESCRIPTION
## Summary

When using Deepseek as the LLM provider, CrewAI sends `response_format: {"type": "json_object"}` which is not supported by Deepseek API, resulting in a 400 error.

## Changes

- Added a check to skip `response_format` when the provider is Deepseek.

## Testing

- Added unit test verifying that `response_format` is omitted for Deepseek models.

Fixes crewAIInc/crewAI#5990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API errors when using DeepSeek providers and models. The system now properly optimizes request formatting for DeepSeek-compatible endpoints, preventing configuration errors and ensuring seamless integration with DeepSeek services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->