### PR TITLE
fix(agents): proxy human input flag through executor state

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -279,6 +279,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Set state messages."""
         self._state.messages = value
 
+    @property  # type: ignore[misc]
+    def ask_for_human_input(self) -> bool:
+        """Compatibility property - returns human-input state flag."""
+        return bool(self._state.ask_for_human_input)
+
+    @ask_for_human_input.setter
+    def ask_for_human_input(self, value: bool) -> None:
+        """Set human-input state flag."""
+        self._state.ask_for_human_input = value
+
     @start()
     def generate_plan(self) -> None:
         """Generate execution plan if planning is enabled.

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -220,6 +220,18 @@ class TestAgentExecutor:
         assert executor.max_iter == 10
         assert executor.use_stop_words is True
 
+    def test_ask_for_human_input_proxies_state(self, mock_dependencies):
+        """Human-input providers should access the executor flag directly."""
+        executor = _build_executor(**mock_dependencies)
+
+        executor.ask_for_human_input = True
+        assert executor.state.ask_for_human_input is True
+        assert executor.ask_for_human_input is True
+
+        executor.ask_for_human_input = False
+        assert executor.state.ask_for_human_input is False
+        assert executor.ask_for_human_input is False
+
     def test_initialize_reasoning(self, mock_dependencies):
         """Test flow entry point."""
         with patch.object(


### PR DESCRIPTION
## Summary
- expose `AgentExecutor.ask_for_human_input` as a compatibility property backed by `AgentExecutorState`
- add a regression test covering direct reads/writes through the executor context surface

## Why
`SyncHumanInputProvider` accesses `context.ask_for_human_input` directly, but the experimental `AgentExecutor` stores the flag only on `self.state`. With `Task(human_input=True)`, that mismatch raises `AttributeError` before the feedback loop can run.

Fixes #6065.

## Validation
- `python3 -m py_compile lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/tests/agents/test_agent_executor.py`

I was not able to run the targeted pytest locally because cloning/checking out the full repository repeatedly failed on this machine with network EOF errors; the change is limited to a state-backed compatibility property plus a focused unit test.

## AI assistance disclosure
This PR was prepared with AI assistance and reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a property to enable reading and modifying the human-input request status for Agent Executor.

* **Tests**
  * Added unit test to verify the human-input property functionality and state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->