### PR TITLE
test(agents): cover human input flag on executor

### DIFF
--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from crewai.agents.tools_handler import ToolsHandler as _ToolsHandler
 from crewai.agents.step_executor import StepExecutor
+from crewai.core.providers.human_input import SyncHumanInputProvider
 
 
 def _build_executor(**kwargs: Any) -> AgentExecutor:
@@ -223,6 +224,36 @@ class TestAgentExecutor:
         assert executor.crew == mock_dependencies["crew"]
         assert executor.max_iter == 10
         assert executor.use_stop_words is True
+
+    def test_ask_for_human_input_delegates_to_state(self, mock_dependencies):
+        """Test ExecutorContext human input flag compatibility."""
+        executor = _build_executor(**mock_dependencies)
+
+        assert executor.ask_for_human_input is False
+
+        executor.state.ask_for_human_input = True
+        assert executor.ask_for_human_input is True
+
+        executor.ask_for_human_input = False
+        assert executor.state.ask_for_human_input is False
+
+    def test_human_input_provider_can_clear_executor_state_flag(
+        self, mock_dependencies
+    ):
+        """Test sync human feedback can read and clear the executor flag."""
+        executor = _build_executor(**mock_dependencies)
+        executor.state.ask_for_human_input = True
+        formatted_answer = AgentFinish(
+            thought="final thoughts", output="Final answer", text="complete"
+        )
+
+        with patch.object(SyncHumanInputProvider, "_prompt_input", return_value=""):
+            result = SyncHumanInputProvider().handle_feedback(
+                formatted_answer, executor
+            )
+
+        assert result is formatted_answer
+        assert executor.state.ask_for_human_input is False
 
     def test_initialize_reasoning(self, mock_dependencies):
         """Test flow entry point."""


### PR DESCRIPTION
## Summary

Fixes #6065.

After rebasing onto current `main`, the implementation fix for `AgentExecutor.ask_for_human_input` is already present upstream. This PR has been narrowed to regression coverage that verifies the executor exposes the human-input flag expected by `ExecutorContext` consumers and that the sync human-input provider can clear the executor state flag after feedback handling.

## Tests

- `uv run pytest lib/crewai/tests/agents/test_agent_executor.py::TestAgentExecutor::test_ask_for_human_input_delegates_to_state lib/crewai/tests/agents/test_agent_executor.py::TestAgentExecutor::test_human_input_provider_can_clear_executor_state_flag -q` -> 2 passed
- `uv run pytest lib/crewai/tests/agents/test_agent_executor.py -q` -> 93 passed
- `uv run ruff check lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/tests/agents/test_agent_executor.py` -> passed
- `uv run ruff format --check lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/tests/agents/test_agent_executor.py` -> passed
- `uv run mypy lib/crewai/src/crewai/experimental/agent_executor.py` -> passed
- `uv run python -m py_compile lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/tests/agents/test_agent_executor.py` -> passed
- `git diff --check` -> passed

## AI disclosure

This PR was authored with AI assistance and reviewed before submission. Per CONTRIBUTING.md, please apply the `llm-generated` label if I cannot apply it from my fork permissions.