### PR TITLE
fix(agent): expose human input flag on executor

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -259,6 +259,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Get thread-safe state proxy."""
         return StateProxy(self._state, self._state_lock)  # type: ignore[return-value]
 
+    @property
+    def ask_for_human_input(self) -> bool:
+        """Whether the executor should request human feedback."""
+        return bool(self._state.ask_for_human_input)
+
+    @ask_for_human_input.setter
+    def ask_for_human_input(self, value: bool) -> None:
+        """Update the human feedback flag stored in executor state."""
+        self._state.ask_for_human_input = value
+
     @property  # type: ignore[misc]
     def iterations(self) -> int:
         """Compatibility property for mixin - returns state iterations."""

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from crewai.agents.tools_handler import ToolsHandler as _ToolsHandler
 from crewai.agents.step_executor import StepExecutor
+from crewai.core.providers.human_input import SyncHumanInputProvider
 
 
 def _build_executor(**kwargs: Any) -> AgentExecutor:
@@ -115,6 +116,29 @@ class TestAgentExecutor:
 
     class StructuredResult(BaseModel):
         value: str
+
+    def test_ask_for_human_input_delegates_to_state(self):
+        """ExecutorContext compatibility should read and write the state flag."""
+        executor = _build_executor()
+
+        executor.state.ask_for_human_input = True
+        assert executor.ask_for_human_input is True
+
+        executor.ask_for_human_input = False
+        assert executor.state.ask_for_human_input is False
+
+    def test_human_input_provider_can_update_executor_state_flag(self):
+        """Human input providers should be able to mutate the executor context."""
+        executor = _build_executor(crew=None)
+        executor.state.ask_for_human_input = True
+        answer = AgentFinish(thought="done", output="final", text="final")
+
+        result = SyncHumanInputProvider()._handle_regular_feedback(
+            answer, "", executor
+        )
+
+        assert result is answer
+        assert executor.state.ask_for_human_input is False
 
     def test_inject_files_from_crew_task_store(self):
         """Crew-level input_files should attach to the LLM user message."""


### PR DESCRIPTION
## Summary
- add an `AgentExecutor.ask_for_human_input` property that delegates to `AgentExecutorState`
- keep the experimental executor compatible with `ExecutorContext`, whose human-input provider reads and writes the flag directly
- add regression coverage for direct state delegation and the sync human-input provider mutation path

Fixes #6065.

## Testing
- `uv run --package crewai --dev python -m pytest lib/crewai/tests/agents/test_agent_executor.py::TestAgentExecutor::test_ask_for_human_input_delegates_to_state lib/crewai/tests/agents/test_agent_executor.py::TestAgentExecutor::test_human_input_provider_can_update_executor_state_flag -q`
- `uv run --package crewai --dev ruff check lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/tests/agents/test_agent_executor.py`
- `git diff --check`

I also ran the full `lib/crewai/tests/agents/test_agent_executor.py` file locally; it reached `76 passed, 13 failed`. The failures were environment/extra dependency issues unrelated to this patch: local SOCKS proxy support missing `socksio`, missing `crewai[anthropic]`, and missing `crewai_tools`.

This PR is AI-assisted and labeled `llm-generated` per the contribution guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent executor now provides a configurable option to request human feedback during agent execution, allowing dynamic control over human input prompts.

* **Tests**
  * Added comprehensive test coverage for human input functionality, validating that feedback requests can be toggled and that feedback processing correctly updates executor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->