### PR TITLE
fix: human_input=True fixes — AttributeError on experimental executor + result hidden when verbose=False

### DIFF
--- a/lib/crewai/src/crewai/core/providers/human_input.py
+++ b/lib/crewai/src/crewai/core/providers/human_input.py
@@ -179,7 +179,13 @@ class SyncHumanInputProvider(HumanInputProvider):
         Returns:
             The final answer after feedback processing.
         """
-        feedback = self._prompt_input(context.crew)
+        is_verbose = context.agent.verbose or bool(
+            context.crew and getattr(context.crew, "verbose", False)
+        )
+        feedback = self._prompt_input(
+            context.crew,
+            answer=None if is_verbose else formatted_answer,
+        )
 
         if context._is_training_mode():
             return self._handle_training_feedback(formatted_answer, feedback, context)
@@ -200,7 +206,13 @@ class SyncHumanInputProvider(HumanInputProvider):
         Returns:
             The final answer after feedback processing.
         """
-        feedback = await self._prompt_input_async(context.crew)
+        is_verbose = context.agent.verbose or bool(
+            context.crew and getattr(context.crew, "verbose", False)
+        )
+        feedback = await self._prompt_input_async(
+            context.crew,
+            answer=None if is_verbose else formatted_answer,
+        )
 
         if context._is_training_mode():
             return await self._handle_training_feedback_async(
@@ -316,11 +328,17 @@ class SyncHumanInputProvider(HumanInputProvider):
         return answer
 
     @staticmethod
-    def _prompt_input(crew: Crew | None) -> str:
+    def _prompt_input(
+        crew: Crew | None,
+        answer: "AgentFinish | None" = None,
+    ) -> str:
         """Show rich panel and prompt for input.
 
         Args:
             crew: The crew instance for context.
+            answer: When provided, the agent result is printed before the
+                feedback prompt so the operator can see it even when verbose
+                is disabled.
 
         Returns:
             User input string from terminal.
@@ -342,6 +360,18 @@ class SyncHumanInputProvider(HumanInputProvider):
                 )
                 title = "🎓 Training Feedback Required"
             else:
+                if answer is not None:
+                    output_str = HumanInputProvider._get_output_string(answer)
+                    result_content = Text()
+                    result_content.append(output_str, style="green")
+                    formatter.console.print(
+                        Panel(
+                            result_content,
+                            title="✅ Agent Final Answer",
+                            border_style="green",
+                            padding=(1, 2),
+                        )
+                    )
                 prompt_text = (
                     "Provide feedback on the Final Result above.\n\n"
                     "• If you are happy with the result, simply hit Enter without typing anything.\n"
@@ -369,11 +399,17 @@ class SyncHumanInputProvider(HumanInputProvider):
             formatter.resume_live_updates()
 
     @staticmethod
-    async def _prompt_input_async(crew: Crew | None) -> str:
+    async def _prompt_input_async(
+        crew: Crew | None,
+        answer: "AgentFinish | None" = None,
+    ) -> str:
         """Show rich panel and prompt for input without blocking the event loop.
 
         Args:
             crew: The crew instance for context.
+            answer: When provided, the agent result is printed before the
+                feedback prompt so the operator can see it even when verbose
+                is disabled.
 
         Returns:
             User input string from terminal.
@@ -395,6 +431,18 @@ class SyncHumanInputProvider(HumanInputProvider):
                 )
                 title = "🎓 Training Feedback Required"
             else:
+                if answer is not None:
+                    output_str = HumanInputProvider._get_output_string(answer)
+                    result_content = Text()
+                    result_content.append(output_str, style="green")
+                    formatter.console.print(
+                        Panel(
+                            result_content,
+                            title="✅ Agent Final Answer",
+                            border_style="green",
+                            padding=(1, 2),
+                        )
+                    )
                 prompt_text = (
                     "Provide feedback on the Final Result above.\n\n"
                     "• If you are happy with the result, simply hit Enter without typing anything.\n"

--- a/lib/crewai/src/crewai/core/providers/human_input.py
+++ b/lib/crewai/src/crewai/core/providers/human_input.py
@@ -190,7 +190,9 @@ class SyncHumanInputProvider(HumanInputProvider):
         if context._is_training_mode():
             return self._handle_training_feedback(formatted_answer, feedback, context)
 
-        return self._handle_regular_feedback(formatted_answer, feedback, context)
+        return self._handle_regular_feedback(
+            formatted_answer, feedback, context, show_answer=not is_verbose
+        )
 
     async def handle_feedback_async(
         self,
@@ -220,7 +222,7 @@ class SyncHumanInputProvider(HumanInputProvider):
             )
 
         return await self._handle_regular_feedback_async(
-            formatted_answer, feedback, context
+            formatted_answer, feedback, context, show_answer=not is_verbose
         )
 
     @staticmethod
@@ -251,6 +253,7 @@ class SyncHumanInputProvider(HumanInputProvider):
         current_answer: AgentFinish,
         initial_feedback: str,
         context: ExecutorContext,
+        show_answer: bool = False,
     ) -> AgentFinish:
         """Process regular feedback with iteration loop.
 
@@ -258,6 +261,7 @@ class SyncHumanInputProvider(HumanInputProvider):
             current_answer: The agent's current answer.
             initial_feedback: Initial human feedback string.
             context: Executor context for callbacks.
+            show_answer: When True, display the updated answer before each prompt.
 
         Returns:
             Final answer after all feedback iterations.
@@ -271,7 +275,10 @@ class SyncHumanInputProvider(HumanInputProvider):
             else:
                 context.messages.append(context._format_feedback_message(feedback))
                 answer = context._invoke_loop()
-                feedback = self._prompt_input(context.crew)
+                feedback = self._prompt_input(
+                    context.crew,
+                    answer=answer if show_answer else None,
+                )
 
         return answer
 
@@ -303,6 +310,7 @@ class SyncHumanInputProvider(HumanInputProvider):
         current_answer: AgentFinish,
         initial_feedback: str,
         context: AsyncExecutorContext,
+        show_answer: bool = False,
     ) -> AgentFinish:
         """Process regular feedback with async iteration loop.
 
@@ -310,6 +318,7 @@ class SyncHumanInputProvider(HumanInputProvider):
             current_answer: The agent's current answer.
             initial_feedback: Initial human feedback string.
             context: Async executor context for callbacks.
+            show_answer: When True, display the updated answer before each prompt.
 
         Returns:
             Final answer after all feedback iterations.
@@ -323,7 +332,10 @@ class SyncHumanInputProvider(HumanInputProvider):
             else:
                 context.messages.append(context._format_feedback_message(feedback))
                 answer = await context._ainvoke_loop()
-                feedback = await self._prompt_input_async(context.crew)
+                feedback = await self._prompt_input_async(
+                    context.crew,
+                    answer=answer if show_answer else None,
+                )
 
         return answer
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -300,16 +300,6 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Set state messages."""
         self._state.messages = value
 
-    @property
-    def ask_for_human_input(self) -> bool:
-        """Compatibility property - returns state ask_for_human_input."""
-        return self._state.ask_for_human_input  # type: ignore[no-any-return]
-
-    @ask_for_human_input.setter
-    def ask_for_human_input(self, value: bool) -> None:
-        """Set state ask_for_human_input."""
-        self._state.ask_for_human_input = value
-
     @start()
     def generate_plan(self) -> None:
         """Generate execution plan if planning is enabled.

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2777,8 +2777,8 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._inject_files_from_inputs(inputs)
 
-            self.ask_for_human_input = bool(
-                inputs.get("ask_for_human_input", False)
+            ask_for_human_input = bool(
+                inputs.get("ask_for_human_input", self.ask_for_human_input)
             )
 
             with _llm_stop_words_applied(self.llm, self):
@@ -2791,7 +2791,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         "Agent execution ended without reaching a final answer."
                     )
 
-                if self.ask_for_human_input:
+                if ask_for_human_input:
                     formatted_answer = self._handle_human_feedback(formatted_answer)
 
             self._save_to_memory(formatted_answer)
@@ -2883,8 +2883,8 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             await self._ainject_files_from_inputs(inputs)
 
-            self.ask_for_human_input = bool(
-                inputs.get("ask_for_human_input", False)
+            ask_for_human_input = bool(
+                inputs.get("ask_for_human_input", self.ask_for_human_input)
             )
 
             with _llm_stop_words_applied(self.llm, self):
@@ -2897,7 +2897,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         "Agent execution ended without reaching a final answer."
                     )
 
-                if self.ask_for_human_input:
+                if ask_for_human_input:
                     formatted_answer = await self._ahandle_human_feedback(
                         formatted_answer
                     )

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -205,6 +205,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
     after_llm_call_hooks: list[AfterLLMCallHookType | AfterLLMCallHookCallable] = Field(
         default_factory=list, exclude=True
     )
+    ask_for_human_input: bool = Field(default=False, exclude=True)
 
     _console: Console = PrivateAttr(default_factory=Console)
     _last_parser_error: OutputParserError | None = PrivateAttr(default=None)
@@ -2787,7 +2788,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             self._inject_files_from_inputs(inputs)
 
-            self.state.ask_for_human_input = bool(
+            self.ask_for_human_input = bool(
                 inputs.get("ask_for_human_input", False)
             )
 
@@ -2801,7 +2802,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         "Agent execution ended without reaching a final answer."
                     )
 
-                if self.state.ask_for_human_input:
+                if self.ask_for_human_input:
                     formatted_answer = self._handle_human_feedback(formatted_answer)
 
             self._save_to_memory(formatted_answer)
@@ -2893,7 +2894,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
             await self._ainject_files_from_inputs(inputs)
 
-            self.state.ask_for_human_input = bool(
+            self.ask_for_human_input = bool(
                 inputs.get("ask_for_human_input", False)
             )
 
@@ -2907,7 +2908,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         "Agent execution ended without reaching a final answer."
                     )
 
-                if self.state.ask_for_human_input:
+                if self.ask_for_human_input:
                     formatted_answer = await self._ahandle_human_feedback(
                         formatted_answer
                     )

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -134,7 +134,6 @@ class AgentExecutorState(BaseModel):
     iterations: int = Field(default=0)
     current_answer: AgentAction | AgentFinish | None = Field(default=None)
     is_finished: bool = Field(default=False)
-    ask_for_human_input: bool = Field(default=False)
     use_native_tools: bool = Field(default=False)
     pending_tool_calls: list[Any] = Field(default_factory=list)
     plan: str | None = Field(default=None, description="Generated execution plan")

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -83,7 +83,6 @@ class TestAgentExecutorState:
         assert state.messages == []
         assert state.current_answer is None
         assert state.is_finished is False
-        assert state.ask_for_human_input is False
         # Planning state fields
         assert state.plan is None
         assert state.plan_ready is False
@@ -105,13 +104,11 @@ class TestAgentExecutorState:
             iterations=5,
             current_answer=AgentFinish(thought="thinking", output="done", text="final"),
             is_finished=True,
-            ask_for_human_input=True,
         )
         assert state.messages == messages
         assert state.iterations == 5
         assert isinstance(state.current_answer, AgentFinish)
         assert state.is_finished is True
-        assert state.ask_for_human_input is True
 
 
 class TestAgentExecutor:


### PR DESCRIPTION
Fixes #6065
Fixes #6072

Two related bugs in the `human_input=True` flow, both observable once either fix is applied:

---

## Fix 1 — `AttributeError: 'AgentExecutor' object has no attribute 'ask_for_human_input'` (#6065)

**File:** `lib/crewai/src/crewai/experimental/agent_executor.py`

The experimental `AgentExecutor` stored `ask_for_human_input` on `self.state` (`AgentExecutorState`), but `SyncHumanInputProvider.handle_feedback` accesses it via the `ExecutorContext` protocol which expects it as a direct attribute on the executor. This caused an `AttributeError` whenever `human_input=True` was set on a `Task` with the default executor.

**Change:** Add `ask_for_human_input: bool = Field(default=False, exclude=True)` directly on `AgentExecutor` (matching `CrewAgentExecutor`) and migrate the four `self.state.ask_for_human_input` references in `_invoke`/`_ainvoke` to `self.ask_for_human_input`.

---

## Fix 2 — Feedback prompt says "Final Result above" but result is never shown when `verbose=False` (#6072)

**File:** `lib/crewai/src/crewai/core/providers/human_input.py`

When `human_input=True` but `verbose=False`, the feedback panel reads *"Provide feedback on the Final Result above"* — but the result was never printed. `AgentLogsExecutionEvent` is verbose-gated; the human-input gate fires unconditionally.

**Change:** `handle_feedback` / `handle_feedback_async` detect when the executor is non-verbose and pass the `AgentFinish` to `_prompt_input` / `_prompt_input_async`. Both methods now print a green **"✅ Agent Final Answer"** panel before the feedback prompt when the caller supplies the answer. Training mode is unaffected.

---

## Testing

The issue body for #6072 includes a minimal reproduction with a `StubLLM`. With this patch applied, running that snippet with `verbose=False` and `human_input=True` shows the result panel before the feedback prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Human feedback prompts can now display the agent’s final answer in a highlighted panel before requesting feedback during iterative execution.
  * Prompt output is more consistent with verbosity settings, reducing unnecessary answer text when verbose output is disabled.
* **Behavior Change**
  * Human-feedback prompting control is now maintained at the executor level for each run, rather than being carried through flow state.
* **Tests**
  * Updated unit tests to match the revised handling and initialization of human-feedback prompting configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->