### PR TITLE
fix: expose ask_for_human_input on experimental AgentExecutor (#6065)

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -279,6 +279,16 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Set state messages."""
         self._state.messages = value
 
+    @property
+    def ask_for_human_input(self) -> bool:
+        """Compatibility property - returns state ask_for_human_input."""
+        return self._state.ask_for_human_input  # type: ignore[no-any-return]
+
+    @ask_for_human_input.setter
+    def ask_for_human_input(self, value: bool) -> None:
+        """Set state ask_for_human_input."""
+        self._state.ask_for_human_input = value
+
     @start()
     def generate_plan(self) -> None:
         """Generate execution plan if planning is enabled.


### PR DESCRIPTION
Closes #6065

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API parity change with no new behavior beyond delegating to existing state; human-input flag handling stays on the same state field.
> 
> **Overview**
> Adds **`ask_for_human_input` getter/setter** on the experimental `AgentExecutor`, wired to `AgentExecutorState.ask_for_human_input` the same way as existing `messages` and `iterations` compatibility properties.
> 
> This lets callers and human-input plumbing that read **`executor.ask_for_human_input`** (instead of only `state`) behave like the classic `CrewAgentExecutor`, so **`task.human_input`** passed through `invoke` can drive post-run human feedback correctly for the experimental executor (#6065).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4e9e100e70359e21c6b420011d919d5cec4541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support configurable human input requests during execution, allowing users to control and query this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->