### PR TITLE
docs: update changelog and version for v1.14.7a3

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -4,6 +4,29 @@ description: "تحديثات المنتج والتحسينات وإصلاحات 
 icon: "clock"
 mode: "wide"
 ---
+<Update label="8 يونيو 2026">
+  ## v1.14.7a3
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a3)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - إصلاح تعرض `ask_for_human_input` في `AgentExecutor` التجريبي
+  - حل مشكلات CVEs الخاصة بـ pip-audit لـ `aiohttp`، `docling`، `docling-core`، و `pip`
+
+  ### إعادة هيكلة
+  - نقل `@start` لقراءة من `FlowDefinition`
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار لـ v1.14.7a2
+
+  ## المساهمون
+
+  @greysonlalonde، @lorenzejay، @vinibrsl
+
+</Update>
+
 <Update label="5 يونيو 2026">
   ## v1.14.7a2
 

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -4,6 +4,29 @@ description: "Product updates, improvements, and bug fixes for CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="Jun 08, 2026">
+  ## v1.14.7a3
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a3)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Fix exposure of `ask_for_human_input` on experimental `AgentExecutor`
+  - Resolve pip-audit CVEs for `aiohttp`, `docling`, `docling-core`, and `pip`
+
+  ### Refactoring
+  - Migrate `@start` to read from `FlowDefinition`
+
+  ### Documentation
+  - Update changelog and version for v1.14.7a2
+
+  ## Contributors
+
+  @greysonlalonde, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="Jun 05, 2026">
   ## v1.14.7a2
 

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -4,6 +4,29 @@ description: "CrewAI의 제품 업데이트, 개선 사항 및 버그 수정"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="2026년 6월 8일">
+  ## v1.14.7a3
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a3)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - 실험적인 `AgentExecutor`에서 `ask_for_human_input` 노출 문제 수정
+  - `aiohttp`, `docling`, `docling-core`, 및 `pip`에 대한 pip-audit CVE 해결
+
+  ### 리팩토링
+  - `@start`를 `FlowDefinition`에서 읽도록 마이그레이션
+
+  ### 문서화
+  - v1.14.7a2에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="2026년 6월 5일">
   ## v1.14.7a2
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -21,7 +21,7 @@ mode: "wide"
   ### Documentação
   - Atualizar o changelog e a versão para v1.14.7a2
 
-  ## Contributors
+  ## Contribuidores
 
   @greysonlalonde, @lorenzejay, @vinibrsl
 

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -4,6 +4,29 @@ description: "Atualizações de produto, melhorias e correções do CrewAI"
 icon: "clock"
 mode: "wide"
 ---
+<Update label="08 jun 2026">
+  ## v1.14.7a3
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7a3)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Corrigir a exposição de `ask_for_human_input` no `AgentExecutor` experimental
+  - Resolver CVEs do pip-audit para `aiohttp`, `docling`, `docling-core` e `pip`
+
+  ### Refatoração
+  - Migrar `@start` para ler de `FlowDefinition`
+
+  ### Documentação
+  - Atualizar o changelog e a versão para v1.14.7a2
+
+  ## Contributors
+
+  @greysonlalonde, @lorenzejay, @vinibrsl
+
+</Update>
+
 <Update label="05 jun 2026">
   ## v1.14.7a2
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or application code changes.
> 
> **Overview**
> Adds a new **v1.14.7a3** release entry at the top of the changelog in **Arabic, English, Korean, and Portuguese (Brazil)**, matching the existing `<Update>` pattern with GitHub release links and contributor credits.
> 
> The entry documents release notes for that version: fixing **`ask_for_human_input`** exposure on experimental **`AgentExecutor`**, resolving pip-audit CVEs for **`aiohttp`**, **`docling`**, **`docling-core`**, and **`pip`**, migrating **`@start`** to read from **`FlowDefinition`**, and a documentation line about updating the changelog for v1.14.7a2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba649b36331f64518505667dd8fd5e21ed17fe97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changelog updated in Arabic, English, Korean, and Portuguese-Brazilian with a new top entry dated Jun 08, 2026 for release v1.14.7a3.
  * Entry includes sections for Bug Fixes, Refactoring, Documentation updates, contributor credits, and links to the GitHub release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->