### PR TITLE
Fix human feedback final answer visibility

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1518,8 +1518,14 @@ class CrewAgentExecutor(BaseAgentExecutor):
             AgentLogsExecutionEvent(
                 agent_role=self.agent.role,
                 formatted_answer=formatted_answer,
-                verbose=self.agent.verbose
-                or (hasattr(self, "crew") and getattr(self.crew, "verbose", False)),
+                verbose=(
+                    self.agent.verbose
+                    or (hasattr(self, "crew") and getattr(self.crew, "verbose", False))
+                    or (
+                        isinstance(formatted_answer, AgentFinish)
+                        and self.ask_for_human_input
+                    )
+                ),
             ),
         )
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2930,8 +2930,14 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             AgentLogsExecutionEvent(
                 agent_role=self.agent.role,
                 formatted_answer=formatted_answer,
-                verbose=self.agent.verbose
-                or (hasattr(self, "crew") and getattr(self.crew, "verbose", False)),
+                verbose=(
+                    self.agent.verbose
+                    or (hasattr(self, "crew") and getattr(self.crew, "verbose", False))
+                    or (
+                        isinstance(formatted_answer, AgentFinish)
+                        and self.state.ask_for_human_input
+                    )
+                ),
             ),
         )
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -231,6 +231,45 @@ class TestAgentExecutor:
             assert result == "initialized"
             mock_show_start.assert_called_once()
 
+    def test_show_logs_displays_final_answer_for_human_input(self, mock_dependencies):
+        """Human feedback prompts must show the final answer under review."""
+        executor = _build_executor(**mock_dependencies)
+        executor.state.ask_for_human_input = True
+        executor.agent.verbose = False
+
+        with patch("crewai.experimental.agent_executor.crewai_event_bus.emit") as emit:
+            executor._show_logs(
+                AgentFinish(
+                    thought="Done",
+                    output="The sky is blue.",
+                    text="Final Answer: The sky is blue.",
+                )
+            )
+
+        event = emit.call_args.args[1]
+        assert event.verbose is True
+
+    def test_show_logs_keeps_non_final_human_input_logs_non_verbose(
+        self, mock_dependencies
+    ):
+        """Human feedback should not enable all intermediate logs."""
+        executor = _build_executor(**mock_dependencies)
+        executor.state.ask_for_human_input = True
+        executor.agent.verbose = False
+
+        with patch("crewai.experimental.agent_executor.crewai_event_bus.emit") as emit:
+            executor._show_logs(
+                AgentAction(
+                    thought="Need a tool",
+                    tool="search",
+                    tool_input="query",
+                    text="Action: search",
+                )
+            )
+
+        event = emit.call_args.args[1]
+        assert event.verbose is False
+
     def test_check_max_iterations_not_reached(self, mock_dependencies):
         """Test routing when iterations < max."""
         executor = _build_executor(**mock_dependencies)

--- a/lib/crewai/tests/agents/test_async_agent_executor.py
+++ b/lib/crewai/tests/agents/test_async_agent_executor.py
@@ -103,6 +103,47 @@ class TestAsyncAgentExecutor:
 
         assert result == {"output": expected_output}
 
+    def test_show_logs_displays_final_answer_for_human_input(
+        self, executor: CrewAgentExecutor
+    ) -> None:
+        """Human feedback prompts must show the final answer under review."""
+        executor.ask_for_human_input = True
+        executor.agent.verbose = False
+
+        with patch("crewai.agents.crew_agent_executor.crewai_event_bus.emit") as emit:
+            emit.return_value = None
+            executor._show_logs(
+                AgentFinish(
+                    thought="Done",
+                    output="The sky is blue.",
+                    text="Final Answer: The sky is blue.",
+                )
+            )
+
+        event = emit.call_args.args[1]
+        assert event.verbose is True
+
+    def test_show_logs_keeps_non_final_human_input_logs_non_verbose(
+        self, executor: CrewAgentExecutor
+    ) -> None:
+        """Human feedback should not enable all intermediate logs."""
+        executor.ask_for_human_input = True
+        executor.agent.verbose = False
+
+        with patch("crewai.agents.crew_agent_executor.crewai_event_bus.emit") as emit:
+            emit.return_value = None
+            executor._show_logs(
+                AgentAction(
+                    thought="Need a tool",
+                    tool="search",
+                    tool_input="query",
+                    text="Action: search",
+                )
+            )
+
+        event = emit.call_args.args[1]
+        assert event.verbose is False
+
     @pytest.mark.asyncio
     async def test_ainvoke_loop_calls_aget_llm_response(
         self, executor: CrewAgentExecutor


### PR DESCRIPTION
## Summary

Fixes #6072.

When `human_input=True` is active, CrewAI now marks final-answer log events as visible even if the agent and crew are non-verbose. That ensures the human feedback prompt's "Final Result above" instruction has an actual final answer above it.

This is intentionally limited to `AgentFinish` events so intermediate tool/action logs still respect the existing verbose gate.

## Tests

- `uv run pytest lib/crewai/tests/agents/test_agent_executor.py lib/crewai/tests/agents/test_async_agent_executor.py -k "show_logs_displays_final_answer_for_human_input or show_logs_keeps_non_final_human_input_logs_non_verbose"`
- `uv run ruff check --no-fix lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/src/crewai/agents/crew_agent_executor.py lib/crewai/tests/agents/test_agent_executor.py lib/crewai/tests/agents/test_async_agent_executor.py`
- `uv run ruff format --check lib/crewai/src/crewai/experimental/agent_executor.py lib/crewai/src/crewai/agents/crew_agent_executor.py lib/crewai/tests/agents/test_agent_executor.py lib/crewai/tests/agents/test_async_agent_executor.py`

Note: running the full `test_agent_executor.py` file in this local environment also hit unrelated optional-dependency/input-prompt failures for missing `crewai[anthropic]` and `exa_py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced execution logging during human-feedback interactions. Logs are now properly displayed with improved visibility when agents request user input for decision-making.
  * Improved tracking of agent execution during interactive workflows requiring human feedback.

* **Tests**
  * Added unit tests validating agent logging behavior during human-feedback scenarios for both synchronous and asynchronous agent executors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->