### PR TITLE
fix(packaging): relax litellm constraint to prevent dependency conflicts

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -86,9 +86,7 @@ watson = [
 voyageai = [
     "voyageai~=0.3.5",
 ]
-litellm = [
-    "litellm>=1.83.7,<1.84",
-]
+litellm = [ "litellm>=1.83.7,<2" ]
 bedrock = [
     "boto3~=1.42.79",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-06T00:11:14.404922Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -1421,7 +1421,7 @@ requires-dist = [
     { name = "json5", specifier = "~=0.10.0" },
     { name = "jsonref", specifier = "~=1.1.0" },
     { name = "lancedb", specifier = ">=0.29.2,<0.30.1" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.83.7,<1.84" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.83.7,<2" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
     { name = "openai", specifier = ">=2.30.0,<3" },


### PR DESCRIPTION
## Description
Relaxes the strict `litellm` package ceiling inside `lib/crewai/pyproject.toml` from `<1.84` to `<2`. 

This resolves an open environment crash where litellm's internal transitive tracking rules collided with CrewAI's modern requirements for `openai` and `python-dotenv`.

Fixes #6089


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded dependency version constraints to accommodate a significantly broader range of compatible versions. This change enables seamless integration with newer library releases while maintaining complete backward compatibility and system stability, ultimately reducing potential version conflicts and dependency issues when updating related packages in your development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->