### PR TITLE
feat(events): add reset_runtime_state to release accumulated bus state

### DIFF
--- a/lib/crewai/src/crewai/events/event_bus.py
+++ b/lib/crewai/src/crewai/events/event_bus.py
@@ -281,6 +281,12 @@ class CrewAIEventsBus:
         """The RuntimeState currently attached to the bus, if any."""
         return self._runtime_state
 
+    def reset_runtime_state(self) -> None:
+        """Detach the RuntimeState and clear the entity registry."""
+        with self._instance_lock:
+            self._runtime_state = None
+            self._registered_entity_ids = set()
+
     def register_entity(self, entity: Any) -> None:
         """Add an entity to the RuntimeState, creating it if needed.
 

--- a/lib/crewai/tests/test_event_record.py
+++ b/lib/crewai/tests/test_event_record.py
@@ -410,3 +410,30 @@ class TestRuntimeStateIntegration:
         )
         assert len(restored.root) == 1
         assert len(restored.event_record) == 0
+
+    def test_reset_runtime_state_clears_state_and_registry(self):
+        from crewai import Agent, Crew, RuntimeState
+        from crewai.events.event_bus import crewai_event_bus
+
+        if RuntimeState is None:
+            pytest.skip("RuntimeState unavailable (model_rebuild failed)")
+
+        agent = Agent(role="test", goal="test", backstory="test", llm="gpt-4o-mini")
+        crew = Crew(agents=[agent], tasks=[], verbose=False)
+
+        previous_state = crewai_event_bus._runtime_state
+        previous_ids = crewai_event_bus._registered_entity_ids
+        crewai_event_bus._runtime_state = None
+        crewai_event_bus._registered_entity_ids = set()
+        try:
+            crewai_event_bus.register_entity(crew)
+            assert crewai_event_bus.runtime_state is not None
+            assert crewai_event_bus._registered_entity_ids
+
+            crewai_event_bus.reset_runtime_state()
+
+            assert crewai_event_bus.runtime_state is None
+            assert crewai_event_bus._registered_entity_ids == set()
+        finally:
+            crewai_event_bus._runtime_state = previous_state
+            crewai_event_bus._registered_entity_ids = previous_ids


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, lock-protected API addition on the event bus with no behavior change until callers use it; test-only impact on the singleton in isolation.
> 
> **Overview**
> Adds **`reset_runtime_state()`** on the singleton `CrewAIEventsBus`, symmetric to `set_runtime_state`: under `_instance_lock` it sets **`_runtime_state`** to `None` and clears **`_registered_entity_ids`**, so handlers stop receiving attached state and entity registration can start fresh after a run.
> 
> A test registers a crew on the bus, calls reset, and asserts both fields are cleared, restoring the bus’s prior state in a `finally` block so other tests are not affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a812277a59426ea6c6ae9b1623584e506203743d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reset and clear the event bus runtime state and registered entity registry.

* **Tests**
  * Added test to verify runtime state reset functionality works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->