### PR TITLE
ci: ignore GHSA-rrmf-rvhw-rf47 (torch alias of PYSEC-2025-194)

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -64,6 +64,7 @@ jobs:
             --ignore-vuln PYSEC-2025-197 \
             --ignore-vuln PYSEC-2025-210 \
             --ignore-vuln PYSEC-2026-139 \
+            --ignore-vuln GHSA-rrmf-rvhw-rf47 \
             --ignore-vuln PYSEC-2025-211 \
             --ignore-vuln PYSEC-2025-212 \
             --ignore-vuln PYSEC-2025-213 \
@@ -81,6 +82,7 @@ jobs:
         #   PYSEC-2025-183      - pyjwt 2.12.1: disputed weak-encryption claim; key length is application-chosen
         #   PYSEC-2025-189..197 - torch 2.11.0: memory-corruption/DoS in functions only reachable via untrusted models; no fix available
         #   PYSEC-2025-210, PYSEC-2026-139 - torch 2.11.0: profiler/deserialization issues; no fix available
+        #   GHSA-rrmf-rvhw-rf47 - torch 2.11.0 (CVE-2025-3000, alias of PYSEC-2025-194): memory corruption in torch.jit.script, CVSS 1.9, local-only; affected <=2.12.0, no fix available. pip-audit reports it under the GHSA id so the PYSEC ignore above does not catch it.
         #   PYSEC-2025-211..218 - transformers 5.5.4: deserialization/code injection via malicious model checkpoints; no fix available
         #   GHSA-f4j7-r4q5-qw2c - chromadb 1.1.1 (CVE-2026-45829): pre-auth RCE via /api/v2/tenants/{tenant}/databases/{db}/collections when trust_remote_code=true.
         #                         Advisory: vulnerable >=1.0.0,<=1.5.9, firstPatchedVersion=none. We only use chromadb.PersistentClient (lib/crewai/src/crewai/rag/chromadb/factory.py)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
           --ignore-vuln PYSEC-2025-197
           --ignore-vuln PYSEC-2025-210
           --ignore-vuln PYSEC-2026-139
+          --ignore-vuln GHSA-rrmf-rvhw-rf47
           --ignore-vuln PYSEC-2025-211
           --ignore-vuln PYSEC-2025-212
           --ignore-vuln PYSEC-2025-213


### PR DESCRIPTION
`GHSA-rrmf-rvhw-rf47` = `CVE-2025-3000` = `PYSEC-2025-194`, already in the ignore list. pip-audit started reporting it under the GHSA id, which `--ignore-vuln PYSEC-2025-194` does not match, so the scan fails on an already-triaged advisory.

Same vuln: memory corruption in `torch.jit.script`, CVSS 1.9 (Low), local-only. Affected `torch <=2.12.0`, no patched version; lock pins 2.11.0, so no bump is possible. Adding the GHSA id to the ignore list, matching how `GHSA-f4j7-r4q5-qw2c` is already handled.

https://github.com/advisories/GHSA-rrmf-rvhw-rf47

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates vulnerability-scan ignore configuration and comments; no application code or dependency bumps.
> 
> **Overview**
> Adds **`--ignore-vuln GHSA-rrmf-rvhw-rf47`** to **pip-audit** in `.github/workflows/vulnerability-scan.yml` and `.pre-commit-config.yaml`, keeping the two ignore lists aligned.
> 
> **pip-audit** began surfacing this torch advisory under the **GHSA** id even though **`PYSEC-2025-194`** was already ignored, which caused CI/pre-push scans to fail on a previously triaged issue (alias of **CVE-2025-3000**). The workflow comment block documents why the extra id is needed, mirroring the existing **`GHSA-f4j7-r4q5-qw2c`** pattern—no dependency version or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7525625359c002fdfa5cb5a508ca49aa5f462e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning configuration to ignore a specific advisory (GHSA-rrmf-rvhw-rf47) in both CI and local scan hooks.
  * Added an explanatory comment noting why this advisory is excluded from the standard PYSEC ignores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->