### PR TITLE
fix(flow): gate restore on a flag so live snapshots don't replay as resume

### DIFF
--- a/lib/crewai/src/crewai/flow/runtime.py
+++ b/lib/crewai/src/crewai/flow/runtime.py
@@ -862,6 +862,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             self._completed_methods = {
                 FlowMethodName(m) for m in self.checkpoint_completed_methods
             }
+            self._restored_from_checkpoint = True
         if self.checkpoint_method_outputs is not None:
             self._method_outputs = list(self.checkpoint_method_outputs)
         if self.checkpoint_method_counts is not None:
@@ -897,6 +898,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
     _completed_methods: set[FlowMethodName] = PrivateAttr(default_factory=set)
     _method_call_counts: dict[FlowMethodName, int] = PrivateAttr(default_factory=dict)
     _is_execution_resuming: bool = PrivateAttr(default=False)
+    _restored_from_checkpoint: bool = PrivateAttr(default=False)
     _event_futures: list[Future[None]] = PrivateAttr(default_factory=list)
     _pending_feedback_context: PendingFeedbackContext | None = PrivateAttr(default=None)
     _human_feedback_method_outputs: dict[str, Any] = PrivateAttr(default_factory=dict)
@@ -2058,7 +2060,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             # Reset flow state for fresh execution unless restoring from persistence
             is_restoring = (
                 inputs and "id" in inputs and self.persistence is not None
-            ) or self.checkpoint_completed_methods is not None
+            ) or self._restored_from_checkpoint
             if not is_restoring:
                 # Clear completed methods and outputs for a fresh start
                 self._completed_methods.clear()
@@ -2074,6 +2076,10 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
                 # suppress cyclic re-execution on the second iteration.
                 if self._completed_methods:
                     self._is_execution_resuming = True
+
+            # Restore is single-shot: a later kickoff on the same instance
+            # starts fresh.
+            self._restored_from_checkpoint = False
 
             # Fork hydration: when restore_from_state_id is set and persistence is
             # available, hydrate self._state from the source UUID's latest snapshot

--- a/lib/crewai/tests/test_checkpoint.py
+++ b/lib/crewai/tests/test_checkpoint.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from crewai.agent.core import Agent
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.crew import Crew
+from crewai.llms.base_llm import BaseLLM
 from crewai.flow.flow import _INITIAL_STATE_CLASS_MARKER, Flow, start
 from crewai.state.checkpoint_config import CheckpointConfig
 from crewai.state.checkpoint_listener import (
@@ -682,3 +683,62 @@ class TestAgentCheckpoint:
             cfg = CheckpointConfig(restore_from=loc)
             restored = Agent.from_checkpoint(cfg)
             assert restored._kickoff_event_id == "evt-456"
+
+
+class _FinalAnswerLLM(BaseLLM):
+    """Stub LLM that always returns a final answer without any API calls."""
+
+    def __init__(self) -> None:
+        super().__init__(model="stub")
+
+    def call(
+        self,
+        messages,
+        tools=None,
+        callbacks=None,
+        available_functions=None,
+        from_task=None,
+        from_agent=None,
+        response_model=None,
+    ):
+        return "Final Answer: done."
+
+    def supports_function_calling(self) -> bool:
+        return False
+
+    def supports_stop_words(self) -> bool:
+        return False
+
+    def get_context_window_size(self) -> int:
+        return 4096
+
+    async def acall(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class TestCheckpointReusedExecutor:
+    """Checkpoint serialization stamps every live Flow's completed methods.
+
+    The agent executor is a Flow reused across a crew's tasks, so the stamp
+    must not be read back as a restore signal on the next task — otherwise the
+    second task replays as a resume and never reaches a final answer.
+    """
+
+    def test_second_task_runs_with_checkpointing_enabled(self) -> None:
+        agent = Agent(role="r", goal="g", backstory="b", llm=_FinalAnswerLLM())
+        task1 = Task(description="first", expected_output="x", agent=agent)
+        task2 = Task(description="second", expected_output="y", agent=agent)
+        with tempfile.TemporaryDirectory() as d:
+            crew = Crew(
+                agents=[agent],
+                tasks=[task1, task2],
+                verbose=False,
+                checkpoint=CheckpointConfig(
+                    provider=JsonProvider(location=d),
+                    on_events=["task_started", "task_completed"],
+                ),
+            )
+            result = crew.kickoff()
+
+        assert len(result.tasks_output) == 2
+        assert result.tasks_output[1].raw


### PR DESCRIPTION
## Problem

A crew with checkpointing enabled and one agent running ≥2 sequential tasks fails on the second task:

```
RuntimeError: Agent execution ended without reaching a final answer.
```

## Root cause

`AgentExecutor` is a `Flow`, reused across a crew's tasks. Checkpoint serialization (`_sync_checkpoint_fields`) stamps `checkpoint_completed_methods` onto every live `Flow` in `RuntimeState.root` — including that executor, mid-run. On the next task, `kickoff_async` read `checkpoint_completed_methods is not None` as a "resume from a checkpoint file" signal, so task 2 replayed task 1's completed methods instead of running fresh, and never produced an `AgentFinish`.

## Why it surfaced now

Three independently-fine layers had to line up:

1. **1.14.2** — `is_restoring` started reading `checkpoint_completed_methods` (latent).
2. **1.14.5** — the Flow-based `AgentExecutor` became the default executor (precondition).
3. **1.14.7 dev (`1357491f0`, conversational flows #5896)** — `FlowStartedEvent` stopped being gated by `suppress_flow_events` so tracing works for all flows. The executor sets `suppress_flow_events = True`, which previously kept it out of the entity registry; once its `flow_started` always fired, it began registering into the checkpointed `RuntimeState.root`, where the serializer poisoned its restore flag. **This is the trigger** — every released version through 1.14.6 kept those events suppressed.

Bisected with a deterministic stub-LLM repro: passes at 1.14.4/1.14.5/1.14.6, first fails at `1357491f0`.

## Fix

Gate `is_restoring` on a new `_restored_from_checkpoint` flag set **only** by `_restore_from_checkpoint()` (the genuine "loaded from a checkpoint file" path), consumed single-shot. An in-place snapshot of a running flow no longer masquerades as a restore. The `@persist` clause and the conversational-flows tracing behavior are untouched.

## Tests

- Added `TestCheckpointReusedExecutor` (checkpoint on + one agent + two tasks, stub LLM): passes with the fix, fails without it.
- Affected flow/checkpoint suites green: 192 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flow kickoff/restore semantics for checkpointed crews; behavior change is intentional and scoped, with a targeted regression test.
> 
> **Overview**
> Fixes a bug where **checkpointing + a reused agent executor** caused the **second sequential task** to fail with “Agent execution ended without reaching a final answer.”
> 
> **What changed:** `kickoff_async` no longer treats populated `checkpoint_completed_methods` (from live snapshot serialization) as a restore. It now uses a **`_restored_from_checkpoint` flag** set only in `_restore_from_checkpoint()` (real checkpoint-file restore), consumed **once per kickoff** so the next run starts fresh.
> 
> **Tests:** Adds `TestCheckpointReusedExecutor` — one agent, two tasks, checkpoint on `task_started`/`task_completed`, stub LLM — to lock in the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b35294d978e7da14816804a4d80b184c0b8073e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint and restore logic to ensure flows correctly handle resumption from saved checkpoints, preventing tasks from being incorrectly skipped when reusing flow executors with checkpointing enabled.

* **Tests**
  * Added regression test validating checkpoint serialization behavior with reused executors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->