### PR TITLE
test(flow): pass show=False in test_flow_plotting to not open a browser

### DIFF
--- a/lib/crewai/tests/test_flow.py
+++ b/lib/crewai/tests/test_flow.py
@@ -1040,7 +1040,7 @@ def test_flow_plotting():
         received_events.append(event)
         event_received.set()
 
-    flow.plot("test_flow")
+    flow.plot("test_flow", show=False)
 
     assert event_received.wait(timeout=5), "Timeout waiting for plot event"
     assert len(received_events) == 1


### PR DESCRIPTION
## Problem

Running the test suite opens a browser tab every time. `test_flow_plotting` calls `flow.plot("test_flow")`, and `Flow.plot(..., show=True)` defaults to opening the rendered HTML via `webbrowser.open` (`flow/visualization/renderers/interactive.py:464`).

## Fix

The test only asserts that `FlowPlotEvent` is emitted — it never inspects the rendered file — so pass `show=False`. `test_flow_visualization.py` already does this.

```diff
-    flow.plot("test_flow")
+    flow.plot("test_flow", show=False)
```

`test_flow.py::test_flow_plotting` still passes, now without launching a browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or runtime behavior is modified.
> 
> **Overview**
> **`test_flow_plotting`** now calls `flow.plot("test_flow", show=False)` instead of relying on the default `show=True`.
> 
> That stops the suite from opening a browser tab on each run while the test still only checks **`FlowPlotEvent`** emission. This matches **`test_flow_visualization.py`**, which already passes `show=False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0e945bc3fb643c70849ff6119ba2fff3d97ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated flow plotting test to prevent displaying plots during automated test execution while maintaining validation of plot event emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->