### PR TITLE
docs: update changelog and version for v1.14.7rc2

### DIFF
--- a/docs/ar/changelog.mdx
+++ b/docs/ar/changelog.mdx
@@ -5,6 +5,25 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="10 يونيو 2026">
+  ## v1.14.7rc2
+
+  [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc2)
+
+  ## ما الذي تغير
+
+  ### إصلاحات الأخطاء
+  - استعادة البوابة على علامة لمنع اللقطات الحية من إعادة التشغيل كاستئناف
+
+  ### الوثائق
+  - تحديث سجل التغييرات والإصدار لـ v1.14.7rc1
+
+  ## المساهمون
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="10 يونيو 2026">
   ## v1.14.7rc1
 
   [عرض الإصدار على GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc1)

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -5,6 +5,25 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="Jun 10, 2026">
+  ## v1.14.7rc2
+
+  [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc2)
+
+  ## What's Changed
+
+  ### Bug Fixes
+  - Gate restore on a flag to prevent live snapshots from replaying as resume
+
+  ### Documentation
+  - Update changelog and version for v1.14.7rc1
+
+  ## Contributors
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="Jun 10, 2026">
   ## v1.14.7rc1
 
   [View release on GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc1)

--- a/docs/ko/changelog.mdx
+++ b/docs/ko/changelog.mdx
@@ -5,6 +5,25 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="2026년 6월 10일">
+  ## v1.14.7rc2
+
+  [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc2)
+
+  ## 변경 사항
+
+  ### 버그 수정
+  - 라이브 스냅샷이 재개로 재생되는 것을 방지하기 위한 플래그에서 게이트 복원
+
+  ### 문서
+  - v1.14.7rc1에 대한 변경 로그 및 버전 업데이트
+
+  ## 기여자
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="2026년 6월 10일">
   ## v1.14.7rc1
 
   [GitHub 릴리스 보기](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc1)

--- a/docs/pt-BR/changelog.mdx
+++ b/docs/pt-BR/changelog.mdx
@@ -5,6 +5,25 @@ icon: "clock"
 mode: "wide"
 ---
 <Update label="10 jun 2026">
+  ## v1.14.7rc2
+
+  [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc2)
+
+  ## O que Mudou
+
+  ### Correções de Bugs
+  - Restauração de portão em uma flag para evitar que snapshots ao vivo sejam reproduzidos como retomar
+
+  ### Documentação
+  - Atualizar changelog e versão para v1.14.7rc1
+
+  ## Contributors
+
+  @greysonlalonde
+
+</Update>
+
+<Update label="10 jun 2026">
   ## v1.14.7rc1
 
   [Ver release no GitHub](https://github.com/crewAIInc/crewAI/releases/tag/1.14.7rc1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog additions across locales; no runtime or application code changes in this diff.
> 
> **Overview**
> Adds a new **v1.14.7rc2** release block at the top of the changelog in **en**, **ar**, **ko**, and **pt-BR**, dated Jun 10, 2026, with a GitHub release link and contributor credit.
> 
> The entry documents one product fix—gating restore behind a flag so live snapshots are not replayed as resume—and a documentation line about changelog/version updates (noting the listed prior version is **v1.14.7rc1** in the diff text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fd9f7491b0355803b1d34636119b5de1840dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published v1.14.7rc2 release notes across all supported language versions

* **Bug Fixes**
  * Fixed an issue where live snapshots were re-running during resume operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->