### PR TITLE
fix(checkpoint): rebuild custom BaseLLM as concrete LLM on restore

### DIFF
--- a/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
+++ b/lib/crewai/src/crewai/agents/agent_builder/base_agent.py
@@ -82,6 +82,7 @@ _LLM_TYPE_REGISTRY: dict[str, str] = {
 def _validate_llm_ref(value: Any) -> Any:
     if isinstance(value, dict):
         import importlib
+        import inspect
 
         llm_type = value.get("llm_type")
         if not llm_type or llm_type not in _LLM_TYPE_REGISTRY:
@@ -92,6 +93,12 @@ def _validate_llm_ref(value: Any) -> Any:
         dotted = _LLM_TYPE_REGISTRY[llm_type]
         mod_path, cls_name = dotted.rsplit(".", 1)
         cls = getattr(importlib.import_module(mod_path), cls_name)
+        if inspect.isabstract(cls):
+            from crewai.llm import LLM
+
+            return LLM(
+                **{k: v for k, v in value.items() if v is not None and k != "llm_type"}
+            )
         return cls(**value)
     return value
 

--- a/lib/crewai/tests/test_checkpoint.py
+++ b/lib/crewai/tests/test_checkpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import sqlite3
@@ -742,3 +743,26 @@ class TestCheckpointReusedExecutor:
 
         assert len(result.tasks_output) == 2
         assert result.tasks_output[1].raw
+
+
+class TestCustomLLMCheckpointRestore:
+    """A custom BaseLLM subclass serializes with the inherited llm_type "base".
+
+    Restoring it must not try to instantiate the abstract BaseLLM; it is rebuilt
+    as a concrete LLM from the saved config instead.
+    """
+
+    def test_restore_does_not_instantiate_abstract_base_llm(self) -> None:
+        agent = Agent(role="r", goal="g", backstory="b", llm=_FinalAnswerLLM())
+        task = Task(description="d", expected_output="e", agent=agent)
+        crew = Crew(agents=[agent], tasks=[task], verbose=False)
+
+        raw = RuntimeState(root=[crew]).model_dump_json()
+        restored = RuntimeState.model_validate_json(
+            raw, context={"from_checkpoint": True}
+        )
+
+        llm = restored.root[0].agents[0].llm
+        assert isinstance(llm, BaseLLM)
+        assert not inspect.isabstract(type(llm))
+        assert llm.model == "stub"


### PR DESCRIPTION
## Problem

Restoring a checkpoint whose agent uses a custom `BaseLLM` subclass crashes:

```
TypeError: Can't instantiate abstract class BaseLLM without an implementation for abstract method 'call'
```

A custom subclass inherits the default `llm_type = "base"`. `_serialize_llm_ref` dumps it with `llm_type: "base"` and records nothing about the concrete class. On restore, `_validate_llm_ref` maps `"base"` → `crewai.llms.base_llm.BaseLLM` via `_LLM_TYPE_REGISTRY` and calls `cls(**value)` — but `BaseLLM` is abstract, so instantiation fails.

The concrete providers (`openai`, `litellm`, …) are unaffected: each sets its own concrete `llm_type` that maps to an instantiable class.

Present since the checkpoint feature landed (`86ce54fc8`); only ever hit on the custom-LLM path.

## Fix

In `_validate_llm_ref`, when the resolved class is abstract, rebuild a concrete `LLM` from the saved config instead of instantiating the abstract base. `None`-valued base fields are dropped since concrete providers reject them (e.g. `stream` must be `bool`). A custom subclass can't be reconstructed exactly (its class/`__init__` aren't recorded), so this is best-effort — restore succeeds and a real model resumes.

## Test

Added `TestCustomLLMCheckpointRestore`: serialize a crew whose agent uses a custom `BaseLLM` subclass, validate it back, assert the restored LLM is concrete (not abstract). 61 checkpoint tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to LLM deserialization on checkpoint restore; only affects `llm_type: "base"` paths and trades exact custom subclass fidelity for successful restore.
> 
> **Overview**
> Fixes **checkpoint restore** when an agent’s LLM is a **custom `BaseLLM` subclass** that serializes with inherited `llm_type: "base"`. Restore no longer calls `BaseLLM(**value)` (which raised *Can't instantiate abstract class*).
> 
> **`_validate_llm_ref`** now checks `inspect.isabstract(cls)` after resolving the registry entry. For abstract `BaseLLM`, it returns a concrete **`LLM`** built from the saved dict, stripping `llm_type` and `None` fields so provider validation still passes. Named providers are unchanged.
> 
> Adds **`TestCustomLLMCheckpointRestore`**: round-trip `RuntimeState` with `_FinalAnswerLLM` and assert the restored LLM is a non-abstract `BaseLLM` with `model == "stub"` (best-effort stand-in, not the original subclass).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4707750147f880aa5fd4097fa18257b4ff4d78d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved LLM class validation to properly distinguish between abstract and concrete LLM implementations, with automatic fallback handling for abstract classes.

* **Tests**
  * Added checkpoint restoration tests for custom LLM subclass implementations to ensure configuration persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->