### PR TITLE
fix(deps): relax litellm extra to resolve install conflict

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -87,7 +87,7 @@ voyageai = [
     "voyageai~=0.3.5",
 ]
 litellm = [
-    "litellm>=1.83.7,<1.84",
+    "litellm>=1.84.0,<2",
 ]
 bedrock = [
     "boto3~=1.42.79",

--- a/lib/crewai/tests/utilities/test_import_utils.py
+++ b/lib/crewai/tests/utilities/test_import_utils.py
@@ -1,6 +1,7 @@
 """Tests for import utilities."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -186,3 +187,10 @@ class TestImportAndValidateDefinition:
         with patch.dict(sys.modules, {"mocked_module": mock_module}):
             result = import_and_validate_definition("mocked_module.MockClass")
             assert result == mock_class
+
+
+def test_litellm_extra_allows_compatible_versions():
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    pyproject_content = pyproject_path.read_text(encoding="utf-8")
+
+    assert 'litellm>=1.84.0,<2' in pyproject_content

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-06T00:11:14.404922Z"
+exclude-newer = "2026-06-08T13:58:27.1559679Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -1421,7 +1421,7 @@ requires-dist = [
     { name = "json5", specifier = "~=0.10.0" },
     { name = "jsonref", specifier = "~=1.1.0" },
     { name = "lancedb", specifier = ">=0.29.2,<0.30.1" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.83.7,<1.84" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<2" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
     { name = "openai", specifier = ">=2.30.0,<3" },
@@ -4066,7 +4066,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4082,9 +4082,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/8c/6cfce5d15554e076b8438a955436e9e6e2a2bd39c76539656c1c3861c369/litellm-1.88.0.tar.gz", hash = "sha256:4ff794493e40bd86c6f13e91dcb3e1aad697403fd46a96902196d93356ba48f4", size = 13886026, upload-time = "2026-06-06T23:25:17.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/da/71/deb6637475253b83eb4577c058863eec4b4ddaef2d08dcd93981b1aa4209/litellm-1.88.0-py3-none-any.whl", hash = "sha256:abd3037e0bf5703f833f5565c87bdfd93578d3de46cbcb36dfa108c3ef58021c", size = 15276203, upload-time = "2026-06-06T23:25:07.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Relax the crewai[litellm] extra so clean installs resolve again with current CrewAI dependency bounds.
- Update the lockfile to the compatible LiteLLM release selected by the resolver.
- Add a regression test that locks the allowed litellm range in lib/crewai/pyproject.toml.

## Verification
- uv lock --check
- uv run pytest -q lib/crewai/tests/utilities/test_import_utils.py
- uv pip check (reported pre-existing unrelated incompatibilities in the workspace; no new conflicts from this change)

## Related issue
- Fixes #6089


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated litellm dependency version constraints to enable compatibility with newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->