### PR TITLE
docs: add Respan observability integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -342,6 +342,7 @@
                       "en/observability/opik",
                       "en/observability/patronus-evaluation",
                       "en/observability/portkey",
+                      "en/observability/respan",
                       "en/observability/weave",
                       "en/observability/truefoundry"
                     ]

--- a/docs/en/observability/overview.mdx
+++ b/docs/en/observability/overview.mdx
@@ -58,6 +58,10 @@ Observability is crucial for understanding how your CrewAI agents perform, ident
   <Card title="Weave" icon="network-wired" href="/en/observability/weave">
     Weights & Biases platform for tracking and evaluating AI applications.
   </Card>
+
+  <Card title="Respan" icon="chart-line" href="/en/observability/respan">
+    Trace CrewAI workflows and optionally route LLM calls through the Respan gateway.
+  </Card>
 </CardGroup>
 
 ### Evaluation & Quality Assurance

--- a/docs/en/observability/respan.mdx
+++ b/docs/en/observability/respan.mdx
@@ -1,0 +1,187 @@
+---
+title: Respan Integration
+description: Trace CrewAI crews with Respan and optionally route LLM calls through the Respan gateway.
+icon: chart-line
+mode: "wide"
+---
+
+# Respan Overview
+
+[Respan](https://platform.respan.ai) gives you tracing, monitoring, and model gateway access for CrewAI applications. The `respan-instrumentation-crewai` package activates the OpenInference CrewAI instrumentor and exports CrewAI crew, agent, task, tool, and LLM spans to Respan.
+
+Use Respan when you want to:
+
+- Trace agent execution, task timelines, tool calls, and LLM calls
+- Monitor latency, token usage, costs, errors, and user metadata
+- Group spans by customer, thread, environment, or custom metadata
+- Optionally route CrewAI LLM calls through the Respan gateway
+
+## Setup Instructions
+
+<Steps>
+  <Step title="Install required packages">
+    ```bash
+    pip install crewai respan-ai respan-instrumentation-crewai
+    ```
+  </Step>
+
+  <Step title="Set environment variables">
+    Create a Respan API key in the [Respan dashboard](https://platform.respan.ai/platform/api/api-keys), then set it in your environment.
+
+    ```bash
+    export RESPAN_API_KEY="YOUR_RESPAN_API_KEY"
+    export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
+    ```
+
+    `RESPAN_API_KEY` exports traces to Respan. `OPENAI_API_KEY` is used by CrewAI for LLM requests when you call the model provider directly.
+  </Step>
+
+  <Step title="Initialize Respan before importing CrewAI">
+    Initialize Respan at the start of your application, before importing `crewai`, so the instrumentor can patch CrewAI early.
+
+    ```python
+    import os
+
+    from respan import Respan
+    from respan_instrumentation_crewai import CrewAIInstrumentor
+
+    respan = Respan(
+        api_key=os.environ["RESPAN_API_KEY"],
+        instrumentations=[CrewAIInstrumentor()],
+    )
+
+    from crewai import Agent, Crew, Process, Task
+
+    researcher = Agent(
+        role="Research Analyst",
+        goal="Research the latest developments in AI agent frameworks",
+        backstory="You are an expert researcher focused on practical AI systems.",
+    )
+
+    writer = Agent(
+        role="Technical Writer",
+        goal="Turn research notes into a concise summary",
+        backstory="You explain complex AI topics clearly and accurately.",
+    )
+
+    research_task = Task(
+        description="Research current trends in AI agent frameworks.",
+        expected_output="A short list of important trends and examples.",
+        agent=researcher,
+    )
+
+    writing_task = Task(
+        description="Write a concise report based on the research.",
+        expected_output="A readable report in markdown format.",
+        agent=writer,
+    )
+
+    crew = Crew(
+        agents=[researcher, writer],
+        tasks=[research_task, writing_task],
+        process=Process.sequential,
+    )
+
+    result = crew.kickoff()
+    print(result)
+
+    respan.flush()
+    ```
+  </Step>
+
+  <Step title="View traces in Respan">
+    Open the [Respan Traces page](https://platform.respan.ai/platform/traces) to inspect your CrewAI run. You should see spans for crew execution, agent work, task execution, tool usage, and LLM calls.
+  </Step>
+</Steps>
+
+## Route LLM Calls Through Respan Gateway
+
+You can also send CrewAI's OpenAI-compatible LLM traffic through the Respan gateway. This lets you use the same Respan API key for LLM routing and tracing.
+
+```python
+import os
+
+from respan import Respan
+from respan_instrumentation_crewai import CrewAIInstrumentor
+
+respan_api_key = os.environ["RESPAN_API_KEY"]
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
+
+os.environ["OPENAI_API_KEY"] = respan_api_key
+os.environ["OPENAI_BASE_URL"] = respan_base_url
+
+respan = Respan(
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+    instrumentations=[CrewAIInstrumentor()],
+)
+
+from crewai import Agent, Crew, LLM, Task
+
+llm = LLM(
+    model="gpt-4o-mini",
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+)
+
+researcher = Agent(
+    role="Researcher",
+    goal="Research practical uses for AI agent frameworks",
+    backstory="You are an experienced AI researcher.",
+    llm=llm,
+)
+
+task = Task(
+    description="Research practical uses for AI agent frameworks.",
+    expected_output="A concise summary with examples.",
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+print(result)
+
+respan.flush()
+```
+
+To switch models, change the `model` value on the CrewAI `LLM` instance and keep the same Respan gateway configuration.
+
+## Add User and Request Metadata
+
+Attach default metadata when you initialize Respan, or use `propagate_attributes` to set request-specific values around a crew run.
+
+```python
+from respan import Respan, propagate_attributes
+from respan_instrumentation_crewai import CrewAIInstrumentor
+
+respan = Respan(
+    instrumentations=[CrewAIInstrumentor()],
+    customer_identifier="user_123",
+    metadata={"service": "crew-research", "environment": "production"},
+)
+
+with propagate_attributes(
+    customer_identifier="user_456",
+    thread_identifier="research-thread-001",
+    metadata={"plan": "pro"},
+):
+    result = crew.kickoff()
+```
+
+These attributes help you filter traces, group conversations, and analyze usage by user or deployment environment.
+
+## Configuration
+
+| Setting | Description |
+| --- | --- |
+| `RESPAN_API_KEY` | Required. Authenticates trace export and gateway requests. |
+| `RESPAN_BASE_URL` | Optional. Defaults to `https://api.respan.ai/api`. |
+| `CrewAIInstrumentor(use_event_listener=True)` | Uses CrewAI's event listener instrumentation. Enabled by default. |
+| `CrewAIInstrumentor(create_llm_spans=True)` | Creates spans for underlying LLM calls. Enabled by default. |
+
+## Resources
+
+- [Respan dashboard](https://platform.respan.ai)
+- [Respan CrewAI tracing docs](https://www.respan.ai/docs/integrations/crewai)
+- [Respan CrewAI gateway docs](https://www.respan.ai/docs/integrations/gateway/crew-ai)
+- [Respan CrewAI examples](https://github.com/respanai/respan-example-projects/tree/main/python/tracing/crewai)


### PR DESCRIPTION
docs: add Respan observability integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive documentation for Respan integration, enabling users to trace CrewAI workflows and optionally route LLM calls through the Respan gateway. Includes installation steps, environment configuration, setup instructions, and metadata attachment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->