### PR TITLE
fix(llm): support wider anthropic model name prefixes

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -455,7 +455,8 @@ class LLM(BaseLLM):
 
         if provider == "anthropic" or provider == "claude":
             return any(
-                model_lower.startswith(prefix) for prefix in ["claude-", "anthropic."]
+                model_lower.startswith(prefix)
+                for prefix in ["claude-", "anthropic.", "anthropic--"]
             )
 
         if provider == "gemini" or provider == "google":
@@ -564,6 +565,17 @@ class LLM(BaseLLM):
 
         if model in AZURE_MODELS:
             return "azure"
+
+        # Fallback: infer provider from known name prefixes embedded in the model
+        # string.  Self-hosted or proxy deployments often encode the provider in
+        # the model name itself (e.g. "anthropic--claude-3.5-sonnet").
+        model_lower = model.lower()
+        if model_lower.startswith(("anthropic", "claude")):
+            return "anthropic"
+        if model_lower.startswith(("gemini", "gemma")):
+            return "gemini"
+        if model_lower.startswith(("gpt-", "o1", "o3", "o4")):
+            return "openai"
 
         return "openai"
 

--- a/lib/crewai/tests/test_model_prefix_matching.py
+++ b/lib/crewai/tests/test_model_prefix_matching.py
@@ -1,0 +1,54 @@
+"""Regression tests for provider prefix matching (issue #5893).
+
+Validates that self-hosted or proxy models with non-standard provider
+name conventions (e.g. "anthropic--claude-...") are correctly routed.
+"""
+
+from crewai.llm import LLM
+
+
+class TestMatchesProviderPattern:
+    """Test LLM._matches_provider_pattern for anthropic provider."""
+
+    def test_accepts_anthropic_double_dash_prefix(self):
+        """Models like 'anthropic--claude-3.5-sonnet' should match anthropic."""
+        assert LLM._matches_provider_pattern("anthropic--claude-3.5-sonnet", "anthropic") is True
+
+    def test_accepts_anthropic_dot_prefix(self):
+        """Models like 'anthropic.claude-3.5-sonnet' should still match."""
+        assert LLM._matches_provider_pattern("anthropic.claude-3.5-sonnet", "anthropic") is True
+
+    def test_accepts_claude_dash_prefix(self):
+        """Models like 'claude-3.5-sonnet' should still match."""
+        assert LLM._matches_provider_pattern("claude-3.5-sonnet", "anthropic") is True
+
+    def test_rejects_unrelated_model(self):
+        """Models with unrelated names should not match anthropic."""
+        assert LLM._matches_provider_pattern("gpt-4o", "anthropic") is False
+
+    def test_case_insensitive(self):
+        """Prefix matching should be case-insensitive."""
+        assert LLM._matches_provider_pattern("ANTHROPIC--CLAUDE-3.5", "anthropic") is True
+
+
+class TestInferProviderFromModel:
+    """Test LLM._infer_provider_from_model fallback logic."""
+
+    def test_anthropic_double_dash_infers_anthropic(self):
+        assert LLM._infer_provider_from_model("anthropic--claude-3.5-sonnet") == "anthropic"
+
+    def test_claude_prefix_infers_anthropic(self):
+        assert LLM._infer_provider_from_model("claude-3.5-sonnet") == "anthropic"
+
+    def test_gemini_prefix_infers_gemini(self):
+        assert LLM._infer_provider_from_model("gemini-pro") == "gemini"
+
+    def test_gpt_prefix_infers_openai(self):
+        assert LLM._infer_provider_from_model("gpt-4o") == "openai"
+
+    def test_unknown_defaults_to_openai(self):
+        assert LLM._infer_provider_from_model("some-custom-model") == "openai"
+
+    def test_anthropic_slash_prefix_infers_anthropic(self):
+        """Standard 'anthropic/' prefix also triggers anthropic inference."""
+        assert LLM._infer_provider_from_model("anthropic/claude-3.5-sonnet") == "anthropic"


### PR DESCRIPTION
## Summary
- Expand _matches_provider_pattern to accept nthropic-- prefix for anthropic provider matching.
- Add provider-name prefix fallback in _infer_provider_from_model so self-hosted models like nthropic--claude-3.5-sonnet are correctly routed without requiring a / separator.
- Add regression tests for both methods covering double-dash, dot, and standard prefix variants.

## Verification
- uv run pytest -q lib/crewai/tests/test_model_prefix_matching.py (11 passed)
- uv run ruff check lib/crewai/src/crewai/llm.py lib/crewai/tests/test_model_prefix_matching.py (all checks passed)

## Related issue
- Fixes #5893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced model provider detection to recognize additional naming patterns for Anthropic, Gemini, and OpenAI models. Improved fallback logic now infers the correct provider from model name prefixes instead of defaulting to a single provider.

* **Tests**
  * Added comprehensive test coverage for provider inference logic with various model naming conventions and separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->