### PR TITLE
fix(bedrock): fold streaming tool input deltas back into tool args (#6149)

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -50,6 +50,26 @@ except ImportError:
 STRUCTURED_OUTPUT_TOOL_NAME = "structured_output"
 
 
+def _parse_streaming_tool_input(
+    accumulated: str, fallback: dict[str, Any]
+) -> dict[str, Any]:
+    """Resolve the final tool-call arguments from a Bedrock Converse stream.
+
+    Converse streams deliver `toolUse.input` as a sequence of partial JSON
+    strings on `contentBlockDelta`. The caller accumulates those into
+    ``accumulated`` and we parse it here at ``contentBlockStop``. When no
+    deltas arrived (some providers send the full input on the start block)
+    we fall back to the dict already attached to the tool-use block.
+    """
+    if accumulated:
+        try:
+            parsed = json.loads(accumulated)
+        except json.JSONDecodeError:
+            return fallback or {}
+        return parsed if isinstance(parsed, dict) else fallback or {}
+    return fallback or {}
+
+
 def _preprocess_structured_data(
     data: dict[str, Any], response_model: type[BaseModel]
 ) -> dict[str, Any]:
@@ -1034,8 +1054,14 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
-                            function_args = cast(
-                                dict[str, Any], current_tool_use.get("input", {})
+                            # Streaming Converse delivers tool input as JSON
+                            # deltas in `accumulated_tool_input`; the start
+                            # event's `input` field is empty, so a direct
+                            # read of `current_tool_use["input"]` returned
+                            # {} for the entire stream (#6149).
+                            function_args = _parse_streaming_tool_input(
+                                accumulated_tool_input,
+                                cast(dict[str, Any], current_tool_use.get("input", {})),
                             )
 
                             # Check if this is the structured_output tool
@@ -1632,8 +1658,14 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
-                            function_args = cast(
-                                dict[str, Any], current_tool_use.get("input", {})
+                            # Streaming Converse delivers tool input as JSON
+                            # deltas in `accumulated_tool_input`; the start
+                            # event's `input` field is empty, so a direct
+                            # read of `current_tool_use["input"]` returned
+                            # {} for the entire stream (#6149).
+                            function_args = _parse_streaming_tool_input(
+                                accumulated_tool_input,
+                                cast(dict[str, Any], current_tool_use.get("input", {})),
                             )
 
                             # Check if this is the structured_output tool

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -1185,3 +1185,68 @@ def test_bedrock_no_cache_tokens_defaults_to_zero():
 
         llm.call("Hello")
         assert llm._token_usage['cached_prompt_tokens'] == 0
+
+
+def _make_streaming_tool_use_events(tool_use_id, tool_name, input_chunks):
+    yield {
+        "contentBlockStart": {
+            "start": {
+                "toolUse": {
+                    "toolUseId": tool_use_id,
+                    "name": tool_name,
+                }
+            }
+        }
+    }
+    for chunk in input_chunks:
+        yield {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"input": chunk}}
+            }
+        }
+    yield {"contentBlockStop": {}}
+    yield {"messageStop": {"stopReason": "tool_use"}}
+
+
+def test_streaming_tool_call_accumulates_input_deltas(bedrock_mocks):
+    """Regression for #6149: streaming Converse must fold tool input deltas
+    back into the tool-call arguments instead of returning {}."""
+    _, mock_client = bedrock_mocks
+    mock_client.converse_stream.return_value = {
+        "stream": _make_streaming_tool_use_events(
+            tool_use_id="tu_test",
+            tool_name="get_weather",
+            input_chunks=['{"city":', ' "Paris"}'],
+        )
+    }
+
+    captured_args = {}
+
+    def get_weather(city: str) -> str:
+        captured_args["city"] = city
+        return f"Sunny in {city}"
+
+    llm = LLM(
+        model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        stream=True,
+    )
+    llm.call(
+        "What's the weather in Paris?",
+        available_functions={"get_weather": get_weather},
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+    )
+
+    assert captured_args == {"city": "Paris"}


### PR DESCRIPTION
Closes #6149. Streaming twin of #4972 (non-streaming case already fixed by #5415).

`_handle_streaming_converse` and `_ahandle_streaming_converse` accumulate Bedrock Converse's `contentBlockDelta` JSON chunks into a local `accumulated_tool_input` string but never fold that string back into `current_tool_use["input"]`. At `contentBlockStop` the code reads `current_tool_use.get("input", {})`, which the start event left as the empty dict, so every streaming tool call reaches `_handle_tool_execution` with `{}` and pydantic raises `Field required [type=missing]`.

The fix is a focused parse-on-stop, shared between the sync and async paths:

- new module-level `_parse_streaming_tool_input(accumulated, fallback)` that returns `json.loads(accumulated)` when deltas arrived, falls back to the start-block's `input` dict otherwise (some providers send the full input up front), and degrades to `{}` on `JSONDecodeError` so a malformed partial doesn't crash the stream
- both `contentBlockStop` branches now call the helper instead of reading `current_tool_use["input"]` directly

`current_tool_use["input"]` is intentionally left untouched in the dict that's later re-appended to `messages` (`{"toolUse": current_tool_use}`) — the assistant turn echoed back to the model uses Bedrock's own start-block payload, not the parsed args, and changing that shape is out of scope here.

## Regression test

`lib/crewai/tests/llms/bedrock/test_bedrock.py::test_streaming_tool_call_accumulates_input_deltas`:

- Builds a synthetic Converse stream — `contentBlockStart(toolUse) → contentBlockDelta('{"city":') → contentBlockDelta(' "Paris"}') → contentBlockStop → messageStop` — exactly the shape the issue describes.
- Stubs an `available_functions["get_weather"]` that records its `city` arg.
- Asserts the captured arg is `{"city": "Paris"}`.

Verified locally — fails against `main` with `AssertionError: {} == {'city': 'Paris'}` and the `WARNING ... Bedrock streaming returned empty content` log; passes with the fix.

No async regression test added: the existing `test_bedrock_async.py` cases are all skipped in CI (VCR doesn't play back aiobotocore), and the parsing logic is shared with the sync path through `_parse_streaming_tool_input`, so the sync test exercises the relevant code in both call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tool call argument reconstruction in Bedrock Converse streaming to properly accumulate fragmented inputs into complete function arguments instead of returning incomplete or empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->