### PR TITLE
fix: don't require inputs when a string has braces but no template variables

### DIFF
--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -127,12 +127,20 @@ def interpolate_only(
         return ""
     if "{" not in input_string and "}" not in input_string:
         return input_string
+
+    variables = _VARIABLE_PATTERN.findall(input_string)
+
+    # Braces can appear without any actual {template} variables (e.g. a JSON
+    # payload). There is nothing to interpolate in that case, so return the
+    # string untouched instead of requiring a non-empty inputs dictionary.
+    if not variables:
+        return input_string
+
     if not inputs:
         raise ValueError(
             "Inputs dictionary cannot be empty when interpolating variables"
         )
 
-    variables = _VARIABLE_PATTERN.findall(input_string)
     result = input_string
 
     missing_vars = [var for var in variables if var not in inputs]

--- a/lib/crewai/tests/utilities/test_string_utils.py
+++ b/lib/crewai/tests/utilities/test_string_utils.py
@@ -184,3 +184,14 @@ class TestInterpolateOnly:
             interpolate_only(template, inputs)
 
         assert "inputs dictionary cannot be empty" in str(excinfo.value).lower()
+
+    def test_braces_without_variables_and_empty_inputs(self):
+        """A string with braces but no {template} variables (e.g. JSON) should be
+        returned untouched even when inputs is empty, rather than raising."""
+        json_string = '{"name": "John", "nested": {"v": 1}}'
+        assert interpolate_only(json_string, {}) == json_string
+        # Non-matching brace patterns are not variables either.
+        assert (
+            interpolate_only("This {123} and {!bad} stay", {})
+            == "This {123} and {!bad} stay"
+        )


### PR DESCRIPTION
### Summary
`interpolate_only` (`crewai.utilities.string_utils`) raised `ValueError: Inputs dictionary cannot be empty when interpolating variables` whenever the input string contained a brace — **before** checking whether any actual `{template}` variables were present.

As a result, a brace-containing string with **no** template variables (e.g. a JSON payload, or non-matching braces like `{123}`) raised when called with empty `inputs`, even though there was nothing to interpolate. This contradicts the function's documented behavior ("Interpolate placeholders … while leaving JSON untouched") and the existing `test_no_variables_in_template` / `test_preserves_non_matching_braces` cases (which only pass because they happen to use non-empty `inputs`).

### Reproduction
```python
from crewai.utilities.string_utils import interpolate_only

interpolate_only('{"name": "John"}', {})
# ValueError: Inputs dictionary cannot be empty when interpolating variables
```

### Fix
Extract the template variables first; if there are none, return the string unchanged. Only require a non-empty `inputs` dict when there is actually something to interpolate. The empty-inputs error is preserved for the real case (a string that *does* contain `{variables}`).

### Testing
- Added `test_braces_without_variables_and_empty_inputs`. Verified it **fails before** this change (raises) and **passes after**.
- `uv run pytest tests/utilities/test_string_utils.py` → **13 passed** (incl. the existing `test_empty_inputs_dictionary`, which still raises for a string with a real variable).
- `ruff check` and `ruff format --check` clean on the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * String interpolation now correctly distinguishes between template variables and non-template braces (e.g., JSON payloads), preventing unnecessary errors when processing strings containing braces without corresponding inputs.

* **Tests**
  * Added test coverage to verify correct handling of non-template brace patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->