### PR TITLE
fix(memory): handle timezone-aware created_at in compute_composite_score

### DIFF
--- a/lib/crewai/src/crewai/memory/types.py
+++ b/lib/crewai/src/crewai/memory/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -361,7 +361,15 @@ def compute_composite_score(
         Tuple of (composite_score, match_reasons). match_reasons includes
         "semantic" always; "recency" if decay > 0.5; "importance" if record.importance > 0.5.
     """
-    age_seconds = (datetime.utcnow() - record.created_at).total_seconds()
+    # Use a timezone-aware "now" and treat a naive created_at as UTC, so the
+    # subtraction works whether created_at was set by the (naive) default
+    # factory or supplied as a timezone-aware datetime. Subtracting a naive
+    # from an aware datetime (or vice versa) raises TypeError.
+    now = datetime.now(timezone.utc)
+    created_at = record.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    age_seconds = (now - created_at).total_seconds()
     age_days = max(age_seconds / 86400.0, 0.0)
     decay = 0.5 ** (age_days / config.recency_half_life_days)
 

--- a/lib/crewai/tests/memory/test_types.py
+++ b/lib/crewai/tests/memory/test_types.py
@@ -1,0 +1,36 @@
+"""Tests for crewai.memory.types scoring helpers."""
+
+from datetime import datetime, timezone
+
+from crewai.memory.types import (
+    MemoryConfig,
+    MemoryRecord,
+    compute_composite_score,
+)
+
+
+def test_compute_composite_score_with_timezone_aware_created_at():
+    """A timezone-aware created_at must not crash.
+
+    Previously the age was computed as `datetime.utcnow() - record.created_at`;
+    subtracting an aware datetime from a naive one raises TypeError.
+    """
+    record = MemoryRecord(content="hello", created_at=datetime.now(timezone.utc))
+
+    score, reasons = compute_composite_score(
+        record, semantic_score=0.8, config=MemoryConfig()
+    )
+
+    assert 0.0 <= score <= 1.0
+    assert "semantic" in reasons
+
+
+def test_compute_composite_score_with_naive_created_at():
+    """A naive created_at (the default factory) still works."""
+    record = MemoryRecord(content="hello", created_at=datetime(2020, 1, 1))
+
+    score, _reasons = compute_composite_score(
+        record, semantic_score=0.5, config=MemoryConfig()
+    )
+
+    assert 0.0 <= score <= 1.0


### PR DESCRIPTION
### Summary
`compute_composite_score` (`crewai.memory.types`) computed the recency age as:

```python
age_seconds = (datetime.utcnow() - record.created_at).total_seconds()
```

`datetime.utcnow()` returns a **naive** datetime. When a `MemoryRecord` is created with a **timezone-aware** `created_at` — e.g. `datetime.now(timezone.utc)`, the modern/recommended idiom — this subtraction raises:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

### Reproduction
```python
from datetime import datetime, timezone
from crewai.memory.types import MemoryRecord, MemoryConfig, compute_composite_score

record = MemoryRecord(content="hi", created_at=datetime.now(timezone.utc))
compute_composite_score(record, semantic_score=0.8, config=MemoryConfig())
# TypeError: can't subtract offset-naive and offset-aware datetimes
```

### Fix
Use a timezone-aware `now` and treat a naive `created_at` as UTC before subtracting, so both the (naive) default-factory value and aware values work. This also removes the deprecated `datetime.utcnow()` call from the scoring path (`utcnow()` is deprecated as of Python 3.12).

> Scoped to the crash. The `created_at`/`last_accessed` default factories still use `datetime.utcnow` (changing those would flip the default to aware and alter serialization) — happy to follow up on the broader `utcnow()` deprecation sweep separately if desired.

### Testing
- Added `tests/memory/test_types.py` covering aware and naive `created_at`. The aware case **fails before** this change (`TypeError`) and **passes after**.
- `uv run pytest tests/memory/test_types.py` → **2 passed**.
- `ruff check` / `ruff format --check` clean on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone handling in memory age calculations to prevent errors when processing different datetime formats.

* **Tests**
  * Added test coverage for memory scoring with various timezone configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->