### PR TITLE
refactor(tools): drop dead repair_json call in _validate_tool_input

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -875,7 +875,7 @@ class ToolUsage:
             if isinstance(arguments, dict):
                 return arguments
         except (ValueError, SyntaxError):
-            repaired_input = repair_json(tool_input)
+            pass
 
         try:
             arguments = json5.loads(tool_input)


### PR DESCRIPTION
### Summary
In `ToolUsage._validate_tool_input`, the `ast.literal_eval` failure branch did:

```python
try:
    arguments = ast.literal_eval(tool_input)
    if isinstance(arguments, dict):
        return arguments
except (ValueError, SyntaxError):
    repaired_input = repair_json(tool_input)   # assigned, never used
```

`repaired_input` is never read here — it is unconditionally **reassigned** a few lines later, where the actual repair is performed:

```python
try:
    repaired_input = str(repair_json(tool_input, skip_json_loads=True))
    ...
    arguments = json.loads(repaired_input)
```

So the first `repair_json(tool_input)` call is a dead store that does redundant work and never affects the result.

### Change
Replace the dead assignment with `pass`, matching the other `except` branches in the same function. **No behavior change** — the repair still happens via the existing `json.loads`/`repair_json` fallback.

### Testing
- `uv run pytest tests/tools/test_tool_usage.py -k validate_tool_input` → **15 passed** (incl. `test_validate_tool_input_invalid_json_repairable`, which exercises the repair path).
- `ruff check` / `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tool input validation to streamline parsing and improve consistency in handling various input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->