### PR TITLE
fix(llm): make set_callbacks thread-safe for concurrent crews

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import json
 import logging
 import os
+import threading
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -77,6 +78,12 @@ logger = logging.getLogger(__name__)
 # stay None until _ensure_litellm() rebinds them.
 _litellm_loaded = False
 LITELLM_AVAILABLE = False
+
+# litellm's success/failure callback lists are process-global mutable state.
+# Concurrent crews (e.g. multiple kickoff_async() dispatched to threads) all
+# mutate them during setup, so guard every read-modify-write with a lock to
+# avoid races such as `ValueError: list.remove(x): x not in list`.
+_CALLBACK_LOCK = threading.Lock()
 
 if TYPE_CHECKING:
     import litellm
@@ -2442,15 +2449,22 @@ class LLM(BaseLLM):
             # but not registered with litellm globals
             return
 
-        with suppress_warnings():
+        with suppress_warnings(), _CALLBACK_LOCK:
             callback_types = [type(callback) for callback in callbacks]
-            for callback in litellm.success_callback[:]:
-                if type(callback) in callback_types:
-                    litellm.success_callback.remove(callback)
-
-            for callback in litellm._async_success_callback[:]:
-                if type(callback) in callback_types:
-                    litellm._async_success_callback.remove(callback)
+            # Filter via slice assignment instead of .remove(): it mutates the
+            # existing global list in place (litellm keeps a reference to it),
+            # is atomic under the GIL, and can never raise ValueError if another
+            # thread already removed the entry.
+            litellm.success_callback[:] = [
+                callback
+                for callback in litellm.success_callback
+                if type(callback) not in callback_types
+            ]
+            litellm._async_success_callback[:] = [
+                callback
+                for callback in litellm._async_success_callback
+                if type(callback) not in callback_types
+            ]
 
             litellm.callbacks = callbacks
 
@@ -2480,7 +2494,7 @@ class LLM(BaseLLM):
             # When litellm is not available, env callbacks have no effect
             return
 
-        with suppress_warnings():
+        with suppress_warnings(), _CALLBACK_LOCK:
             success_callbacks_str = os.environ.get("LITELLM_SUCCESS_CALLBACKS", "")
             success_callbacks: list[str | Callable[..., Any]] = []
             if success_callbacks_str:

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import sys
+import threading
 from time import sleep
 from unittest.mock import MagicMock, patch
 
@@ -1177,3 +1179,57 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+def test_set_callbacks_is_thread_safe():
+    """Regression test for concurrent set_callbacks (discussion #2939).
+
+    Multiple crews launched via ``kickoff_async()`` end up running
+    ``LLM.set_callbacks`` from different threads. Because it mutated litellm's
+    process-global ``success_callback`` list with ``list.remove`` it could race
+    and raise ``ValueError: list.remove(x): x not in list``. This hammers the
+    method from many threads and asserts it never raises.
+    """
+    from crewai import llm as llm_module
+
+    if not llm_module._ensure_litellm():
+        pytest.skip("litellm not available")
+
+    litellm = llm_module.litellm
+
+    n_threads = 24
+    errors: list[BaseException] = []
+    start = threading.Barrier(n_threads)
+
+    def worker() -> None:
+        start.wait()  # release all threads together to maximise contention
+        try:
+            for _ in range(150):
+                # Register a SINGLE-copy callback of the filtered type, then call
+                # set_callbacks. Many threads now race to remove each other's
+                # single entry: the old list.remove() implementation raises
+                # `ValueError: list.remove(x): x not in list` when another thread
+                # removed it first. The fixed slice-assignment cannot.
+                cb = TokenCalcHandler(token_cost_process=TokenProcess())
+                litellm.success_callback.append(cb)
+                litellm._async_success_callback.append(cb)
+                LLM.set_callbacks(
+                    [TokenCalcHandler(token_cost_process=TokenProcess())]
+                )
+        except BaseException as exc:  # noqa: BLE001 - capture for assertion
+            errors.append(exc)
+
+    # Force frequent thread switches so the read-modify-write window in the old
+    # implementation is actually interleaved rather than completed in one slice.
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    assert not errors, f"set_callbacks raced under concurrency: {errors[:3]}"


### PR DESCRIPTION
## What

Make `LLM.set_callbacks` (and `set_env_callbacks`) thread-safe so concurrent crews don't crash during setup.

## Why

When several crews are launched with `kickoff_async()` and `asyncio.gather()`, each ends up in `asyncio.to_thread()`, so `kickoff()` runs on real OS threads concurrently. During LLM setup they all mutate litellm's **process-global** `success_callback` / `_async_success_callback` lists.

The old code did a read-modify-write with `list.remove()`:

```python
for callback in litellm.success_callback[:]:
    if type(callback) in callback_types:
        litellm.success_callback.remove(callback)
```

Two threads can snapshot the same entry, both call `.remove()`, and the second raises:

```
ValueError: list.remove(x): x not in list
```

Reported in #2939.

## Fix

- Add a module-level `_CALLBACK_LOCK` and guard the critical sections of both `set_callbacks` and `set_env_callbacks`.
- Replace the `.remove()` loop with in-place slice assignment that filters by type. It mutates the same global list object (litellm keeps a reference), is atomic under the GIL, and can never raise `ValueError` even if another thread already removed the entry.

Behaviour is unchanged for the single-threaded path: the same callbacks are removed.

## Test

Added `test_set_callbacks_is_thread_safe`, which hammers `set_callbacks` from 24 threads with a lowered `sys.setswitchinterval` to force interleaving. It **fails on `main`** (raises the `ValueError`) and **passes with this fix**.

```
uv run --package crewai pytest lib/crewai/tests/test_llm.py::test_set_callbacks_is_thread_safe
```

Ruff + strict mypy pass on the changed files.

Fixes #2939

---

Disclosure: this PR was prepared with the help of an AI coding assistant (Claude Code), so it carries the `llm-generated` label as required by `CONTRIBUTING.md`. (If I lack permission to set the label, please add it.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread safety for LLM callback management to prevent race conditions when callbacks are updated concurrently across multiple threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->