### PR TITLE
fix: chunk CSV/JSON knowledge file content, not the dict repr

### DIFF
--- a/lib/crewai/src/crewai/knowledge/source/csv_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/csv_knowledge_source.py
@@ -27,20 +27,16 @@ class CSVKnowledgeSource(BaseFileKnowledgeSource):
         Add CSV file content to the knowledge source, chunk it, compute embeddings,
         and save the embeddings.
         """
-        content_str = (
-            str(self.content) if isinstance(self.content, dict) else self.content
-        )
-        new_chunks = self._chunk_text(content_str)
-        self.chunks.extend(new_chunks)
+        for content in self.content.values():
+            new_chunks = self._chunk_text(content)
+            self.chunks.extend(new_chunks)
         self._save_documents()
 
     async def aadd(self) -> None:
         """Add CSV file content asynchronously."""
-        content_str = (
-            str(self.content) if isinstance(self.content, dict) else self.content
-        )
-        new_chunks = self._chunk_text(content_str)
-        self.chunks.extend(new_chunks)
+        for content in self.content.values():
+            new_chunks = self._chunk_text(content)
+            self.chunks.extend(new_chunks)
         await self._asave_documents()
 
     def _chunk_text(self, text: str) -> list[str]:

--- a/lib/crewai/src/crewai/knowledge/source/json_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/json_knowledge_source.py
@@ -39,20 +39,16 @@ class JSONKnowledgeSource(BaseFileKnowledgeSource):
         Add JSON file content to the knowledge source, chunk it, compute embeddings,
         and save the embeddings.
         """
-        content_str = (
-            str(self.content) if isinstance(self.content, dict) else self.content
-        )
-        new_chunks = self._chunk_text(content_str)
-        self.chunks.extend(new_chunks)
+        for content in self.content.values():
+            new_chunks = self._chunk_text(content)
+            self.chunks.extend(new_chunks)
         self._save_documents()
 
     async def aadd(self) -> None:
         """Add JSON file content asynchronously."""
-        content_str = (
-            str(self.content) if isinstance(self.content, dict) else self.content
-        )
-        new_chunks = self._chunk_text(content_str)
-        self.chunks.extend(new_chunks)
+        for content in self.content.values():
+            new_chunks = self._chunk_text(content)
+            self.chunks.extend(new_chunks)
         await self._asave_documents()
 
     def _chunk_text(self, text: str) -> list[str]:

--- a/lib/crewai/tests/knowledge/test_knowledge.py
+++ b/lib/crewai/tests/knowledge/test_knowledge.py
@@ -1,7 +1,7 @@
 """Test Knowledge creation and querying functionality."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from crewai.knowledge.source.crew_docling_source import CrewDoclingSource
@@ -477,6 +477,45 @@ def test_json_knowledge_source(mock_vector_db, tmpdir):
 
     assert any("los angeles" in result["content"].lower() for result in results)
     mock_vector_db.query.assert_called_once()
+
+
+def test_csv_knowledge_source_chunks_hold_content_not_dict_repr(tmpdir):
+    """CSV chunks must hold the file *content*, not ``str({Path: content})``.
+
+    Regression for embedding the dict repr — which leaks ``PosixPath('...')``
+    and the absolute file path into the knowledge — instead of the data, the
+    way ``TextFileKnowledgeSource``/``ExcelKnowledgeSource`` already do.
+    """
+    csv_path = Path(tmpdir.join("data.csv"))
+    with open(csv_path, "w", encoding="utf-8") as f:
+        f.write("Name,City\nBrandon,New York\n")
+
+    source = CSVKnowledgeSource(file_paths=[csv_path])
+    source.storage = MagicMock()
+    source.add()
+
+    joined = "\n".join(source.chunks)
+    assert "Brandon" in joined and "New York" in joined
+    assert "PosixPath" not in joined
+    assert "{" not in joined
+
+
+def test_json_knowledge_source_chunks_hold_content_not_dict_repr(tmpdir):
+    """JSON chunks must hold the formatted file content, not ``str({Path: content})``."""
+    import json as json_module
+
+    json_path = Path(tmpdir.join("data.json"))
+    with open(json_path, "w", encoding="utf-8") as f:
+        json_module.dump({"name": "Brandon", "city": "New York"}, f)
+
+    source = JSONKnowledgeSource(file_paths=[json_path])
+    source.storage = MagicMock()
+    source.add()
+
+    joined = "\n".join(source.chunks)
+    assert "Brandon" in joined and "New York" in joined
+    assert "PosixPath" not in joined
+    assert "{" not in joined
 
 
 def test_excel_knowledge_source(mock_vector_db, tmpdir):


### PR DESCRIPTION
Found while reviewing the knowledge-source siblings for consistency.

## Problem

`CSVKnowledgeSource.add()` / `aadd()` and `JSONKnowledgeSource.add()` / `aadd()` build their chunks from:

```python
content_str = str(self.content) if isinstance(self.content, dict) else self.content
new_chunks = self._chunk_text(content_str)
```

But `content` is declared in `BaseFileKnowledgeSource` as `dict[Path, str]` and is always populated (in `model_post_init` → `load_content()`), so the `isinstance(..., dict)` branch is always taken. The chunks therefore contain the **`str()` of the dict**, e.g.

```
{PosixPath('/abs/path/data.csv'): 'Name City\nBrandon New York\n'}
```

i.e. the embedded/indexed knowledge holds the Python dict repr, the **absolute file path**, and escaped newlines — instead of the file content. This degrades retrieval quality and leaks local filesystem paths into the vector store.

`TextFileKnowledgeSource` and `ExcelKnowledgeSource` already do the right thing — they iterate `self.content.values()`. CSV and JSON are the inconsistent ones.

## Fix

Make `CSVKnowledgeSource` and `JSONKnowledgeSource` (both `add` and `aadd`) iterate `self.content.values()` and chunk each file's content, matching the existing text/excel sources.

## Tests

Added `test_csv_knowledge_source_chunks_hold_content_not_dict_repr` and `test_json_knowledge_source_chunks_hold_content_not_dict_repr`, which call `add()` and assert the chunks contain the data and **not** `PosixPath(...)` / dict-repr noise. Both fail before the change (the failure surfaces the `{PosixPath(...): ...}` chunk) and pass after. Existing CSV/JSON/text/string knowledge tests still pass; `ruff check` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV and JSON knowledge source chunking to process individual data entries separately instead of converting entire structures into single strings. Generated knowledge chunks now contain actual content values rather than internal Python representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->