### PR TITLE
fix: keep only first line of parsed action so tool name matches

### DIFF
--- a/lib/crewai/src/crewai/agents/parser.py
+++ b/lib/crewai/src/crewai/agents/parser.py
@@ -149,13 +149,19 @@ def _extract_thought(text: str) -> str:
 def _clean_action(text: str) -> str:
     """Clean action string by removing non-essential formatting characters.
 
+    Only the first line is kept: models sometimes emit explanatory text between
+    ``Action:`` and ``Action Input:``, which the action regex captures into the
+    tool name. Keeping just the first line ensures the tool name still matches a
+    registered tool instead of becoming a multi-line string that never matches.
+
     Args:
         text: The action text to clean.
 
     Returns:
-        The cleaned action string.
+        The cleaned tool name.
     """
-    return text.strip().strip("*").strip()
+    first_line = text.strip().split("\n", 1)[0]
+    return first_line.strip().strip("*").strip()
 
 
 def _safe_repair_json(tool_input: str) -> str:

--- a/lib/crewai/tests/agents/test_crew_agent_parser.py
+++ b/lib/crewai/tests/agents/test_crew_agent_parser.py
@@ -142,6 +142,25 @@ def test_valid_action_parsing_with_unbalanced_quotes():
     assert result.tool_input == "what is the temperature in SF?"
 
 
+def test_valid_action_parsing_with_text_between_action_and_action_input():
+    text = (
+        "Thought: Let's find the temperature\n"
+        "Action: search\n"
+        "I will look up the temperature in SF\n"
+        "Action Input: what is the temperature in SF?"
+    )
+    result = parser.parse(text)
+    assert isinstance(result, AgentAction)
+    assert result.tool == "search"
+    assert result.tool_input == "what is the temperature in SF?"
+
+
+def test_clean_action_with_text_after_tool_name():
+    action = "search\nI will look up the temperature in SF"
+    cleaned_action = parser._clean_action(action)
+    assert cleaned_action == "search"
+
+
 def test_clean_action_no_formatting():
     action = "Ask question to senior researcher"
     cleaned_action = parser._clean_action(action)


### PR DESCRIPTION
## Summary

When a model emits explanatory text between `Action:` and `Action Input:`, the parsed tool name ends up containing that extra text (and newlines), so it no longer matches any registered tool and the tool call fails.

`ACTION_INPUT_REGEX` uses `re.DOTALL`, so the action group captures everything up to `Action Input:` — including newlines. `_clean_action` only stripped outer whitespace, leaving a multi-line tool name.

## Reproduction

```python
from crewai.agents import parser

text = (
    "Thought: The user is asking about France\n"
    "Action: web_search\n"
    "I will search for information about France's population\n"
    "Action Input: France population 2024"
)
result = parser.parse(text)
print(repr(result.tool))
```

**Expected:** `'web_search'`
**Actual:** `"web_search\nI will search for information about France's population"` → never matches a registered tool.

## Fix

Keep only the first line in `_clean_action`, so the tool name still matches even when the model adds stray text before `Action Input:`. One-line behavioral change; existing asterisk/whitespace cleaning is preserved.

## Tests

Added two regression tests in `test_crew_agent_parser.py`:
- `test_valid_action_parsing_with_text_between_action_and_action_input` (through the public `parser.parse`)
- `test_clean_action_with_text_after_tool_name`

I verified the fix against all existing parser cases plus the new one. Note: I was unable to run the full local suite in my environment (disk constraints during dependency install), so I'm relying on CI to run `lib/crewai/tests/` — happy to adjust if anything there flags.

## Disclosure

This PR was prepared with AI assistance (Claude Code), reviewed by me. Please apply the **`llm-generated`** label per CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent action parser to correctly handle action strings with multi-line explanatory text. The parser now properly extracts tool names from action definitions, ensuring agents reliably execute the correct tools even when explanations are included between action name and input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->