### PR TITLE
fix: keep full filename for BaseFile inputs in normalize_input_files

### DIFF
--- a/lib/crewai-files/src/crewai_files/resolution/utils.py
+++ b/lib/crewai-files/src/crewai_files/resolution/utils.py
@@ -65,8 +65,6 @@ def normalize_input_files(
     for i, item in enumerate(input_files):
         if isinstance(item, BaseFile):
             name = item.filename or f"file_{i}"
-            if "." in name:
-                name = name.rsplit(".", 1)[0]
             result[name] = item
             continue
 

--- a/lib/crewai/tests/utilities/test_files.py
+++ b/lib/crewai/tests/utilities/test_files.py
@@ -375,6 +375,21 @@ class TestNormalizeInputFiles:
         result = normalize_input_files([])
         assert result == {}
 
+    def test_normalize_base_file_keeps_full_filename(self) -> None:
+        """BaseFile inputs keep the full filename (with extension), like file sources do.
+
+        Files sharing a base name but different extensions must not collide into a
+        single entry, which would silently drop one of them.
+        """
+        json_file = TextFile(source=FileBytes(data=b"json", filename="data.json"))
+        text_file = TextFile(source=FileBytes(data=b"text", filename="data.txt"))
+
+        result = normalize_input_files([json_file, text_file])
+
+        assert "data.json" in result
+        assert "data.txt" in result
+        assert len(result) == 2
+
 
 class TestGenericFile:
     """Tests for the generic File class with auto-detection."""


### PR DESCRIPTION
## Summary

`normalize_input_files` builds a `{name: file}` dict. For most input types the key is the **full filename** (extension included) — that's what the existing tests assert (e.g. `doc1.txt`, `named.txt`). But the `BaseFile` branch strips the extension before using it as the key, which is both inconsistent with every other branch and causes **silent data loss**: two `BaseFile` inputs that share a base name but differ in extension collapse to one entry, and the first is dropped.

## Reproduction

```python
from crewai_files import TextFile
from crewai_files.core.sources import FileBytes
from crewai_files.resolution.utils import normalize_input_files

result = normalize_input_files([
    TextFile(source=FileBytes(data=b"json", filename="data.json")),
    TextFile(source=FileBytes(data=b"text", filename="data.txt")),
])
print(list(result.keys()))
```

**Expected:** `['data.json', 'data.txt']` (2 entries)
**Actual:** `['data']` (1 entry — the `data.json` file is silently dropped)

## Fix

Keep the full filename for `BaseFile` inputs (don't strip the extension), matching the behavior of the file-source branch and the existing tests. Same-base-name files with different extensions no longer collide.

## Tests

Added `test_normalize_base_file_keeps_full_filename` in `test_files.py`.

Verified locally:
- `uv run pytest lib/crewai/tests/utilities/test_files.py` → **54 passed**
- `uv run pytest lib/crewai-files/tests/` (resolution) → passed
- `uv run ruff check` / `ruff format --check` / `uv run mypy` on the changed files → clean

## Disclosure

This PR was prepared with AI assistance (Claude Code), reviewed by me. Please apply the **`llm-generated`** label per CONTRIBUTING.
