### PR TITLE
Make flow definition files importable

### DIFF
--- a/lib/cli/src/crewai_cli/run_flow_definition.py
+++ b/lib/cli/src/crewai_cli/run_flow_definition.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 from typing import Any
 
 import click
@@ -21,6 +22,7 @@ def run_flow_definition(definition: str, inputs: str | None = None) -> None:
 
     parsed_inputs = _parse_inputs(inputs)
     definition_source = _read_definition_source(definition)
+    _ensure_definition_dir_importable(definition)
 
     try:
         flow_definition = _parse_flow_definition(FlowDefinition, definition_source)
@@ -83,6 +85,19 @@ def _read_definition_source(definition: str) -> str:
         raise SystemExit(1) from exc
 
     return definition
+
+
+def _ensure_definition_dir_importable(definition: str) -> None:
+    path = Path(definition).expanduser()
+    try:
+        if not path.is_file():
+            return
+    except OSError:
+        return
+
+    project_dir = str(path.resolve().parent)
+    if project_dir not in sys.path:
+        sys.path.append(project_dir)
 
 
 def _looks_like_inline_definition(definition: str) -> bool:

--- a/lib/cli/tests/test_run_flow_definition.py
+++ b/lib/cli/tests/test_run_flow_definition.py
@@ -129,6 +129,25 @@ def test_run_flow_definition_accepts_definition_files(
     assert _captured_json(capsys) == {"flow": expected_flow_name, "inputs": {}}
 
 
+def test_run_flow_definition_makes_definition_dir_importable(
+    tmp_path, capsys, fake_flow_runtime, monkeypatch
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "lead_flow.py").write_text("MARKER = 'loaded'\n")
+    definition_path = project_dir / "flow.yaml"
+    definition_path.write_text("schema: crewai.flow/v1\nname: TestFlow\n")
+
+    monkeypatch.delitem(sys.modules, "lead_flow", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    run_flow_definition(str(definition_path))
+
+    import lead_flow
+
+    assert lead_flow.MARKER == "loaded"
+
+
 def test_run_flow_definition_rejects_non_object_inputs(fake_flow_runtime, capsys):
     with pytest.raises(SystemExit):
         run_flow_definition("name: TestFlow", '["not", "an", "object"]')


### PR DESCRIPTION
When `crewai run --definition` receives a file path, add that file parent to `sys.path` before parsing and running the Flow Definition.

That lets definitions use nearby Python references like `lead_flow.tools:LogLeadTool` without requiring users to run from the example directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped CLI behavior change for file-based definitions only; mirrors existing `sys.path` patterns elsewhere and does not alter auth or data handling.
> 
> **Overview**
> When `crewai run --definition` points at a **file path**, the CLI now appends that file’s parent directory to `sys.path` before parsing and kicking off the flow (via new `_ensure_definition_dir_importable`). **Inline** YAML/JSON definitions are unchanged.
> 
> This lets flow definitions reference **local Python modules** next to the definition (e.g. `lead_flow.tools:LogLeadTool`) without requiring the user to `cd` into the project folder first.
> 
> A test confirms that after running a definition file, a sibling module like `lead_flow.py` can be imported when the cwd is elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5359966950c73678fbb8d392d9cd482a8192052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->