### PR TITLE
Serialize concrete Pydantic subclasses

### DIFF
--- a/lib/crewai/src/crewai/utilities/serialization.py
+++ b/lib/crewai/src/crewai/utilities/serialization.py
@@ -99,7 +99,7 @@ def to_serializable(
     if isinstance(obj, BaseModel):
         try:
             return to_serializable(
-                obj=obj.model_dump(mode="json", exclude=exclude),
+                obj=obj.model_dump(mode="json", exclude=exclude, serialize_as_any=True),
                 max_depth=max_depth,
                 _current_depth=_current_depth + 1,
                 _ancestors=new_ancestors,

--- a/lib/crewai/tests/utilities/test_serialization.py
+++ b/lib/crewai/tests/utilities/test_serialization.py
@@ -21,6 +21,10 @@ class Person(BaseModel):
     skills: List[str]
 
 
+class Container(BaseModel):
+    payload: BaseModel | None = None
+
+
 @dataclass
 class DataclassPerson:
     name: str
@@ -112,6 +116,16 @@ def test_pydantic_model_serialization():
         to_string(result)
         == '{"single_model": {"street": "123 Main St", "city": "Tech City", "country": "Pythonia"}, "nested_model": {"name": "John Doe", "age": 30, "address": {"street": "123 Main St", "city": "Tech City", "country": "Pythonia"}, "birthday": "1994-01-01", "skills": ["Python", "Testing"]}, "model_list": [{"street": "123 Main St", "city": "Tech City", "country": "Pythonia"}, {"street": "123 Main St", "city": "Tech City", "country": "Pythonia"}], "model_dict": {"home": {"street": "123 Main St", "city": "Tech City", "country": "Pythonia"}}}'
     )
+
+
+def test_polymorphic_field_serializes_concrete_subclass():
+    container = Container(
+        payload=Address(street="1 Main", city="Tech City", country="Pythonia")
+    )
+
+    assert to_serializable(container) == {
+        "payload": {"street": "1 Main", "city": "Tech City", "country": "Pythonia"}
+    }
 
 
 def test_dataclass_serialization_recurses_into_nested_values():


### PR DESCRIPTION
Preserve concrete Pydantic subclass fields when serializing a model through a field typed as `BaseModel`.

This uses Pydantic `serialize_as_any=True` in `to_serializable`, so nested polymorphic values keep their real shape instead of being reduced to the annotated base type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to shared serialization used for events and tracing; output becomes more complete for polymorphic models with no auth or data-mutation risk.
> 
> **Overview**
> **`to_serializable`** now passes **`serialize_as_any=True`** when calling **`model_dump`** on Pydantic models, so nested values keep their **runtime subclass fields** instead of being trimmed to whatever the static **`BaseModel`** annotation allows.
> 
> A regression test covers a model whose **`payload`** is typed as **`BaseModel | None`** but holds an **`Address`** instance, asserting the serialized output includes **`street`**, **`city`**, and **`country`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f7d60b74d85ca5e7653020ae35a7ec9c910e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON serialization handling for Pydantic model subclasses to improve output behavior.

* **Tests**
  * Added test coverage for polymorphic model field serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->