### PR TITLE
fix(llm): strip cache_breakpoint marker on the litellm provider path

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2280,11 +2280,26 @@ class LLM(BaseLLM):
         if messages is None:
             raise TypeError("Messages cannot be None")
 
+        from crewai.llms.cache import CACHE_BREAKPOINT_KEY
+        from crewai.utilities.types import LLMMessage as _LLMMessage
+
+        # Strip the provider-agnostic cache-breakpoint marker. Only the native
+        # Anthropic adapter consumes it; on the litellm path every provider
+        # (Groq, OpenAI-compatible, etc.) receives the raw message dict and
+        # rejects the unknown ``cache_breakpoint`` key, so it must never reach
+        # the wire. Copy rather than mutate, since the executor reuses this
+        # message buffer across iterations of the tool-use loop.
+        cleaned: list[LLMMessage] = []
         for msg in messages:
             if not isinstance(msg, dict) or "role" not in msg or "content" not in msg:
                 raise TypeError(
                     "Invalid message format. Each message must be a dict with 'role' and 'content' keys"
                 )
+            copy: dict[str, Any] = {
+                k: v for k, v in msg.items() if k != CACHE_BREAKPOINT_KEY
+            }
+            cleaned.append(cast(_LLMMessage, copy))
+        messages = cleaned
 
         if "o1" in self.model.lower():
             formatted_messages = []

--- a/lib/crewai/tests/llms/test_prompt_cache.py
+++ b/lib/crewai/tests/llms/test_prompt_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from crewai.llm import LLM
 from crewai.llms.cache import (
     CACHE_BREAKPOINT_KEY,
     mark_cache_breakpoint,
@@ -189,3 +190,36 @@ class TestNonAnthropicStripsMarker:
         formatted = llm._format_messages(messages)
         for m in formatted:
             assert CACHE_BREAKPOINT_KEY not in m
+
+
+class TestLiteLLMStripsMarker:
+    """Providers routed through the litellm ``LLM`` class (Groq, generic
+    OpenAI-compatible endpoints, etc.) do not go through ``BaseLLM._format_messages``.
+    Their messages are shaped by ``LLM._format_messages_for_provider``, which must
+    also strip the marker — otherwise the raw ``cache_breakpoint`` key reaches the
+    provider API and is rejected (e.g. Groq: "property 'cache_breakpoint' is
+    unsupported"). Regression test for #5886.
+    """
+
+    def test_groq_format_strips_marker_from_wire_payload(self) -> None:
+        llm = LLM(model="groq/llama-3.3-70b-versatile")
+        messages = [
+            mark_cache_breakpoint({"role": "system", "content": "stable"}),
+            mark_cache_breakpoint({"role": "user", "content": "hi"}),
+        ]
+        formatted = llm._format_messages_for_provider(messages)
+        for m in formatted:
+            assert CACHE_BREAKPOINT_KEY not in m
+
+    def test_litellm_format_does_not_mutate_caller_buffer(self) -> None:
+        """The executor reuses one messages buffer across tool-loop iterations,
+        so stripping must copy rather than mutate the caller's dicts.
+        """
+        llm = LLM(model="groq/llama-3.3-70b-versatile")
+        messages = [
+            mark_cache_breakpoint({"role": "system", "content": "stable"}),
+            mark_cache_breakpoint({"role": "user", "content": "hi"}),
+        ]
+        llm._format_messages_for_provider(messages)
+        assert messages[0][CACHE_BREAKPOINT_KEY] is True
+        assert messages[1][CACHE_BREAKPOINT_KEY] is True


### PR DESCRIPTION
## Problem

The prompt-cache breakpoint marker is injected provider-agnostically by the agent executors (`mark_cache_breakpoint`), but only the native Anthropic adapter consumes it. Native providers route through `BaseLLM._format_messages`, which already strips the marker. The default litellm-based `LLM` does **not**: `_format_messages_for_provider` returned messages untouched for non-Anthropic providers, so the raw `cache_breakpoint` key reached the wire and was rejected — e.g. Groq:

```
GroqException - 'messages.0': property 'cache_breakpoint' is unsupported
```

This breaks any crew using Groq or other OpenAI-compatible models on the litellm path.

## Fix

Strip the marker in `LLM._format_messages_for_provider`, mirroring the base class. It copies rather than mutates, so the executor's reused message buffer keeps its markers across tool-loop iterations (preserving Anthropic prompt caching).

## Tests

Added `TestLiteLLMStripsMarker` in `test_prompt_cache.py` covering the litellm path (the existing tests only exercised native providers). Verified the new tests fail without the fix and pass with it; `ruff` and `mypy` clean.

Fixes #5886

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of message structure to ensure compatibility across providers.
  * Enhanced handling of internal caching metadata during message formatting.

* **Tests**
  * Added regression tests to verify message formatting and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->