### PR TITLE
fix(llm): detect Anthropic models with custom deployment naming

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -703,9 +703,13 @@ class LLM(BaseLLM):
             self.set_env_callbacks()
         return self
 
-    @staticmethod
-    def _is_anthropic_model(model: str) -> bool:
+    @classmethod
+    def _is_anthropic_model(cls, model: str) -> bool:
         """Determine if the model is from Anthropic provider.
+
+        Delegates to the same pattern matcher used for native-provider
+        routing so detection stays consistent across both, including custom
+        deployment naming such as ``anthropic--claude-...`` (#5893).
 
         Args:
             model: The model identifier string.
@@ -713,8 +717,7 @@ class LLM(BaseLLM):
         Returns:
             bool: True if the model is from Anthropic, False otherwise.
         """
-        anthropic_prefixes = ("anthropic/", "claude-", "claude/")
-        return any(prefix in model.lower() for prefix in anthropic_prefixes)
+        return cls._matches_provider_pattern(model, "anthropic")
 
     def _prepare_completion_params(
         self,

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -508,9 +508,11 @@ class LLM(BaseLLM):
             )
 
         if provider == "anthropic" or provider == "claude":
-            return any(
-                model_lower.startswith(prefix) for prefix in ["claude-", "anthropic."]
-            )
+            # Match Anthropic models regardless of custom deployment naming
+            # (e.g. "anthropic--claude-...", "anthropic.claude-...") rather than
+            # only the canonical "claude-" / "anthropic." prefixes (#5893).
+            # "anthropomorphic" does not start with "anthropic", so it is safe.
+            return "claude" in model_lower or model_lower.startswith("anthropic")
 
         if provider == "gemini" or provider == "google":
             return any(
@@ -618,6 +620,15 @@ class LLM(BaseLLM):
 
         if model in AZURE_MODELS:
             return "azure"
+
+        # Before defaulting to OpenAI, fall back to provider naming patterns so
+        # unprefixed but recognizable model ids (e.g. "anthropic--claude-...")
+        # are not silently misrouted to OpenAI (#5893). Only families with
+        # specific prefix rules are consulted; broad patterns (e.g. bedrock's
+        # bare "." match) are intentionally excluded to avoid false positives.
+        for candidate in ("anthropic", "gemini"):
+            if cls._matches_provider_pattern(model, candidate):
+                return candidate
 
         return "openai"
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -951,6 +951,18 @@ def test_validate_model_in_constants():
         LLM._validate_model_in_constants("claude-3-5-sonnet-latest", "claude") is True
     )
     assert LLM._validate_model_in_constants("unknown-model", "claude") is False
+    # Custom Anthropic deployment naming should still be recognized (#5893)
+    assert (
+        LLM._validate_model_in_constants("anthropic--claude-3-5-sonnet", "anthropic")
+        is True
+    )
+    assert (
+        LLM._validate_model_in_constants("anthropic.claude-3-5-sonnet", "anthropic")
+        is True
+    )
+    assert LLM._validate_model_in_constants("my-claude-deploy", "anthropic") is True
+    # ...but lookalikes that are not Anthropic must not match
+    assert LLM._validate_model_in_constants("anthropomorphic", "anthropic") is False
 
     # Gemini models
     assert LLM._validate_model_in_constants("gemini-2.5-pro", "gemini") is True
@@ -973,6 +985,23 @@ def test_validate_model_in_constants():
         LLM._validate_model_in_constants("anthropic.claude-future-v1:0", "bedrock")
         is True
     )
+
+
+def test_infer_provider_from_model_custom_naming():
+    """Unprefixed but recognizable model ids must not default to OpenAI (#5893)."""
+    # Custom Anthropic deployment names route to the Anthropic provider instead
+    # of being silently misrouted to OpenAI.
+    assert (
+        LLM._infer_provider_from_model("anthropic--claude-3-5-sonnet") == "anthropic"
+    )
+    assert LLM._infer_provider_from_model("anthropic.claude-3-5-sonnet") == "anthropic"
+    assert LLM._infer_provider_from_model("claude-3-5-sonnet") == "anthropic"
+    assert LLM._infer_provider_from_model("gemini-2.5-pro") == "gemini"
+    # No regression: genuine OpenAI and unknown models still resolve to OpenAI.
+    assert LLM._infer_provider_from_model("gpt-4o") == "openai"
+    assert LLM._infer_provider_from_model("some-unknown-model") == "openai"
+    assert LLM._infer_provider_from_model("anthropomorphic-model") == "openai"
+
 
 @pytest.mark.vcr(record_mode="once",decode_compressed_response=True)
 def test_usage_info_non_streaming_with_call():

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -441,6 +441,9 @@ def test_anthropic_model_detection():
         ("anthropic/claude-3", True),
         ("claude-instant", True),
         ("claude/v1", True),
+        # Custom deployment naming is detected consistently with native routing (#5893)
+        ("anthropic--claude-3-5-sonnet", True),
+        ("anthropic.claude-3-5-sonnet", True),
         ("gpt-4", False),
         ("anthropomorphic", False),
     ]


### PR DESCRIPTION
## Problem

Provider detection only recognized the canonical `claude-` / `anthropic.` prefixes. A self-deployed Anthropic model named e.g. `anthropic--claude-3-5-sonnet` was therefore:

- mis-detected by `_infer_provider_from_model`, which defaulted unknown unprefixed ids to **OpenAI**, and
- not matched by `_matches_provider_pattern`,

so it was routed to the OpenAI adapter, losing all Anthropic-specific request handling (stop-sequence normalization, thinking blocks, prompt caching, etc.).

## Fix

- Broaden the Anthropic pattern in `_matches_provider_pattern` to match `claude` anywhere or an `anthropic` prefix.
- Let `_infer_provider_from_model` fall back to the Anthropic/Gemini patterns before defaulting to OpenAI.

`anthropic` is matched via `startswith`, so lookalikes like `anthropomorphic` are unaffected; broad patterns such as bedrock's bare `.` match are intentionally excluded to avoid false positives.

## Tests

Extended `test_validate_model_in_constants` and added `test_infer_provider_from_model_custom_naming` in `test_llm.py`, including no-regression and no-false-positive cases. Verified failing-without/passing-with the fix; the 20 existing model-routing tests still pass; `ruff` and `mypy` clean.

Fixes #5893

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved recognition of Anthropic Claude model names, now supporting custom deployment naming formats and names containing “claude” anywhere.
  * Enhanced provider routing to better identify unprefixed Anthropic and Gemini model identifiers, reducing misrouting to OpenAI.

* **Tests**
  * Added coverage for custom model naming patterns and provider inference logic, including additional Anthropic naming variants and fallback/ambiguity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->