### PR TITLE
test(agents): cover Bedrock Converse toolUse arg parsing

### DIFF
--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -1337,6 +1337,75 @@ class TestNativeToolCallingJsonParseError:
 
         assert result["result"] == "ran: x = 42"
 
+    def test_bedrock_converse_tooluse_args_pass_through(self) -> None:
+        """A raw Bedrock Converse toolUse block must yield its ``input`` as the
+        tool args, not an empty dict. Regression guard for #4972, where the
+        Converse args were dropped and every tool received ``{}``.
+
+        Bedrock returns blocks shaped as
+        ``{"toolUseId": ..., "name": ..., "input": {...}}`` (no ``function``
+        wrapper and no ``arguments`` key), so the parser must read ``input``.
+        """
+
+        class SearchTool(BaseTool):
+            name: str = "my_tool"
+            description: str = "Search for information"
+
+            def _run(self, search_query: str) -> str:
+                return f"searched: {search_query}"
+
+        executor = self._make_executor([SearchTool()])
+
+        bedrock_tool_use = {
+            "toolUseId": "abc",
+            "name": "my_tool",
+            "input": {"search_query": "test"},
+        }
+
+        parsed = executor._parse_native_tool_call(bedrock_tool_use)
+        assert parsed is not None
+        call_id, func_name, func_args = parsed
+
+        assert call_id == "abc"
+        assert func_name == "my_tool"
+        assert func_args == {"search_query": "test"}  # not {}
+
+    def test_bedrock_converse_tooluse_args_reach_the_tool(self) -> None:
+        """End-to-end: args parsed from a Bedrock Converse block execute the
+        tool with the real arguments (not an empty dict)."""
+
+        class SearchTool(BaseTool):
+            name: str = "my_tool"
+            description: str = "Search for information"
+
+            def _run(self, search_query: str) -> str:
+                return f"searched: {search_query}"
+
+        tool = SearchTool()
+        executor = self._make_executor([tool])
+
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
+
+        bedrock_tool_use = {
+            "toolUseId": "abc",
+            "name": "my_tool",
+            "input": {"search_query": "test"},
+        }
+        call_id, func_name, func_args = executor._parse_native_tool_call(
+            bedrock_tool_use
+        )
+
+        result = executor._execute_single_native_tool_call(
+            call_id=call_id,
+            func_name=func_name,
+            func_args=func_args,
+            available_functions=available_functions,
+        )
+
+        assert result["result"] == "searched: test"
+
     def test_schema_validation_catches_missing_args_on_native_path(self) -> None:
         """The native function calling path should now enforce args_schema,
         catching missing required fields before _run is called."""


### PR DESCRIPTION
## Summary

Bedrock's Converse API returns tool calls shaped as `{"toolUseId": ..., "name": ..., "input": {...}}` — no `function` wrapper and no `arguments` key — so `CrewAgentExecutor._parse_native_tool_call` must read `input`. Today it does (`func_info.get("arguments") or tool_call.get("input", {})`), but this path has **no offline coverage**: the existing Bedrock tests are gated behind live AWS credentials (`RUN_BEDROCK_LIVE_TESTS`), leaving the arg extraction unprotected against regression.

This is exactly what #4972 reported (Converse args dropped, every tool receiving `{}`). The bug is already fixed at `main`; this PR locks the behavior in.

## Tests

Adds two credential-free unit tests to `TestNativeToolCallingJsonParseError`:
- `test_bedrock_converse_tooluse_args_pass_through` — a raw Converse `toolUse` dict yields its `input` as the args (not `{}`).
- `test_bedrock_converse_tooluse_args_reach_the_tool` — those args actually execute the tool with real values.

Both would have failed under the buggy behavior described in the issue.

Refs #4972

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for tool calling to improve reliability of tool input argument processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->