### PR TITLE
Enhance memory reset functionality and JSON crew handling

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -88,7 +88,7 @@ voyageai = [
     "voyageai~=0.3.5",
 ]
 litellm = [
-    "litellm>=1.83.7,<1.84",
+    "litellm>=1.84.0,<1.85",
 ]
 bedrock = [
     "boto3~=1.42.79",

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -2275,6 +2275,8 @@ class Crew(FlowTrackable, BaseModel):
         """
 
         def default_reset(memory: Any) -> Any:
+            if isinstance(memory, Memory):
+                return memory.reset_all()
             return memory.reset()
 
         def knowledge_reset(memory: Any) -> Any:

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -990,12 +990,18 @@ class Memory(BaseModel):
             scope: Scope to reset. If None and root_scope is set, resets only
                 within root_scope. If None and no root_scope, resets all.
         """
+        self.drain_writes()
         effective_scope = scope
         if effective_scope is None and self.root_scope:
             effective_scope = self.root_scope
         elif effective_scope is not None and self.root_scope:
             effective_scope = join_scope_paths(self.root_scope, effective_scope)
         self._storage.reset(scope_prefix=effective_scope)
+
+    def reset_all(self) -> None:
+        """Reset the entire backing memory store, ignoring ``root_scope``."""
+        self.drain_writes()
+        self._storage.reset(scope_prefix=None)
 
     async def aextract_memories(self, content: str) -> list[str]:
         """Async variant of extract_memories."""

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -149,6 +149,7 @@ class Memory(BaseModel):
     )
     _pending_saves: list[Future[Any]] = PrivateAttr(default_factory=list)
     _pending_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _reset_lock: Any = PrivateAttr(default_factory=threading.RLock)
 
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Memory:
         """Deepcopy that handles unpickleable private attrs (ThreadPoolExecutor, Lock)."""
@@ -168,7 +169,10 @@ class Memory(BaseModel):
         )
         private = {}
         for k, v in (self.__pydantic_private__ or {}).items():
-            if isinstance(v, (ThreadPoolExecutor, threading.Lock)):
+            if k in {"_save_pool", "_pending_lock", "_reset_lock"}:
+                attr = self.__private_attributes__[k]
+                private[k] = attr.get_default()
+            elif isinstance(v, (ThreadPoolExecutor, threading.Lock)):
                 attr = self.__private_attributes__[k]
                 private[k] = attr.get_default()
             else:
@@ -275,22 +279,25 @@ class Memory(BaseModel):
         If the pool has been shut down (e.g. after ``close()``), the save
         runs synchronously as a fallback so late saves still succeed.
         """
-        ctx = contextvars.copy_context()
-        try:
-            future: Future[Any] = self._save_pool.submit(ctx.run, fn, *args, **kwargs)
-        except RuntimeError:
-            # Pool shut down -- run synchronously as fallback
-            future = Future()
+        with self._reset_lock:
+            ctx = contextvars.copy_context()
             try:
-                result = fn(*args, **kwargs)
-                future.set_result(result)
-            except Exception as exc:
-                future.set_exception(exc)
+                future: Future[Any] = self._save_pool.submit(
+                    ctx.run, fn, *args, **kwargs
+                )
+            except RuntimeError:
+                # Pool shut down -- run synchronously as fallback
+                future = Future()
+                try:
+                    result = fn(*args, **kwargs)
+                    future.set_result(result)
+                except Exception as exc:
+                    future.set_exception(exc)
+                return future
+            with self._pending_lock:
+                self._pending_saves.append(future)
+            future.add_done_callback(self._on_save_done)
             return future
-        with self._pending_lock:
-            self._pending_saves.append(future)
-        future.add_done_callback(self._on_save_done)
-        return future
 
     def _on_save_done(self, future: Future[Any]) -> None:
         """Remove a completed future from the pending list and emit failure event if needed.
@@ -990,18 +997,20 @@ class Memory(BaseModel):
             scope: Scope to reset. If None and root_scope is set, resets only
                 within root_scope. If None and no root_scope, resets all.
         """
-        self.drain_writes()
-        effective_scope = scope
-        if effective_scope is None and self.root_scope:
-            effective_scope = self.root_scope
-        elif effective_scope is not None and self.root_scope:
-            effective_scope = join_scope_paths(self.root_scope, effective_scope)
-        self._storage.reset(scope_prefix=effective_scope)
+        with self._reset_lock:
+            self.drain_writes()
+            effective_scope = scope
+            if effective_scope is None and self.root_scope:
+                effective_scope = self.root_scope
+            elif effective_scope is not None and self.root_scope:
+                effective_scope = join_scope_paths(self.root_scope, effective_scope)
+            self._storage.reset(scope_prefix=effective_scope)
 
     def reset_all(self) -> None:
         """Reset the entire backing memory store, ignoring ``root_scope``."""
-        self.drain_writes()
-        self._storage.reset(scope_prefix=None)
+        with self._reset_lock:
+            self.drain_writes()
+            self._storage.reset(scope_prefix=None)
 
     async def aextract_memories(self, content: str) -> list[str]:
         """Async variant of extract_memories."""

--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -63,7 +63,14 @@ def _get_json_crew() -> Any | None:
     if crew_path is None:
         return None
 
-    crew, _ = load_crew(crew_path)
+    try:
+        crew, _ = load_crew(crew_path)
+    except Exception as exc:
+        click.echo(
+            f"Skipping JSON crew at {crew_path}: failed to load ({exc}).",
+            err=True,
+        )
+        return None
     return crew
 
 

--- a/lib/crewai/src/crewai/utilities/reset_memories.py
+++ b/lib/crewai/src/crewai/utilities/reset_memories.py
@@ -6,7 +6,10 @@ from typing import Any
 import click
 
 from crewai.flow import Flow
-from crewai.utilities.project_utils import get_crews, get_flows
+from crewai.memory.unified_memory import Memory
+from crewai.project.crew_loader import load_crew
+from crewai.project.json_loader import find_crew_json_file
+from crewai.utilities.project_utils import get_crews, get_flows, read_toml
 
 
 def _reset_flow_memory(flow: Flow[Any]) -> None:
@@ -23,7 +26,9 @@ def _reset_flow_memory(flow: Flow[Any]) -> None:
     if mem is None:
         return
     try:
-        if hasattr(mem, "reset"):
+        if isinstance(mem, Memory):
+            mem.reset_all()
+        elif hasattr(mem, "reset"):
             mem.reset()
         elif hasattr(mem, "_memory") and mem._memory is not None:
             mem._memory.reset()
@@ -35,6 +40,31 @@ def _reset_flow_memory(flow: Flow[Any]) -> None:
     except RuntimeError as exc:
         # Restored MemoryScope/MemorySlice without a rebound Memory.
         click.echo(f"Memory reset skipped: {exc}", err=True)
+
+
+def _current_project_declares_flow() -> bool:
+    try:
+        pyproject_data = read_toml()
+    except Exception:
+        return False
+
+    declared_type: str | None = (
+        pyproject_data.get("tool", {}).get("crewai", {}).get("type")
+    )
+    return declared_type == "flow"
+
+
+def _get_json_crew() -> Any | None:
+    """Load a JSON-first crew from the current project, if present."""
+    if _current_project_declares_flow():
+        return None
+
+    crew_path = find_crew_json_file()
+    if crew_path is None:
+        return None
+
+    crew, _ = load_crew(crew_path)
+    return crew
 
 
 def reset_memories_command(
@@ -61,6 +91,8 @@ def reset_memories_command(
             return
 
         crews = get_crews()
+        if json_crew := _get_json_crew():
+            crews.append(json_crew)
         flows = get_flows()
 
         if not crews and not flows:

--- a/lib/crewai/tests/cli/test_cli.py
+++ b/lib/crewai/tests/cli/test_cli.py
@@ -4,6 +4,7 @@ Non-core CLI tests (train, test, version, deploy, login, flow_add_crew)
 have moved to lib/cli/tests/test_cli.py.
 """
 
+from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
@@ -30,6 +31,8 @@ def mock_get_crews(mock_crew):
         "crewai.utilities.reset_memories.get_crews", return_value=[mock_crew]
     ) as mock_get_crew, mock.patch(
         "crewai.utilities.reset_memories.get_flows", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
     ):
         yield mock_get_crew
 
@@ -170,6 +173,8 @@ def mock_get_flows(mock_flow):
         "crewai.utilities.reset_memories.get_flows", return_value=[mock_flow]
     ) as mock_get_flow, mock.patch(
         "crewai.utilities.reset_memories.get_crews", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
     ):
         yield mock_get_flow
 
@@ -197,9 +202,52 @@ def test_reset_no_crew_or_flow_found(runner):
         "crewai.utilities.reset_memories.get_crews", return_value=[]
     ), mock.patch(
         "crewai.utilities.reset_memories.get_flows", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
     ):
         result = runner.invoke(reset_memories, ["-m"])
         assert "No crew or flow found." in result.output
+
+
+def test_reset_json_crew_memory(mock_crew, runner, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "crew.jsonc").write_text("{}")
+
+    with mock.patch(
+        "crewai.utilities.reset_memories.get_crews", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.get_flows", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.load_crew",
+        return_value=(mock_crew, {}),
+    ) as mock_load_crew:
+        result = runner.invoke(reset_memories, ["-m"])
+
+    mock_load_crew.assert_called_once_with(Path("crew.jsonc"))
+    mock_crew.reset_memories.assert_called_once_with(command_type="memory")
+    assert f"[Crew ({mock_crew.name})] Memory has been reset." in result.output
+
+
+def test_reset_json_crew_skipped_for_declared_flow_project(
+    mock_crew, runner, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "crew.jsonc").write_text("{}")
+    (tmp_path / "pyproject.toml").write_text('[tool.crewai]\ntype = "flow"\n')
+
+    with mock.patch(
+        "crewai.utilities.reset_memories.get_crews", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.get_flows", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.load_crew",
+        return_value=(mock_crew, {}),
+    ) as mock_load_crew:
+        result = runner.invoke(reset_memories, ["-m"])
+
+    mock_load_crew.assert_not_called()
+    mock_crew.reset_memories.assert_not_called()
+    assert "No crew or flow found." in result.output
 
 
 def test_reset_crew_and_flow_memory(mock_crew, mock_flow, runner):
@@ -207,6 +255,8 @@ def test_reset_crew_and_flow_memory(mock_crew, mock_flow, runner):
         "crewai.utilities.reset_memories.get_crews", return_value=[mock_crew]
     ), mock.patch(
         "crewai.utilities.reset_memories.get_flows", return_value=[mock_flow]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
     ):
         result = runner.invoke(reset_memories, ["-m"])
         mock_crew.reset_memories.assert_called_once_with(command_type="memory")
@@ -223,6 +273,8 @@ def test_reset_flow_memory_none(runner):
         "crewai.utilities.reset_memories.get_crews", return_value=[]
     ), mock.patch(
         "crewai.utilities.reset_memories.get_flows", return_value=[mock_flow]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
     ):
         result = runner.invoke(reset_memories, ["-m"])
         assert "[Flow (NoMemFlow)] Memory has been reset." in result.output

--- a/lib/crewai/tests/cli/test_cli.py
+++ b/lib/crewai/tests/cli/test_cli.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from click.testing import CliRunner
 from crewai.crew import Crew
+from crewai.memory.unified_memory import Memory
 from crewai_cli.cli import reset_memories
 import pytest
 
@@ -185,6 +186,33 @@ def test_reset_flow_memory(mock_get_flows, mock_flow, runner):
     assert "[Flow (TestFlow)] Memory has been reset." in result.output
 
 
+def test_reset_flow_unified_memory_uses_full_reset(runner, tmp_path):
+    flow = mock.Mock()
+    flow.name = "TestFlow"
+    flow.memory = Memory(
+        storage=str(tmp_path / "db"),
+        llm=mock.Mock(),
+        embedder=lambda texts: [[0.1] * 4 for _ in texts],
+    )
+
+    with mock.patch(
+        "crewai.utilities.reset_memories.get_flows", return_value=[flow]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.get_crews", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories._get_json_crew", return_value=None
+    ), mock.patch.object(
+        Memory, "reset_all"
+    ) as reset_all, mock.patch.object(
+        Memory, "reset"
+    ) as reset:
+        result = runner.invoke(reset_memories, ["-m"])
+
+    reset_all.assert_called_once_with()
+    reset.assert_not_called()
+    assert "[Flow (TestFlow)] Memory has been reset." in result.output
+
+
 def test_reset_flow_all_memories(mock_get_flows, mock_flow, runner):
     result = runner.invoke(reset_memories, ["-a"])
     mock_flow.memory.reset.assert_called_once()
@@ -225,6 +253,28 @@ def test_reset_json_crew_memory(mock_crew, runner, monkeypatch, tmp_path):
 
     mock_load_crew.assert_called_once_with(Path("crew.jsonc"))
     mock_crew.reset_memories.assert_called_once_with(command_type="memory")
+    assert f"[Crew ({mock_crew.name})] Memory has been reset." in result.output
+
+
+def test_reset_invalid_json_crew_does_not_block_classic_crew(
+    mock_crew, runner, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "crew.jsonc").write_text("{invalid")
+
+    with mock.patch(
+        "crewai.utilities.reset_memories.get_crews", return_value=[mock_crew]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.get_flows", return_value=[]
+    ), mock.patch(
+        "crewai.utilities.reset_memories.load_crew",
+        side_effect=ValueError("invalid JSON"),
+    ) as mock_load_crew:
+        result = runner.invoke(reset_memories, ["-m"])
+
+    mock_load_crew.assert_called_once_with(Path("crew.jsonc"))
+    mock_crew.reset_memories.assert_called_once_with(command_type="memory")
+    assert "Skipping JSON crew at crew.jsonc: failed to load (invalid JSON)." in result.output
     assert f"[Crew ({mock_crew.name})] Memory has been reset." in result.output
 
 

--- a/lib/crewai/tests/memory/test_dimension_mismatch.py
+++ b/lib/crewai/tests/memory/test_dimension_mismatch.py
@@ -8,6 +8,7 @@ not silently zero-fill vectors or return empty search results.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -95,6 +96,33 @@ def test_lancedb_reopened_store_detects_mismatch(lancedb_path: Path) -> None:
         reopened.save([_record(8)])
     with pytest.raises(EmbeddingDimensionMismatchError):
         reopened.search([0.1] * 8)
+
+
+def test_memory_reset_all_rebuilds_reopened_store_with_new_dimension(
+    lancedb_path: Path,
+) -> None:
+    from crewai.memory.storage.lancedb_storage import LanceDBStorage
+    from crewai.memory.unified_memory import Memory
+
+    old = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    old.save([_record(4)])
+
+    mem = Memory(
+        storage=str(lancedb_path),
+        llm=MagicMock(),
+        embedder=lambda texts: [[0.1] * 8 for _ in texts],
+        root_scope="/crew/test",
+    )
+
+    mem.reset_all()
+    mem.remember(
+        "new embedder output",
+        scope="/facts",
+        categories=["test"],
+        importance=0.5,
+    )
+
+    assert mem.recall("new embedder output", scope="/facts", depth="shallow")
 
 
 def test_lancedb_matching_dim_still_works(lancedb_path: Path) -> None:

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -954,6 +954,54 @@ def test_remember_many_returns_immediately(tmp_path: Path) -> None:
     assert mem._storage.count() == 2
 
 
+def test_reset_all_blocks_new_save_submission_until_reset_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A save cannot be submitted between draining writes and resetting storage."""
+    from crewai.memory.unified_memory import Memory
+
+    mem = Memory(
+        storage=str(tmp_path / "db"),
+        llm=MagicMock(),
+        embedder=lambda texts: [[0.1] * 4 for _ in texts],
+    )
+    reset_started = threading.Event()
+    release_reset = threading.Event()
+    submission_returned = threading.Event()
+    order: list[str] = []
+    original_reset = mem._storage.reset
+
+    def blocking_reset(scope_prefix: str | None = None) -> None:
+        order.append("reset-start")
+        reset_started.set()
+        assert release_reset.wait(timeout=2)
+        original_reset(scope_prefix=scope_prefix)
+        order.append("reset-end")
+
+    def submit_save() -> None:
+        mem._submit_save(lambda: order.append("save"))
+        order.append("submit-returned")
+        submission_returned.set()
+
+    monkeypatch.setattr(mem._storage, "reset", blocking_reset)
+
+    reset_thread = threading.Thread(target=mem.reset_all)
+    reset_thread.start()
+    assert reset_started.wait(timeout=2)
+
+    submit_thread = threading.Thread(target=submit_save)
+    submit_thread.start()
+    assert not submission_returned.wait(timeout=0.1)
+
+    release_reset.set()
+    reset_thread.join(timeout=2)
+    submit_thread.join(timeout=2)
+
+    assert not reset_thread.is_alive()
+    assert not submit_thread.is_alive()
+    assert order.index("reset-end") < order.index("submit-returned")
+
+
 def test_recall_drains_pending_writes(tmp_path: Path, mock_embedder: MagicMock) -> None:
     """recall() should automatically wait for pending background saves."""
     from crewai.memory.unified_memory import Memory

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -4584,6 +4584,26 @@ def test_reset_knowledge_with_no_crew_knowledge(researcher, writer):
     )
 
 
+def test_reset_memory_uses_full_unified_memory_reset(researcher):
+    crew = Crew(
+        agents=[researcher],
+        process=Process.sequential,
+        tasks=[
+            Task(description="Task 1", expected_output="output", agent=researcher),
+        ],
+        memory=True,
+    )
+
+    assert isinstance(crew._memory, Memory)
+    with patch.object(Memory, "reset_all") as reset_all, patch.object(
+        Memory, "reset"
+    ) as reset:
+        crew.reset_memories(command_type="memory")
+
+    reset_all.assert_called_once_with()
+    reset.assert_not_called()
+
+
 def test_reset_knowledge_with_only_crew_knowledge(researcher, writer):
     mock_ks = MagicMock(spec=Knowledge)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,8 @@ exclude-newer = "3 days"
 # pip <26.1.1 has GHSA-58qw-9mgm-455v (archive handling); OSV considers 26.1.1 unaffected.
 # paramiko <5.0.0 has GHSA-r374-rxx8-8654 (SHA-1 in rsakey.py); OSV considers 5.0.0 unaffected. Transitive via composio-core.
 # starlette <1.3.1 has PYSEC-2026-161, GHSA-jp82-jpqv-5vv3, and GHSA-82w8-qh3p-5jfq. Transitive via fastapi.
-# litellm 1.83.8+ hard-pins openai==2.24.0, missing openai.types.responses used by crewai;
-# override to >=2.30.0 (the version litellm 1.83.7 used) until upstream relaxes the pin.
+# Keep OpenAI on the SDK range required by CrewAI when transitive dependencies
+# loosen or pin their own lower versions.
 override-dependencies = [
     "openai>=2.30.0,<3",
     "rich>=13.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ requires-dist = [
     { name = "json5", specifier = "~=0.10.0" },
     { name = "jsonref", specifier = "~=1.1.0" },
     { name = "lancedb", specifier = ">=0.29.2,<0.30.1" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.83.7,<1.84" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<1.85" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
     { name = "openai", specifier = ">=2.30.0,<3" },
@@ -4078,7 +4078,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.84.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4094,9 +4094,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2c/eda7995bc9d6a7277be409a317893df52a25131a21ed572651a3c27ac20e/litellm-1.84.8.tar.gz", hash = "sha256:5a6349ce1c153fc27c9b1f88c39a396779c30af16704d9ef3633ccb24d04d374", size = 15117432, upload-time = "2026-06-13T01:25:25.125Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/70a4f3378130564505046e94ce521363f50d075198e16b7663b66b11eb23/litellm-1.84.8-py3-none-any.whl", hash = "sha256:297b81d56b3fdfc39411b0330edce0f29a4b2e82e90d5f73efdc102b57cb45e7", size = 16747828, upload-time = "2026-06-13T01:25:12.964Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added `reset_all` method to the `Memory` class to reset the entire memory store, ignoring `root_scope`.
- Updated the `Crew` class to utilize `reset_all` when resetting memory.
- Enhanced the `_reset_flow_memory` function to check for `Memory` instances and call `reset_all` accordingly.
- Introduced helper functions to load JSON crew configurations and handle project declarations, improving the reset command's flexibility.
- Added tests to validate the new JSON crew memory reset behavior and ensure proper handling of declared flow projects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistent memory wipe semantics and concurrent save behavior during reset; incorrect locking could cause data loss or stuck saves, though coverage targets the race.
> 
> **Overview**
> Improves **unified memory reset** so CLI and crew/flow paths clear the whole backing store (not only `root_scope`), and coordinates resets with background saves. Bumps the optional **litellm** extra to `>=1.84.0,<1.85` (lockfile updated).
> 
> **Memory:** Adds `reset_all()` (full storage wipe via `scope_prefix=None`). `reset()` and `reset_all()` now take an `_reset_lock`, call `drain_writes()` first, and `_submit_save` runs under the same lock so new saves cannot slip in mid-reset. Crew and flow reset paths call `reset_all()` for `Memory` instances.
> 
> **CLI `reset-memories`:** Discovers JSON-first crews from `crew.jsonc` (via `load_crew`) and appends them to the crew list; skips that path when `pyproject.toml` declares `type = "flow"`. Invalid JSON crews log a skip message without blocking classic crews.
> 
> **Tests** cover full reset for crews/flows, reset/save ordering, JSON crew scenarios, and `reset_all` after embedding dimension mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f357e7f814e9ce1b49ddb4386dff081e0e8448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of unified memory resets by coordinating with background save activity to prevent race conditions.
  * Unified memory resets now follow the full-reset path for applicable flow and crew scenarios.
  * JSON crew handling during memory reset is more robust: invalid JSON won’t block classic resets, and flow-typed projects skip JSON loading appropriately.

* **Tests**
  * Expanded CLI and unified memory test coverage, including concurrency blocking and reset-all behavior.

* **Chores**
  * Updated the optional `litellm` version range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->