### PR TITLE
fix(tools): pin FileWriterTool writes to the workspace directory

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/file_writer_tool/file_writer_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/file_writer_tool/file_writer_tool.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from crewai_tools.security.safe_path import (
     format_error_for_display,
     format_path_for_display,
+    validate_file_path,
 )
 
 
@@ -57,6 +58,19 @@ class FileWriterTool(BaseTool):
                 or real_filepath == real_directory
             ):
                 return "Error: Invalid file path — the filename must not escape the target directory."
+
+            # The is_relative_to() check above only confines ``filename`` within
+            # ``directory`` — but ``directory`` is itself a model-controlled
+            # argument with no workspace anchoring, so an absolute root such as
+            # ``/etc/cron.d`` or ``~/.ssh`` would otherwise allow writes outside
+            # the working directory. Pin the resolved target to the workspace
+            # (cwd) using the same validator FileReadTool relies on. The
+            # CREWAI_TOOLS_ALLOW_UNSAFE_PATHS escape hatch remains available for
+            # callers that intentionally need to write outside the workspace.
+            try:
+                validate_file_path(str(real_filepath))
+            except ValueError as e:
+                return f"Error: Invalid file path: {e!s}"
 
             if kwargs.get("directory"):
                 os.makedirs(real_directory, exist_ok=True)

--- a/lib/crewai-tools/tests/tools/test_file_writer_tool.py
+++ b/lib/crewai-tools/tests/tools/test_file_writer_tool.py
@@ -12,8 +12,13 @@ def tool():
 
 
 @pytest.fixture
-def temp_env():
-    temp_dir = tempfile.mkdtemp()
+def temp_env(tmp_path, monkeypatch):
+    # FileWriterTool pins writes to the current working directory (the
+    # workspace), so the target directory must live inside the cwd. Run each
+    # test from an isolated workspace and use a nested directory within it.
+    monkeypatch.chdir(tmp_path)
+    temp_dir = os.path.join(str(tmp_path), "workspace")
+    os.makedirs(temp_dir, exist_ok=True)
     test_file = "test.txt"
     test_content = "Hello, World!"
 
@@ -194,5 +199,69 @@ def test_blocks_symlink_escape(tool, temp_env):
         )
         assert "Error" in result
         assert not os.path.exists(outside_file)
+    finally:
+        shutil.rmtree(outside_dir, ignore_errors=True)
+
+
+def test_blocks_absolute_directory_outside_workspace(tool, tmp_path, monkeypatch):
+    # The directory argument is fully model-controlled. An absolute directory
+    # outside the workspace (cwd) must be refused even when the filename itself
+    # is benign, otherwise the resolved path escapes the workspace.
+    monkeypatch.chdir(tmp_path)
+    outside_dir = tempfile.mkdtemp()
+    outside_file = os.path.join(outside_dir, "authorized_keys")
+    try:
+        result = tool._run(
+            filename="authorized_keys",
+            directory=outside_dir,
+            content="ssh-rsa AAAA...",
+            overwrite=True,
+        )
+        assert "Error" in result
+        assert "Invalid file path" in result
+        assert not os.path.exists(outside_file)
+        # The error must not disclose the absolute workspace/target prefix.
+        assert str(tmp_path) not in result
+    finally:
+        shutil.rmtree(outside_dir, ignore_errors=True)
+
+
+def test_does_not_create_directory_outside_workspace(tool, tmp_path, monkeypatch):
+    # os.makedirs(real_directory) must not run for a rejected out-of-workspace
+    # target — the model must not be able to create arbitrary directories.
+    monkeypatch.chdir(tmp_path)
+    parent = tempfile.mkdtemp()
+    target_dir = os.path.join(parent, "should_not_be_created")
+    try:
+        result = tool._run(
+            filename="x.txt",
+            directory=target_dir,
+            content="nope",
+            overwrite=True,
+        )
+        assert "Error" in result
+        assert not os.path.exists(target_dir)
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
+
+
+def test_escape_hatch_allows_outside_workspace_write(tool, tmp_path, monkeypatch):
+    # Callers that intentionally need to write outside the workspace can opt in
+    # via the documented CREWAI_TOOLS_ALLOW_UNSAFE_PATHS escape hatch. This keeps
+    # the guard backward-compatible for explicit, trusted usage.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CREWAI_TOOLS_ALLOW_UNSAFE_PATHS", "true")
+    outside_dir = tempfile.mkdtemp()
+    outside_file = os.path.join(outside_dir, "test.txt")
+    try:
+        result = tool._run(
+            filename="test.txt",
+            directory=outside_dir,
+            content="explicitly allowed",
+            overwrite=True,
+        )
+        assert "successfully written" in result
+        assert os.path.exists(outside_file)
+        assert read_file(outside_file) == "explicitly allowed"
     finally:
         shutil.rmtree(outside_dir, ignore_errors=True)


### PR DESCRIPTION
FileWriterTool already rejected filename escapes (../, absolute filename, symlink) by checking that the resolved path is relative to the target directory. However, that directory is itself a fully model-controlled argument with no workspace anchoring, so an absolute root such as /etc/cron.d or ~/.ssh passed as `directory` resolved the final path "inside" an attacker-chosen root and the containment check passed — yielding an out-of-workspace write (and os.makedirs of the chosen root) with no non-default flag.

Anchor the resolved write target to the current working directory using validate_file_path() from crewai_tools.security.safe_path — the same cwd-pinned validator FileReadTool already uses. The existing is_relative_to() filename-escape guard is kept as defense in depth.

The documented CREWAI_TOOLS_ALLOW_UNSAFE_PATHS escape hatch continues to let callers opt in to writes outside the workspace, so explicit/trusted usage stays backward compatible. The public _run() signature is unchanged.

Existing tests that wrote to absolute temp dirs are updated to run inside an isolated workspace (the established FileReadTool test idiom). New regression tests cover the directory-as-root vector and the opt-in escape hatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced security test coverage for FileWriterTool to validate path confinement behavior and prevent unauthorized writes outside the workspace directory.
  * Added tests confirming the tool rejects writes to absolute paths outside the workspace and supports optional unsafe path handling via environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->