### PR TITLE
fix(deps): widen litellm extra to >=1.84,<2

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -88,7 +88,7 @@ voyageai = [
     "voyageai~=0.3.5",
 ]
 litellm = [
-    "litellm>=1.84.0,<1.85",
+    "litellm>=1.84.0,<2",
 ]
 bedrock = [
     "boto3~=1.42.79",

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ requires-dist = [
     { name = "json5", specifier = "~=0.10.0" },
     { name = "jsonref", specifier = "~=1.1.0" },
     { name = "lancedb", specifier = ">=0.29.2,<0.30.1" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<1.85" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<2" },
     { name = "mcp", specifier = "~=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.0,<3" },
     { name = "openai", specifier = ">=2.30.0,<3" },


### PR DESCRIPTION
## Summary

The `litellm` extra in `lib/crewai/pyproject.toml` was capped at `>=1.84.0,<1.85`. The upper bound excludes future patch lines and reintroduces uv/pip resolution failures.

Widen to `>=1.84.0,<2` so the extra resolves cleanly against crewai's own `openai>=2.30.0,<3` and `python-dotenv>=1.2.2,<2` pins. litellm 1.84+ loosens its transitive `openai`/`python-dotenv` pins, so the intersection is satisfiable without a downstream uv override.

## Changes

- `lib/crewai/pyproject.toml`: `litellm>=1.84.0,<1.85` → `litellm>=1.84.0,<2`
- `uv.lock`: regenerated (`uv lock`); resolves 476 packages, litellm stays at 1.84.8

Closes OSS-71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-range-only change with no runtime code; slightly broader litellm surface for consumers who opt into the extra.
> 
> **Overview**
> Relaxes the **`litellm` optional extra** version cap from `>=1.84.0,<1.85` to **`>=1.84.0,<2`** in `lib/crewai/pyproject.toml`, so installs with `crewai[litellm]` can pick newer 1.x releases and uv/pip resolution is less likely to fail against crewai’s existing **`openai`** and **`python-dotenv`** pins.
> 
> **`uv.lock`** is updated to match the new specifier; resolved **`litellm`** version remains on the 1.84 line (e.g. 1.84.8).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30cd69e685ef3c04f65a199705969dc4b79f448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated litellm optional dependency constraint to support a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->