### PR TITLE
fix(reasoning): detect short-form "READY" when concluding a plan

### DIFF
--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -409,7 +409,7 @@ class AgentReasoning:
             return (
                 response_str,
                 [],
-                "READY: I am ready to execute the task." in response_str,
+                AgentReasoning._check_ready(response_str),
             )
 
         except Exception as e:
@@ -433,7 +433,7 @@ class AgentReasoning:
                 return (
                     fallback_str,
                     [],
-                    "READY: I am ready to execute the task." in fallback_str,
+                    AgentReasoning._check_ready(fallback_str),
                 )
             except Exception as inner_e:
                 self.logger.error(f"Error during fallback text parsing: {inner_e!s}")
@@ -580,6 +580,29 @@ class AgentReasoning:
             )
 
     @staticmethod
+    def _check_ready(response: str) -> bool:
+        """Return True when the response signals readiness.
+
+        Accepts the full-sentence form used by the initial-plan prompt
+        ('READY: I am ready to execute the task.') and the short 'READY' /
+        'NOT READY' form used by the refine-plan and planning prompts.
+
+        Only the last meaningful line is inspected for the short form, so a plan
+        body that merely mentions the word "ready" is not misread as readiness,
+        and 'NOT READY' is never matched. Surrounding markdown emphasis and
+        punctuation (e.g. ``**READY**``, ``## READY``, ``READY.``) are stripped,
+        and pure-separator lines (e.g. ``---``) are skipped.
+        """
+        if "READY: I am ready to execute the task." in response:
+            return True
+        for line in reversed(response.splitlines()):
+            conclusion = line.strip().strip("*`#_-.!:> ").upper()
+            if not conclusion:
+                continue
+            return conclusion == "READY"
+        return False
+
+    @staticmethod
     def _parse_planning_response(response: str) -> tuple[str, bool]:
         """Parses the planning response to extract the plan and readiness.
 
@@ -593,7 +616,7 @@ class AgentReasoning:
             return "No plan was generated.", False
 
         plan = response
-        ready = "READY: I am ready to execute the task." in response
+        ready = AgentReasoning._check_ready(response)
 
         return plan, ready
 

--- a/lib/crewai/tests/utilities/test_structured_planning.py
+++ b/lib/crewai/tests/utilities/test_structured_planning.py
@@ -667,3 +667,92 @@ class TestTodoListIntegration:
         todo_list.mark_completed(3)
 
         assert can_execute(todo_list.items[3]) is True
+
+
+class TestCheckReady:
+    """Tests for AgentReasoning._check_ready and _parse_planning_response.
+
+    The ready-detection must accept both the full-sentence form produced by the
+    initial-plan prompt and the short 'READY' / 'NOT READY' form produced by
+    the refine-plan and planning prompts.  Previously only the full sentence
+    was recognised, so a refine-loop response of just 'READY' was treated as
+    'NOT READY', causing infinite re-planning (#6204).
+    """
+
+    def test_full_sentence_ready(self):
+        """Full-sentence form from reasoning.create_plan_prompt is accepted."""
+        response = "Step 1: do X\n\nREADY: I am ready to execute the task."
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_ready(self):
+        """Short 'READY' at the end of a response (refine/planning prompts) is accepted."""
+        response = "Step 1: do X\nStep 2: do Y\n\n---\n\nREADY"
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_ready_with_trailing_period(self):
+        """'READY.' (with punctuation) at the last line is accepted."""
+        response = "My plan.\n\nREADY."
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_ready_markdown_bold(self):
+        """Markdown-emphasised '**READY**' is accepted (models often bold it)."""
+        response = "Step 1: do X\nStep 2: do Y\n\n**READY**"
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_ready_markdown_heading(self):
+        """A markdown heading '## READY' is accepted."""
+        response = "Plan body.\n\n## READY"
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_ready_after_separator_line(self):
+        """A trailing '---' separator after READY does not hide readiness."""
+        response = "Plan body.\n\n---\n\nREADY\n\n---"
+        assert AgentReasoning._check_ready(response) is True
+
+    def test_short_form_not_ready(self):
+        """Short 'NOT READY' is correctly treated as not ready."""
+        response = "My plan.\n\nNOT READY"
+        assert AgentReasoning._check_ready(response) is False
+
+    def test_short_form_not_ready_markdown_bold(self):
+        """Emphasised '**NOT READY**' is never matched as ready."""
+        response = "My plan.\n\n**NOT READY**"
+        assert AgentReasoning._check_ready(response) is False
+
+    def test_word_ready_in_body_only_is_not_ready(self):
+        """A plan body that mentions 'ready' but ends with NOT READY is not ready."""
+        response = "I am almost ready but a tool is missing.\n\nNOT READY"
+        assert AgentReasoning._check_ready(response) is False
+
+    def test_already_in_last_line_is_not_a_false_positive(self):
+        """A last line like 'ALREADY DONE' must not be read as 'READY'."""
+        response = "Plan.\n\nALREADY DONE"
+        assert AgentReasoning._check_ready(response) is False
+
+    def test_full_sentence_not_ready(self):
+        """Full-sentence NOT READY is correctly treated as not ready."""
+        response = "My plan.\n\nNOT READY: I need to refine because the tools are unclear."
+        assert AgentReasoning._check_ready(response) is False
+
+    def test_empty_response_not_ready(self):
+        """Empty response is not ready."""
+        assert AgentReasoning._check_ready("") is False
+
+    def test_parse_planning_response_short_ready(self):
+        """_parse_planning_response returns ready=True for short-form READY."""
+        response = "Do X.\nDo Y.\n\nREADY"
+        plan, ready = AgentReasoning._parse_planning_response(response)
+        assert ready is True
+        assert plan == response
+
+    def test_parse_planning_response_short_not_ready(self):
+        """_parse_planning_response returns ready=False for short-form NOT READY."""
+        response = "Do X.\n\nNOT READY"
+        plan, ready = AgentReasoning._parse_planning_response(response)
+        assert ready is False
+
+    def test_parse_planning_response_empty(self):
+        """_parse_planning_response returns ready=False for empty response."""
+        plan, ready = AgentReasoning._parse_planning_response("")
+        assert ready is False
+        assert plan == "No plan was generated."


### PR DESCRIPTION
## Summary

Fixes #6204. When an agent uses reasoning/planning, the executor asks the model to conclude its plan with a readiness signal and re-plans while "not ready". The model frequently replies with a bare **`READY`**, but the parser only recognised the *full sentence* `READY: I am ready to execute the task.` — so a ready model was read as **not ready** and the agent kept refining the plan (indefinitely when `max_attempts is None`).

The mismatch is between the prompts and the parser:

| Prompt (`translations/en.json`) | What it asks the model to output |
|---|---|
| `reasoning.create_plan_prompt` | `"READY: I am ready to execute the task."` (full sentence) |
| `reasoning.refine_plan_prompt` | **`Conclude with READY or NOT READY.`** (bare token) |
| `planning.create_plan_prompt` | **`After your plan, state READY or NOT READY.`** (bare token) |
| `planning.refine_plan_prompt` | **`Conclude with READY or NOT READY as before.`** (bare token) |

The readiness check only matched the full sentence:

```python
# reasoning_handler.py — before
ready = "READY: I am ready to execute the task." in response
```

So three of the four prompts could never produce a "ready" verdict. In `_refine_plan_if_needed`, `while not ready and (max_attempts is None or attempt < max_attempts)` then loops — wasted refine calls, or no termination at all with the default `max_attempts=None`.

## Fix

Add `AgentReasoning._check_ready`, used by `_parse_planning_response` and the two `_call_with_function` fallback paths. It accepts **both** forms and inspects only the *last meaningful line* for the short form, so a plan body that merely mentions the word "ready" isn't misread, and **`NOT READY` is never matched**:

```python
@staticmethod
def _check_ready(response: str) -> bool:
    if "READY: I am ready to execute the task." in response:
        return True
    for line in reversed(response.splitlines()):
        conclusion = line.strip().strip("*`#_-.!:> ").upper()
        if not conclusion:
            continue
        return conclusion == "READY"
    return False
```

Surrounding markdown emphasis/punctuation (`**READY**`, `## READY`, `READY.`) is stripped and pure-separator lines (`---`) are skipped, since real model output (the report used an Ollama GLM model) is rarely a clean bare token.

## Test plan

New `TestCheckReady` (15 cases) in `tests/utilities/test_structured_planning.py` covering full-sentence and short forms, markdown/heading/separator variants, and the critical negatives (`NOT READY`, `ALREADY DONE`, body-only "ready").

Fail-before / pass-after (source stashed, tests kept):

- **Before** (`origin/main`): `13 failed, 2 passed` — e.g. `test_parse_planning_response_short_ready` fails `assert False is True`.
- **After**: `15 passed`.

Full file: `38 passed`; the 3 remaining failures are pre-existing optional-provider import errors (`azure`/`anthropic`/`gemini` native providers not installed) unrelated to this change. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent readiness detection to reliably interpret multiple “READY/NOT READY” response formats (including markdown, headings, and punctuation) while reducing false positives from unrelated text.
  * Updated structured planning parsing to use the same readiness detection logic for consistent `ready` behavior.
* **Tests**
  * Added unit tests covering common and edge-case planning response formats, including empty responses and “ALREADY DONE” negative scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
