### PR TITLE
fix(bedrock): parse streaming tool args from contentBlockDelta events

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -1034,9 +1034,19 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
-                            function_args = cast(
-                                dict[str, Any], current_tool_use.get("input", {})
-                            )
+                            if accumulated_tool_input:
+                                try:
+                                    function_args = json.loads(accumulated_tool_input)
+                                except json.JSONDecodeError:
+                                    function_args = {}
+                                    logging.warning(
+                                        f"Failed to parse accumulated tool input: {accumulated_tool_input[:200]}"
+                                    )
+                            else:
+                                function_args = cast(
+                                    dict[str, Any], current_tool_use.get("input", {})
+                                )
+                            current_tool_use["input"] = function_args
 
                             # Check if this is the structured_output tool
                             if (
@@ -1632,9 +1642,19 @@ class BedrockCompletion(BaseLLM):
                         logging.debug("Content block stopped in stream")
                         if current_tool_use:
                             function_name = current_tool_use["name"]
-                            function_args = cast(
-                                dict[str, Any], current_tool_use.get("input", {})
-                            )
+                            if accumulated_tool_input:
+                                try:
+                                    function_args = json.loads(accumulated_tool_input)
+                                except json.JSONDecodeError:
+                                    function_args = {}
+                                    logging.warning(
+                                        f"Failed to parse accumulated tool input: {accumulated_tool_input[:200]}"
+                                    )
+                            else:
+                                function_args = cast(
+                                    dict[str, Any], current_tool_use.get("input", {})
+                                )
+                            current_tool_use["input"] = function_args
 
                             # Check if this is the structured_output tool
                             if (

--- a/lib/crewai/tests/llms/bedrock/test_bedrock_streaming_tool_args.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock_streaming_tool_args.py
@@ -1,0 +1,250 @@
+"""Tests for Bedrock streaming tool argument parsing (fixes #6149).
+
+The Bedrock Converse streaming API delivers tool-call arguments as JSON
+string fragments across ``contentBlockDelta`` events.  At
+``contentBlockStop`` the handler must parse the accumulated string and
+use the result — not read ``current_tool_use["input"]`` which is always
+empty in the streaming path.
+"""
+
+import os
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from crewai.llm import LLM
+
+
+@pytest.fixture(autouse=True)
+def mock_aws_credentials():
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test-access-key",
+        "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }):
+        with patch(
+            "crewai.llms.providers.bedrock.completion.Session"
+        ) as mock_session_class:
+            mock_session_instance = MagicMock()
+            mock_client = MagicMock()
+
+            default_response = {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"text": "Test response"}],
+                    }
+                },
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 5,
+                    "totalTokens": 15,
+                },
+            }
+            mock_client.converse.return_value = default_response
+            mock_client.converse_stream.return_value = {"stream": []}
+            mock_session_instance.client.return_value = mock_client
+            mock_session_class.return_value = mock_session_instance
+            yield mock_session_class, mock_client
+
+
+def _build_stream_events(tool_name, tool_use_id, arg_chunks):
+    """Build a synthetic Converse stream that delivers tool args in chunks.
+
+    ``arg_chunks`` is a list of JSON string fragments that, when
+    concatenated, form the complete arguments object.
+    """
+    events = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {
+                    "toolUse": {
+                        "toolUseId": tool_use_id,
+                        "name": tool_name,
+                    }
+                },
+            }
+        },
+    ]
+    for chunk in arg_chunks:
+        events.append(
+            {
+                "contentBlockDelta": {
+                    "delta": {"toolUse": {"input": chunk}},
+                    "contentBlockIndex": 0,
+                }
+            }
+        )
+    events.append({"contentBlockStop": {"contentBlockIndex": 0}})
+    events.append({"messageStop": {"stopReason": "tool_use"}})
+    events.append(
+        {
+            "metadata": {
+                "usage": {
+                    "inputTokens": 100,
+                    "outputTokens": 50,
+                    "totalTokens": 150,
+                }
+            }
+        }
+    )
+    return events
+
+
+def test_streaming_tool_args_parsed_from_deltas():
+    """Tool arguments accumulated across contentBlockDelta events must be
+    passed to the tool function — not the empty dict from
+    contentBlockStart.
+    """
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", stream=True)
+
+    received_args = {}
+
+    def mock_weather_tool(city: str) -> str:
+        received_args.update({"city": city})
+        return f"Sunny in {city}"
+
+    available_functions = {"get_weather": mock_weather_tool}
+
+    arg_chunks = ['{"city":', ' "Paris"}']
+    stream_events = _build_stream_events("get_weather", "tool-001", arg_chunks)
+
+    final_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "It is sunny in Paris."}],
+            }
+        },
+        "usage": {"inputTokens": 120, "outputTokens": 30, "totalTokens": 150},
+    }
+
+    with patch.object(llm._client, "converse_stream") as mock_stream, \
+         patch.object(llm._client, "converse") as mock_converse:
+        mock_stream.return_value = {"stream": iter(stream_events)}
+        mock_converse.return_value = final_response
+
+        messages = [{"role": "user", "content": "What's the weather in Paris?"}]
+        result = llm.call(messages=messages, available_functions=available_functions)
+
+    assert received_args == {"city": "Paris"}
+    assert "sunny" in result.lower() or "paris" in result.lower()
+
+
+def test_streaming_tool_args_single_chunk():
+    """When the full JSON arrives in one delta, parsing still works."""
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", stream=True)
+
+    received_args = {}
+
+    def mock_search(query: str, limit: int) -> str:
+        received_args.update({"query": query, "limit": limit})
+        return "results"
+
+    available_functions = {"search": mock_search}
+
+    full_json = json.dumps({"query": "crewai bedrock", "limit": 10})
+    stream_events = _build_stream_events("search", "tool-002", [full_json])
+
+    final_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Here are the results."}],
+            }
+        },
+        "usage": {"inputTokens": 50, "outputTokens": 20, "totalTokens": 70},
+    }
+
+    with patch.object(llm._client, "converse_stream") as mock_stream, \
+         patch.object(llm._client, "converse") as mock_converse:
+        mock_stream.return_value = {"stream": iter(stream_events)}
+        mock_converse.return_value = final_response
+
+        messages = [{"role": "user", "content": "Search for crewai bedrock"}]
+        result = llm.call(messages=messages, available_functions=available_functions)
+
+    assert received_args == {"query": "crewai bedrock", "limit": 10}
+
+
+def test_streaming_tool_args_many_chunks():
+    """Arguments split across many small deltas are reassembled correctly."""
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", stream=True)
+
+    received_args = {}
+
+    def mock_tool(name: str, value: int) -> str:
+        received_args.update({"name": name, "value": value})
+        return "ok"
+
+    available_functions = {"my_tool": mock_tool}
+
+    arg_chunks = ["{", '"name"', ": ", '"hello', ' world"', ", ", '"value"', ": ", "42", "}"]
+    stream_events = _build_stream_events("my_tool", "tool-003", arg_chunks)
+
+    final_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Done."}],
+            }
+        },
+        "usage": {"inputTokens": 30, "outputTokens": 10, "totalTokens": 40},
+    }
+
+    with patch.object(llm._client, "converse_stream") as mock_stream, \
+         patch.object(llm._client, "converse") as mock_converse:
+        mock_stream.return_value = {"stream": iter(stream_events)}
+        mock_converse.return_value = final_response
+
+        messages = [{"role": "user", "content": "Do the thing"}]
+        llm.call(messages=messages, available_functions=available_functions)
+
+    assert received_args == {"name": "hello world", "value": 42}
+
+
+def test_streaming_tool_use_input_set_on_current_tool_use():
+    """After parsing, current_tool_use['input'] must be populated so the
+    assistant message appended to the conversation carries the real args.
+    """
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", stream=True)
+
+    def mock_tool(x: int) -> str:
+        return str(x * 2)
+
+    available_functions = {"double": mock_tool}
+
+    arg_chunks = ['{"x": 21}']
+    stream_events = _build_stream_events("double", "tool-004", arg_chunks)
+
+    final_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "42"}],
+            }
+        },
+        "usage": {"inputTokens": 30, "outputTokens": 5, "totalTokens": 35},
+    }
+
+    with patch.object(llm._client, "converse_stream") as mock_stream, \
+         patch.object(llm._client, "converse") as mock_converse:
+        mock_stream.return_value = {"stream": iter(stream_events)}
+        mock_converse.return_value = final_response
+
+        messages = [{"role": "user", "content": "Double 21"}]
+        llm.call(messages=messages, available_functions=available_functions)
+
+    # The second call (non-streaming follow-up) should have received
+    # messages containing the assistant's toolUse block with populated input.
+    follow_up_messages = mock_converse.call_args[1].get(
+        "messages", mock_converse.call_args[0][0] if mock_converse.call_args[0] else []
+    )
+    assistant_msg = next(
+        (m for m in follow_up_messages if m["role"] == "assistant"), None
+    )
+    assert assistant_msg is not None
+    tool_use_block = assistant_msg["content"][0]["toolUse"]
+    assert tool_use_block["input"] == {"x": 21}


### PR DESCRIPTION
## Problem

Every Bedrock streaming tool call silently receives empty arguments (`{}`), causing pydantic `Field required` validation failures on any tool with required parameters. This makes native tool calling unusable for all Bedrock models when streaming is enabled — the streaming counterpart of #4972 (fixed for non-streaming in #5415).

**Before (broken):**
```
contentBlockStart → toolUse: {name: "get_weather", toolUseId: "abc"}     # no "input"
contentBlockDelta → toolUse: {input: '{"city":'}                          # fragment 1
contentBlockDelta → toolUse: {input: ' "Paris"}'}                         # fragment 2
contentBlockStop  → function_args = current_tool_use.get("input", {})     # ← always {}
                  → tool receives: {}
                  → Field required [type=missing, input_value={}, input_type=dict]
```

**After (fixed):**
```
contentBlockStop  → function_args = json.loads('{"city": "Paris"}')       # accumulated string
                  → current_tool_use["input"] = {"city": "Paris"}         # backfilled for history
                  → tool receives: {"city": "Paris"}                      # ✓
```

## Root cause

Both `_handle_streaming_converse` (sync) and `_ahandle_streaming_converse` (async) accumulate tool input deltas into `accumulated_tool_input` during `contentBlockDelta` events — but at `contentBlockStop`, they read from `current_tool_use.get("input", {})` instead. `current_tool_use` is set at `contentBlockStart`, which only carries `name` and `toolUseId`. The Converse streaming API never puts `input` on the start block; it delivers arguments as JSON string fragments across delta events.

The non-streaming path works because Bedrock's `converse()` response includes the complete `input` dict on the `toolUse` block.

This is an instance of a general pattern in streaming APIs (SSE, WebSocket, Converse): payloads arrive fragmented, so any handler that reads from the initial block instead of the accumulated buffer will silently drop content.

## Fix

At `contentBlockStop`, parse `accumulated_tool_input` via `json.loads()` when it's non-empty. Fall back to `current_tool_use.get("input", {})` only when no deltas were received (defensive). Write the parsed result back to `current_tool_use["input"]` so the assistant message appended to conversation history also carries the real arguments.

Applied identically to both sync and async streaming handlers. The change is 13 lines per handler (26 total production lines).

## Tests

4 new tests in `test_bedrock_streaming_tool_args.py`, each constructing a synthetic Converse stream:

| Test | What it verifies |
|------|-----------------|
| `test_streaming_tool_args_parsed_from_deltas` | Args split across 2 chunks → tool receives `{"city": "Paris"}` |
| `test_streaming_tool_args_single_chunk` | Full JSON in one delta → multi-key args parsed correctly |
| `test_streaming_tool_args_many_chunks` | Args split across 10 small fragments → reassembled correctly |
| `test_streaming_tool_use_input_set_on_current_tool_use` | `current_tool_use["input"]` populated in conversation history |

**Results:** 4/4 new tests pass. 35/36 pre-existing Bedrock tests pass (1 pre-existing failure in `test_bedrock_raises_error_when_model_not_found` is unrelated — fails on `main` too).

## Impact

This unblocks all Bedrock streaming tool calls in CrewAI. Any crew using `bedrock/...` models with `stream=True` and tools with required parameters was hitting silent argument loss → validation errors → max-iteration exhaustion.

## Related

- #6149 — this issue (streaming twin of #4972)
- #4972 — non-streaming Bedrock tool arg dropping (fixed by #5415)
- #5739 — prior attempt at this fix (stalled, no tests)