### PR TITLE
ci: fail PRs over 1500 lines of python changes

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -43,13 +43,16 @@ jobs:
         env:
           MAX: "1500"
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Three-dot base...head == merge-base(base, head)..head: matches GitHub's
+          # "Files changed" diff and ignores the synthetic merge commit at HEAD.
           # Sum added + deleted lines across changed .py files; skip binaries ("-").
-          total=$(git diff --numstat "$BASE_SHA...HEAD" -- '*.py' \
+          total=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" -- '*.py' \
             | awk '$1 != "-" && $2 != "-" { sum += $1 + $2 } END { print sum + 0 }')
           echo "Python churn: $total lines (limit $MAX)"
           if [ "$total" -gt "$MAX" ]; then
             echo "::error::Python changes total $total lines, over the $MAX-line limit. Split into smaller PRs."
-            git diff --numstat "$BASE_SHA...HEAD" -- '*.py' | sort -rn
+            git diff --numstat "$BASE_SHA...$HEAD_SHA" -- '*.py' | sort -rn
             exit 1
           fi

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -30,3 +30,24 @@ jobs:
             **/*.json
             **/test_durations/**
             **/cassettes/**
+
+  python-diff-size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - name: Enforce Python diff size limit
+        env:
+          MAX: "1500"
+        run: |
+          base="origin/${{ github.base_ref }}"
+          # Sum added + deleted lines across changed .py files; skip binaries ("-").
+          total=$(git diff --numstat "$base...HEAD" -- '*.py' \
+            | awk '$1 != "-" && $2 != "-" { sum += $1 + $2 } END { print sum + 0 }')
+          echo "Python churn: $total lines (limit $MAX)"
+          if [ "$total" -gt "$MAX" ]; then
+            echo "::error::Python changes total $total lines, over the $MAX-line limit. Split into smaller PRs."
+            git diff --numstat "$base...HEAD" -- '*.py' | sort -rn
+            exit 1
+          fi

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -33,6 +33,8 @@ jobs:
 
   python-diff-size:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -40,14 +42,14 @@ jobs:
       - name: Enforce Python diff size limit
         env:
           MAX: "1500"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          base="origin/${{ github.base_ref }}"
           # Sum added + deleted lines across changed .py files; skip binaries ("-").
-          total=$(git diff --numstat "$base...HEAD" -- '*.py' \
+          total=$(git diff --numstat "$BASE_SHA...HEAD" -- '*.py' \
             | awk '$1 != "-" && $2 != "-" { sum += $1 + $2 } END { print sum + 0 }')
           echo "Python churn: $total lines (limit $MAX)"
           if [ "$total" -gt "$MAX" ]; then
             echo "::error::Python changes total $total lines, over the $MAX-line limit. Split into smaller PRs."
-            git diff --numstat "$base...HEAD" -- '*.py' | sort -rn
+            git diff --numstat "$BASE_SHA...HEAD" -- '*.py' | sort -rn
             exit 1
           fi


### PR DESCRIPTION
Adds a `python-diff-size` job to the existing PR Size Check workflow that fails when a PR's `.py` churn (added + deleted) exceeds 1500 lines.

- Counts only `.py` files, `origin/<base>...HEAD`, skips binaries.
- Runs unconditionally on every PR so it always reports — safe to mark required.
- Self-contained inline shell; no extra script or dependency.

The existing `pr-size-labeler` only labels XS–XL on total diff and never fails; this is the Python-specific hard gate.

Follow-up after merge: add the `python-diff-size` check to ruleset `main` (id 2686846), alongside `lint` / `tests (3.x)`, to make it block merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no runtime or application code impact; merge blocking depends on making the new check required in branch rules.
> 
> **Overview**
> Adds a **`python-diff-size`** job to the PR Size Check workflow that **fails the check** when added + deleted lines across `*.py` files exceed **1500**, complementing the existing labeler job which only assigns size labels and never blocks merges.
> 
> The job checks out full history, uses a three-dot `base...head` diff (aligned with GitHub’s “Files changed” view), sums line churn via `git diff --numstat`, and on failure emits a workflow error plus a sorted per-file breakdown. It runs on every PR open/sync/reopen with read-only `contents` permission and no extra dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4068fa3cfd549f63fd53a756f59a8885e7672c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation by adding an automated check for Python diff size, enforcing a maximum churn threshold and providing a per-file breakdown when the limit is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->