### PR TITLE
fix: force output visibility for human_input when verbose is False

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2802,8 +2802,15 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     )
 
                 if self.state.ask_for_human_input:
-                    formatted_answer = self._handle_human_feedback(formatted_answer)
+                            # Force output display using standard print & console utilities
+                            if formatted_answer and hasattr(formatted_answer, "output"):
+                                print(f"\n[FORCED OUTPUT] Final Answer: {formatted_answer.output}\n")
+                                try:
+                                    self._console.print(f"[bold purple]Final Answer:[/bold purple] {formatted_answer.output}")
+                                except Exception:
+                                    pass
 
+                            formatted_answer = self._handle_human_feedback(formatted_answer)
             self._save_to_memory(formatted_answer)
 
             return {"output": formatted_answer.output}
@@ -2908,10 +2915,17 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     )
 
                 if self.state.ask_for_human_input:
-                    formatted_answer = await self._ahandle_human_feedback(
-                        formatted_answer
-                    )
-
+                            # Force output display using standard print & console utilities
+                            if formatted_answer and hasattr(formatted_answer, "output"):
+                                print(f"\n[FORCED OUTPUT] Final Answer: {formatted_answer.output}\n")
+                                try:
+                                    self._console.print(f"[bold purple]Final Answer:[/bold purple] {formatted_answer.output}")
+                                except Exception:
+                                    pass
+                                    
+                            formatted_answer = await self._ahandle_human_feedback(
+                                formatted_answer
+                            )
             self._save_to_memory(formatted_answer)
 
             return {"output": formatted_answer.output}

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -2802,13 +2802,8 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     )
 
                 if self.state.ask_for_human_input:
-                            # Force output display using standard print & console utilities
-                            if formatted_answer and hasattr(formatted_answer, "output"):
-                                print(f"\n[FORCED OUTPUT] Final Answer: {formatted_answer.output}\n")
-                                try:
-                                    self._console.print(f"[bold purple]Final Answer:[/bold purple] {formatted_answer.output}")
-                                except Exception:
-                                    pass
+                            self._force_display_final_answer(formatted_answer)
+                            formatted_answer = self._handle_human_feedback(formatted_answer)
 
                             formatted_answer = self._handle_human_feedback(formatted_answer)
             self._save_to_memory(formatted_answer)
@@ -2915,17 +2910,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     )
 
                 if self.state.ask_for_human_input:
-                            # Force output display using standard print & console utilities
-                            if formatted_answer and hasattr(formatted_answer, "output"):
-                                print(f"\n[FORCED OUTPUT] Final Answer: {formatted_answer.output}\n")
-                                try:
-                                    self._console.print(f"[bold purple]Final Answer:[/bold purple] {formatted_answer.output}")
-                                except Exception:
-                                    pass
-                                    
-                            formatted_answer = await self._ahandle_human_feedback(
-                                formatted_answer
-                            )
+                                self._force_display_final_answer(formatted_answer)
+                                formatted_answer = await self._ahandle_human_feedback(
+                                    formatted_answer
+                                )
             self._save_to_memory(formatted_answer)
 
             return {"output": formatted_answer.output}
@@ -2944,7 +2932,13 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             raise
         finally:
             self._is_executing = False
-
+    def _force_display_final_answer(self, formatted_answer: Any) -> None:
+            """Forces display of the agent's final answer before human feedback loop."""
+            if formatted_answer and hasattr(formatted_answer, "output"):
+                try:
+                    self._console.print(f"[bold purple]Final Answer:[/bold purple] {formatted_answer.output}")
+                except Exception:
+                    print(f"\nFinal Answer: {formatted_answer.output}\n")
     async def ainvoke(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Async version of invoke. Alias for invoke_async."""
         return await self.invoke_async(inputs)

--- a/test_bug.py
+++ b/test_bug.py
@@ -1,0 +1,23 @@
+import sys
+# Forcing Python to read the precise source directories for both components
+sys.path.insert(0, r"C:\Users\zero\crewAI\lib\crewai\src")
+sys.path.insert(0, r"C:\Users\zero\crewAI\lib\crewai-core\src")
+
+from crewai import Agent, Crew, Task, Process
+from crewai.llms.base_llm import BaseLLM
+
+class StubLLM(BaseLLM):
+    def call(self, messages, tools=None, callbacks=None, available_functions=None,
+             from_task=None, from_agent=None, response_model=None):
+        return "Thought: I know it.\nFinal Answer: The sky is blue."
+        
+    def supports_function_calling(self) -> bool:
+        return False
+
+agent = Agent(role="Tester", goal="Be a Minimal Reproduction", backstory="bg",
+              llm=StubLLM(model="stub"), verbose=False)
+              
+task = Task(description="Sky colour?", expected_output="a colour",
+            agent=agent, human_input=True)
+            
+Crew(agents=[agent], tasks=[task], process=Process.sequential, verbose=False).kickoff()


### PR DESCRIPTION
This PR fixes a bug where enabling `human_input=True` on a task while the agent or crew has `verbose=False` causes the execution loop to halt and request feedback on a blank terminal screen. Because logs are suppressed, the human reviewer is prompted for input without any context regarding the agent's final answer.

### Changes
* Updated `AgentExecutor.invoke` and `AgentExecutor.invoke_async` within the experimental agent executor pipeline.
* Forced a dedicated print statement displaying the agent's `Final Answer` right before triggering the `_handle_human_feedback` prompt, ensuring execution visibility even when global verbosity is disabled.

### Testing Done
Verified using a minimal reproduction script containing an agent with a stubbed LLM (`verbose=False`) and a task (`human_input=True`). The console successfully prints the final agent output immediately prior to displaying the yellow "Human Feedback Required" panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * When human feedback is enabled, the agent’s final response is now shown immediately in the console (using the formatted “Final Answer” presentation when available) before human feedback is requested and processed.

* **Tests**
  * Added a targeted regression test that exercises the human-input flow with a stubbed LLM to ensure the updated console output behavior occurs during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->