### PR TITLE
fix(bedrock): resolve context window for cross-region inference profiles

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -2090,6 +2090,24 @@ class BedrockCompletion(BaseLLM):
         """Check if the model supports stop words."""
         return True
 
+    def _base_model_id(self) -> str:
+        """Strip the cross-region inference profile prefix from the model id.
+
+        AWS recommends invoking newer models through cross-region inference
+        profiles, whose ids carry a geographic prefix (e.g.
+        ``us.anthropic.claude-sonnet-4-...`` or ``eu.anthropic.claude-...``).
+        Lookups keyed on the bare model id must compare against the prefix-free
+        form so a profile id resolves to the same model as the base id.
+
+        Returns:
+            The model id with any cross-region prefix removed, lowercased.
+        """
+        model_lower = self.model.lower()
+        for prefix in ("us-gov.", "us.", "eu.", "apac."):
+            if model_lower.startswith(prefix):
+                return model_lower[len(prefix) :]
+        return model_lower
+
     def get_context_window_size(self) -> int:
         """Get the context window size for the model."""
         from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
@@ -2114,8 +2132,11 @@ class BedrockCompletion(BaseLLM):
             "deepseek.r1": 32768,
         }
 
+        # Match against the prefix-free id so cross-region inference profiles
+        # (e.g. ``us.anthropic.claude-sonnet-4-...``) resolve like the base id.
+        base_model = self._base_model_id()
         for model_prefix, size in context_windows.items():
-            if self.model.startswith(model_prefix):
+            if base_model.startswith(model_prefix):
                 return int(size * CONTEXT_WINDOW_USAGE_RATIO)
 
         return int(8192 * CONTEXT_WINDOW_USAGE_RATIO)
@@ -2128,7 +2149,9 @@ class BedrockCompletion(BaseLLM):
         Returns:
             True if the model supports images.
         """
-        model_lower = self.model.lower()
+        # Match against the prefix-free id so cross-region inference profiles
+        # (``us.``/``eu.``/``apac.``) resolve like the base id.
+        base_model = self._base_model_id()
         vision_models = (
             "anthropic.claude-3",
             "anthropic.claude-sonnet-4",
@@ -2137,14 +2160,8 @@ class BedrockCompletion(BaseLLM):
             "amazon.nova-lite",
             "amazon.nova-pro",
             "amazon.nova-premier",
-            "us.amazon.nova-lite",
-            "us.amazon.nova-pro",
-            "us.amazon.nova-premier",
-            "us.anthropic.claude-sonnet-4",
-            "us.anthropic.claude-opus-4",
-            "us.anthropic.claude-haiku-4",
         )
-        return any(model_lower.startswith(m) for m in vision_models)
+        return any(base_model.startswith(m) for m in vision_models)
 
     def _is_nova_model(self) -> bool:
         """Check if the model is an Amazon Nova model.

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -530,6 +530,51 @@ def test_bedrock_context_window_size():
     assert context_size_titan > 5000
 
 
+def test_bedrock_context_window_size_cross_region_inference_profile():
+    """
+    Cross-region inference profile ids (us./eu./apac.) must resolve to the
+    same context window as the base model id.
+
+    AWS recommends invoking newer models through cross-region inference
+    profiles, whose ids carry a geographic prefix. Without stripping that
+    prefix the lookup falls through to the 8192-token default, so a 200K
+    model is treated as an 8K one and conversations are truncated early.
+    """
+    base = LLM(model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0")
+    base_size = base.get_context_window_size()
+    assert base_size > 150000  # 200K with ratio, not the 8192 fallback
+
+    for profile_model in (
+        "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+    ):
+        llm = LLM(model=profile_model)
+        assert llm.get_context_window_size() == base_size, (
+            f"{profile_model} should match the base model context window"
+        )
+
+
+def test_bedrock_supports_multimodal_cross_region_inference_profile():
+    """
+    Vision support must be detected for cross-region inference profiles
+    across all geographic prefixes, matching the base model id.
+    """
+    base = LLM(model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0")
+    assert base.supports_multimodal() is True
+
+    for profile_model in (
+        "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/eu.amazon.nova-pro-v1:0",
+    ):
+        llm = LLM(model=profile_model)
+        assert llm.supports_multimodal() is True, (
+            f"{profile_model} should be detected as multimodal"
+        )
+
+
 def test_bedrock_message_formatting():
     """
     Test that messages are properly formatted for Bedrock Converse API

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -548,6 +548,7 @@ def test_bedrock_context_window_size_cross_region_inference_profile():
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/us-gov.anthropic.claude-sonnet-4-20250514-v1:0",
     ):
         llm = LLM(model=profile_model)
         assert llm.get_context_window_size() == base_size, (
@@ -567,7 +568,9 @@ def test_bedrock_supports_multimodal_cross_region_inference_profile():
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/us-gov.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.amazon.nova-pro-v1:0",
+        "bedrock/us-gov.amazon.nova-pro-v1:0",
     ):
         llm = LLM(model=profile_model)
         assert llm.supports_multimodal() is True, (


### PR DESCRIPTION
Thanks to the maintainers for the native Bedrock provider. This is a small, single-purpose fix for a context-window mis-sizing on cross-region inference profiles, framed as filling a gap in an already-established prefix-agnostic pattern.

### Problem

AWS recommends invoking newer Bedrock models through cross-region inference profiles, whose ids carry a geographic prefix (`us.`/`eu.`/`apac.`/`us-gov.`), e.g. `bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0`. `get_context_window_size()` matches a bare-id table with `self.model.startswith(...)`, so a prefixed id never matches and falls through to the `8192` default — a 200K model is treated as ~8K and conversations are truncated/summarized early.

```python
from crewai import LLM
LLM(model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0").get_context_window_size()     # 170000
LLM(model="bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0").get_context_window_size()  # 6963 (bug)
```

### Cause

The lookup keys on the bare id but compares against `self.model`, which keeps the cross-region prefix. The sibling `_normalize_bedrock_fields` validator is already prefix-agnostic; `get_context_window_size`/`supports_multimodal` are the spots that weren't.

### Change

- Add `_base_model_id()` that strips `us.`/`eu.`/`apac.`/`us-gov.` (lowercased).
- `get_context_window_size()` and `supports_multimodal()` match against the prefix-free id.
- `supports_multimodal()` drops its hardcoded `us.*` duplicates (now covered by the helper), which also fixes `eu.`/`apac.` vision detection. (+19/-9 source)

### Before / After

| Item | Before | After |
|------|--------|-------|
| `us.anthropic.claude-sonnet-4` context window | ❌ 6963 (8192 fallback) | ✅ 170000 |
| `eu.`/`apac.` Claude 4 context window | ❌ 6963 | ✅ 170000 |
| `eu.`/`apac.` Claude/Nova `supports_multimodal()` | ❌ False | ✅ True |
| Bare-id models (`anthropic.claude-3-5-sonnet`, `amazon.titan-...`) context window | ✅ unchanged | ✅ unchanged |
| `us.` multimodal detection | ✅ True | ✅ True (unchanged) |
| Public API / method signatures / return types | — | Unchanged |
| Context-window table values & default fallback | — | Unchanged |

### Tests

Two regression tests (no AWS credentials needed — `mock_aws_credentials` autouse fixture) assert prefixed ids return the **same** value as the bare id.

Before/after proof — with the source fix reverted but the new tests kept:

```
FAILED test_bedrock_context_window_size_cross_region_inference_profile
  assert llm.get_context_window_size() == base_size
  assert 6963 == 170000
FAILED test_bedrock_supports_multimodal_cross_region_inference_profile
  assert llm.supports_multimodal() is True
  assert False is True
2 failed
```

With the fix restored:

```
uv run pytest lib/crewai/tests/llms/bedrock/test_bedrock.py -q
37 passed, 1 skipped
```

Local checks all green:

```
uv run ruff check   lib/.../bedrock/completion.py   -> All checks passed!
uv run ruff format --check lib/.../bedrock/completion.py -> 1 file already formatted
uv run mypy         lib/.../bedrock/completion.py   -> Success: no issues found
```

Fixes #6244

### Scope note (follow-up)

This is the minimal, low-risk fix for the reported sizing problem. A larger follow-up could query the live model metadata instead of the hardcoded table, but that's out of scope here.

---

*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, rationale, and test results before submitting. Labeling this PR `llm-generated` per CONTRIBUTING.md.*