### PR TITLE
fix: scroll to anchor links on Safari

### DIFF
--- a/docs/safari-anchor-fix.js
+++ b/docs/safari-anchor-fix.js
@@ -12,7 +12,13 @@
     var hash = window.location.hash;
     if (!hash) return;
 
-    var id = hash.substring(1);
+    var rawId = hash.substring(1);
+    var id;
+    try {
+      id = decodeURIComponent(rawId);
+    } catch (e) {
+      id = rawId;
+    }
     var el = document.getElementById(id);
     if (el) {
       el.scrollIntoView();

--- a/docs/safari-anchor-fix.js
+++ b/docs/safari-anchor-fix.js
@@ -1,0 +1,43 @@
+/**
+ * Fix for anchor/hash links not scrolling on Safari.
+ *
+ * Safari does not re-scroll to the hash target after Next.js hydration
+ * replaces the server-rendered DOM. This script watches for the target
+ * element and scrolls to it once it appears.
+ */
+(function () {
+  if (typeof window === 'undefined') return;
+
+  function scrollToHash() {
+    var hash = window.location.hash;
+    if (!hash) return;
+
+    var id = hash.substring(1);
+    var el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView();
+      return true;
+    }
+    return false;
+  }
+
+  // Try immediately (works in Chrome/Firefox).
+  if (scrollToHash()) return;
+
+  // For Safari: retry after hydration settles.
+  // Use requestAnimationFrame + small delay to wait for React hydration.
+  var attempts = 0;
+  var maxAttempts = 20; // ~2 seconds max
+
+  function retry() {
+    attempts++;
+    if (scrollToHash() || attempts >= maxAttempts) return;
+    setTimeout(retry, 100);
+  }
+
+  if (document.readyState === 'complete') {
+    retry();
+  } else {
+    window.addEventListener('load', retry);
+  }
+})();


### PR DESCRIPTION
## Problem

Anchored links like [docs.crewai.com/edge/en/concepts/tools#typed-tool-outputs](https://docs.crewai.com/edge/en/concepts/tools#typed-tool-outputs) don't scroll to the target section on Safari. The page loads at the top instead.

**Root cause:** Safari does not re-scroll to hash fragment targets after Next.js (Mintlify) client-side hydration replaces the server-rendered DOM. Chrome and Firefox handle this natively, but Safari does not retry the scroll after the DOM is swapped during hydration.

## Fix

Adds a lightweight custom JS script (`docs/safari-anchor-fix.js`) that:
1. Checks for a URL hash fragment on page load
2. Attempts to scroll to the target element
3. If the element isn't in the DOM yet (pre-hydration), retries with a polling strategy until the element appears (up to ~2 seconds)

Mintlify automatically includes any `.js` file in the docs directory on every page, so this requires no configuration changes.

## Testing

- **Safari 18 (macOS):** Navigate to any anchored link (e.g. `#typed-tool-outputs`) — page should scroll to the section
- **Chrome/Firefox:** No change in behavior (the script exits early since native scrolling already works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Safari behavior where hash/anchor links wouldn’t scroll to the correct target after the page loads, including after hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->