### PR TITLE
fix(docs): correct broken Stagehand reference link in stagehand_tool README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/README.md
@@ -262,7 +262,7 @@ stagehand_tool = StagehandTool(
 
 ## Resources
 
-- [Stagehand Documentation](https://docs.stagehand.dev/reference/introduction) - Complete reference for the Stagehand framework
+- [Stagehand Documentation](https://docs.stagehand.dev) - Complete reference for the Stagehand framework
 - [Browserbase](https://www.browserbase.com) - Browser automation platform
 - [Join Slack Community](https://stagehand.dev/slack) - Get help and connect with other users of Stagehand
 


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.stagehand.dev/reference/introduction` in `lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/README.md`
- The Stagehand docs restructured under `/v3/first-steps/introduction`; linking to the docs root lets users land on the current entry point.

## Test plan
- Verified replacement URL `https://docs.stagehand.dev` returns 200 (auto-redirects to `/v3/first-steps/introduction`).
- Old URL `/reference/introduction` confirmed 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stagehand documentation link in the Resources section to direct to the main documentation site for improved access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->