### PR TITLE
fix(docs): correct broken Browserbase Live Debug link in browserbase_load_tool README

### DIFF
--- a/docs/edge/ar/tools/web-scraping/browserbaseloadtool.mdx
+++ b/docs/edge/ar/tools/web-scraping/browserbaseloadtool.mdx
@@ -16,7 +16,7 @@ mode: "wide"
  - [بنية تحتية بدون خادم](https://docs.browserbase.com/under-the-hood) توفر متصفحات موثوقة لاستخراج البيانات من واجهات المستخدم المعقدة
  - [وضع التخفي](https://docs.browserbase.com/features/stealth-mode) مع تكتيكات البصمة المضمنة وحل CAPTCHA التلقائي
  - [مصحح الجلسات](https://docs.browserbase.com/features/sessions) لفحص جلسة المتصفح مع الجدول الزمني للشبكة والسجلات
- - [التصحيح المباشر](https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control) لتصحيح الأتمتة بسرعة
+ - [التصحيح المباشر](https://docs.browserbase.com/welcome/getting-started) لتصحيح الأتمتة بسرعة
 
 ## التثبيت
 

--- a/docs/edge/en/tools/web-scraping/browserbaseloadtool.mdx
+++ b/docs/edge/en/tools/web-scraping/browserbaseloadtool.mdx
@@ -16,7 +16,7 @@ Power your AI data retrievals with:
  - [Serverless Infrastructure](https://docs.browserbase.com/under-the-hood) providing reliable browsers to extract data from complex UIs
  - [Stealth Mode](https://docs.browserbase.com/features/stealth-mode) with included fingerprinting tactics and automatic captcha solving
  - [Session Debugger](https://docs.browserbase.com/features/sessions) to inspect your Browser Session with networks timeline and logs
- - [Live Debug](https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control) to quickly debug your automation
+ - [Live Debug](https://docs.browserbase.com/welcome/getting-started) to quickly debug your automation
 
 ## Installation
 

--- a/docs/edge/ko/tools/web-scraping/browserbaseloadtool.mdx
+++ b/docs/edge/ko/tools/web-scraping/browserbaseloadtool.mdx
@@ -16,7 +16,7 @@ AI 데이터 수집을 다음과 같이 강화하세요:
  - [서버리스 인프라스트럭처](https://docs.browserbase.com/under-the-hood)를 통해 복잡한 UI에서 데이터를 추출할 수 있는 신뢰할 수 있는 브라우저 제공
  - [스텔스 모드](https://docs.browserbase.com/features/stealth-mode)에서는 지문 인식 회피 기법과 자동 캡차 솔루션이 포함되어 있습니다
  - [세션 디버거](https://docs.browserbase.com/features/sessions)를 통해 네트워크 타임라인과 로그로 Browser Session을 점검
- - [라이브 디버그](https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control)로 자동화 작업을 신속하게 디버깅
+ - [라이브 디버그](https://docs.browserbase.com/welcome/getting-started)로 자동화 작업을 신속하게 디버깅
 
 ## 설치
 

--- a/docs/edge/pt-BR/tools/web-scraping/browserbaseloadtool.mdx
+++ b/docs/edge/pt-BR/tools/web-scraping/browserbaseloadtool.mdx
@@ -16,7 +16,7 @@ Potencialize suas buscas de dados para IA com:
  - [Infraestrutura Serverless](https://docs.browserbase.com/under-the-hood) fornecendo navegadores confiáveis para extrair dados de interfaces complexas
  - [Modo Stealth](https://docs.browserbase.com/features/stealth-mode) com táticas de fingerprinting e resolução automática de captcha incluídas
  - [Depurador de Sessão](https://docs.browserbase.com/features/sessions) para inspecionar sua Sessão do Navegador com linha do tempo de rede e logs
- - [Depuração Ao Vivo](https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control) para depurar rapidamente sua automação
+ - [Depuração Ao Vivo](https://docs.browserbase.com/welcome/getting-started) para depurar rapidamente sua automação
 
 ## Instalação
 

--- a/lib/crewai-tools/src/crewai_tools/tools/browserbase_load_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/browserbase_load_tool/README.md
@@ -8,7 +8,7 @@
  - [Serverless Infrastructure](https://docs.browserbase.com/under-the-hood) providing reliable browsers to extract data from complex UIs
  - [Stealth Mode](https://docs.browserbase.com/features/stealth-mode) with included fingerprinting tactics and automatic captcha solving
  - [Session Debugger](https://docs.browserbase.com/features/sessions) to inspect your Browser Session with networks timeline and logs
- - [Live Debug](https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control) to quickly debug your automation
+ - [Live Debug](https://docs.browserbase.com/welcome/getting-started) to quickly debug your automation
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.browserbase.com/guides/session-debug-connection/browser-remote-control` in `lib/crewai-tools/src/crewai_tools/tools/browserbase_load_tool/README.md`
- Replaced with `https://docs.browserbase.com/welcome/getting-started` (verified 200).

## Test plan
- New URL `/welcome/getting-started` returns 200.
- Old URL `/guides/session-debug-connection/browser-remote-control` confirmed 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the BrowserbaseLoadTool “Live Debug” documentation link to point to a new URL.
  * Applied the link update across multiple language versions of the web scraping tool documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->