### PR TITLE
fix(docs): correct broken Parallel Processors link in parallel_tools README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/parallel_tools/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/parallel_tools/README.md
@@ -3,7 +3,7 @@
 Unified Parallel web search tool using the Parallel Search API (v1beta). Returns ranked results with compressed excerpts optimized for LLMs.
 
 - **Quickstart**: see the official docs: [Search API Quickstart](https://docs.parallel.ai/search-api/search-quickstart)
-- **Processors**: guidance on `base` vs `pro`: [Processors](https://docs.parallel.ai/search-api/processors)
+- **Processors**: guidance on `base` vs `pro`: [Processors](https://docs.parallel.ai/getting-started/overview)
 
 ## Why this tool
 


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.parallel.ai/search-api/processors` in `lib/crewai-tools/src/crewai_tools/tools/parallel_tools/README.md`
- Replaced with `https://docs.parallel.ai/getting-started/overview` (verified 200).

## Test plan
- New URL returns 200.
- Old URL confirmed 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference link in ParallelSearchTool README to improve navigation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->