### PR TITLE
fix(docs): correct broken Hyperbrowser SDK reference links

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/hyperbrowser_load_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/hyperbrowser_load_tool/README.md
@@ -39,4 +39,4 @@ tool = HyperbrowserLoadTool()
 `run` arguments:
 - `url`: The base URL to start scraping or crawling from.
 - `operation`: Optional. Specifies the operation to perform on the website. Either 'scrape' or 'crawl'. Defaults is 'scrape'.
-- `params`: Optional. Specifies the params for the operation. For more information on the supported params, visit https://docs.hyperbrowser.ai/reference/sdks/python/scrape#start-scrape-job-and-wait or https://docs.hyperbrowser.ai/reference/sdks/python/crawl#start-crawl-job-and-wait.
+- `params`: Optional. Specifies the params for the operation. For more information on the supported params, visit https://www.hyperbrowser.ai/docs/home or https://docs.hyperbrowser.ai.


### PR DESCRIPTION
## Summary
- Fix two 404 links in `lib/crewai-tools/src/crewai_tools/tools/hyperbrowser_load_tool/README.md`:
  - `https://docs.hyperbrowser.ai/reference/sdks/python/scrape#start-scrape-job-and-wait` → `https://www.hyperbrowser.ai/docs/home`
  - `https://docs.hyperbrowser.ai/reference/sdks/python/crawl#start-crawl-job-and-wait` → `https://docs.hyperbrowser.ai`

## Test plan
- New URLs both return 200.
- Old URLs both confirmed 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference links in the Hyperbrowser load tool's README file to direct users toward more general, platform-wide documentation resources instead of specific SDK documentation paths. This change improves documentation accessibility, reduces long-term maintenance burden, and provides greater flexibility for supporting future documentation updates, product changes, and overall platform evolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->