### PR TITLE
fix(docs): remove dead merge.dev/discord link in merge_agent_handler_tool README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/merge_agent_handler_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/merge_agent_handler_tool/README.md
@@ -227,5 +227,4 @@ All tool executions are:
 
 For questions or issues:
 - 📚 [Documentation](https://docs.ah.merge.dev)
-- 💬 [Discord Community](https://merge.dev/discord)
 - 📧 [Support Email](mailto:support@merge.dev)


### PR DESCRIPTION
## Summary
- Removed `https://merge.dev/discord` link from `lib/crewai-tools/src/crewai_tools/tools/merge_agent_handler_tool/README.md` (404).
- merge.dev no longer publishes a Discord invite on their site (`/community`, `/slack`, `/join` all 404). Removed to keep the README accurate.

## Test plan
- Verified old URL returns 404.
- Verified alternate URLs (`/community`, `/slack`, `/join`) all return 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated support documentation by removing the Discord Community link, while maintaining documentation and email-based support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->