### PR TITLE
fix(docs): correct broken Tavily Python SDK link in tavily_extractor_tool README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/README.md
@@ -96,4 +96,4 @@ When running the tool (`_run` or `_arun` methods, or via agent execution), it us
 
 ## Response Format
 
-The tool returns a JSON string representing the structured data extracted from the provided URL(s). The exact structure depends on the content of the pages and the `extract_depth` used. Refer to the [Tavily API documentation](https://docs.tavily.com/docs/tavily-api/python-sdk#extract) for details on the response structure.
+The tool returns a JSON string representing the structured data extracted from the provided URL(s). The exact structure depends on the content of the pages and the `extract_depth` used. Refer to the [Tavily API documentation](https://docs.tavily.com) for details on the response structure.


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.tavily.com/docs/tavily-api/python-sdk#extract` in `lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/README.md`.
- Tavily restructured their docs; canonical landing page is `https://docs.tavily.com` (200, redirects to `/welcome`). Dropped the stale `#extract` fragment.

## Test plan
- New URL returns 200.
- Old URL confirmed 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the TavilyExtractorTool documentation link reference for API response format information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->