### PR TITLE
fix(docs): correct broken AWS IAM Roles link in aws/s3 README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/aws/s3/README.md
+++ b/lib/crewai-tools/src/crewai_tools/aws/s3/README.md
@@ -15,7 +15,7 @@ pip install 'crewai[tools]'
 ## AWS Connectivity
 
 The tools use `boto3` to connect to AWS S3.
-You can configure your environment to use AWS IAM roles, see [AWS IAM Roles documentation](https://docs.aws.amazon.com/sdk-for-python/v1/developer-guide/iam-roles.html#creating-an-iam-role)
+You can configure your environment to use AWS IAM roles, see [AWS IAM Roles documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
 
 Set the following environment variables:
 

--- a/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/tavily_extractor_tool/README.md
@@ -96,4 +96,4 @@ When running the tool (`_run` or `_arun` methods, or via agent execution), it us
 
 ## Response Format
 
-The tool returns a JSON string representing the structured data extracted from the provided URL(s). The exact structure depends on the content of the pages and the `extract_depth` used. Refer to the [Tavily API documentation](https://docs.tavily.com/docs/tavily-api/python-sdk#extract) for details on the response structure.
+The tool returns a JSON string representing the structured data extracted from the provided URL(s). The exact structure depends on the content of the pages and the `extract_depth` used. Refer to the [Tavily API documentation](https://docs.tavily.com) for details on the response structure.


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.aws.amazon.com/sdk-for-python/v1/developer-guide/iam-roles.html#creating-an-iam-role` in `lib/crewai-tools/src/crewai_tools/aws/s3/README.md`.
- AWS retired the v1 developer guide; canonical replacement is `https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html` (verified 200).

## Test plan
- New URL returns 200.
- Old URL confirmed 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AWS connectivity documentation link to current IAM resources
  * Updated Tavily extractor tool documentation link to general API documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->