### PR TITLE
fix(docs): correct broken MindsDB data_sources link in ai_mind_tool README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/ai_mind_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/ai_mind_tool/README.md
@@ -61,7 +61,7 @@ The `datasources` parameter is a list of dictionaries, each containing the follo
 - `connection_data`: A dictionary containing the connection parameters for the datasource. Find a list of connection parameters for each engine in the link below.
 - `tables`: A list of tables that the data source will use. This is optional and can be omitted if all tables in the data source are to be used.
 
-A list of supported data sources and their connection parameters can be found [here](https://docs.mdb.ai/docs/data_sources).
+A list of supported data sources and their connection parameters can be found [here](https://docs.mdb.ai).
 
 ```python
 from crewai import Agent


### PR DESCRIPTION
## Summary
- Fix 404 link `https://docs.mdb.ai/docs/data_sources` in `lib/crewai-tools/src/crewai_tools/tools/ai_mind_tool/README.md`.
- MDB docs restructured; canonical landing page is `https://docs.mdb.ai` (200, redirects to onboarding).

## Test plan
- New URL returns 200.
- Old URL confirmed 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference link for data sources and connection parameters to direct users to the main documentation portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->