### PR TITLE
fix(reasoning): accept short-form READY keyword from model responses

### DIFF
--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from pydantic import BaseModel, Field
@@ -589,8 +590,11 @@ class AgentReasoning:
         so that models following either convention work correctly.
         """
         upper = response.upper()
-        return "READY: I AM READY TO EXECUTE THE TASK." in upper or (
-            "READY" in upper and "NOT READY" not in upper
+        if "NOT READY" in upper:
+            return False
+        return bool(
+            "READY: I AM READY TO EXECUTE THE TASK." in upper
+            or re.search(r"\bREADY\b", upper)
         )
 
     @staticmethod

--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -409,7 +409,7 @@ class AgentReasoning:
             return (
                 response_str,
                 [],
-                "READY: I am ready to execute the task." in response_str,
+                self._is_ready(response_str),
             )
 
         except Exception as e:
@@ -433,7 +433,7 @@ class AgentReasoning:
                 return (
                     fallback_str,
                     [],
-                    "READY: I am ready to execute the task." in fallback_str,
+                    self._is_ready(fallback_str),
                 )
             except Exception as inner_e:
                 self.logger.error(f"Error during fallback text parsing: {inner_e!s}")
@@ -580,6 +580,20 @@ class AgentReasoning:
             )
 
     @staticmethod
+    def _is_ready(response: str) -> bool:
+        """Check whether a text response indicates the agent is ready.
+
+        The prompt templates instruct models to conclude with "READY" or
+        "NOT READY".  Older prompts used the full phrase
+        "READY: I am ready to execute the task."  Both forms are accepted
+        so that models following either convention work correctly.
+        """
+        upper = response.upper()
+        return "READY: I AM READY TO EXECUTE THE TASK." in upper or (
+            "READY" in upper and "NOT READY" not in upper
+        )
+
+    @staticmethod
     def _parse_planning_response(response: str) -> tuple[str, bool]:
         """Parses the planning response to extract the plan and readiness.
 
@@ -592,10 +606,7 @@ class AgentReasoning:
         if not response:
             return "No plan was generated.", False
 
-        plan = response
-        ready = "READY: I am ready to execute the task." in response
-
-        return plan, ready
+        return response, AgentReasoning._is_ready(response)
 
 
 AgentPlanning = AgentReasoning

--- a/lib/crewai/tests/agents/test_agent_reasoning.py
+++ b/lib/crewai/tests/agents/test_agent_reasoning.py
@@ -6,6 +6,61 @@ import pytest
 
 from crewai import Agent, PlanningConfig, Task
 from crewai.llm import LLM
+from crewai.utilities.reasoning_handler import AgentReasoning
+
+
+class TestIsReady:
+    """Regression tests for AgentReasoning._is_ready.
+
+    The prompt templates tell models to conclude with "READY" or "NOT READY".
+    The detection must handle both the short form from current prompts and the
+    legacy long form, and must never treat "NOT READY" as ready.
+    """
+
+    def test_legacy_full_phrase(self):
+        assert AgentReasoning._is_ready("READY: I am ready to execute the task.")
+
+    def test_legacy_full_phrase_case_insensitive(self):
+        assert AgentReasoning._is_ready("ready: i am ready to execute the task.")
+
+    def test_short_form_uppercase(self):
+        assert AgentReasoning._is_ready("Here is my plan.\n\nREADY")
+
+    def test_short_form_mixed_case(self):
+        assert AgentReasoning._is_ready("My plan is complete.\n\nReady")
+
+    def test_not_ready_returns_false(self):
+        assert not AgentReasoning._is_ready("NOT READY")
+
+    def test_not_ready_inline_returns_false(self):
+        assert not AgentReasoning._is_ready("My plan needs more work. NOT READY")
+
+    def test_empty_string_returns_false(self):
+        assert not AgentReasoning._is_ready("")
+
+    def test_no_keyword_returns_false(self):
+        assert not AgentReasoning._is_ready("Here is my plan. I need more information.")
+
+
+class TestParsePlanningResponse:
+    def test_empty_response(self):
+        plan, ready = AgentReasoning._parse_planning_response("")
+        assert plan == "No plan was generated."
+        assert ready is False
+
+    def test_short_ready(self):
+        _, ready = AgentReasoning._parse_planning_response("Step 1: do X.\n\nREADY")
+        assert ready is True
+
+    def test_not_ready(self):
+        _, ready = AgentReasoning._parse_planning_response("Step 1: do X.\n\nNOT READY")
+        assert ready is False
+
+    def test_legacy_phrase(self):
+        _, ready = AgentReasoning._parse_planning_response(
+            "Step 1: do X.\nREADY: I am ready to execute the task."
+        )
+        assert ready is True
 
 
 

--- a/lib/crewai/tests/agents/test_agent_reasoning.py
+++ b/lib/crewai/tests/agents/test_agent_reasoning.py
@@ -41,6 +41,12 @@ class TestIsReady:
     def test_no_keyword_returns_false(self):
         assert not AgentReasoning._is_ready("Here is my plan. I need more information.")
 
+    def test_ready_as_substring_returns_false(self):
+        assert not AgentReasoning._is_ready("I already need more info.")
+
+    def test_unready_substring_returns_false(self):
+        assert not AgentReasoning._is_ready("The system is unready for deployment.")
+
 
 class TestParsePlanningResponse:
     def test_empty_response(self):


### PR DESCRIPTION
Prompt templates instruct models to conclude with "READY" or "NOT READY", but the detection logic only matched the legacy phrase "READY: I am ready to execute the task." -- so models following the current prompts always triggered a NOT READY result and looped indefinitely.

Adds AgentReasoning._is_ready() which accepts both the short keyword form and the legacy phrase, while correctly rejecting "NOT READY". Updates _parse_planning_response and both fallback branches in _call_with_function to use the new helper.

Note: pre-commit hooks were skipped locally due to a Windows path 
incompatibility (.venv/bin/activate). ruff and mypy were run manually 
and passed. CI will confirm on Linux.


Fixes #6204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved agent readiness detection to recognize multiple “READY” formats, including simplified markers and case-insensitive variants.

* **Bug Fixes**
  * Prevents false positives by correctly treating responses containing “NOT READY” as not ready.

* **Tests**
  * Added regression tests covering readiness detection (legacy and new formats, edge cases) and planning-response parsing outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->