### PR TITLE
fix: append traceback to tool execution error messages

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
 import inspect
 import logging
+import traceback
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 import warnings
 
@@ -1006,7 +1007,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 result = format_native_tool_output_for_agent(output_tool, raw_result)
             except Exception as e:
-                result = f"Error executing tool: {e}"
+                result = f"Error executing tool: {e}\nTraceback:\n{traceback.format_exc(limit=5)}"
                 raw_tool_result = result
                 if self.task:
                     self.task.increment_tools_errors()

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import inspect
 import json
 import threading
+import traceback
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 from uuid import uuid4
 
@@ -1611,13 +1612,13 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             )
         except Exception as e:
             if self.agent and self.agent.verbose:
-                PRINTER.print(content=f"Error in tool execution: {e}", color="red")
+                PRINTER.print(content=f"Error in tool execution: {e}\n{traceback.format_exc(limit=5)}", color="red")
             if self.task:
                 self.task.increment_tools_errors()
 
-            error_observation = f"\nObservation: Error executing tool: {e}"
+            error_observation = f"\nObservation: Error executing tool: {e}\nTraceback:\n{traceback.format_exc(limit=5)}"
             action.text += error_observation
-            action.result = str(e)
+            action.result = str(e) + f"\nTraceback:\n{traceback.format_exc(limit=5)}"
             self._append_message_to_state(action.text)
 
             reasoning_prompt = I18N_DEFAULT.slice("post_tool_reasoning")
@@ -1736,7 +1737,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         ordered_results[idx] = {
                             "call_id": call_id,
                             "func_name": func_name,
-                            "result": f"Error executing tool: {e}",
+                            "result": f"Error executing tool: {e}\nTraceback:\n{traceback.format_exc(limit=5)}",
                             "from_cache": False,
                             "original_tool": None,
                         }
@@ -1999,7 +2000,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         output_tool, raw_result
                     )
                 except Exception as e:
-                    result = f"Error executing tool: {e}"
+                    result = f"Error executing tool: {e}\nTraceback:\n{traceback.format_exc(limit=5)}"
                     raw_tool_result = result
                     if self.task:
                         self.task.increment_tools_errors()

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -14,6 +14,7 @@ from typing import (
     TypedDict,
     cast,
 )
+import traceback
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, model_validator
@@ -1755,11 +1756,11 @@ class LLM(BaseLLM):
                 return result
             except Exception as e:
                 fn = available_functions.get(function_name, lambda: None)
-                logging.error(f"Error executing function '{function_name}': {e}")
+                logging.error(f"Error executing function '{function_name}': {e}\n{traceback.format_exc(limit=5)}")
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
-                        error=f"Tool execution error: {e!s}",
+                        error=f"Tool execution error: {e!s}\nTraceback:\n{traceback.format_exc(limit=5)}",
                         from_task=from_task,
                         from_agent=from_agent,
                         call_id=get_current_call_id(),
@@ -1770,7 +1771,7 @@ class LLM(BaseLLM):
                     event=ToolUsageErrorEvent(
                         tool_name=function_name,
                         tool_args=function_args,
-                        error=f"Tool execution error: {e!s}",
+                        error=f"Tool execution error: {e!s}\nTraceback:\n{traceback.format_exc(limit=5)}",
                         from_task=from_task,
                         from_agent=from_agent,
                     ),

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import inspect
 import json
 import re
+import traceback
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict
 
 from crewai_core.printer import PRINTER, ColoredText, Printer
@@ -1546,7 +1547,7 @@ def execute_single_native_tool_call(
 
                 result = format_native_tool_output_for_agent(output_tool, raw_result)
             except Exception as e:
-                result = f"Error executing tool: {e}"
+                result = f"Error executing tool: {e}\nTraceback:\n{traceback.format_exc(limit=5)}"
                 raw_tool_result = result
                 if task:
                     task.increment_tools_errors()


### PR DESCRIPTION
Closes #6262

## Problem
When a tool raised an exception, CrewAI caught it and 
returned a generic string like "Error executing tool: {e}",
discarding the original traceback. This made debugging 
impossible — users couldn't tell if the failure was a 
network error, validation error, rate limit, or tool bug.

## Fix
Appended `traceback.format_exc(limit=5)` to all tool 
execution error returns across 4 files:

- `agents/crew_agent_executor.py` — main tool execution handler
- `experimental/agent_executor.py` — 4 exception handlers
  including printer output and `action.result`
- `utilities/agent_utils.py` — native tool call handler  
- `llm.py` — `LLMCallFailedEvent` and `ToolUsageErrorEvent`

## Design Decisions
- `"Error executing tool:"` prefix preserved — avoids 
  breaking existing parsing logic
- `limit=5` chosen to balance debuggability vs LLM 
  context window consumption
- Full exception type and message still visible at start
  of error string before the traceback

## Testing
Pre-existing test failures (`RuntimeError: Network is 
disabled`) confirmed unrelated to this change via 
`git stash` verification on Windows Python 3.13 
with pytest-recording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics by including detailed stack traces in tool failure messages, enabling better troubleshooting and debugging when tools encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->