### PR TITLE
fix(docs): correct broken Weaviate WCS /connect link in weaviate_tool README

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/weaviate_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/weaviate_tool/README.md
@@ -3,7 +3,7 @@
 ## Description
 This tool is specifically crafted for conducting semantic searches within docs within a Weaviate vector database. Use this tool to find semantically similar docs to a given query.
 
-Weaviate is a vector database that is used to store and query vector embeddings. You can follow their docs here: https://weaviate.io/developers/wcs/connect
+Weaviate is a vector database that is used to store and query vector embeddings. You can follow their docs here: https://weaviate.io/developers/wcs
 
 ## Installation
 Install the crewai_tools package by executing the following command in your terminal:
@@ -60,7 +60,7 @@ Preloading the Weaviate database with documents:
 ```python
 from crewai_tools import WeaviateVectorSearchTool
 
-# Use before hooks to generate the documents and add them to the Weaviate database. Follow the weaviate docs: https://weaviate.io/developers/wcs/connect
+# Use before hooks to generate the documents and add them to the Weaviate database. Follow the weaviate docs: https://weaviate.io/developers/wcs
 test_docs = client.collections.get("example_collections")
 
 


### PR DESCRIPTION
## Summary
Fixes 2 broken references in `lib/crewai-tools/src/crewai_tools/tools/weaviate_tool/README.md`:
- `https://weaviate.io/developers/wcs/connect` → `https://weaviate.io/developers/wcs`

The `/connect` subpath was retired when Weaviate restructured their docs site; the connection details now live on the parent `/developers/wcs` page.

## Verification
- New URL returns HTTP 200
- Old URL returns HTTP 404

## Diff
```
.../tools/weaviate_tool/README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Pattern matches the existing crewAI PR series (#6253-#6260, all sibling fixes for dead/broken tool README links).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Weaviate tool documentation links to reference current developer resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->