### PR TITLE
fix(llm): mask api_key in BaseLLM.__repr__

### DIFF
--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -168,6 +168,13 @@ class BaseLLM(BaseModel, ABC):
     )
     additional_params: dict[str, Any] = Field(default_factory=dict)
 
+    def __repr__(self) -> str:
+        """Return a representation with sensitive fields masked."""
+        d = self.model_dump()
+        if d.get("api_key"):
+            d["api_key"] = "***"
+        return f"{self.__class__.__name__}({d})"
+
     @field_serializer("response_format", when_used="json", check_fields=False)
     def _serialize_response_format(self, value: Any) -> Any:
         return serialize_model_class(value)

--- a/lib/crewai/tests/test_custom_llm.py
+++ b/lib/crewai/tests/test_custom_llm.py
@@ -75,8 +75,29 @@ class CustomLLM(BaseLLM):
         """
         return 4096
 
-    async def acall(self, messages, tools=None, callbacks=None, available_functions=None, from_task=None, from_agent=None, response_model=None):
+    async def acall(
+        self,
+        messages,
+        tools=None,
+        callbacks=None,
+        available_functions=None,
+        from_task=None,
+        from_agent=None,
+        response_model=None,
+    ):
+        """Raise because async calls are not implemented for this test LLM."""
         raise NotImplementedError
+
+
+def test_base_llm_repr_masks_api_key():
+    """Test that BaseLLM repr does not expose the API key."""
+    llm = CustomLLM()
+    llm.api_key = "sk-secret"
+
+    representation = repr(llm)
+
+    assert "sk-secret" not in representation
+    assert "'api_key': '***'" in representation
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
Prevent API key exposure in logs and debug output when LLM objects are printed or logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Masked sensitive API credential values in language model instance `repr()` output to prevent accidental exposure.
* **Tests**
  * Added unit coverage to confirm API keys are redacted in `repr()` results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->