### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -14,6 +14,7 @@ ANTHROPIC_API_KEY=fake-anthropic-key
 GEMINI_API_KEY=fake-gemini-key
 AZURE_API_KEY=fake-azure-key
 OPENROUTER_API_KEY=fake-openrouter-key
+REQUESTY_API_KEY=fake-requesty-key
 
 # -----------------------------------------------------------------------------
 # AWS Credentials

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1270,7 +1270,8 @@ In this section, you'll find detailed examples that help you select, configure, 
   <Accordion title="Requesty">
     Set the following environment variables in your `.env` file:
     ```toml Code
-    REQUESTY_API_KEY=***    ```
+    REQUESTY_API_KEY=***
+    ```
 
     Example usage in your CrewAI project:
     ```python Code

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1267,6 +1267,31 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="Requesty">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    REQUESTY_API_KEY=***    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="requesty/openai/gpt-4o-mini",
+        base_url="https://router.requesty.ai/v1",
+        api_key=REQUESTY_API_KEY
+    )
+    ```
+
+    <Info>
+      Requesty is an OpenAI-compatible gateway that uses `provider/model` naming.
+      Browse available models at [app.requesty.ai/router/list](https://app.requesty.ai/router/list).
+      Examples:
+      - requesty/openai/gpt-4o-mini
+      - requesty/anthropic/claude-sonnet-4-5
+
+      See [requesty.ai](https://requesty.ai) and [docs.requesty.ai](https://docs.requesty.ai) for more details.
+    </Info>
+  </Accordion>
+
   <Accordion title="Nebius AI Studio">
     Set the following environment variables in your `.env` file:
     ```toml Code

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1129,6 +1129,31 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="Requesty">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    REQUESTY_API_KEY=***    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="requesty/openai/gpt-4o-mini",
+        base_url="https://router.requesty.ai/v1",
+        api_key=REQUESTY_API_KEY
+    )
+    ```
+
+    <Info>
+      Requesty is an OpenAI-compatible gateway that uses `provider/model` naming.
+      Browse available models at [app.requesty.ai/router/list](https://app.requesty.ai/router/list).
+      Examples:
+      - requesty/openai/gpt-4o-mini
+      - requesty/anthropic/claude-sonnet-4-5
+
+      See [requesty.ai](https://requesty.ai) and [docs.requesty.ai](https://docs.requesty.ai) for more details.
+    </Info>
+  </Accordion>
+
   <Accordion title="Nebius AI Studio">
     Set the following environment variables in your `.env` file:
     ```toml Code

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1132,7 +1132,8 @@ In this section, you'll find detailed examples that help you select, configure, 
   <Accordion title="Requesty">
     Set the following environment variables in your `.env` file:
     ```toml Code
-    REQUESTY_API_KEY=***    ```
+    REQUESTY_API_KEY=***
+    ```
 
     Example usage in your CrewAI project:
     ```python Code

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -335,6 +335,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "bedrock",
     "aws",
     "openrouter",
+    "requesty",
     "deepseek",
     "ollama",
     "ollama_chat",
@@ -424,6 +425,7 @@ class LLM(BaseLLM):
                 "bedrock": "bedrock",
                 "aws": "bedrock",
                 "openrouter": "openrouter",
+                "requesty": "requesty",
                 "deepseek": "deepseek",
                 "ollama": "ollama",
                 "ollama_chat": "ollama_chat",
@@ -550,6 +552,10 @@ class LLM(BaseLLM):
             # OpenRouter uses org/model format but accepts anything
             return True
 
+        if provider == "requesty":
+            # Requesty uses provider/model format but accepts anything
+            return True
+
         if provider == "snowflake":
             return True
 
@@ -658,6 +664,7 @@ class LLM(BaseLLM):
 
         openai_compatible_providers = {
             "openrouter",
+            "requesty",
             "deepseek",
             "ollama",
             "ollama_chat",

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -338,6 +338,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "bedrock",
     "aws",
     "openrouter",
+    "requesty",
     "deepseek",
     "ollama",
     "ollama_chat",
@@ -443,6 +444,7 @@ class LLM(BaseLLM):
                 "bedrock": "bedrock",
                 "aws": "bedrock",
                 "openrouter": "openrouter",
+                "requesty": "requesty",
                 "deepseek": "deepseek",
                 "ollama": "ollama",
                 "ollama_chat": "ollama_chat",
@@ -580,6 +582,10 @@ class LLM(BaseLLM):
             # OpenRouter uses org/model format but accepts anything
             return True
 
+        if provider == "requesty":
+            # Requesty uses provider/model format but accepts anything
+            return True
+
         if provider == "snowflake":
             return True
 
@@ -715,6 +721,7 @@ class LLM(BaseLLM):
 
         openai_compatible_providers = {
             "openrouter",
+            "requesty",
             "deepseek",
             "ollama",
             "ollama_chat",

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -1,12 +1,13 @@
 """OpenAI-compatible providers implementation.
 
 This module provides a thin subclass of OpenAICompletion that supports
-various OpenAI-compatible APIs like OpenRouter, DeepSeek, Ollama, vLLM,
-Cerebras, and Dashscope (Alibaba/Qwen).
+various OpenAI-compatible APIs like OpenRouter, Requesty, DeepSeek, Ollama,
+vLLM, Cerebras, and Dashscope (Alibaba/Qwen).
 
 Usage:
     llm = LLM(model="deepseek/deepseek-chat")  # Uses DeepSeek API
     llm = LLM(model="openrouter/anthropic/claude-3-opus")  # Uses OpenRouter
+    llm = LLM(model="requesty/openai/gpt-4o-mini")  # Uses Requesty
     llm = LLM(model="ollama/llama3")  # Uses local Ollama
 """
 
@@ -48,6 +49,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         api_key_env="OPENROUTER_API_KEY",
         base_url_env="OPENROUTER_BASE_URL",
         default_headers={"HTTP-Referer": "https://crewai.com"},
+        api_key_required=True,
+    ),
+    "requesty": ProviderConfig(
+        base_url="https://router.requesty.ai/v1",
+        api_key_env="REQUESTY_API_KEY",
+        base_url_env="REQUESTY_BASE_URL",
         api_key_required=True,
     ),
     "deepseek": ProviderConfig(
@@ -119,6 +126,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
 
     Supported providers:
         - openrouter: OpenRouter (https://openrouter.ai)
+        - requesty: Requesty (https://requesty.ai)
         - deepseek: DeepSeek (https://deepseek.com)
         - ollama: Ollama local server (https://ollama.ai)
         - ollama_chat: Alias for ollama

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -1,12 +1,13 @@
 """OpenAI-compatible providers implementation.
 
 This module provides a thin subclass of OpenAICompletion that supports
-various OpenAI-compatible APIs like OpenRouter, DeepSeek, Ollama, vLLM,
-Cerebras, and Dashscope (Alibaba/Qwen).
+various OpenAI-compatible APIs like OpenRouter, Requesty, DeepSeek, Ollama,
+vLLM, Cerebras, and Dashscope (Alibaba/Qwen).
 
 Usage:
     llm = LLM(model="deepseek/deepseek-chat")  # Uses DeepSeek API
     llm = LLM(model="openrouter/anthropic/claude-3-opus")  # Uses OpenRouter
+    llm = LLM(model="requesty/openai/gpt-4o-mini")  # Uses Requesty
     llm = LLM(model="ollama/llama3")  # Uses local Ollama
 """
 
@@ -49,6 +50,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         api_key_env="OPENROUTER_API_KEY",
         base_url_env="OPENROUTER_BASE_URL",
         default_headers={"HTTP-Referer": "https://crewai.com"},
+        api_key_required=True,
+    ),
+    "requesty": ProviderConfig(
+        base_url="https://router.requesty.ai/v1",
+        api_key_env="REQUESTY_API_KEY",
+        base_url_env="REQUESTY_BASE_URL",
         api_key_required=True,
     ),
     "deepseek": ProviderConfig(
@@ -136,6 +143,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
 
     Supported providers:
         - openrouter: OpenRouter (https://openrouter.ai)
+        - requesty: Requesty (https://requesty.ai)
         - deepseek: DeepSeek (https://deepseek.com)
         - ollama: Ollama local server (https://ollama.ai)
         - ollama_chat: Alias for ollama

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -50,6 +50,14 @@ class TestProviderRegistry:
         assert "HTTP-Referer" in config.default_headers
         assert config.api_key_required is True
 
+    def test_requesty_config(self):
+        """Test Requesty provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["requesty"]
+        assert config.base_url == "https://router.requesty.ai/v1"
+        assert config.api_key_env == "REQUESTY_API_KEY"
+        assert config.base_url_env == "REQUESTY_BASE_URL"
+        assert config.api_key_required is True
+
     def test_deepseek_config(self):
         """Test DeepSeek provider configuration."""
         config = OPENAI_COMPATIBLE_PROVIDERS["deepseek"]
@@ -250,6 +258,16 @@ class TestLLMIntegration:
             assert llm.provider == "openrouter"
             # Model should include the full path after provider prefix
             assert llm.model == "anthropic/claude-3-opus"
+
+    def test_llm_creates_openai_compatible_for_requesty(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for Requesty."""
+        with patch.dict(os.environ, {"REQUESTY_API_KEY": "test-key"}):
+            llm = LLM(model="requesty/openai/gpt-4o-mini")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "requesty"
+            # Model should include the full path after provider prefix
+            assert llm.model == "openai/gpt-4o-mini"
+            assert llm.base_url == "https://router.requesty.ai/v1"
 
     def test_llm_creates_openai_compatible_for_hosted_vllm(self):
         """Test LLM factory creates OpenAICompatibleCompletion for hosted_vllm."""

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -50,6 +50,14 @@ class TestProviderRegistry:
         assert "HTTP-Referer" in config.default_headers
         assert config.api_key_required is True
 
+    def test_requesty_config(self):
+        """Test Requesty provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["requesty"]
+        assert config.base_url == "https://router.requesty.ai/v1"
+        assert config.api_key_env == "REQUESTY_API_KEY"
+        assert config.base_url_env == "REQUESTY_BASE_URL"
+        assert config.api_key_required is True
+
     def test_deepseek_config(self):
         """Test DeepSeek provider configuration."""
         config = OPENAI_COMPATIBLE_PROVIDERS["deepseek"]
@@ -277,6 +285,16 @@ class TestLLMIntegration:
             assert llm.provider == "openrouter"
             # Model should include the full path after provider prefix
             assert llm.model == "anthropic/claude-3-opus"
+
+    def test_llm_creates_openai_compatible_for_requesty(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for Requesty."""
+        with patch.dict(os.environ, {"REQUESTY_API_KEY": "test-key"}):
+            llm = LLM(model="requesty/openai/gpt-4o-mini")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "requesty"
+            # Model should include the full path after provider prefix
+            assert llm.model == "openai/gpt-4o-mini"
+            assert llm.base_url == "https://router.requesty.ai/v1"
 
     def test_llm_creates_openai_compatible_for_hosted_vllm(self):
         """Test LLM factory creates OpenAICompatibleCompletion for hosted_vllm."""


### PR DESCRIPTION
Adds Requesty (an OpenAI-compatible LLM gateway) as a supported provider, mirroring the existing OpenRouter routing.

Requesty uses the same `provider/model` naming as OpenRouter (e.g. `requesty/openai/gpt-4o-mini`), so it routes through the existing OpenAI-compatible path rather than needing litellm-native support. `requesty` is registered in `llm.py` (supported-providers list, prefix map, the pattern-match passthrough branch, and the openai_compatible provider set) and gets a `ProviderConfig` in the openai_compatible completion module (`base_url` `https://router.requesty.ai/v1`, `REQUESTY_API_KEY`). A model string like `requesty/openai/gpt-4o-mini` has its `requesty/` prefix stripped before the upstream call — identical mechanics to openrouter.

Changes:
- `lib/crewai/src/crewai/llm.py` — add `requesty` to SUPPORTED_NATIVE_PROVIDERS, the provider mapping, the pattern-match branch, and the openai_compatible provider set.
- `lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py` — add the Requesty ProviderConfig.
- `lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py` — add config + factory-routing tests mirroring the OpenRouter cases.
- `docs/edge/en/concepts/llms.mdx` — Requesty accordion mirroring OpenRouter, linking requesty.ai / docs.requesty.ai / app.requesty.ai/router/list.
- `.env.test` — add REQUESTY_API_KEY placeholder.

Verification: `uv run ruff check` clean on changed files; `uv run pytest tests/llms/openai_compatible/test_openai_compatible.py` → 37 passed (including the 2 new requesty tests). A live call to `https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` returned HTTP 200 with a completion.

Disclosure: I work at Requesty. This mirrors the existing OpenRouter provider routing; happy to adjust wording/placement or close if it's not a fit.