### PR TITLE
docs(llm-connections): default tutorial example to gpt-4o-mini

### DIFF
--- a/docs/edge/en/learn/llm-connections.mdx
+++ b/docs/edge/en/learn/llm-connections.mdx
@@ -85,7 +85,7 @@ To use a different LLM with your CrewAI agents, you have several options:
             from crewai import Agent, LLM
 
             llm = LLM(
-                model="gpt-4",
+                model="gpt-4o-mini",
                 temperature=0.7,
                 base_url="https://api.openai.com/v1",
                 api_key="your-api-key-here"


### PR DESCRIPTION
The 'Using the LLM Class' tutorial example instantiates LLM(model="gpt-4"), which costs ~20x more per token than gpt-4o-mini ($30/1M vs $0.15/1M input) without adding tutorial value. 

New users copy-paste tutorials verbatim.

The default they see is the default they ship.

One-line doc change. No code paths, no public API, no breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LLM connections documentation with refreshed code examples reflecting the latest best practices for initializing language models. The documentation now demonstrates recommended model configurations and proper API connection setup patterns, helping developers implement language model integrations effectively and maintain alignment with current industry standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->