### PR TITLE
feat(tools): add HlidoTrustTool for independent agent trust checks

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -26,6 +26,9 @@ Documentation = "https://docs.crewai.com"
 
 
 [project.optional-dependencies]
+hlido-trust = [
+    "hlido-trust>=0.1.0",
+]
 scrapfly-sdk = [
     "scrapfly-sdk>=0.8.19",
 ]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -95,6 +95,7 @@ from crewai_tools.tools.generate_crewai_automation_tool.generate_crewai_automati
     GenerateCrewaiAutomationTool,
 )
 from crewai_tools.tools.github_search_tool.github_search_tool import GithubSearchTool
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import HlidoTrustTool
 from crewai_tools.tools.hyperbrowser_load_tool.hyperbrowser_load_tool import (
     HyperbrowserLoadTool,
 )
@@ -267,6 +268,7 @@ __all__ = [
     "FirecrawlSearchTool",
     "GenerateCrewaiAutomationTool",
     "GithubSearchTool",
+    "HlidoTrustTool",
     "HyperbrowserLoadTool",
     "InvokeCrewAIAutomationTool",
     "JSONSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -84,6 +84,7 @@ from crewai_tools.tools.generate_crewai_automation_tool.generate_crewai_automati
     GenerateCrewaiAutomationTool,
 )
 from crewai_tools.tools.github_search_tool.github_search_tool import GithubSearchTool
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import HlidoTrustTool
 from crewai_tools.tools.hyperbrowser_load_tool.hyperbrowser_load_tool import (
     HyperbrowserLoadTool,
 )
@@ -251,6 +252,7 @@ __all__ = [
     "FirecrawlSearchTool",
     "GenerateCrewaiAutomationTool",
     "GithubSearchTool",
+    "HlidoTrustTool",
     "HyperbrowserLoadTool",
     "InvokeCrewAIAutomationTool",
     "JSONSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/README.md
@@ -1,0 +1,54 @@
+# HlidoTrustTool
+
+## Description
+
+`HlidoTrustTool` lets a CrewAI agent vet another AI agent against its independent
+[Hlido](https://hlido.eu) review **before delegating to it**. Hlido publishes
+independent, evidence-backed trust scores for AI agents (independent — it doesn't
+take money to rank anyone). The tool returns a PASS/FAIL gate plus the agent's
+score, tier, what it fails at, red flags, and an evidence URL.
+
+Agents with no Hlido review, or with recorded red flags, **fail the gate**
+(fail-closed).
+
+## Installation
+
+```shell
+pip install 'crewai[tools]' hlido-trust
+```
+
+No API key is required for trust checks.
+
+## Example
+
+```python
+from crewai import Agent
+from crewai_tools import HlidoTrustTool
+
+tool = HlidoTrustTool()
+
+router = Agent(
+    role="Delegation Router",
+    goal="Only delegate to agents that pass an independent Hlido trust check.",
+    backstory="You refuse to rely on any agent Hlido hasn't vetted to STEADY tier or above.",
+    tools=[tool],
+)
+```
+
+The agent calls the tool with an agent `slug` (e.g. `"aider"`) and an optional
+`min_score` (default `70`):
+
+```
+[PASS @ min_score=70.0] Aider — VITAL (92/100), confidence high. Evidence: https://hlido.eu/reviews/aider/
+```
+
+## Arguments
+
+- `slug` (str, required): the Hlido agent slug to vet, e.g. `"aider"` or `"crewai"`.
+- `min_score` (float, optional, default `70.0`): minimum acceptable Hlido score
+  (0–100). `70` = STEADY tier or above.
+
+## Environment variables
+
+- `HLIDO_API_KEY` (optional): a `hlk_live_*` key from <https://hlido.eu/api/>,
+  needed only for top-k recommendations — not for trust checks.

--- a/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/hlido_trust_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/hlido_trust_tool.py
@@ -1,0 +1,85 @@
+from typing import TYPE_CHECKING, Any, List, Optional, Type
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+if TYPE_CHECKING:
+    from hlido_trust import HlidoClient
+
+
+try:
+    from hlido_trust import HlidoClient
+
+    HLIDO_TRUST_AVAILABLE = True
+except ImportError:
+    HLIDO_TRUST_AVAILABLE = False
+
+
+class HlidoTrustToolSchema(BaseModel):
+    """Input for HlidoTrustTool."""
+
+    slug: str = Field(
+        ...,
+        description="The Hlido agent slug to vet, e.g. 'aider' or 'crewai'.",
+    )
+    min_score: float = Field(
+        70.0,
+        description="Minimum acceptable Hlido score (0-100). 70 = STEADY tier or above.",
+    )
+
+
+class HlidoTrustTool(BaseTool):
+    """Vet an AI agent against its independent Hlido review before delegating to it.
+
+    `Hlido <https://hlido.eu>`_ publishes independent, evidence-backed trust scores
+    for AI agents. This tool returns a PASS/FAIL gate plus the agent's score, tier,
+    what it fails at, red flags, and an evidence URL — so an agent can decide whether
+    to trust a tool or sub-agent before relying on it. Agents with no Hlido review, or
+    with recorded red flags, fail the gate (fail-closed).
+
+    No API key is required for trust checks. Set ``HLIDO_API_KEY`` (a ``hlk_live_*``
+    key from https://hlido.eu/api/) only if you also need top-k recommendations.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True, frozen=False
+    )
+    name: str = "Hlido Agent Trust Check"
+    description: str = (
+        "Vet an AI agent against its independent, evidence-backed Hlido review by slug "
+        "before delegating to it. Returns a PASS/FAIL trust gate plus score, tier, red "
+        "flags, and an evidence URL."
+    )
+    args_schema: Type[BaseModel] = HlidoTrustToolSchema
+    api_key: Optional[str] = None
+    _client: Optional["HlidoClient"] = PrivateAttr(None)
+    package_dependencies: List[str] = ["hlido-trust"]
+    env_vars: List[EnvVar] = [
+        EnvVar(
+            name="HLIDO_API_KEY",
+            description=(
+                "Optional Hlido API key (hlk_live_*) for top-k recommendations; "
+                "not required for trust checks"
+            ),
+            required=False,
+        ),
+    ]
+
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        if not HLIDO_TRUST_AVAILABLE:
+            raise ImportError(
+                "`hlido-trust` package is required to use the HlidoTrustTool. "
+                "Install it with `uv add hlido-trust` or `pip install hlido-trust`."
+            )
+        self.api_key = api_key
+        self._client = HlidoClient(api_key=api_key, framework="crewai")
+
+    def _run(self, **kwargs: Any) -> str:
+        slug = kwargs.get("slug")
+        if not slug:
+            raise ValueError("`slug` is required to run a Hlido trust check")
+        min_score = kwargs.get("min_score", 70.0)
+        verdict = self._client.trust_check(slug)
+        gate = "PASS" if verdict.recommended(min_score=min_score) else "FAIL"
+        return f"[{gate} @ min_score={min_score}] {verdict.summary()}"

--- a/lib/crewai-tools/tests/tools/hlido_trust_tool_test.py
+++ b/lib/crewai-tools/tests/tools/hlido_trust_tool_test.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import HlidoTrustTool
+
+
+def _fake_verdict(*, recommended: bool, summary: str):
+    v = MagicMock()
+    v.recommended.return_value = recommended
+    v.summary.return_value = summary
+    return v
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.HlidoClient")
+def test_hlido_trust_tool_pass(mock_client_cls):
+    instance = mock_client_cls.return_value
+    instance.trust_check.return_value = _fake_verdict(
+        recommended=True,
+        summary="Aider — VITAL (92/100), confidence high. Evidence: https://hlido.eu/reviews/aider/",
+    )
+
+    tool = HlidoTrustTool()
+    result = tool.run(slug="aider", min_score=70)
+
+    assert "PASS" in result
+    assert "Aider" in result
+    instance.trust_check.assert_called_once_with("aider")
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.HlidoClient")
+def test_hlido_trust_tool_fails_closed_on_red_flag(mock_client_cls):
+    mock_client_cls.return_value.trust_check.return_value = _fake_verdict(
+        recommended=False,
+        summary="X — VITAL (95/100) — red flags: hallucinates deletions. Evidence: https://hlido.eu/reviews/x/",
+    )
+
+    result = HlidoTrustTool().run(slug="x", min_score=70)
+
+    assert "FAIL" in result


### PR DESCRIPTION
## What

Adds **`HlidoTrustTool`** (in `lib/crewai-tools`) — a tool that lets a CrewAI agent vet another AI agent against its independent [Hlido](https://hlido.eu) review **before delegating to it**.

Given an agent `slug`, it returns a `PASS`/`FAIL` trust gate plus the agent's score, tier, what it fails at, red flags, and an evidence URL:

```python
from crewai import Agent
from crewai_tools import HlidoTrustTool

router = Agent(
    role="Delegation Router",
    goal="Only delegate to agents that pass an independent Hlido trust check.",
    tools=[HlidoTrustTool()],
)
```

```
[PASS @ min_score=70.0] Aider — VITAL (92/100), confidence high. Evidence: https://hlido.eu/reviews/aider/
```

Agents with no Hlido review, or with recorded red flags, **fail the gate** (fail-closed).

## Why

CrewAI agents increasingly delegate to other agents and tools. Hlido publishes independent, evidence-backed reliability scores for AI agents, so this gives an agent a way to *vet before it delegates* rather than trusting blindly.

## Notes

- **No new base dependencies.** Wraps the published [`hlido-trust`](https://pypi.org/project/hlido-trust/) package, declared as an optional extra in `lib/crewai-tools/pyproject.toml`, following the same pattern as the other API-backed tools.
- **No API key required** for trust checks. `HLIDO_API_KEY` is optional (top-k recommendations only) and declared `required=False`.
- Registered in `crewai_tools` imports + `__all__` (alphabetical placement); per-tool `README.md` included.
- **Tests:** `lib/crewai-tools/tests/tools/hlido_trust_tool_test.py` — mocked, no network (PASS gate + fail-closed on red flag). Verified passing locally on Python 3.12.
- `tool.specs.json` left untouched to keep this PR free of unrelated churn; it can be regenerated by the `generate-tool-specs` workflow.

## Disclosure

I'm the founder of Hlido. This integration is **opt-in**, uses only the **public Hlido API**, requires **no API key** for trust checks, and adds **no new base dependencies**. Happy to adjust naming or scope to fit the project's conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HlidoTrustTool to gate AI agent delegation based on independent trust reviews, applying a fail-closed PASS/FAIL validation.

* **Documentation**
  * Added installation guide and usage examples for the new trust vetting tool.

* **Tests**
  * Added test coverage for HlidoTrustTool validation scenarios.

* **Chores**
  * Added optional dependency support for trust verification functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->