### PR TITLE
docs(cli): align test example with documented default model

### DIFF
--- a/docs/edge/en/concepts/cli.mdx
+++ b/docs/edge/en/concepts/cli.mdx
@@ -149,7 +149,7 @@ crewai test [OPTIONS]
 Example:
 
 ```shell Terminal
-crewai test -n 5 -m gpt-3.5-turbo
+crewai test -n 5 -m gpt-4o-mini
 ```
 
 ### 8. Run


### PR DESCRIPTION
The crewai test command's documented default is already gpt-4o-mini (see the -m, --model TEXT line above), but the example command below still passes -m gpt-3.5-turbo. That model retired on the OpenAI API (legacy gpt-3.5-turbo endpoints) and copy-paste users hit deprecation warnings on first run.

Align the example with the documented default. One-line docs change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example model argument in the CLI test command documentation to reflect the current recommended model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->