### PR TITLE
docs(learn): replace deprecated claude-2 example with claude-3-5-haiku

### DIFF
--- a/docs/edge/en/learn/llm-connections.mdx
+++ b/docs/edge/en/learn/llm-connections.mdx
@@ -73,7 +73,7 @@ To use a different LLM with your CrewAI agents, you have several options:
                 role='Anthropic Expert',
                 goal='Analyze data using Claude',
                 backstory="An AI assistant leveraging Anthropic's language model.",
-                llm='claude-2'
+                llm='claude-3-5-haiku-20241022'
             )
             ```
         </CodeGroup>
@@ -108,7 +108,7 @@ When configuring an LLM for your agent, you have access to a wide range of param
 
 | Parameter | Type | Description |
 |:----------|:-----:|:-------------|
-| **model** | `str` | The name of the model to use (e.g., "gpt-4", "claude-2") |
+| **model** | `str` | The name of the model to use (e.g., "gpt-4o-mini", "claude-3-5-haiku-20241022") |
 | **temperature** | `float` | Controls randomness in output (0.0 to 1.0) |
 | **max_tokens** | `int` | Maximum number of tokens to generate |
 | **top_p** | `float` | Controls diversity of output (0.0 to 1.0) |


### PR DESCRIPTION
The 'Connect to any LLM' guide demonstrates Anthropic usage with llm='claude-2', and the parameter reference table lists claude-2 as an example model name. Anthropic retired claude-2 on the API. Users copy-pasting either snippet hit a 'model not found' error on first run.

Swap both references to a current Anthropic model:
  - example agent: claude-3-5-haiku-20241022 (modern, low-cost)
  - table example pair: gpt-4o-mini, claude-3-5-haiku-20241022

Docs-only. No code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LLM connection documentation examples to reference current Anthropic model naming in the "Changing the LLM" and "Configuration Options" sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->