### PR TITLE
docs(llms): update Azure features list to current model lineup

### DIFF
--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -697,7 +697,7 @@ In this section, you'll find detailed examples that help you select, configure, 
     - `AZURE_API_VERSION`: API version (optional, defaults to `2024-06-01`)
 
     **Features:**
-    - Native function calling support for Azure OpenAI models (gpt-4, gpt-4o, gpt-3.5-turbo, etc.)
+    - Native function calling support for Azure OpenAI models (gpt-4o, gpt-4o-mini, gpt-4, etc.)
     - Streaming support for real-time responses
     - Automatic endpoint URL validation and correction
     - Comprehensive error handling with retry logic


### PR DESCRIPTION
The Azure section's 'Features' bullet lists supported function-calling models as 'gpt-4, gpt-4o, gpt-3.5-turbo'. The legacy gpt-3.5-turbo endpoint is deprecated on Azure OpenAI and gpt-4o-mini is the current low-cost successor.

Update the example list to reflect the modern lineup:
  gpt-4o, gpt-4o-mini, gpt-4

Docs-only. No code paths, no public API. One-line change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure native function calling documentation to reflect current supported language models (GPT-4o, GPT-4o mini, GPT-4, and others).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->