### PR TITLE
Keep flow method progress visible for nested crews

### DIFF
--- a/lib/crewai/src/crewai/events/utils/console_formatter.py
+++ b/lib/crewai/src/crewai/events/utils/console_formatter.py
@@ -373,9 +373,6 @@ To enable tracing, do any one of these:
         status: str = "running",
     ) -> None:
         """Show method status panel."""
-        if not self.verbose:
-            return
-
         if status == "running":
             style = "yellow"
             panel_title = "🔄 Flow Method Running"

--- a/lib/crewai/tests/utilities/test_console_formatter_pause_resume.py
+++ b/lib/crewai/tests/utilities/test_console_formatter_pause_resume.py
@@ -46,6 +46,16 @@ class TestConsoleFormatterPauseResume:
 
         formatter.resume_live_updates()
 
+    def test_flow_method_status_ignores_formatter_verbose(self):
+        formatter = ConsoleFormatter(verbose=False)
+
+        with patch.object(formatter, "print_panel") as mock_print_panel:
+            formatter.handle_method_status("categorize_tickets")
+
+        mock_print_panel.assert_called_once()
+        _, kwargs = mock_print_panel.call_args
+        assert kwargs["is_flow"] is True
+
     def test_streaming_after_pause_resume_creates_new_session(self):
         """Test that streaming after pause/resume creates new Live session."""
         formatter = ConsoleFormatter()


### PR DESCRIPTION
Inline crews default to `verbose=False`. They set the shared formatter's `verbose` value in `lib/crewai/src/crewai/crew.py`, which could hide flow method status from `lib/crewai/src/crewai/events/utils/ console_formatter.py`.

Remove that `verbose` check for flow method status. Flow output is still controlled by `suppress_flow_events`.

Normal quiet crews are unchanged because crew, task, and agent logs still use their own `verbose` checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small console-formatting change with no auth, data, or execution logic; slightly more console output during flows when crews are quiet.
> 
> **Overview**
> **Flow method progress panels** (running/completed/paused/failed) are shown again even when the shared `ConsoleFormatter` has `verbose=False`.
> 
> The early `verbose` guard was removed from `handle_method_status`. Nested crews often set `event_listener.formatter.verbose` from their own `verbose` flag (including default quiet crews), which had been suppressing flow method status even though other flow UI already prints via `print_panel(..., is_flow=True)` without respecting formatter verbosity.
> 
> Crew/task/agent console noise is unchanged because those paths still check `verbose` themselves. Flow output can still be turned off with `suppress_flow_events` on the flow.
> 
> A unit test asserts `handle_method_status` still invokes `print_panel` with `is_flow=True` when the formatter is not verbose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16a19433e88451bfa8c8194c055d84feb2be3c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Method status panels are now consistently displayed in console output regardless of verbose mode setting, ensuring visibility of task progress.

* **Tests**
  * Added test coverage to verify method status panels display correctly when verbose mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->