### PR TITLE
Improve `crewai run` startup UX

### DIFF
--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -787,9 +787,13 @@ def flow() -> None:
     """Flow related commands."""
 
 
-@flow.command(name="kickoff", deprecated=True)
+@flow.command(name="kickoff")
 def flow_run() -> None:
     """Kickoff the Flow."""
+    click.secho(
+        "The command 'crewai flow kickoff' is deprecated. Use 'crewai run' instead.",
+        fg="yellow",
+    )
     run_crew(trained_agents_file=None, definition=None, inputs=None)
 
 

--- a/lib/cli/src/crewai_cli/run_crew.py
+++ b/lib/cli/src/crewai_cli/run_crew.py
@@ -595,7 +595,6 @@ def _run_flow_project(
     if trained_agents_file is not None:
         raise click.UsageError("--filename can only be used when running crews")
 
-    click.echo("Running the Flow")
     from crewai_cli.run_declarative_flow import (
         configured_project_declarative_flow,
         run_declarative_flow_in_project_env,
@@ -611,7 +610,6 @@ def _run_flow_project(
 def _run_classic_crew_project(
     pyproject_data: dict[str, Any], trained_agents_file: str | None
 ) -> None:
-    click.echo("Running the Crew")
     _execute_uv_script(
         "run_crew",
         entity_type="crew",

--- a/lib/cli/tests/test_cli.py
+++ b/lib/cli/tests/test_cli.py
@@ -190,7 +190,10 @@ def test_flow_kickoff_is_deprecated_and_uses_run_path(run_crew, runner):
         definition=None,
         inputs=None,
     )
-    assert "DeprecationWarning" in result.output
+    assert (
+        "The command 'crewai flow kickoff' is deprecated. Use 'crewai run' instead."
+        in result.output
+    )
 
 
 @mock.patch("crewai_cli.create_json_crew.create_json_crew")

--- a/lib/cli/tests/test_create_flow.py
+++ b/lib/cli/tests/test_create_flow.py
@@ -31,5 +31,5 @@ def test_create_flow_declarative_project_can_run(
     result = CliRunner().invoke(crewai, ["run"], env={"UV_RUN_RECURSION_DEPTH": "1"})
 
     assert result.exit_code == 0
-    assert "Running the Flow" in result.output
+    assert "Running the Flow" not in result.output
     assert "AI agents" in result.output

--- a/lib/cli/tests/test_flow_commands.py
+++ b/lib/cli/tests/test_flow_commands.py
@@ -44,8 +44,12 @@ def test_flow_kickoff_runs_configured_declarative_definition(
     result = CliRunner().invoke(flow_run)
 
     assert result.exit_code == 0
-    assert "DeprecationWarning" in result.output
-    assert "Running the Flow\nAI\n" in result.output
+    assert (
+        "The command 'crewai flow kickoff' is deprecated. Use 'crewai run' instead."
+        in result.output
+    )
+    assert "AI\n" in result.output
+    assert "Running the Flow" not in result.output
 
 
 def test_plot_flow_runs_configured_declarative_definition(

--- a/lib/cli/tests/test_run_crew.py
+++ b/lib/cli/tests/test_run_crew.py
@@ -622,7 +622,7 @@ def test_run_crew_runs_classic_crew_project(monkeypatch, capsys):
 
     run_crew_module.run_crew(trained_agents_file="trained.pkl")
 
-    assert capsys.readouterr().out == "Running the Crew\n"
+    assert capsys.readouterr().out == ""
     assert calls == [
         (
             "run_crew",
@@ -648,7 +648,7 @@ def test_run_crew_runs_python_flow_project(monkeypatch, capsys):
 
     run_crew_module.run_crew()
 
-    assert capsys.readouterr().out == "Running the Flow\n"
+    assert capsys.readouterr().out == ""
     assert calls == [("kickoff", {"entity_type": "flow"})]
 
 
@@ -694,5 +694,5 @@ def test_run_crew_runs_configured_declarative_flow_project(monkeypatch, capsys):
 
     run_crew_module.run_crew()
 
-    assert capsys.readouterr().out == "Running the Flow\n"
+    assert capsys.readouterr().out == ""
     assert calls == [("flow.yaml", None)]

--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -2455,11 +2455,6 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
                     object.__setattr__(
                         self, "_deferred_flow_started_event_id", started_event.event_id
                     )
-                if not self.suppress_flow_events:
-                    self._log_flow_event(
-                        f"Flow started with ID: {self.flow_id}", color="bold magenta"
-                    )
-
             # After FlowStarted: env events must not pre-empt trace batch init
             # with implicit "crew" execution_type.
             get_env_context()


### PR DESCRIPTION
Remove redundant startup logs from `crewai run` and make the legacy flow command warning actionable.

- Stop printing `Running the Flow` and `Running the Crew` before project execution.
- Stop printing the redundant `Flow started with ID: ...` line while preserving flow lifecycle event emission.
- Replace Click's generic `kickoff` deprecation warning with a clearer message that tells users to use `crewai run`.

<img width="500" alt="Screenshot 2026-06-22 at 21 05 45" src="https://github.com/user-attachments/assets/611a1ac8-c7e9-4618-8378-8aaa2c9684c2" />
<img width="500" alt="Screenshot 2026-06-22 at 21 05 55" src="https://github.com/user-attachments/assets/cd07d8d4-276b-4a42-a0a0-8b26a22dc57c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `crewai flow kickoff` deprecation warning to display an explicit message directing users to use `crewai run` instead.
  * Removed extraneous "Running the Flow" and "Running the Crew" messages from CLI output for cleaner execution feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only logging and messaging changes with test updates; no changes to run routing or flow event emission logic beyond removing a console line.
> 
> **Overview**
> **Quieter `crewai run`** — The CLI no longer prints **`Running the Crew`** or **`Running the Flow`** before delegating to project scripts, so startup output is less noisy while execution behavior is unchanged.
> 
> **Legacy `crewai flow kickoff`** — Click’s built-in deprecated-command warning is removed in favor of an explicit yellow message: use **`crewai run`** instead. The command still calls the same **`run_crew`** path.
> 
> **Flow runtime console** — The extra **`Flow started with ID: …`** line from **`_log_flow_event`** is dropped when deferred trace finalization is enabled; **`FlowStartedEvent`** and related lifecycle handling are unchanged.
> 
> Tests were updated to expect the new deprecation text and the absence of the removed startup banners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1592dfbf976037aa5ce3e33a525a07560e118981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->