### PR TITLE
fix(tools): serialize plain structured outputs as json

### DIFF
--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -64,7 +64,7 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
         ):
             try:
                 return json.dumps(raw_result)
-            except TypeError:
+            except (TypeError, ValueError):
                 pass
         return str(raw_result)
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 import inspect
 import json
 import textwrap
@@ -58,6 +58,14 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
 
     result_schema = getattr(tool, "result_schema", None)
     if not (isinstance(result_schema, type) and issubclass(result_schema, BaseModel)):
+        if isinstance(raw_result, Mapping) or (
+            isinstance(raw_result, Sequence)
+            and not isinstance(raw_result, str | bytes | bytearray)
+        ):
+            try:
+                return json.dumps(raw_result)
+            except TypeError:
+                pass
         return str(raw_result)
 
     try:

--- a/lib/crewai/tests/tools/test_base_tool.py
+++ b/lib/crewai/tests/tools/test_base_tool.py
@@ -471,6 +471,13 @@ class TestToolOutputSchema:
             "score": 0.5,
         }
 
+    def test_base_tool_falls_back_for_unserializable_mapping_output(self) -> None:
+        t = DictAnnotatedSearchTool()
+        raw_result: dict[str, object] = {}
+        raw_result["self"] = raw_result
+
+        assert t.format_output_for_agent(raw_result) == str(raw_result)
+
     @pytest.mark.parametrize(
         ("make_tool", "expected_raw", "expected_agent_payload"),
         [
@@ -524,6 +531,19 @@ class TestToolOutputSchema:
             "query": "crew",
             "score": 0.5,
         }
+
+    def test_decorator_tool_falls_back_for_unserializable_mapping_output(
+        self,
+    ) -> None:
+        @tool("search")
+        def search(query: str) -> dict[str, object]:
+            """Search for a query."""
+            return {"query": query, "score": 0.5}
+
+        raw_result: dict[str, object] = {}
+        raw_result["self"] = raw_result
+
+        assert search.format_output_for_agent(raw_result) == str(raw_result)
 
     def test_explicit_result_schema_wins_over_return_annotation(self) -> None:
         class AlternateOutput(BaseModel):

--- a/lib/crewai/tests/tools/test_base_tool.py
+++ b/lib/crewai/tests/tools/test_base_tool.py
@@ -460,13 +460,16 @@ class TestToolOutputSchema:
             expected_agent_payload
         )
 
-    def test_base_tool_does_not_infer_non_pydantic_return_annotation(self) -> None:
+    def test_base_tool_serializes_non_pydantic_mapping_output_as_json(self) -> None:
         t = DictAnnotatedSearchTool()
 
         raw_result = t.run(query="crew")
 
         assert raw_result == {"query": "crew", "score": 0.5}
-        assert t.format_output_for_agent(raw_result) == str(raw_result)
+        assert json.loads(t.format_output_for_agent(raw_result)) == {
+            "query": "crew",
+            "score": 0.5,
+        }
 
     @pytest.mark.parametrize(
         ("make_tool", "expected_raw", "expected_agent_payload"),
@@ -506,7 +509,7 @@ class TestToolOutputSchema:
             expected_agent_payload
         )
 
-    def test_decorator_tool_does_not_infer_non_pydantic_return_annotation(
+    def test_decorator_tool_serializes_non_pydantic_mapping_output_as_json(
         self,
     ) -> None:
         @tool("search")
@@ -517,7 +520,10 @@ class TestToolOutputSchema:
         raw_result = search.run(query="crew")
 
         assert raw_result == {"query": "crew", "score": 0.5}
-        assert search.format_output_for_agent(raw_result) == str(raw_result)
+        assert json.loads(search.format_output_for_agent(raw_result)) == {
+            "query": "crew",
+            "score": 0.5,
+        }
 
     def test_explicit_result_schema_wins_over_return_annotation(self) -> None:
         class AlternateOutput(BaseModel):

--- a/lib/crewai/tests/tools/test_structured_tool.py
+++ b/lib/crewai/tests/tools/test_structured_tool.py
@@ -164,7 +164,7 @@ def test_from_function_returns_raw_result_and_json_agent_text(
     )
 
 
-def test_from_function_does_not_infer_non_pydantic_result_schema():
+def test_from_function_serializes_non_pydantic_mapping_output_as_json():
     tool = CrewStructuredTool.from_function(
         func=_build_plain_structured_value,
         name="build_value",
@@ -173,7 +173,10 @@ def test_from_function_does_not_infer_non_pydantic_result_schema():
     raw_result = tool.invoke({"value": "crew"})
 
     assert raw_result == {"value": "crew", "count": 1}
-    assert tool.format_output_for_agent(raw_result) == str(raw_result)
+    assert json.loads(tool.format_output_for_agent(raw_result)) == {
+        "value": "crew",
+        "count": 1,
+    }
 
 
 def test_invalid_typed_output_warns_and_uses_string_agent_text():

--- a/lib/crewai/tests/tools/test_structured_tool.py
+++ b/lib/crewai/tests/tools/test_structured_tool.py
@@ -179,6 +179,24 @@ def test_from_function_serializes_non_pydantic_mapping_output_as_json():
     }
 
 
+def test_from_function_falls_back_for_circular_mapping_output():
+    def build_value(value: str) -> dict[str, object]:
+        """Build a value."""
+        result: dict[str, object] = {"value": value}
+        result["self"] = result
+        return result
+
+    tool = CrewStructuredTool.from_function(
+        func=build_value,
+        name="build_value",
+    )
+
+    raw_result = tool.invoke({"value": "crew"})
+
+    assert raw_result["self"] is raw_result
+    assert tool.format_output_for_agent(raw_result) == str(raw_result)
+
+
 def test_invalid_typed_output_warns_and_uses_string_agent_text():
     def build_value(value: str) -> dict[str, object]:
         """Build a value."""

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -24,6 +24,7 @@ from crewai.hooks.tool_hooks import (
     register_after_tool_call_hook,
 )
 from crewai.tools import BaseTool
+from crewai.tools.base_tool import Tool
 from crewai.tools.tool_calling import ToolCalling
 from crewai.tools.tool_usage import ToolUsage
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
@@ -60,6 +61,15 @@ class TypedSearchTool(BaseTool):
 
     def _run(self, query: str) -> SearchOutput:
         return SearchOutput(query=query, score=0.7)
+
+
+class NestedDictLangChainTool:
+    name = "mock_api_tool"
+    description = "Fetches data from a mock API."
+
+    @staticmethod
+    def func(query: str) -> dict[str, object]:
+        return {"status": "success", "data": {"items": [{"id": 1, "value": query}]}}
 
 
 # Example agent and task
@@ -161,6 +171,28 @@ def test_tool_usage_returns_json_agent_text_for_typed_output():
     )
 
     assert json.loads(result) == {"query": "crew", "score": 0.7}
+
+
+def test_tool_usage_serializes_plain_nested_dict_output_as_json():
+    structured_tool = Tool.from_langchain(
+        NestedDictLangChainTool()
+    ).to_structured_tool()
+    action = AgentAction(
+        thought="",
+        tool="mock_api_tool",
+        tool_input='{"query": "crew"}',
+        text='Action: mock_api_tool\nAction Input: {"query": "crew"}',
+    )
+
+    result = execute_tool_and_check_finality(
+        agent_action=action,
+        tools=[structured_tool],
+    )
+
+    assert json.loads(result.result) == {
+        "status": "success",
+        "data": {"items": [{"id": 1, "value": "crew"}]},
+    }
 
 
 def test_tool_usage_cache_callback_receives_raw_typed_output():


### PR DESCRIPTION
## Summary

Fixes #6267.

This makes plain JSON-like tool outputs (for example nested dict/list responses from LangChain-style tools) serialize to JSON before they are sent back to the agent. Non-JSON-serializable outputs still fall back to the existing `str(raw_result)` behavior.

## Why

CrewAI already supports `format_output_for_agent()` for Pydantic result schemas, but tools without a Pydantic `result_schema` still used Python repr for dict/list outputs. That leaves nested API responses as single-quoted Python dict strings instead of JSON the LLM can reliably parse.

## Validation

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run pytest lib/crewai/tests/tools/test_structured_tool.py lib/crewai/tests/tools/test_base_tool.py lib/crewai/tests/tools/test_tool_usage.py -q` -> `96 passed`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run ruff check lib/crewai/src/crewai/tools/structured_tool.py lib/crewai/tests/tools/test_structured_tool.py lib/crewai/tests/tools/test_base_tool.py lib/crewai/tests/tools/test_tool_usage.py` -> `All checks passed!`
- Manual smoke: a LangChain-shaped `mock_api_tool` returning `{"status": "success", "data": {"items": [...]}}` now produces `json.loads(result.result)`-parseable agent text.

## AI assistance

AI assistance was used to inspect the issue and current tool execution path, implement this focused change, and run the validation above. I reviewed the final diff and test output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Tool outputs that are structured mappings (and non-string sequences) are now serialized as JSON for clearer, agent-friendly consumption.
  * If the output can’t be serialized to JSON (for example, circular references), formatting falls back to plain string output.

* **Tests**
  * Updated and expanded coverage for base tools, structured tools, and end-to-end tool usage to verify JSON output for non-Pydantic mapping returns, including circular-reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->