### PR TITLE
fix(tools): return structured JSON error data from tool exceptions

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -80,6 +80,7 @@ from crewai.utilities.tool_utils import (
     aexecute_tool_and_check_finality,
     execute_tool_and_check_finality,
 )
+from crewai.utilities.tool_errors import format_tool_error
 from crewai.utilities.training_handler import CrewTrainingHandler
 
 
@@ -1006,7 +1007,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
                 result = format_native_tool_output_for_agent(output_tool, raw_result)
             except Exception as e:
-                result = f"Error executing tool: {e}"
+                result = format_tool_error(e)
                 raw_tool_result = result
                 if self.task:
                     self.task.increment_tools_errors()

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -108,6 +108,7 @@ from crewai.utilities.planning_types import (
 )
 from crewai.utilities.step_execution_context import StepExecutionContext, StepResult
 from crewai.utilities.string_utils import sanitize_tool_name
+from crewai.utilities.tool_errors import format_tool_error
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from crewai.utilities.training_handler import CrewTrainingHandler
 from crewai.utilities.types import LLMMessage
@@ -1615,9 +1616,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             if self.task:
                 self.task.increment_tools_errors()
 
-            error_observation = f"\nObservation: Error executing tool: {e}"
+            structured_error = format_tool_error(e)
+            error_observation = f"\nObservation: {structured_error}"
             action.text += error_observation
-            action.result = str(e)
+            action.result = structured_error
             self._append_message_to_state(action.text)
 
             reasoning_prompt = I18N_DEFAULT.slice("post_tool_reasoning")
@@ -1736,7 +1738,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         ordered_results[idx] = {
                             "call_id": call_id,
                             "func_name": func_name,
-                            "result": f"Error executing tool: {e}",
+                            "result": format_tool_error(e),
                             "from_cache": False,
                             "original_tool": None,
                         }
@@ -1999,7 +2001,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                         output_tool, raw_result
                     )
                 except Exception as e:
-                    result = f"Error executing tool: {e}"
+                    result = format_tool_error(e)
                     raw_tool_result = result
                     if self.task:
                         self.task.increment_tools_errors()

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -52,6 +52,7 @@ from crewai.utilities.exceptions.context_window_exceeding_exception import (
 from crewai.utilities.logger_utils import suppress_warnings
 from crewai.utilities.string_utils import sanitize_tool_name
 from crewai.utilities.token_counter_callback import TokenCalcHandler
+from crewai.utilities.tool_errors import format_tool_error
 
 
 try:
@@ -1755,11 +1756,12 @@ class LLM(BaseLLM):
                 return result
             except Exception as e:
                 fn = available_functions.get(function_name, lambda: None)
+                structured_error = format_tool_error(e)
                 logging.error(f"Error executing function '{function_name}': {e}")
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
-                        error=f"Tool execution error: {e!s}",
+                        error=structured_error,
                         from_task=from_task,
                         from_agent=from_agent,
                         call_id=get_current_call_id(),
@@ -1770,7 +1772,7 @@ class LLM(BaseLLM):
                     event=ToolUsageErrorEvent(
                         tool_name=function_name,
                         tool_args=function_args,
-                        error=f"Tool execution error: {e!s}",
+                        error=structured_error,
                         from_task=from_task,
                         from_agent=from_agent,
                     ),

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -37,6 +37,7 @@ from crewai.utilities.i18n import I18N_DEFAULT
 from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.string_utils import sanitize_tool_name
 from crewai.utilities.token_counter_callback import TokenCalcHandler
+from crewai.utilities.tool_errors import format_tool_error
 from crewai.utilities.types import LLMMessage
 
 
@@ -1546,7 +1547,7 @@ def execute_single_native_tool_call(
 
                 result = format_native_tool_output_for_agent(output_tool, raw_result)
             except Exception as e:
-                result = f"Error executing tool: {e}"
+                result = format_tool_error(e)
                 raw_tool_result = result
                 if task:
                     task.increment_tools_errors()

--- a/lib/crewai/src/crewai/utilities/tool_errors.py
+++ b/lib/crewai/src/crewai/utilities/tool_errors.py
@@ -1,0 +1,29 @@
+"""Structured tool error formatting for agent consumption.
+
+When a tool raises an exception, the agent needs structured information
+to decide whether to retry, fix its input, or skip the tool entirely.
+This module provides a consistent error format across all executors.
+"""
+
+import json
+import traceback
+
+RETRYABLE_EXCEPTIONS = (TimeoutError, ConnectionError, OSError)
+
+
+def format_tool_error(exception: Exception, include_traceback: bool = False) -> str:
+    """Format a tool execution error as structured JSON for the agent.
+
+    Returns a string with the "Error executing tool:" prefix (for backward
+    compatibility with existing parsing) followed by a JSON object containing
+    the exception type, message, and retryability hint.
+    """
+    error_data = {
+        "error": True,
+        "type": type(exception).__name__,
+        "message": str(exception),
+        "retryable": isinstance(exception, RETRYABLE_EXCEPTIONS),
+    }
+    if include_traceback:
+        error_data["traceback"] = traceback.format_exc(limit=3)
+    return f"Error executing tool: {json.dumps(error_data)}"

--- a/lib/crewai/tests/test_tool_errors.py
+++ b/lib/crewai/tests/test_tool_errors.py
@@ -1,0 +1,121 @@
+"""Tests for structured tool error formatting."""
+
+import json
+
+import pytest
+
+from crewai.utilities.tool_errors import RETRYABLE_EXCEPTIONS, format_tool_error
+
+
+class TestFormatToolError:
+    """Tests for the format_tool_error utility function."""
+
+    def test_returns_string_with_prefix(self):
+        err = ValueError("bad input")
+        result = format_tool_error(err)
+        assert result.startswith("Error executing tool: ")
+
+    def test_contains_valid_json_after_prefix(self):
+        err = ValueError("bad input")
+        result = format_tool_error(err)
+        json_str = result[len("Error executing tool: "):]
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+    def test_error_flag_is_true(self):
+        err = RuntimeError("something broke")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["error"] is True
+
+    def test_preserves_exception_type(self):
+        err = KeyError("missing_key")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["type"] == "KeyError"
+
+    def test_preserves_exception_message(self):
+        err = ValueError("count must be positive")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["message"] == "count must be positive"
+
+    def test_retryable_true_for_timeout(self):
+        err = TimeoutError("connection timed out")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is True
+
+    def test_retryable_true_for_connection_error(self):
+        err = ConnectionError("refused")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is True
+
+    def test_retryable_true_for_os_error(self):
+        err = OSError("disk full")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is True
+
+    def test_retryable_false_for_value_error(self):
+        err = ValueError("invalid")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is False
+
+    def test_retryable_false_for_type_error(self):
+        err = TypeError("wrong type")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is False
+
+    def test_retryable_false_for_key_error(self):
+        err = KeyError("not found")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["retryable"] is False
+
+    def test_no_traceback_by_default(self):
+        err = ValueError("test")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert "traceback" not in parsed
+
+    def test_traceback_included_when_requested(self):
+        try:
+            raise ValueError("deliberate error")
+        except ValueError as e:
+            result = format_tool_error(e, include_traceback=True)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert "traceback" in parsed
+        assert "ValueError" in parsed["traceback"]
+
+    def test_handles_exception_with_special_characters(self):
+        err = ValueError('path "C:\\Users\\test" not found')
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert 'C:\\Users\\test' in parsed["message"]
+
+    def test_handles_exception_with_empty_message(self):
+        err = RuntimeError()
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["type"] == "RuntimeError"
+        assert parsed["message"] == ""
+
+    def test_handles_custom_exception(self):
+        class MyToolError(Exception):
+            pass
+
+        err = MyToolError("custom failure")
+        result = format_tool_error(err)
+        parsed = json.loads(result[len("Error executing tool: "):])
+        assert parsed["type"] == "MyToolError"
+        assert parsed["message"] == "custom failure"
+        assert parsed["retryable"] is False
+
+    def test_retryable_exceptions_tuple_contains_expected_types(self):
+        assert TimeoutError in RETRYABLE_EXCEPTIONS
+        assert ConnectionError in RETRYABLE_EXCEPTIONS
+        assert OSError in RETRYABLE_EXCEPTIONS


### PR DESCRIPTION
## Summary

Closes #6262

When a tool raises an exception, CrewAI currently catches it and returns a generic string like `"Error executing tool: {e}"` — discarding the exception type, retryability classification, and structured data that agents need to make informed decisions.

This PR replaces all generic error strings with **structured JSON** containing:
- `error: true` — unambiguous error flag
- `type` — exception class name (e.g. `"TimeoutError"`, `"ValueError"`)
- `message` — original exception message
- `retryable` — boolean hint based on exception type (`True` for `TimeoutError`, `ConnectionError`, `OSError`)

### Before
```
Error executing tool: connection timed out
```

### After
```
Error executing tool: {"error": true, "type": "TimeoutError", "message": "connection timed out", "retryable": true}
```

The `"Error executing tool:"` prefix is preserved for backward compatibility with existing parsing logic.

## Changes

- **New:** `crewai/utilities/tool_errors.py` — `format_tool_error()` utility with retryable classification
- **Modified:** 4 files where generic error strings were returned:
  - `agents/crew_agent_executor.py` (native tool call handler)
  - `experimental/agent_executor.py` (3 locations: ReAct loop, parallel tool calls, native tool handler)
  - `utilities/agent_utils.py` (shared tool execution utility)
  - `llm.py` (event emissions for `LLMCallFailedEvent` and `ToolUsageErrorEvent`)
- **New:** `tests/test_tool_errors.py` — 17 unit tests covering all error scenarios

## Design Decisions

1. **Structured JSON over raw traceback** — Agents can parse JSON to make decisions; raw tracebacks waste context tokens and aren't actionable by an LLM.
2. **`retryable` hint** — Lets agents automatically retry transient failures (network, timeout) without wasting iterations on permanent errors (validation, type errors).
3. **Backward-compatible prefix** — Keeps `"Error executing tool:"` so any existing regex/startswith checks continue to work.
4. **No traceback by default** — Available via `include_traceback=True` for debugging, but excluded by default to save LLM context window.

## Test plan

- [x] All 17 unit tests pass for `format_tool_error()`
- [x] Verified backward compatibility (prefix preserved)
- [x] Syntax validation passes for all 6 modified/new files
- [ ] Existing test suite (`pytest lib/crewai/tests/agents/`) — CI will verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool and function errors are now returned in a consistent, structured format.
  * Error details now include the exception type, message, and whether the error may be retryable.

* **Bug Fixes**
  * Improved how tool execution failures appear in agent history and event outputs.
  * Added clearer handling for tracebacks when available, while keeping them hidden by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->