### PR TITLE
fix(cli): update Groq model list to match current API availability

### DIFF
--- a/lib/cli/src/crewai_cli/constants.py
+++ b/lib/cli/src/crewai_cli/constants.py
@@ -258,11 +258,11 @@ MODELS: dict[str, list[str]] = {
         "nvidia_nim/baichuan-inc/baichuan2-13b-chat",
     ],
     "groq": [
+        "groq/llama-3.3-70b-versatile",
         "groq/llama-3.1-8b-instant",
-        "groq/llama-3.1-70b-versatile",
-        "groq/llama-3.1-405b-reasoning",
-        "groq/gemma2-9b-it",
-        "groq/gemma-7b-it",
+        "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+        "groq/qwen/qwen3-32b",
+        "groq/allam-2-7b",
     ],
     "ollama": ["ollama/llama3.1", "ollama/mixtral"],
     "watson": [


### PR DESCRIPTION
## Summary

Updates the Groq model list in `crewai create crew` CLI to reflect currently available models from the Groq API.

### Removed (deprecated/unavailable)
- `groq/llama-3.1-405b-reasoning` — no longer available on Groq
- `groq/gemma-7b-it` — deprecated
- `groq/gemma2-9b-it` — deprecated

### Added (currently available)
- `groq/llama-3.3-70b-versatile` — current flagship model
- `groq/meta-llama/llama-4-scout-17b-16e-instruct` — newest Llama 4
- `groq/qwen/qwen3-32b` — popular reasoning model
- `groq/allam-2-7b` — lightweight model

### Verification

Verified against the live Groq API (`GET /v1/models`) on 2026-06-24.

## Test plan

- [x] Models verified against Groq API response
- [x] `constants.py` syntax validation passes
- [ ] `crewai create crew` → select Groq → model list shows updated options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the available Groq model options in the CLI with newer model identifiers.
  * Added support for additional Groq choices, including several latest Llama, Qwen, and Allam variants.
* **Bug Fixes**
  * Removed outdated model options from the Groq list to keep the available selections current and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->