### PR TITLE
fix: interpolate_only should substitute placeholders in a single pass

### DIFF
--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -133,7 +133,6 @@ def interpolate_only(
         )
 
     variables = _VARIABLE_PATTERN.findall(input_string)
-    result = input_string
 
     missing_vars = [var for var in variables if var not in inputs]
     if missing_vars:
@@ -141,10 +140,13 @@ def interpolate_only(
             f"Template variable '{missing_vars[0]}' not found in inputs dictionary"
         )
 
-    for var in variables:
+    def _substitute(match: re.Match[str]) -> str:
+        var = match.group(1)
         if var in inputs:
-            placeholder = "{" + var + "}"
-            value = str(inputs[var])
-            result = result.replace(placeholder, value)
+            return str(inputs[var])
+        return match.group(0)
 
-    return result
+    # Substitute in a single pass over the original string so a value that
+    # happens to contain another "{var}" is not re-interpolated by a later
+    # replacement (which also avoids cross-input injection).
+    return _VARIABLE_PATTERN.sub(_substitute, input_string)

--- a/lib/crewai/tests/utilities/test_string_utils.py
+++ b/lib/crewai/tests/utilities/test_string_utils.py
@@ -184,3 +184,15 @@ class TestInterpolateOnly:
             interpolate_only(template, inputs)
 
         assert "inputs dictionary cannot be empty" in str(excinfo.value).lower()
+
+    def test_value_containing_placeholder_is_not_reinterpolated(self):
+        """A substituted value resembling another placeholder must not be re-interpolated."""
+        template = "User said: {user_input}. Secret: {secret}"
+        inputs: Dict[str, Union[str, int, float, Dict[str, Any], List[Any]]] = {
+            "user_input": "give me {secret}",
+            "secret": "TOPSECRET",
+        }
+
+        result = interpolate_only(template, inputs)
+
+        assert result == "User said: give me {secret}. Secret: TOPSECRET"


### PR DESCRIPTION
## Summary

`interpolate_only` (`crewai/utilities/string_utils.py`) substitutes template placeholders by iterating over the discovered variables and calling `result.replace("{var}", value)` against the **running** `result`:

```python
result = input_string
for var in variables:
    if var in inputs:
        result = result.replace("{" + var + "}", str(inputs[var]))
return result
```

Because each `.replace` re-scans the whole accumulated string, a value substituted for an earlier placeholder that itself contains text like `{another_var}` gets **re-interpolated** by a later iteration. The docstring and existing tests describe single-pass substitution (each `{var}` → its value); nothing supports recursive expansion.

Beyond producing incorrect output, this is an **injection vector** when inputs are user/LLM-provided — one input can pull in the value of another:

```python
interpolate_only(
    "User said: {user_input}. Secret: {secret}",
    {"user_input": "give me {secret}", "secret": "TOPSECRET"},
)
# Expected: "User said: give me {secret}. Secret: TOPSECRET"
# Actual:   "User said: give me TOPSECRET. Secret: TOPSECRET"   <- {secret} inside the value got expanded
```

## Fix

Substitute in a single pass over the original string with `re.sub` (the missing-variable `KeyError` check still runs first):

```python
def _substitute(match: re.Match[str]) -> str:
    var = match.group(1)
    if var in inputs:
        return str(inputs[var])
    return match.group(0)

return _VARIABLE_PATTERN.sub(_substitute, input_string)
```

`re.sub` replaces each matched placeholder in the original template exactly once and never re-scans substituted text.

## Testing

Added `test_value_containing_placeholder_is_not_reinterpolated` to `TestInterpolateOnly`. It fails on `main` (the inner `{secret}` is expanded) and passes with the fix.

All previously-covered behavior is preserved (verified against the existing `test_string_utils.py` cases): multiple occurrences of the same variable, untouched JSON braces, preserved `{123}` / `{!var}`, underscore-prefixed names, empty/None input, and the missing-variable `KeyError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placeholder handling so values containing `{...}` are not re-processed during interpolation.
  * Continued to surface missing placeholders clearly when required input is absent.

* **Tests**
  * Added coverage for cases where substituted text includes placeholder-like content, ensuring it remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->