### PR TITLE
perf(utilities): memoize sanitize_tool_name

### DIFF
--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -23,11 +23,16 @@ def _duplicate_separator_pattern(separator: str) -> re.Pattern[str]:
     return re.compile(f"(?:{re.escape(separator)}){{2,}}")
 
 
+@functools.lru_cache(maxsize=1024)
 def sanitize_tool_name(name: str, max_length: int = _MAX_TOOL_NAME_LENGTH) -> str:
     """Sanitize tool name for LLM provider compatibility.
 
     Normalizes Unicode, splits camelCase, lowercases, replaces invalid characters
     with underscores, and truncates to max_length. Conforms to OpenAI/Bedrock requirements.
+
+    Pure function of its arguments, so results are memoized: it is called many
+    times per agent iteration over the same small, stable set of tool names
+    (each call does an NFKD normalize, ascii round-trip and several regex subs).
 
     Args:
         name: Original tool name.

--- a/lib/crewai/tests/utilities/test_string_utils.py
+++ b/lib/crewai/tests/utilities/test_string_utils.py
@@ -1,7 +1,40 @@
 from typing import Any, Dict, List, Union
 
 import pytest
-from crewai.utilities.string_utils import interpolate_only
+from crewai.utilities.string_utils import interpolate_only, sanitize_tool_name
+
+
+class TestSanitizeToolName:
+    """Tests for sanitize_tool_name, including memoization (perf)."""
+
+    def test_sanitization_rules_preserved(self):
+        assert sanitize_tool_name("Calculator Tool") == "calculator_tool"
+        assert sanitize_tool_name("getWeatherForecast") == "get_weather_forecast"
+        assert sanitize_tool_name("search!!the@@web") == "search_the_web"
+        # Over-length names are truncated with a stable hash suffix.
+        long = "a" * 100
+        result = sanitize_tool_name(long)
+        assert len(result) <= 64
+        assert sanitize_tool_name(long) == result  # deterministic
+
+    def test_is_memoized(self):
+        sanitize_tool_name.cache_clear()
+        name = "Some Repeatedly Sanitized Tool"
+        first = sanitize_tool_name(name)
+        for _ in range(50):
+            assert sanitize_tool_name(name) == first
+        info = sanitize_tool_name.cache_info()
+        # One miss (first call) and the rest served from cache.
+        assert info.misses == 1
+        assert info.hits == 50
+
+    def test_cache_respects_max_length_argument(self):
+        sanitize_tool_name.cache_clear()
+        name = "x" * 80
+        full = sanitize_tool_name(name)
+        short = sanitize_tool_name(name, max_length=16)
+        assert full != short
+        assert len(short) <= 16
 
 
 class TestInterpolateOnly:


### PR DESCRIPTION
## Summary

`sanitize_tool_name` is a pure function called many times per agent iteration over the same small, stable set of tool names — tool selection, schema/name rendering, and name comparisons (139 call sites; 38 in `tool_usage.py` alone). Each call does an NFKD Unicode normalize, an ascii encode/decode round-trip, and several regex substitutions (plus a SHA-256 for over-length names).

## Change

Memoize it with `functools.lru_cache(maxsize=1024)`. The function depends only on its `(name, max_length)` arguments (both hashable) and has no side effects, so caching is safe; `maxsize` bounds memory, and the module already uses `lru_cache` for `_duplicate_separator_pattern`.

## Benchmark

Repeated calls over a fixed name (local, `timeit`):

| | µs/call |
|---|---|
| uncached | ~5.4 |
| cached | ~0.04 |

~120× on repeat calls. Within a single agent run the cache hit rate is ~100% since tool names are stable.

## Tests
Added `TestSanitizeToolName` (sanitization rules preserved, memoization via `cache_info`, `max_length` cache-key correctness). `ruff` + `mypy` clean; `test_tool_usage.py` and `test_base_tool_adapter.py` green.

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved tool-name sanitization by caching repeated results, which can speed up frequent agent operations.

* **Tests**
  * Added coverage for sanitization behavior, deterministic truncation, cache usage, and support for custom maximum length values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->