### PR TITLE
Fix JSON schema flow state kickoff inputs

### DIFF
--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -227,7 +227,12 @@ def _build_definition_state_model(
             pass
 
         model_class = StateWithId
-    return model_class(**kwargs)
+    try:
+        return model_class(**kwargs)
+    except ValidationError as e:
+        if any(error.get("type") != "missing" for error in e.errors()):
+            raise
+        return model_class.model_construct(**kwargs)
 
 
 def _iter_condition_events(condition: FlowDefinitionCondition) -> Iterator[str]:

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -357,6 +357,27 @@ methods:
     listen: begin
 """
 
+JSON_SCHEMA_REQUIRED_INPUT_STATE_YAML = """
+schema: crewai.flow/v1
+name: JsonSchemaRequiredInputStateFlow
+state:
+  type: json_schema
+  json_schema:
+    title: LeadState
+    type: object
+    required:
+      - lead_name
+    properties:
+      lead_name:
+        type: string
+methods:
+  begin:
+    start: true
+    do:
+      call: expression
+      expr: state.lead_name
+"""
+
 PYDANTIC_REF_WITH_SCHEMA_FALLBACK_YAML = f"""
 schema: crewai.flow/v1
 name: SchemaFallbackFlow
@@ -2296,6 +2317,18 @@ def test_json_schema_state_validates_inputs():
     flow = Flow.from_definition(FlowDefinition.from_declaration(contents=JSON_SCHEMA_STATE_YAML))
     with pytest.raises(ValueError, match="Invalid inputs"):
         flow.kickoff(inputs={"count": "not-a-number"})
+
+
+def test_json_schema_state_required_fields_can_come_from_kickoff_inputs():
+    flow = Flow.from_definition(
+        FlowDefinition.from_declaration(contents=JSON_SCHEMA_REQUIRED_INPUT_STATE_YAML)
+    )
+
+    result = flow.kickoff(inputs={"lead_name": "Ada Lovelace"})
+
+    assert result == "Ada Lovelace"
+    assert flow.state.lead_name == "Ada Lovelace"
+    assert flow.state.id
 
 
 def test_pydantic_state_falls_back_to_json_schema_when_ref_unimportable():


### PR DESCRIPTION
Allow required JSON schema state fields to be supplied by kickoff inputs instead of requiring every field to exist in state.default before runtime.

Example: a flow with required lead_name and no state.default can now run with kickoff inputs={"lead_name": "Ada Lovelace"}.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to initial state construction; non-missing validation still fails fast, and kickoff continues to validate merged state.
> 
> **Overview**
> **JSON-schema flows no longer fail at startup when required fields are absent from `state.default`.** `_build_definition_state_model` still tries normal construction from defaults; if Pydantic reports only **missing** field errors, it falls back to `model_construct` so kickoff can supply those values via `_initialize_state`. Any other validation errors are unchanged and still raise.
> 
> A regression test covers a declarative flow with a required `lead_name` and no default, kicked off with `inputs={"lead_name": "Ada Lovelace"}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c2fff74a2f383a193797c553f981bbb515e55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of required input fields when starting a flow, so missing-field validation no longer blocks runs that provide those values at launch.
  * Flows using structured state now preserve supplied input data more reliably, including required fields and generated identifiers.
* **Tests**
  * Added coverage for flows with required structured state fields provided through kickoff inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->