### PR TITLE
Restrict docs broken-links workflow permissions

### DIFF
--- a/.github/workflows/docs-broken-links.yml
+++ b/.github/workflows/docs-broken-links.yml
@@ -13,6 +13,9 @@ on:
       - "docs.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     name: Check broken links


### PR DESCRIPTION
## Summary

Fixes CodeQL alert 60 (`actions/missing-workflow-permissions`) by adding an explicit least-privilege permissions block to the docs broken-links workflow.

## Change

- Adds `permissions: contents: read` to `.github/workflows/docs-broken-links.yml`

## Validation

- Parsed workflow YAML successfully with Ruby
- Pre-commit ran during commit; Python-only hooks skipped because only workflow YAML changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to use read-only repository access.
  * No user-facing behavior or app functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->