### PR TITLE
fix: support custom model naming prefixes for anthropic provider (#5893)

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -508,8 +508,11 @@ class LLM(BaseLLM):
             )
 
         if provider == "anthropic" or provider == "claude":
-            return any(
-                model_lower.startswith(prefix) for prefix in ["claude-", "anthropic."]
+            # Match standard prefixes and any model containing "claude" or "anthropic"
+            # to support custom deployments with non-standard naming (e.g., "anthropic--claude-...")
+            return (
+                "claude" in model_lower
+                or "anthropic" in model_lower
             )
 
         if provider == "gemini" or provider == "google":
@@ -618,6 +621,15 @@ class LLM(BaseLLM):
 
         if model in AZURE_MODELS:
             return "azure"
+
+        # Pattern-based inference for custom deployments
+        model_lower = model.lower()
+        if "claude" in model_lower or "anthropic" in model_lower:
+            return "anthropic"
+        if model_lower.startswith("gpt-") or model_lower.startswith("o1") or model_lower.startswith("o3"):
+            return "openai"
+        if "gemini" in model_lower:
+            return "gemini"
 
         return "openai"
 

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -626,7 +626,10 @@ class LLM(BaseLLM):
         model_lower = model.lower()
         if "claude" in model_lower or "anthropic" in model_lower:
             return "anthropic"
-        if model_lower.startswith("gpt-") or model_lower.startswith("o1") or model_lower.startswith("o3"):
+        if any(
+            model_lower.startswith(prefix)
+            for prefix in ["gpt-", "o1", "o3", "o4", "whisper-"]
+        ):
             return "openai"
         if "gemini" in model_lower:
             return "gemini"
@@ -714,8 +717,8 @@ class LLM(BaseLLM):
         Returns:
             bool: True if the model is from Anthropic, False otherwise.
         """
-        anthropic_prefixes = ("anthropic/", "claude-", "claude/")
-        return any(prefix in model.lower() for prefix in anthropic_prefixes)
+        model_lower = model.lower()
+        return "claude" in model_lower or "anthropic" in model_lower
 
     def _prepare_completion_params(
         self,

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1177,3 +1177,27 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+class TestModelPrefixFiltering:
+    """Test that model prefix filtering supports custom deployments."""
+
+    def test_anthropic_custom_prefix(self):
+        """Models with 'anthropic--claude' prefix should be recognized."""
+        from crewai.llm import LLM
+        assert LLM._matches_provider_pattern("anthropic--claude-3-sonnet", "anthropic")
+
+    def test_anthropic_standard_prefix(self):
+        """Standard claude- prefix should still work."""
+        from crewai.llm import LLM
+        assert LLM._matches_provider_pattern("claude-3-sonnet", "anthropic")
+
+    def test_anthropic_dot_prefix(self):
+        """Standard anthropic. prefix should still work."""
+        from crewai.llm import LLM
+        assert LLM._matches_provider_pattern("anthropic.claude-3-sonnet", "anthropic")
+
+    def test_infer_anthropic_from_custom_name(self):
+        """Should infer anthropic provider from custom model names."""
+        from crewai.llm import LLM
+        assert LLM._infer_provider_from_model("anthropic--claude-3-sonnet") == "anthropic"


### PR DESCRIPTION
## Description

The model prefix filtering for the Anthropic provider was too strict, only matching `claude-` and `anthropic.` prefixes. Custom deployments with non-standard naming conventions (e.g., `anthropic--claude-...`) were incorrectly filtered out.

This PR makes the prefix matching more flexible by using substring matching for `claude` and `anthropic`, supporting any naming convention for custom deployments.

## Changes

- `lib/crewai/src/crewai/llm.py`: 
  - Updated `_matches_provider_pattern` to use substring matching for anthropic models
  - Updated `_infer_provider_from_model` to infer provider from model name patterns
- `lib/crewai/tests/test_llm.py`: Added tests for custom prefix support

## Testing

Added `TestModelPrefixFiltering` test class verifying that:
- Custom prefixes like `anthropic--claude-` are recognized
- Standard prefixes like `claude-` and `anthropic.` still work
- Provider inference works for custom model names

Closes #5893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider detection for models with non-standard naming, with enhanced handling for Anthropic/Claude and similar variants.
  * Added broader fallback inference for custom deployment names, better mapping common prefixes/patterns (e.g., GPT, o1/o3/o4, Whisper) to the correct provider, with sensible defaults.
* **Tests**
  * Added test coverage for both standard and custom model naming formats to verify provider matching and inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->