### PR TITLE
fix: serialize dict/list tool output to JSON (#6267)

### DIFF
--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -58,6 +58,8 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
 
     result_schema = getattr(tool, "result_schema", None)
     if not (isinstance(result_schema, type) and issubclass(result_schema, BaseModel)):
+        if isinstance(raw_result, (dict, list)):
+            return json.dumps(raw_result)
         return str(raw_result)
 
     try:
@@ -80,6 +82,8 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
             RuntimeWarning,
             stacklevel=2,
         )
+        if isinstance(raw_result, (dict, list)):
+            return json.dumps(raw_result)
         return str(raw_result)
 
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -59,7 +59,7 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
     result_schema = getattr(tool, "result_schema", None)
     if not (isinstance(result_schema, type) and issubclass(result_schema, BaseModel)):
         if isinstance(raw_result, (dict, list)):
-            return json.dumps(raw_result)
+            return json.dumps(raw_result, default=str)
         return str(raw_result)
 
     try:
@@ -77,13 +77,13 @@ def _format_tool_output_for_agent(tool: Any, raw_result: Any) -> str:
                 f"Failed to validate or serialize output from tool "
                 f"'{getattr(tool, 'name', '<unknown>')}' using result_schema "
                 f"'{result_schema.__name__}': {exc.__class__.__name__}. "
-                "Falling back to str(raw_result)."
+                "Falling back to JSON for dict/list, otherwise str(raw_result)."
             ),
             RuntimeWarning,
             stacklevel=2,
         )
         if isinstance(raw_result, (dict, list)):
-            return json.dumps(raw_result)
+            return json.dumps(raw_result, default=str)
         return str(raw_result)
 
 


### PR DESCRIPTION
Fixes #6267

## Summary
- When a tool returns a `dict` or `list`, `str()` produces Python repr (e.g. `{'key': 'value'}`) instead of valid JSON. This causes parsing issues for agents expecting JSON.
- The fix checks `isinstance(raw_result, (dict, list))` and uses `json.dumps()` in both fallback paths of `_format_tool_output_for_agent`.

## Changes
- `lib/crewai/src/crewai/tools/structured_tool.py`: In `_format_tool_output_for_agent`, use `json.dumps(raw_result)` instead of `str(raw_result)` when `raw_result` is a `dict` or `list` (both in the no-schema early return and the validation-failure except fallback).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Structured tool outputs are now returned as JSON when the result is a list or dictionary, making responses more consistent and easier to consume.
  * Fallback behavior now preserves structured data more reliably when output validation or serialization issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->