### PR TITLE
fix: show task result before human feedback prompt (#6072)

### DIFF
--- a/lib/crewai/src/crewai/core/providers/human_input.py
+++ b/lib/crewai/src/crewai/core/providers/human_input.py
@@ -179,6 +179,7 @@ class SyncHumanInputProvider(HumanInputProvider):
         Returns:
             The final answer after feedback processing.
         """
+        self._show_result(formatted_answer)
         feedback = self._prompt_input(context.crew)
 
         if context._is_training_mode():
@@ -200,6 +201,7 @@ class SyncHumanInputProvider(HumanInputProvider):
         Returns:
             The final answer after feedback processing.
         """
+        self._show_result(formatted_answer)
         feedback = await self._prompt_input_async(context.crew)
 
         if context._is_training_mode():
@@ -259,6 +261,7 @@ class SyncHumanInputProvider(HumanInputProvider):
             else:
                 context.messages.append(context._format_feedback_message(feedback))
                 answer = context._invoke_loop()
+                self._show_result(answer)
                 feedback = self._prompt_input(context.crew)
 
         return answer
@@ -311,9 +314,36 @@ class SyncHumanInputProvider(HumanInputProvider):
             else:
                 context.messages.append(context._format_feedback_message(feedback))
                 answer = await context._ainvoke_loop()
+                self._show_result(answer)
                 feedback = await self._prompt_input_async(context.crew)
 
         return answer
+
+    @staticmethod
+    def _show_result(answer: AgentFinish) -> None:
+        """Display the agent's result before prompting for feedback.
+
+        Args:
+            answer: The agent's finished answer to display.
+        """
+        from rich.panel import Panel
+        from rich.text import Text
+
+        from crewai.events.event_listener import event_listener
+
+        formatter = event_listener.formatter
+
+        output = HumanInputProvider._get_output_string(answer)
+        content = Text()
+        content.append(output)
+
+        result_panel = Panel(
+            content,
+            title="\U0001f4dd Task Result",
+            border_style="green",
+            padding=(1, 2),
+        )
+        formatter.console.print(result_panel)
 
     @staticmethod
     def _prompt_input(crew: Crew | None) -> str:


### PR DESCRIPTION
Fixes #6072

## Problem

When `human_input=True` is set on a task, the feedback prompt says *"Provide feedback on the Final Result above"* but the result is never actually displayed — it only appears when `verbose=True`. This leaves users unable to see what they're supposed to give feedback on.

## Fix

Added a `_show_result()` method to `SyncHumanInputProvider` that displays the agent's result in a Rich panel before prompting for feedback. This is called in:

1. `handle_feedback` / `handle_feedback_async` — shows the initial result before the first feedback prompt
2. `_handle_regular_feedback` / `_handle_regular_feedback_async` — shows updated results after each feedback iteration, before prompting again

The result is now always visible regardless of the `verbose` setting, so users can make informed feedback decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The current task result is now shown before asking for human feedback, making it easier to review the agent’s output.
  * Feedback rounds now consistently display the latest result each time additional input is requested, in both sync and async flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->