### PR TITLE
feat(tools): add TwelveLabs video analysis tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -280,6 +280,7 @@
                           "edge/en/tools/ai-ml/overview",
                           "edge/en/tools/ai-ml/dalletool",
                           "edge/en/tools/ai-ml/visiontool",
+                          "edge/en/tools/ai-ml/twelvelabsanalyzetool",
                           "edge/en/tools/ai-ml/aimindtool",
                           "edge/en/tools/ai-ml/llamaindextool",
                           "edge/en/tools/ai-ml/langchaintool",

--- a/docs/edge/en/tools/ai-ml/twelvelabsanalyzetool.mdx
+++ b/docs/edge/en/tools/ai-ml/twelvelabsanalyzetool.mdx
@@ -1,0 +1,88 @@
+---
+title: TwelveLabs Analyze Tool
+description: The `TwelveLabsAnalyzeTool` analyzes video content using TwelveLabs' Pegasus video-understanding model.
+icon: video
+mode: "wide"
+---
+
+# `TwelveLabsAnalyzeTool`
+
+## Description
+
+The `TwelveLabsAnalyzeTool` uses [TwelveLabs'](https://twelvelabs.io) Pegasus
+video-understanding model to analyze video content and answer natural-language
+prompts about it. Pegasus reasons over a video's visuals, speech, and on-screen
+text, making the tool useful for summarization, question answering over video,
+content moderation, and metadata extraction.
+
+The tool accepts either a public video URL or the `video_id` of a video already
+indexed in TwelveLabs.
+
+## Installation
+
+Install the `crewai_tools` package along with the TwelveLabs SDK:
+
+```shell
+pip install 'crewai[tools]' twelvelabs
+```
+
+You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
+## Usage
+
+Set your TwelveLabs API key in the environment variable `TWELVELABS_API_KEY`,
+then pass the tool to an agent.
+
+```python Code
+from crewai_tools import TwelveLabsAnalyzeTool
+
+analyze_tool = TwelveLabsAnalyzeTool()
+
+@agent
+def video_researcher(self) -> Agent:
+    '''
+    This agent uses the TwelveLabsAnalyzeTool to understand video content.
+    '''
+    return Agent(
+        config=self.agents_config["video_researcher"],
+        allow_delegation=False,
+        tools=[analyze_tool],
+    )
+```
+
+### Direct invocation
+
+```python Code
+from crewai_tools import TwelveLabsAnalyzeTool
+
+tool = TwelveLabsAnalyzeTool()
+
+# Analyze a public video URL
+result = tool.run(
+    prompt="Summarize this video in three bullet points.",
+    video_url="https://example.com/my-video.mp4",
+)
+
+# Or analyze a video already indexed in TwelveLabs
+result = tool.run(
+    prompt="List every product shown in this video.",
+    video_id="your_indexed_video_id",
+)
+```
+
+## Arguments
+
+| Argument    | Type  | Description                                                                        |
+| ----------- | ----- | ---------------------------------------------------------------------------------- |
+| `prompt`    | `str` | **Required.** Instruction describing what to extract from the video.               |
+| `video_url` | `str` | Public URL of the video to analyze. Provide this or `video_id`.                    |
+| `video_id`  | `str` | ID of a video already indexed in TwelveLabs. Provide this or `video_url`.          |
+
+## Constructor Options
+
+| Option        | Type    | Default        | Description                                              |
+| ------------- | ------- | -------------- | -------------------------------------------------------- |
+| `api_key`     | `str`   | env var        | TwelveLabs API key. Falls back to `TWELVELABS_API_KEY`.  |
+| `model_name`  | `str`   | `pegasus1.5`   | Pegasus model to use.                                    |
+| `max_tokens`  | `int`   | `2048`         | Maximum tokens in the answer (must be at least 512).     |
+| `temperature` | `float` | `None`         | Optional sampling temperature.                           |

--- a/lib/crewai-tools/README.md
+++ b/lib/crewai-tools/README.md
@@ -27,7 +27,7 @@ CrewAI provides an extensive collection of powerful tools ready to enhance your 
 - **Database Integrations**: `MySQLSearchTool`
 - **Vector Database Integrations**: `MongoDBVectorSearchTool`, `QdrantVectorSearchTool`, `WeaviateVectorSearchTool`
 - **API Integrations**: `SerperApiTool`, `ExaSearchTool`
-- **AI-powered Tools**: `DallETool`, `VisionTool`, `StagehandTool`
+- **AI-powered Tools**: `DallETool`, `VisionTool`, `StagehandTool`, `TwelveLabsAnalyzeTool`
 
 And many more robust tools to simplify your agent integrations.
 

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -147,6 +147,9 @@ e2b = [
     "e2b~=2.20.0",
     "e2b-code-interpreter~=2.6.0",
 ]
+twelvelabs = [
+    "twelvelabs>=1.2.8",
+]
 
 
 [tool.uv]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -204,6 +204,10 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.twelvelabs_analyze_tool.twelvelabs_analyze_tool import (
+    TwelveLabsAnalyzeTool,
+    TwelveLabsAnalyzeToolSchema,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
@@ -320,6 +324,8 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TwelveLabsAnalyzeTool",
+    "TwelveLabsAnalyzeToolSchema",
     "VisionTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -191,6 +191,10 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.twelvelabs_analyze_tool.twelvelabs_analyze_tool import (
+    TwelveLabsAnalyzeTool,
+    TwelveLabsAnalyzeToolSchema,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.weaviate_tool.vector_search import WeaviateVectorSearchTool
@@ -303,6 +307,8 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TwelveLabsAnalyzeTool",
+    "TwelveLabsAnalyzeToolSchema",
     "VisionTool",
     "WeaviateVectorSearchTool",
     "WebsiteSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/twelvelabs_analyze_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/twelvelabs_analyze_tool/README.md
@@ -1,0 +1,64 @@
+# TwelveLabsAnalyzeTool
+
+## Description
+A tool that uses [TwelveLabs'](https://twelvelabs.io) Pegasus video-understanding
+model to analyze video content and answer natural-language prompts about it.
+Pegasus reasons over a video's visuals, speech, and on-screen text, making the
+tool useful for summarization, question answering over video, content
+moderation, and metadata extraction.
+
+You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
+
+## Installation
+Install the required packages:
+```shell
+pip install 'crewai[tools]' twelvelabs
+```
+
+Set your API key:
+```shell
+export TWELVELABS_API_KEY="your_api_key"
+```
+
+## Example Usage
+
+### Analyze a public video URL
+```python
+from crewai_tools import TwelveLabsAnalyzeTool
+
+tool = TwelveLabsAnalyzeTool()
+result = tool.run(
+    prompt="Summarize this video in three bullet points.",
+    video_url="https://example.com/my-video.mp4",
+)
+print(result)
+```
+
+### Analyze a video already indexed in TwelveLabs
+```python
+tool = TwelveLabsAnalyzeTool()
+result = tool.run(
+    prompt="List every product shown in this video.",
+    video_id="your_indexed_video_id",
+)
+```
+
+### Customize the model and generation
+```python
+tool = TwelveLabsAnalyzeTool(
+    api_key="your_api_key",   # or rely on TWELVELABS_API_KEY
+    model_name="pegasus1.5",
+    max_tokens=4096,
+)
+```
+
+## Arguments
+- `prompt` (str, required): What to extract from the video.
+- `video_url` (str): Public URL of the video to analyze. Provide this or `video_id`.
+- `video_id` (str): ID of a video already indexed in TwelveLabs. Provide this or `video_url`.
+
+## Constructor Options
+- `api_key` (str): TwelveLabs API key. Falls back to `TWELVELABS_API_KEY`.
+- `model_name` (str): Pegasus model to use. Defaults to `pegasus1.5`.
+- `max_tokens` (int): Maximum tokens in the answer (must be at least 512). Defaults to `2048`.
+- `temperature` (float): Optional sampling temperature.

--- a/lib/crewai-tools/src/crewai_tools/tools/twelvelabs_analyze_tool/twelvelabs_analyze_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/twelvelabs_analyze_tool/twelvelabs_analyze_tool.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TwelveLabsAnalyzeToolSchema(BaseModel):
+    """Input schema for the TwelveLabs video-analysis tool."""
+
+    prompt: str = Field(
+        ...,
+        description=(
+            "Instruction describing what to extract from the video, e.g. "
+            "'Summarize this video' or 'List every product shown'."
+        ),
+    )
+    video_url: str | None = Field(
+        default=None,
+        description=(
+            "Publicly accessible URL of the video to analyze. Provide this or "
+            "video_id (one is required)."
+        ),
+    )
+    video_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of a video already indexed in TwelveLabs. Provide this or "
+            "video_url (one is required)."
+        ),
+    )
+
+
+class TwelveLabsAnalyzeTool(BaseTool):
+    """Analyze video content using TwelveLabs' Pegasus video-understanding model.
+
+    Given a video (either a public URL or an already-indexed ``video_id``) and a
+    natural-language prompt, the tool returns a text answer generated from the
+    video's visuals, speech, and on-screen text. Useful for summarization,
+    question answering over video, content moderation, and metadata extraction.
+
+    Get a free API key at https://twelvelabs.io and set ``TWELVELABS_API_KEY``.
+
+    Attributes:
+        model_name: TwelveLabs Pegasus model to use (default ``pegasus1.5``).
+        max_tokens: Maximum number of tokens in the generated answer. Must be at
+            least 512 for the Pegasus model.
+        temperature: Sampling temperature for generation.
+        api_key: TwelveLabs API key. Falls back to ``TWELVELABS_API_KEY``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str = "TwelveLabs Video Analysis"
+    description: str = (
+        "Analyze a video with TwelveLabs Pegasus and answer a natural-language "
+        "prompt about its content (summaries, Q&A, moderation, metadata). "
+        "Accepts a public video URL or an indexed TwelveLabs video_id."
+    )
+    args_schema: type[BaseModel] = TwelveLabsAnalyzeToolSchema
+
+    model_name: str = "pegasus1.5"
+    max_tokens: int = 2048
+    temperature: float | None = None
+    api_key: str | None = None
+    _client: Any = None
+
+    package_dependencies: list[str] = Field(default_factory=lambda: ["twelvelabs"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="TWELVELABS_API_KEY",
+                description="API key for TwelveLabs (https://twelvelabs.io)",
+                required=False,
+            ),
+        ]
+    )
+
+    def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError:
+            import click
+
+            if click.confirm(
+                "You are missing the 'twelvelabs' package. Would you like to "
+                "install it?"
+            ):
+                import subprocess
+
+                subprocess.run(["uv", "add", "twelvelabs"], check=True)  # noqa: S607
+                from twelvelabs import TwelveLabs
+            else:
+                raise ImportError(
+                    "`twelvelabs` package not found, please run `uv add twelvelabs`"
+                ) from None
+
+        self.api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "TwelveLabs API key is required. Set TWELVELABS_API_KEY or pass "
+                "api_key. Get a free key at https://twelvelabs.io."
+            )
+        self._client = TwelveLabs(api_key=self.api_key)
+
+    def _run(self, **kwargs: Any) -> str:
+        prompt = kwargs.get("prompt")
+        video_url = kwargs.get("video_url")
+        video_id = kwargs.get("video_id")
+
+        if not prompt:
+            return "A prompt is required."
+        if not video_url and not video_id:
+            return "Either video_url or video_id is required."
+
+        if self._client is None:
+            raise RuntimeError("TwelveLabs client not initialized")
+
+        analyze_kwargs: dict[str, Any] = {
+            "model_name": self.model_name,
+            "prompt": prompt,
+            "max_tokens": self.max_tokens,
+        }
+        if self.temperature is not None:
+            analyze_kwargs["temperature"] = self.temperature
+
+        if video_id:
+            analyze_kwargs["video_id"] = video_id
+        else:
+            from twelvelabs.types.video_context import VideoContext_Url
+
+            analyze_kwargs["video"] = VideoContext_Url(url=video_url)
+
+        try:
+            response = self._client.analyze(**analyze_kwargs)
+        except Exception as e:
+            raise RuntimeError(f"TwelveLabs analysis failed: {e!s}") from e
+
+        return response.data or ""

--- a/lib/crewai-tools/tests/tools/twelvelabs_analyze_tool_test.py
+++ b/lib/crewai-tools/tests/tools/twelvelabs_analyze_tool_test.py
@@ -1,0 +1,75 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools.tools.twelvelabs_analyze_tool.twelvelabs_analyze_tool import (
+    TwelveLabsAnalyzeTool,
+)
+
+
+def _make_tool() -> TwelveLabsAnalyzeTool:
+    """Build a tool with the SDK client stubbed so no network/SDK is needed."""
+    with patch(
+        "twelvelabs.TwelveLabs", create=True, return_value=MagicMock()
+    ):
+        return TwelveLabsAnalyzeTool(api_key="test-key")
+
+
+def test_requires_api_key() -> None:
+    with patch("twelvelabs.TwelveLabs", create=True, return_value=MagicMock()):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="API key is required"):
+                TwelveLabsAnalyzeTool()
+
+
+def test_requires_video_input() -> None:
+    tool = _make_tool()
+    result = tool.run(prompt="Summarize this video.")
+    assert "video_url or video_id is required" in result
+
+
+def test_run_with_video_id() -> None:
+    tool = _make_tool()
+    mock_response = MagicMock()
+    mock_response.data = "A cat plays with a ball of yarn."
+    tool._client.analyze.return_value = mock_response
+
+    result = tool.run(prompt="What happens?", video_id="vid_123")
+
+    assert result == "A cat plays with a ball of yarn."
+    call_kwargs = tool._client.analyze.call_args.kwargs
+    assert call_kwargs["video_id"] == "vid_123"
+    assert call_kwargs["model_name"] == "pegasus1.5"
+    assert call_kwargs["prompt"] == "What happens?"
+    assert call_kwargs["max_tokens"] == 2048
+
+
+def test_run_with_video_url_builds_url_context() -> None:
+    tool = _make_tool()
+    mock_response = MagicMock()
+    mock_response.data = "ok"
+    tool._client.analyze.return_value = mock_response
+
+    tool.run(prompt="Describe.", video_url="https://example.com/v.mp4")
+
+    video_arg = tool._client.analyze.call_args.kwargs["video"]
+    assert video_arg.url == "https://example.com/v.mp4"
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set",
+)
+def test_analyze_integration() -> None:
+    """End-to-end smoke test against the live TwelveLabs API.
+
+    Requires TWELVELABS_API_KEY and an indexed video; skipped otherwise.
+    """
+    tool = TwelveLabsAnalyzeTool()
+    video_id = os.getenv("TWELVELABS_TEST_VIDEO_ID")
+    if not video_id:
+        pytest.skip("TWELVELABS_TEST_VIDEO_ID not set")
+    result = tool.run(prompt="Summarize this video in one sentence.", video_id=video_id)
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -25724,6 +25724,142 @@
       }
     },
     {
+      "description": "Analyze a video with TwelveLabs Pegasus and answer a natural-language prompt about its content (summaries, Q&A, moderation, metadata). Accepts a public video URL or an indexed TwelveLabs video_id.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for TwelveLabs (https://twelvelabs.io)",
+          "name": "TWELVELABS_API_KEY",
+          "required": false
+        }
+      ],
+      "humanized_name": "TwelveLabs Video Analysis",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "description": "Analyze video content using TwelveLabs' Pegasus video-understanding model.\n\nGiven a video (either a public URL or an already-indexed ``video_id``) and a\nnatural-language prompt, the tool returns a text answer generated from the\nvideo's visuals, speech, and on-screen text. Useful for summarization,\nquestion answering over video, content moderation, and metadata extraction.\n\nGet a free API key at https://twelvelabs.io and set ``TWELVELABS_API_KEY``.\n\nAttributes:\n    model_name: TwelveLabs Pegasus model to use (default ``pegasus1.5``).\n    max_tokens: Maximum number of tokens in the generated answer. Must be at\n        least 512 for the Pegasus model.\n    temperature: Sampling temperature for generation.\n    api_key: TwelveLabs API key. Falls back to ``TWELVELABS_API_KEY``.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Key"
+          },
+          "max_tokens": {
+            "default": 2048,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "model_name": {
+            "default": "pegasus1.5",
+            "title": "Model Name",
+            "type": "string"
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Temperature"
+          }
+        },
+        "required": [],
+        "title": "TwelveLabsAnalyzeTool",
+        "type": "object"
+      },
+      "name": "TwelveLabsAnalyzeTool",
+      "package_dependencies": [
+        "twelvelabs"
+      ],
+      "run_params_schema": {
+        "description": "Input schema for the TwelveLabs video-analysis tool.",
+        "properties": {
+          "prompt": {
+            "description": "Instruction describing what to extract from the video, e.g. 'Summarize this video' or 'List every product shown'.",
+            "title": "Prompt",
+            "type": "string"
+          },
+          "video_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of a video already indexed in TwelveLabs. Provide this or video_url (one is required).",
+            "title": "Video Id"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Publicly accessible URL of the video to analyze. Provide this or video_id (one is required).",
+            "title": "Video Url"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "title": "TwelveLabsAnalyzeToolSchema",
+        "type": "object"
+      }
+    },
+    {
       "description": "This tool uses OpenAI's Vision API to describe the contents of an image.",
       "env_vars": [
         {


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new opt-in `TwelveLabsAnalyzeTool` in `crewai-tools` that analyzes video content with TwelveLabs' Pegasus video-understanding model. Given a video — either a public URL or an already-indexed `video_id` — and a natural-language prompt, it returns a text answer generated from the video's visuals, speech, and on-screen text. Useful for video summarization, Q&A over video, content moderation, and metadata extraction.

```python
from crewai_tools import TwelveLabsAnalyzeTool

tool = TwelveLabsAnalyzeTool()
result = tool.run(
    prompt="Summarize this video in three bullet points.",
    video_url="https://example.com/my-video.mp4",
)
```

## Why it helps crewAI

crewAI agents can already reason over text, images (VisionTool), and web content, but there's no first-class way to give an agent an understanding of *video*. This tool closes that gap, letting agents answer questions about, summarize, or moderate video content as part of a crew.

## Opt-in / non-breaking

- New tool only — no existing behavior, defaults, or imports are changed.
- The `twelvelabs` SDK is added as an **optional** dependency (`[project.optional-dependencies] twelvelabs`); the base package still imports without it (lazy import inside `__init__`, mirroring `ScrapegraphScrapeTool` and other SDK-backed tools).
- Registered in both `crewai_tools/__init__.py` and `crewai_tools/tools/__init__.py`, with `package_dependencies` and `env_vars` (`TWELVELABS_API_KEY`) declared the same way as sibling tools.

## How it was tested

- Added `lib/crewai-tools/tests/tools/twelvelabs_analyze_tool_test.py`: no-network unit tests (SDK client mocked) covering API-key validation, required-input validation, `video_id` and `video_url` request wiring, plus a live integration test gated on `TWELVELABS_API_KEY` (skipped without it).
- `uv run ruff check` and `uv run ruff format` clean on all changed files; `uv run mypy` passes on the new tool.
- Regenerated `tool.specs.json` so the new tool's spec is included.
- Verified the Pegasus `analyze` wiring end-to-end against the live API (auth, `model_name`, `prompt`, `max_tokens` all validated server-side).

## Notes

Per `CONTRIBUTING.md`, this PR was prepared with AI assistance, so it should carry the `llm-generated` label — I'm disclosing that here and will add the label.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new video analysis tool powered by TwelveLabs, usable with either a public video URL or an indexed video ID.
  * Exposed the tool in the package so it can be imported directly by users.

* **Documentation**
  * Added usage guides and reference docs for setup, configuration, and example workflows.
  * Updated the tools catalog to include the new AI-powered option.

* **Tests**
  * Added automated coverage for input validation and core usage paths, plus an optional live integration check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->