### PR TITLE
Defer from_repository agent resolution until execution

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -200,6 +200,7 @@ class Agent(BaseAgent):
     _times_executed: int = PrivateAttr(default=0)
     _mcp_resolver: MCPToolResolver | None = PrivateAttr(default=None)
     _last_messages: list[LLMMessage] = PrivateAttr(default_factory=list)
+    _from_repository_resolved: bool = PrivateAttr(default=False)
     max_execution_time: int | None = Field(
         default=None,
         description="Maximum execution time for an agent to execute a task",
@@ -346,10 +347,41 @@ class Agent(BaseAgent):
     @model_validator(mode="before")
     @classmethod
     def validate_from_repository(cls, v: Any) -> dict[str, Any] | None | Any:
-        """Merge repository agent config with provided values before validation."""
-        if v is not None and (from_repository := v.get("from_repository")):
-            return load_agent_from_repository(from_repository) | v
+        """Defer repository resolution until the agent first runs.
+
+        Loading an agent from the repository requires an authenticated network
+        call. Performing it here — during construction — forces that call while a
+        crew is being loaded, before the runtime has wired deployment auth, which
+        breaks ``from_repository`` agents in deployed environments. Instead we keep
+        ``from_repository`` and seed the required identity fields with placeholders
+        so the model validates now; the real definition is fetched on first use
+        (see ``_resolve_from_repository``).
+        """
+        if isinstance(v, dict) and v.get("from_repository"):
+            for field in ("role", "goal", "backstory"):
+                v.setdefault(field, "")
         return v
+
+    def _resolve_from_repository(self) -> None:
+        """Fetch and apply the repository agent definition on first use.
+
+        Values supplied explicitly at construction take precedence; the
+        repository fills in everything else (including the placeholder identity
+        fields). Runs at most once and only when ``from_repository`` is set.
+        """
+        if not self.from_repository or self._from_repository_resolved:
+            return
+
+        attributes = load_agent_from_repository(self.from_repository)
+        identity_fields = ("role", "goal", "backstory")
+        for key, value in attributes.items():
+            if key in identity_fields:
+                if not getattr(self, key, None):
+                    setattr(self, key, value)
+            elif key not in self.model_fields_set and hasattr(self, key):
+                setattr(self, key, value)
+
+        self._from_repository_resolved = True
 
     @model_validator(mode="after")
     def post_init_setup(self) -> Self:
@@ -804,6 +836,7 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
+        self._resolve_from_repository()
         task_prompt = self._prepare_task_execution(task, context)
 
         knowledge_config = get_knowledge_config(self)
@@ -940,6 +973,7 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
+        self._resolve_from_repository()
         task_prompt = self._prepare_task_execution(task, context)
 
         knowledge_config = get_knowledge_config(self)
@@ -1418,6 +1452,7 @@ class Agent(BaseAgent):
         Returns:
             Tuple of (executor, inputs, agent_info, parsed_tools) ready for execution.
         """
+        self._resolve_from_repository()
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
             if platform_tools:

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -376,9 +376,12 @@ class Agent(BaseAgent):
             if not getattr(self, field):  # placeholder, not a user-supplied value
                 explicit.discard(field)
 
+        fields = type(self).model_fields
         for key, value in load_agent_from_repository(self.from_repository).items():
-            if key not in explicit and hasattr(self, key):
-                setattr(self, key, value)
+            if key not in explicit and key in fields:
+                # Validate as construction would (e.g. an llm string -> LLM),
+                # without re-running the model's after-validators.
+                self.__pydantic_validator__.validate_assignment(self, key, value)
 
         self._from_repository_resolved = True
 

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -168,6 +168,10 @@ def _serialize_executor_class(value: Any) -> str:
     return value.__name__ if isinstance(value, type) else str(value)
 
 
+# Required fields seeded with placeholders when an agent defers to a repository.
+_REPOSITORY_IDENTITY_FIELDS = ("role", "goal", "backstory")
+
+
 class Agent(BaseAgent):
     """Represents an agent in a system.
 
@@ -347,41 +351,42 @@ class Agent(BaseAgent):
     @model_validator(mode="before")
     @classmethod
     def validate_from_repository(cls, v: Any) -> dict[str, Any] | None | Any:
-        """Defer repository resolution until the agent first runs.
+        """Defer repository resolution to first execution.
 
-        Loading an agent from the repository requires an authenticated network
-        call. Performing it here — during construction — forces that call while a
-        crew is being loaded, before the runtime has wired deployment auth, which
-        breaks ``from_repository`` agents in deployed environments. Instead we keep
-        ``from_repository`` and seed the required identity fields with placeholders
-        so the model validates now; the real definition is fetched on first use
-        (see ``_resolve_from_repository``).
+        Fetching needs authenticated network access; doing it at construction
+        breaks ``from_repository`` agents in deployments, where a crew loads
+        before auth is wired. Seed required fields so the model validates now;
+        the definition is fetched on first run (see ``_resolve_from_repository``).
         """
         if isinstance(v, dict) and v.get("from_repository"):
-            for field in ("role", "goal", "backstory"):
+            for field in _REPOSITORY_IDENTITY_FIELDS:
                 v.setdefault(field, "")
         return v
 
     def _resolve_from_repository(self) -> None:
-        """Fetch and apply the repository agent definition on first use.
+        """Fetch and apply the repository definition once, on first execution.
 
-        Values supplied explicitly at construction take precedence; the
-        repository fills in everything else (including the placeholder identity
-        fields). Runs at most once and only when ``from_repository`` is set.
+        Values set explicitly at construction win; the repository fills the rest.
         """
         if not self.from_repository or self._from_repository_resolved:
             return
 
-        attributes = load_agent_from_repository(self.from_repository)
-        identity_fields = ("role", "goal", "backstory")
-        for key, value in attributes.items():
-            if key in identity_fields:
-                if not getattr(self, key, None):
-                    setattr(self, key, value)
-            elif key not in self.model_fields_set and hasattr(self, key):
+        explicit = set(self.model_fields_set)
+        for field in _REPOSITORY_IDENTITY_FIELDS:
+            if not getattr(self, field):  # placeholder, not a user-supplied value
+                explicit.discard(field)
+
+        for key, value in load_agent_from_repository(self.from_repository).items():
+            if key not in explicit and hasattr(self, key):
                 setattr(self, key, value)
 
         self._from_repository_resolved = True
+
+    async def _aresolve_from_repository(self) -> None:
+        """Async variant: run the blocking repository fetch off the event loop."""
+        if not self.from_repository or self._from_repository_resolved:
+            return
+        await asyncio.to_thread(self._resolve_from_repository)
 
     @model_validator(mode="after")
     def post_init_setup(self) -> Self:
@@ -973,7 +978,7 @@ class Agent(BaseAgent):
             ValueError: If the max execution time is not a positive integer.
             RuntimeError: If the agent execution fails for other reasons.
         """
-        self._resolve_from_repository()
+        await self._aresolve_from_repository()
         task_prompt = self._prepare_task_execution(task, context)
 
         knowledge_config = get_knowledge_config(self)
@@ -1452,7 +1457,6 @@ class Agent(BaseAgent):
         Returns:
             Tuple of (executor, inputs, agent_info, parsed_tools) ready for execution.
         """
-        self._resolve_from_repository()
         if self.apps:
             platform_tools = self.get_platform_tools(self.apps)
             if platform_tools:
@@ -1646,6 +1650,7 @@ class Agent(BaseAgent):
         if is_inside_event_loop():
             return self.kickoff_async(messages, response_format, input_files)
 
+        self._resolve_from_repository()
         executor, inputs, agent_info, parsed_tools = self._prepare_kickoff(
             messages, response_format, input_files
         )
@@ -1961,6 +1966,7 @@ class Agent(BaseAgent):
                 input_files=input_files,
             )
 
+        await self._aresolve_from_repository()
         executor, inputs, agent_info, parsed_tools = self._prepare_kickoff(
             messages, response_format, input_files
         )

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2207,6 +2207,11 @@ def test_agent_from_repository(mock_get_agent, mock_get_auth_token):
     mock_get_agent.return_value = mock_get_response
 
     agent = Agent(from_repository="test_agent")
+    # Resolution is deferred: nothing is fetched at construction.
+    assert mock_get_agent.called is False
+
+    # Resolution happens on first execution (triggered here directly).
+    agent._resolve_from_repository()
 
     assert agent.role == "test role"
     assert agent.goal == "test goal"
@@ -2217,6 +2222,32 @@ def test_agent_from_repository(mock_get_agent, mock_get_auth_token):
     assert agent.tools[0].n_results == 30
     assert isinstance(agent.tools[1], FileReadTool)
     assert agent.tools[1].file_path == "test.txt"
+
+
+@patch("crewai.plus_api.PlusAPI.get_agent")
+def test_agent_from_repository_is_deferred_until_execution(
+    mock_get_agent, mock_get_auth_token
+):
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.json.return_value = {
+        "role": "test role",
+        "goal": "test goal",
+        "backstory": "test backstory",
+    }
+    mock_get_agent.return_value = mock_get_response
+
+    # Construction must not touch the network — this is what lets from_repository
+    # agents be built while a crew loads, before deployment auth is wired.
+    agent = Agent(from_repository="test_agent")
+    assert mock_get_agent.called is False
+    assert agent.role == ""
+
+    # Executing the agent resolves the definition; a second run does not refetch.
+    agent._resolve_from_repository()
+    agent._resolve_from_repository()
+    assert agent.role == "test role"
+    assert mock_get_agent.call_count == 1
 
 
 @patch("crewai.plus_api.PlusAPI.get_agent")
@@ -2235,6 +2266,7 @@ def test_agent_from_repository_override_attributes(mock_get_agent, mock_get_auth
     }
     mock_get_agent.return_value = mock_get_response
     agent = Agent(from_repository="test_agent", role="Custom Role")
+    agent._resolve_from_repository()
 
     assert agent.role == "Custom Role"
     assert agent.goal == "test goal"
@@ -2259,11 +2291,12 @@ def test_agent_from_repository_with_invalid_tools(mock_get_agent, mock_get_auth_
         ],
     }
     mock_get_agent.return_value = mock_get_response
+    agent = Agent(from_repository="test_agent")
     with pytest.raises(
         AgentRepositoryError,
         match="Tool DoesNotExist could not be loaded: module 'crewai_tools' has no attribute 'DoesNotExist'",
     ):
-        Agent(from_repository="test_agent")
+        agent._resolve_from_repository()
 
 
 @patch("crewai.plus_api.PlusAPI.get_agent")
@@ -2272,11 +2305,12 @@ def test_agent_from_repository_internal_error(mock_get_agent, mock_get_auth_toke
     mock_get_response.status_code = 500
     mock_get_response.text = "Internal server error"
     mock_get_agent.return_value = mock_get_response
+    agent = Agent(from_repository="test_agent")
     with pytest.raises(
         AgentRepositoryError,
         match="Agent test_agent could not be loaded: Internal server error",
     ):
-        Agent(from_repository="test_agent")
+        agent._resolve_from_repository()
 
 
 @patch("crewai.plus_api.PlusAPI.get_agent")
@@ -2285,11 +2319,12 @@ def test_agent_from_repository_agent_not_found(mock_get_agent, mock_get_auth_tok
     mock_get_response.status_code = 404
     mock_get_response.text = "Agent not found"
     mock_get_agent.return_value = mock_get_response
+    agent = Agent(from_repository="test_agent")
     with pytest.raises(
         AgentRepositoryError,
         match="Agent test_agent does not exist, make sure the name is correct or the agent is available on your organization",
     ):
-        Agent(from_repository="test_agent")
+        agent._resolve_from_repository()
 
 
 @patch("crewai.plus_api.PlusAPI.get_agent")
@@ -2314,6 +2349,7 @@ def test_agent_from_repository_displays_org_info(
     mock_get_agent.return_value = mock_get_response
 
     agent = Agent(from_repository="test_agent")
+    agent._resolve_from_repository()
 
     mock_console.print.assert_any_call(
         "Fetching agent from organization: Test Organization (test-org-uuid)",
@@ -2341,11 +2377,12 @@ def test_agent_from_repository_without_org_set(
     mock_get_response.text = "Unauthorized access"
     mock_get_agent.return_value = mock_get_response
 
+    agent = Agent(from_repository="test_agent")
     with pytest.raises(
         AgentRepositoryError,
         match="Agent test_agent could not be loaded: Unauthorized access",
     ):
-        Agent(from_repository="test_agent")
+        agent._resolve_from_repository()
 
     mock_console.print.assert_any_call(
         "No organization currently set. We recommend setting one before using: `crewai org switch <org_id>` command.",

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2207,10 +2207,8 @@ def test_agent_from_repository(mock_get_agent, mock_get_auth_token):
     mock_get_agent.return_value = mock_get_response
 
     agent = Agent(from_repository="test_agent")
-    # Resolution is deferred: nothing is fetched at construction.
-    assert mock_get_agent.called is False
+    assert mock_get_agent.called is False  # deferred until execution
 
-    # Resolution happens on first execution (triggered here directly).
     agent._resolve_from_repository()
 
     assert agent.role == "test role"
@@ -2237,15 +2235,36 @@ def test_agent_from_repository_is_deferred_until_execution(
     }
     mock_get_agent.return_value = mock_get_response
 
-    # Construction must not touch the network — this is what lets from_repository
-    # agents be built while a crew loads, before deployment auth is wired.
+    # Construction must not touch the network; resolution fetches once.
     agent = Agent(from_repository="test_agent")
     assert mock_get_agent.called is False
     assert agent.role == ""
 
-    # Executing the agent resolves the definition; a second run does not refetch.
     agent._resolve_from_repository()
     agent._resolve_from_repository()
+    assert agent.role == "test role"
+    assert mock_get_agent.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("crewai.plus_api.PlusAPI.get_agent")
+async def test_agent_from_repository_resolves_inside_event_loop(
+    mock_get_agent, mock_get_auth_token
+):
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.json.return_value = {
+        "role": "test role",
+        "goal": "test goal",
+        "backstory": "test backstory",
+    }
+    mock_get_agent.return_value = mock_get_response
+
+    # The blocking fetch must run off the loop (load_agent_from_repository uses
+    # asyncio.run), so async execution does not raise.
+    agent = Agent(from_repository="test_agent")
+    await agent._aresolve_from_repository()
+
     assert agent.role == "test role"
     assert mock_get_agent.call_count == 1
 


### PR DESCRIPTION
## Summary

`Agent(from_repository=...)` resolves the agent definition **at construction time**, inside a `@model_validator(mode="before")`. Loading from the repository is an authenticated network call, so simply *instantiating* the `Agent` performs network I/O and requires valid credentials at that exact moment — typically while a crew module is being imported/loaded, well before the agent is ever run.

This couples object construction to network and auth availability:

- Constructing an agent you never execute still hits the network.
- In environments where credentials are established at runtime (rather than statically present at import), construction can fail with an auth error even though the agent would have valid credentials by the time it actually runs.

This PR **defers repository resolution to first execution**. Construction becomes side-effect free, and the definition is fetched once, lazily, when the agent is first used.

## What changed

- `validate_from_repository` (before-validator) no longer performs the network fetch. When `from_repository` is set it seeds the required identity fields (`role`/`goal`/`backstory`) with placeholders so the model still validates.
- New `_resolve_from_repository()` performs the fetch + merge once, on first use. Values passed explicitly at construction win; the repository fills in the rest.
  - Attributes are applied via `validate_assignment`, so repository values go through the same field validation as construction (e.g. an `llm` string is converted to an LLM object), without re-running the model's after-validators.
- New `_aresolve_from_repository()` runs the (blocking) fetch off the event loop via `asyncio.to_thread`, so async execution doesn't hit `asyncio.run()`-inside-a-running-loop.
- Resolution is triggered at the execution entry points: `execute_task` / `aexecute_task` and `kickoff` / `kickoff_async`.

## Behavior changes (please review)

1. **`agent.role`/`goal`/`backstory` are empty until the agent first runs.** Previously they were populated immediately at construction. Code that reads these attributes on a `from_repository` agent *before* executing it will now see empty strings until resolution.
2. **`Crew(config={...})` that references a `from_repository` agent by its remote `role`** no longer resolves at construction (the dict-config path matches tasks to agents by `role`). The common paths are unaffected, `@CrewBase` decorators map by method name, and `Crew(agents=[...], tasks=[Task(agent=...)])` passes agents by object.
Resolving at construction is precisely what reintroduces the original auth issue, so this is an inherent trade-off of deferral.

Both are consequences of the definition no longer being fetched eagerly; they’re called out here so they can be weighed explicitly.