### PR TITLE
Fix JSON crew version pin

### DIFF
--- a/lib/cli/src/crewai_cli/create_flow.py
+++ b/lib/cli/src/crewai_cli/create_flow.py
@@ -4,6 +4,8 @@ import shutil
 import click
 from crewai_core.telemetry import Telemetry
 
+from crewai_cli.version import get_crewai_tools_dependency
+
 
 DECLARATIVE_FLOW_FOLDERS = ("crews", "tools", "knowledge", "skills")
 
@@ -71,6 +73,9 @@ def _create_python_flow(
         content = content.replace("{{name}}", name)
         content = content.replace("{{flow_name}}", class_name)
         content = content.replace("{{folder_name}}", folder_name)
+        content = content.replace(
+            "{{crewai_tools_dependency}}", get_crewai_tools_dependency()
+        )
 
         with open(dst_file, "w") as file:
             file.write(content)
@@ -138,6 +143,9 @@ def _create_declarative_flow(
         content = content.replace("{{name}}", name)
         content = content.replace("{{flow_name}}", class_name)
         content = content.replace("{{folder_name}}", folder_name)
+        content = content.replace(
+            "{{crewai_tools_dependency}}", get_crewai_tools_dependency()
+        )
         dst_file.write_text(content, encoding="utf-8")
 
     (project_root / ".env").write_text("OPENAI_API_KEY=YOUR_API_KEY", encoding="utf-8")

--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -12,6 +12,7 @@ import click
 from rich.console import Console
 from rich.text import Text
 
+import crewai_cli
 from crewai_cli.constants import ENV_VARS
 from crewai_cli.tui_picker import pick_many, pick_one
 from crewai_cli.utils import (
@@ -89,7 +90,7 @@ description = "{name} using crewAI"
 authors = [{{ name = "Your Name", email = "you@example.com" }}]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.14.8a1"
+    "crewai[tools]=={crewai_version}"
 ]
 
 [build-system]
@@ -1134,7 +1135,11 @@ def create_json_crew(
 
     # Write pyproject.toml
     (folder_path / "pyproject.toml").write_text(
-        _PYPROJECT_TOML.format(folder_name=folder_name, name=name),
+        _PYPROJECT_TOML.format(
+            folder_name=folder_name,
+            name=name,
+            crewai_version=crewai_cli.__version__,
+        ),
         encoding="utf-8",
     )
 

--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -12,7 +12,6 @@ import click
 from rich.console import Console
 from rich.text import Text
 
-import crewai_cli
 from crewai_cli.constants import ENV_VARS
 from crewai_cli.tui_picker import pick_many, pick_one
 from crewai_cli.utils import (
@@ -21,6 +20,7 @@ from crewai_cli.utils import (
     load_env_vars,
     write_env_file,
 )
+from crewai_cli.version import get_crewai_tools_dependency
 
 
 # ── Provider / model data ───────────────────────────────────────
@@ -90,7 +90,7 @@ description = "{name} using crewAI"
 authors = [{{ name = "Your Name", email = "you@example.com" }}]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]=={crewai_version}"
+    "{crewai_tools_dependency}"
 ]
 
 [build-system]
@@ -1138,7 +1138,7 @@ def create_json_crew(
         _PYPROJECT_TOML.format(
             folder_name=folder_name,
             name=name,
-            crewai_version=crewai_cli.__version__,
+            crewai_tools_dependency=get_crewai_tools_dependency(),
         ),
         encoding="utf-8",
     )

--- a/lib/cli/src/crewai_cli/run_crew.py
+++ b/lib/cli/src/crewai_cli/run_crew.py
@@ -13,14 +13,13 @@ import click
 from crewai_core.constants import CREWAI_TRAINED_AGENTS_FILE_ENV
 from packaging import version
 
-import crewai_cli
 from crewai_cli.utils import (
     build_env_with_all_tool_credentials,
     enable_prompt_line_editing,
     is_dmn_mode_enabled,
     read_toml,
 )
-from crewai_cli.version import get_crewai_version
+from crewai_cli.version import get_crewai_tools_dependency, get_crewai_version
 
 
 if TYPE_CHECKING:
@@ -38,7 +37,7 @@ CrewAI CLI is installed without the `crewai` package required to run crews.
 
 Install the full CrewAI package:
 
-  uv tool install --force 'crewai[tools]=={crewai_cli.__version__}'
+  uv tool install --force '{get_crewai_tools_dependency()}'
 
 The quotes are required in zsh so `crewai[tools]` is not treated as a glob.
 """

--- a/lib/cli/src/crewai_cli/run_crew.py
+++ b/lib/cli/src/crewai_cli/run_crew.py
@@ -13,6 +13,7 @@ import click
 from crewai_core.constants import CREWAI_TRAINED_AGENTS_FILE_ENV
 from packaging import version
 
+import crewai_cli
 from crewai_cli.utils import (
     build_env_with_all_tool_credentials,
     enable_prompt_line_editing,
@@ -32,12 +33,12 @@ if TYPE_CHECKING:
 _INPUT_PLACEHOLDER_RE = re.compile(r"(?<!{){([A-Za-z_][A-Za-z0-9_\-]*)}(?!})")
 _CREWAI_CLI_RUNNER_PACKAGE_DIR_ENV = "CREWAI_CLI_RUNNER_PACKAGE_DIR"
 _CREWAI_RUNNER_SOURCE_DIR_ENV = "CREWAI_RUNNER_SOURCE_DIR"
-_FULL_CREWAI_INSTALL_MESSAGE = """\
+_FULL_CREWAI_INSTALL_MESSAGE = f"""\
 CrewAI CLI is installed without the `crewai` package required to run crews.
 
-Install the full CrewAI prerelease package:
+Install the full CrewAI package:
 
-  uv tool install --force --prerelease=allow 'crewai[tools]==1.14.8a1'
+  uv tool install --force 'crewai[tools]=={crewai_cli.__version__}'
 
 The quotes are required in zsh so `crewai[tools]` is not treated as a glob.
 """

--- a/lib/cli/src/crewai_cli/templates/crew/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/crew/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.15.0"
+    "{{crewai_tools_dependency}}"
 ]
 
 [project.scripts]

--- a/lib/cli/src/crewai_cli/templates/declarative_flow/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/declarative_flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.15.0"
+    "{{crewai_tools_dependency}}"
 ]
 
 [build-system]

--- a/lib/cli/src/crewai_cli/templates/flow/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/flow/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.15.0"
+    "{{crewai_tools_dependency}}"
 ]
 
 [project.scripts]

--- a/lib/cli/src/crewai_cli/templates/tool/pyproject.toml
+++ b/lib/cli/src/crewai_cli/templates/tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "crewai[tools]==1.15.0"
+    "{{crewai_tools_dependency}}"
 ]
 
 [tool.crewai]

--- a/lib/cli/src/crewai_cli/tools/main.py
+++ b/lib/cli/src/crewai_cli/tools/main.py
@@ -23,6 +23,7 @@ from crewai_cli.utils import (
     tree_copy,
     tree_find_and_replace,
 )
+from crewai_cli.version import get_crewai_tools_dependency
 
 
 console = Console()
@@ -81,6 +82,9 @@ class ToolCommand(BaseCommand, PlusAPIMixin):
         tree_copy(template_dir, project_root)
         tree_find_and_replace(project_root, "{{folder_name}}", folder_name)
         tree_find_and_replace(project_root, "{{class_name}}", class_name)
+        tree_find_and_replace(
+            project_root, "{{crewai_tools_dependency}}", get_crewai_tools_dependency()
+        )
 
         agents_md_src = Path(__file__).parent.parent / "templates" / "AGENTS.md"
         if agents_md_src.exists():

--- a/lib/cli/src/crewai_cli/utils.py
+++ b/lib/cli/src/crewai_cli/utils.py
@@ -19,6 +19,8 @@ from crewai_core.tool_credentials import (
 )
 from rich.console import Console
 
+from crewai_cli.version import get_crewai_tools_dependency
+
 
 __all__ = [
     "build_env_with_all_tool_credentials",
@@ -73,6 +75,9 @@ def copy_template(
     content = content.replace("{{name}}", name)
     content = content.replace("{{crew_name}}", class_name)
     content = content.replace("{{folder_name}}", folder_name)
+    content = content.replace(
+        "{{crewai_tools_dependency}}", get_crewai_tools_dependency()
+    )
 
     with open(dst, "w") as file:
         file.write(content)

--- a/lib/cli/src/crewai_cli/version.py
+++ b/lib/cli/src/crewai_cli/version.py
@@ -13,10 +13,26 @@ from crewai_core.version import (
     is_current_version_yanked as is_current_version_yanked,
     is_newer_version_available as is_newer_version_available,
 )
+from packaging.version import Version
+
+from crewai_cli import __version__ as _crewai_cli_version
+
+
+def get_crewai_dependency_range(current_version: str | None = None) -> str:
+    """Return the supported CrewAI dependency range for generated projects."""
+    parsed_version = Version(current_version or _crewai_cli_version)
+    return f">={parsed_version},<{parsed_version.major + 1}.0.0"
+
+
+def get_crewai_tools_dependency(current_version: str | None = None) -> str:
+    """Return the generated-project dependency for CrewAI with tools."""
+    return f"crewai[tools]{get_crewai_dependency_range(current_version)}"
 
 
 __all__ = [
     "check_version",
+    "get_crewai_dependency_range",
+    "get_crewai_tools_dependency",
     "get_crewai_version",
     "get_latest_version_from_pypi",
     "is_current_version_yanked",

--- a/lib/cli/tests/deploy/test_archive.py
+++ b/lib/cli/tests/deploy/test_archive.py
@@ -176,7 +176,7 @@ def test_create_project_zip_keeps_json_project_root_shape(tmp_path: Path):
 [project]
 name = "json_crew"
 version = "0.1.0"
-dependencies = ["crewai[tools]==1.15.0"]
+dependencies = ["crewai[tools]>=1.15.0,<2.0.0"]
 
 [tool.crewai]
 type = "crew"

--- a/lib/cli/tests/deploy/test_archive.py
+++ b/lib/cli/tests/deploy/test_archive.py
@@ -176,7 +176,7 @@ def test_create_project_zip_keeps_json_project_root_shape(tmp_path: Path):
 [project]
 name = "json_crew"
 version = "0.1.0"
-dependencies = ["crewai[tools]==1.14.8a1"]
+dependencies = ["crewai[tools]==1.15.0"]
 
 [tool.crewai]
 type = "crew"

--- a/lib/cli/tests/test_create_crew.py
+++ b/lib/cli/tests/test_create_crew.py
@@ -735,8 +735,9 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
 
     pyproject = tomli.loads((tmp_path / "json_crew" / "pyproject.toml").read_text())
     dependency = pyproject["project"]["dependencies"][0]
-    assert dependency == "crewai[tools]==1.15.0"
+    assert dependency == "crewai[tools]>=1.15.0,<2.0.0"
     assert Version("1.15.0") in Requirement(dependency).specifier
+    assert Version("2.0.0") not in Requirement(dependency).specifier
     assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"][
         "only-include"
     ] == ["agents", "crew.jsonc", "tools", "knowledge", "skills"]

--- a/lib/cli/tests/test_create_crew.py
+++ b/lib/cli/tests/test_create_crew.py
@@ -735,8 +735,8 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
 
     pyproject = tomli.loads((tmp_path / "json_crew" / "pyproject.toml").read_text())
     dependency = pyproject["project"]["dependencies"][0]
-    assert dependency == "crewai[tools]==1.14.8a1"
-    assert Version("1.14.8a1") in Requirement(dependency).specifier
+    assert dependency == "crewai[tools]==1.15.0"
+    assert Version("1.15.0") in Requirement(dependency).specifier
     assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"][
         "only-include"
     ] == ["agents", "crew.jsonc", "tools", "knowledge", "skills"]

--- a/lib/cli/tests/test_run_crew.py
+++ b/lib/cli/tests/test_run_crew.py
@@ -25,7 +25,7 @@ def test_missing_crewai_package_shows_full_install_hint(monkeypatch):
 
     message = exc_info.value.message
     assert "CrewAI CLI is installed without the `crewai` package" in message
-    assert "uv tool install --force 'crewai[tools]==1.15.0'" in message
+    assert "uv tool install --force 'crewai[tools]>=1.15.0,<2.0.0'" in message
     assert "quotes are required in zsh" in message
 
 

--- a/lib/cli/tests/test_run_crew.py
+++ b/lib/cli/tests/test_run_crew.py
@@ -25,10 +25,7 @@ def test_missing_crewai_package_shows_full_install_hint(monkeypatch):
 
     message = exc_info.value.message
     assert "CrewAI CLI is installed without the `crewai` package" in message
-    assert (
-        "uv tool install --force --prerelease=allow 'crewai[tools]==1.14.8a1'"
-        in message
-    )
+    assert "uv tool install --force 'crewai[tools]==1.15.0'" in message
     assert "quotes are required in zsh" in message
 
 

--- a/lib/cli/tests/test_version.py
+++ b/lib/cli/tests/test_version.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from crewai_cli.version import get_crewai_version as _get_ver
 from crewai_cli.version import (
+    get_crewai_dependency_range,
+    get_crewai_tools_dependency,
     get_crewai_version,
     get_latest_version_from_pypi,
     is_current_version_yanked,
@@ -29,6 +31,11 @@ def test_dynamic_versioning_consistency() -> None:
 
     assert package_version is not None
     assert len(package_version.strip()) > 0
+
+
+def test_generated_project_dependency_uses_next_major_upper_bound() -> None:
+    assert get_crewai_dependency_range("1.15.0") == ">=1.15.0,<2.0.0"
+    assert get_crewai_tools_dependency("1.15.0") == "crewai[tools]>=1.15.0,<2.0.0"
 
 
 class TestVersionChecking:

--- a/lib/cli/tests/tools/test_main.py
+++ b/lib/cli/tests/tools/test_main.py
@@ -54,6 +54,10 @@ def test_create_success(mock_subprocess, capsys, tool_command):
         )
         assert os.path.isfile(os.path.join("test_tool", "src", "test_tool", "tool.py"))
 
+        with open(os.path.join("test_tool", "pyproject.toml"), "r") as f:
+            content = f.read()
+            assert '"crewai[tools]>=1.15.0,<2.0.0"' in content
+
         with open(os.path.join("test_tool", "src", "test_tool", "tool.py"), "r") as f:
             content = f.read()
             assert "class TestTool" in content


### PR DESCRIPTION
## Summary
- update JSON crew project scaffolding to pin crewai[tools] from the CLI package version
- update the missing-package install hint to reference the stable 1.15.0 package
- update related CLI/archive tests

## Tests
- uv run ruff check lib/cli/src/crewai_cli/create_json_crew.py lib/cli/src/crewai_cli/run_crew.py lib/cli/tests/test_create_crew.py lib/cli/tests/test_run_crew.py lib/cli/tests/deploy/test_archive.py
- uv run pytest lib/cli/tests/test_create_crew.py lib/cli/tests/test_run_crew.py lib/cli/tests/deploy/test_archive.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding and user-facing install text only; no runtime crew execution or dependency resolution logic changes beyond what new projects declare in pyproject.toml.
> 
> **Overview**
> Generated projects no longer pin a fixed `crewai[tools]==…` (including old prerelease strings). **`get_crewai_dependency_range`** and **`get_crewai_tools_dependency`** in `version.py` build a constraint from the installed CLI version: `>=that version,<next major.0.0` (e.g. `crewai[tools]>=1.15.0,<2.0.0`).
> 
> That value is wired through JSON crew creation, flow/crew/tool templates, `copy_template`, and custom tool scaffolding via the `{{crewai_tools_dependency}}` placeholder. The “CLI without `crewai`” install hint in `run_crew` now uses the same helper and drops prerelease-only wording.
> 
> Tests were updated to assert the new range in generated `pyproject.toml` files and install messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218b48c431eff4920b563fd8e5bbd683ad2dd1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated `pyproject.toml` files now use the correct `crewai[tools]` dependency range based on the installed CLI/next supported major version, instead of a fixed prerelease pin.
  * Template-based project, flow, and tool scaffolding now consistently inject the computed `crewai[tools]` constraint.
  * Updated the “missing dependency” install hint to match the new recommended `crewai[tools]` range.
* **Tests**
  * Refreshed and expanded assertions to validate the new `crewai[tools]>=...<...` dependency behavior in generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->