### PR TITLE
Open deployment page after CLI deploy

### DIFF
--- a/lib/cli/src/crewai_cli/deploy/main.py
+++ b/lib/cli/src/crewai_cli/deploy/main.py
@@ -106,8 +106,7 @@ def _deployment_page_url(base_url: str, json_response: dict[str, Any]) -> str | 
     if not identifier:
         return None
     return (
-        f"{base_url.rstrip('/')}/crewai_plus/deployments/"
-        f"{quote(identifier, safe='')}"
+        f"{base_url.rstrip('/')}/crewai_plus/deployments/{quote(identifier, safe='')}"
     )
 
 
@@ -224,7 +223,7 @@ class DeployCommand(BaseCommand, PlusAPIMixin):
         console.print(f"\nOpening deployment page: [blue]{deployment_url}[/blue]")
         try:
             webbrowser.open(deployment_url)
-        except Exception:  # pragma: no cover - browser backends are environment-specific
+        except Exception:  # pragma: no cover
             console.print(
                 "Could not open the deployment page automatically.",
                 style="yellow",

--- a/lib/cli/src/crewai_cli/deploy/main.py
+++ b/lib/cli/src/crewai_cli/deploy/main.py
@@ -17,7 +17,8 @@ from crewai_cli.utils import fetch_and_json_env_file, get_project_name
 
 console = Console()
 _MISSING_LOCKFILE_ERROR_CODES = {"missing_lockfile"}
-_DEPLOYMENT_IDENTIFIER_KEYS = ("deployment_id", "deploymentId", "id", "uuid")
+_DEPLOYMENT_ID_KEYS = ("deployment_id", "deploymentId")
+_DEPLOYMENT_FALLBACK_IDENTIFIER_KEYS = ("id", "uuid")
 
 
 def _run_predeploy_validation(
@@ -85,17 +86,23 @@ def _env_summary(env_vars: dict[str, str]) -> str:
 
 def _deployment_identifier(json_response: dict[str, Any]) -> str | None:
     """Return the best available identifier for a deployment show URL."""
-    for key in _DEPLOYMENT_IDENTIFIER_KEYS:
+    deployment = json_response.get("deployment")
+
+    for key in _DEPLOYMENT_ID_KEYS:
         value = json_response.get(key)
         if value:
             return str(value)
 
-    deployment = json_response.get("deployment")
     if isinstance(deployment, dict):
-        for key in _DEPLOYMENT_IDENTIFIER_KEYS:
+        for key in _DEPLOYMENT_ID_KEYS + _DEPLOYMENT_FALLBACK_IDENTIFIER_KEYS:
             value = deployment.get(key)
             if value:
                 return str(value)
+
+    for key in _DEPLOYMENT_FALLBACK_IDENTIFIER_KEYS:
+        value = json_response.get(key)
+        if value:
+            return str(value)
 
     return None
 

--- a/lib/cli/src/crewai_cli/deploy/main.py
+++ b/lib/cli/src/crewai_cli/deploy/main.py
@@ -222,8 +222,11 @@ class DeployCommand(BaseCommand, PlusAPIMixin):
 
         console.print(f"\nOpening deployment page: [blue]{deployment_url}[/blue]")
         try:
-            webbrowser.open(deployment_url)
-        except Exception:  # pragma: no cover
+            opened = webbrowser.open(deployment_url)
+        except Exception:
+            opened = False
+
+        if not opened:
             console.print(
                 "Could not open the deployment page automatically.",
                 style="yellow",

--- a/lib/cli/src/crewai_cli/deploy/main.py
+++ b/lib/cli/src/crewai_cli/deploy/main.py
@@ -1,12 +1,15 @@
 from pathlib import Path
 import subprocess
 from typing import Any
+from urllib.parse import quote
+import webbrowser
 
 from crewai_core.plus_api import CreateCrewPayload
 from rich.console import Console
 
 from crewai_cli import git
 from crewai_cli.command import BaseCommand, PlusAPIMixin
+from crewai_cli.constants import DEFAULT_CREWAI_ENTERPRISE_URL
 from crewai_cli.deploy.archive import create_project_zip
 from crewai_cli.deploy.validate import DeployValidator, Severity, render_report
 from crewai_cli.utils import fetch_and_json_env_file, get_project_name
@@ -14,6 +17,7 @@ from crewai_cli.utils import fetch_and_json_env_file, get_project_name
 
 console = Console()
 _MISSING_LOCKFILE_ERROR_CODES = {"missing_lockfile"}
+_DEPLOYMENT_IDENTIFIER_KEYS = ("deployment_id", "deploymentId", "id", "uuid")
 
 
 def _run_predeploy_validation(
@@ -77,6 +81,34 @@ def _env_summary(env_vars: dict[str, str]) -> str:
         return "0 env vars"
     keys = ", ".join(sorted(env_vars))
     return f"{len(env_vars)} env vars: {keys}"
+
+
+def _deployment_identifier(json_response: dict[str, Any]) -> str | None:
+    """Return the best available identifier for a deployment show URL."""
+    for key in _DEPLOYMENT_IDENTIFIER_KEYS:
+        value = json_response.get(key)
+        if value:
+            return str(value)
+
+    deployment = json_response.get("deployment")
+    if isinstance(deployment, dict):
+        for key in _DEPLOYMENT_IDENTIFIER_KEYS:
+            value = deployment.get(key)
+            if value:
+                return str(value)
+
+    return None
+
+
+def _deployment_page_url(base_url: str, json_response: dict[str, Any]) -> str | None:
+    """Build the CrewAI deployment show URL for a response payload."""
+    identifier = _deployment_identifier(json_response)
+    if not identifier:
+        return None
+    return (
+        f"{base_url.rstrip('/')}/crewai_plus/deployments/"
+        f"{quote(identifier, safe='')}"
+    )
 
 
 def _needs_lockfile_for_deploy(project_root: Path | None = None) -> bool:
@@ -165,6 +197,7 @@ class DeployCommand(BaseCommand, PlusAPIMixin):
         console.print("crewai deploy status")
         console.print(" or")
         console.print(f'crewai deploy status --uuid "{json_response["uuid"]}"')
+        self._open_deployment_page(json_response)
 
     def _display_logs(self, log_messages: list[dict[str, Any]]) -> None:
         """
@@ -176,6 +209,25 @@ class DeployCommand(BaseCommand, PlusAPIMixin):
         for log_message in log_messages:
             console.print(
                 f"{log_message['timestamp']} - {log_message['level']}: {log_message['message']}"
+            )
+
+    def _open_deployment_page(self, json_response: dict[str, Any]) -> None:
+        """Open the deployment show page in the user's browser when possible."""
+        base_url = str(
+            getattr(self.plus_api_client, "base_url", None)
+            or DEFAULT_CREWAI_ENTERPRISE_URL
+        )
+        deployment_url = _deployment_page_url(base_url, json_response)
+        if not deployment_url:
+            return
+
+        console.print(f"\nOpening deployment page: [blue]{deployment_url}[/blue]")
+        try:
+            webbrowser.open(deployment_url)
+        except Exception:  # pragma: no cover - browser backends are environment-specific
+            console.print(
+                "Could not open the deployment page automatically.",
+                style="yellow",
             )
 
     def deploy(self, uuid: str | None = None, skip_validate: bool = False) -> None:
@@ -438,6 +490,7 @@ class DeployCommand(BaseCommand, PlusAPIMixin):
         console.print("crewai deploy push")
         console.print(" or")
         console.print(f"crewai deploy push --uuid {json_response['uuid']}")
+        self._open_deployment_page(json_response)
 
     def list_crews(self) -> None:
         """

--- a/lib/cli/tests/deploy/test_deploy_main.py
+++ b/lib/cli/tests/deploy/test_deploy_main.py
@@ -167,6 +167,26 @@ def test_prepare_project_for_deploy_creates_missing_lock_after_validation(
     assert validators == []
 
 
+def test_deployment_page_url_prefers_deployment_id():
+    assert (
+        deploy_main._deployment_page_url(
+            "https://app.crewai.com",
+            {"uuid": "crew-uuid", "deployment_id": 128687},
+        )
+        == "https://app.crewai.com/crewai_plus/deployments/128687"
+    )
+
+
+def test_deployment_page_url_falls_back_to_nested_uuid():
+    assert (
+        deploy_main._deployment_page_url(
+            "https://app.crewai.com/",
+            {"deployment": {"uuid": "deployment-uuid"}},
+        )
+        == "https://app.crewai.com/crewai_plus/deployments/deployment-uuid"
+    )
+
+
 class TestDeployCommand(unittest.TestCase):
     @patch("crewai_cli.command.get_auth_token")
     @patch("crewai_cli.deploy.main.get_project_name")
@@ -186,6 +206,12 @@ class TestDeployCommand(unittest.TestCase):
 
         self.deploy_command = deploy_main.DeployCommand()
         self.mock_client = self.deploy_command.plus_api_client
+        self.mock_client.base_url = "https://app.crewai.com"
+        self.mock_browser_open_patcher = patch(
+            "crewai_cli.deploy.main.webbrowser.open"
+        )
+        self.mock_browser_open = self.mock_browser_open_patcher.start()
+        self.addCleanup(self.mock_browser_open_patcher.stop)
 
     def test_init_success(self):
         self.assertEqual(self.deploy_command.project_name, "test_project")
@@ -272,11 +298,18 @@ class TestDeployCommand(unittest.TestCase):
     def test_display_deployment_info(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             self.deploy_command._display_deployment_info(
-                {"uuid": "test-uuid", "status": "deployed"}
+                {"uuid": "test-uuid", "id": 128687, "status": "deployed"}
             )
             self.assertIn("Deploying the crew...", fake_out.getvalue())
             self.assertIn("test-uuid", fake_out.getvalue())
             self.assertIn("deployed", fake_out.getvalue())
+            self.assertIn(
+                "https://app.crewai.com/crewai_plus/deployments/128687",
+                fake_out.getvalue(),
+            )
+        self.mock_browser_open.assert_called_once_with(
+            "https://app.crewai.com/crewai_plus/deployments/128687"
+        )
 
     def test_display_logs(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:

--- a/lib/cli/tests/deploy/test_deploy_main.py
+++ b/lib/cli/tests/deploy/test_deploy_main.py
@@ -311,6 +311,38 @@ class TestDeployCommand(unittest.TestCase):
             "https://app.crewai.com/crewai_plus/deployments/128687"
         )
 
+    def test_display_deployment_info_warns_when_browser_open_returns_false(self):
+        self.mock_browser_open.return_value = False
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            self.deploy_command._display_deployment_info(
+                {"uuid": "test-uuid", "id": 128687, "status": "deployed"}
+            )
+            self.assertIn(
+                "Could not open the deployment page automatically.",
+                fake_out.getvalue(),
+            )
+
+        self.mock_browser_open.assert_called_once_with(
+            "https://app.crewai.com/crewai_plus/deployments/128687"
+        )
+
+    def test_display_deployment_info_warns_when_browser_open_raises(self):
+        self.mock_browser_open.side_effect = RuntimeError("no browser")
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            self.deploy_command._display_deployment_info(
+                {"uuid": "test-uuid", "id": 128687, "status": "deployed"}
+            )
+            self.assertIn(
+                "Could not open the deployment page automatically.",
+                fake_out.getvalue(),
+            )
+
+        self.mock_browser_open.assert_called_once_with(
+            "https://app.crewai.com/crewai_plus/deployments/128687"
+        )
+
     def test_display_logs(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             self.deploy_command._display_logs(

--- a/lib/cli/tests/deploy/test_deploy_main.py
+++ b/lib/cli/tests/deploy/test_deploy_main.py
@@ -177,6 +177,16 @@ def test_deployment_page_url_prefers_deployment_id():
     )
 
 
+def test_deployment_page_url_prefers_nested_deployment_id_over_crew_uuid():
+    assert (
+        deploy_main._deployment_page_url(
+            "https://app.crewai.com",
+            {"uuid": "crew-uuid", "deployment": {"deployment_id": 128687}},
+        )
+        == "https://app.crewai.com/crewai_plus/deployments/128687"
+    )
+
+
 def test_deployment_page_url_falls_back_to_nested_uuid():
     assert (
         deploy_main._deployment_page_url(


### PR DESCRIPTION
## Summary
- open the CrewAI deployment show page in the browser after successful CLI deploy/create responses
- build the show-page URL from deployment_id/deploymentId/id, falling back to uuid
- keep browser launch failures non-fatal and covered by deploy tests

## Tests
- uv run ruff check lib/cli/src/crewai_cli/deploy/main.py lib/cli/tests/deploy/test_deploy_main.py
- uv run pytest lib/cli/tests/deploy/test_deploy_main.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX after successful deploy/create; no auth, API, or deployment pipeline changes.
> 
> **Overview**
> After a successful **deploy** or **create**, the CLI now prints the Enterprise deployment show URL and tries to open it in the default browser.
> 
> URLs are built from the Plus API `base_url` (with fallback to `DEFAULT_CREWAI_ENTERPRISE_URL`) as `{base}/crewai_plus/deployments/{id}`, picking an identifier from `deployment_id` / `deploymentId`, then nested or top-level `id` / `uuid`. If `webbrowser.open` fails or returns false, the command still succeeds and shows a yellow warning.
> 
> Unit tests cover URL precedence and browser-open success and failure paths on `_display_deployment_info`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff36dd8f3d0ae34d96237282befb478c5da30283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment output now includes a link to the deployment’s web page.
  * When a deployment is shown or created, the CLI can automatically open that page in your browser.

* **Bug Fixes**
  * Improved deployment ID detection to support multiple response formats.
  * If the browser can’t be opened, the CLI now shows a warning instead of failing.

* **Tests**
  * Added unit tests covering deployment page URL generation and browser-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->