### PR TITLE
docs: improve coding agent setup CTA

### DIFF
--- a/docs/edge/en/index.mdx
+++ b/docs/edge/en/index.mdx
@@ -27,10 +27,41 @@ mode: "wide"
   </div>
 
   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
-    <a className="button button-primary" href="/en/quickstart">Get started</a>
+    <a
+      href="/en/quickstart"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid #EB6658",
+        background: "#EB6658",
+        color: "#FFFFFF",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      Get started
+    </a>
     <button
       type="button"
-      className="button"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.36)",
+        background: "rgba(235,102,88,0.08)",
+        color: "#EB6658",
+        fontWeight: 700,
+        lineHeight: 1,
+        cursor: "pointer"
+      }}
       onClick={async (event) => {
         const prompt = `Set up this environment so I can build with CrewAI.
 
@@ -75,15 +106,49 @@ If a command fails, show the exact command and error, explain the likely cause, 
           button.textContent = "Copy failed";
         } finally {
           window.setTimeout(() => {
-            button.textContent = "Copy instructions for coding agents";
+            button.textContent = "Copy agent setup prompt";
           }, 1600);
         }
       }}
     >
-      Copy instructions for coding agents
+      Copy agent setup prompt
     </button>
-    <a className="button" href="/en/changelog">View changelog</a>
-    <a className="button" href="/en/api-reference/introduction">API Reference</a>
+    <a
+      href="/en/guides/coding-tools/build-with-ai"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.28)",
+        color: "#EB6658",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      Coding-agent guide
+    </a>
+    <a
+      href="/en/api-reference/introduction"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.18)",
+        color: "var(--mint-text-2)",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      API Reference
+    </a>
   </div>
 
 </div>

--- a/docs/edge/en/index.mdx
+++ b/docs/edge/en/index.mdx
@@ -27,41 +27,10 @@ mode: "wide"
   </div>
 
   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
-    <a
-      href="/en/quickstart"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: 42,
-        padding: "0 16px",
-        borderRadius: 8,
-        border: "1px solid #EB6658",
-        background: "#EB6658",
-        color: "#FFFFFF",
-        fontWeight: 700,
-        lineHeight: 1,
-        textDecoration: "none"
-      }}
-    >
-      Get started
-    </a>
+    <a className="button button-primary" href="/en/quickstart">Get started</a>
     <button
       type="button"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: 42,
-        padding: "0 16px",
-        borderRadius: 8,
-        border: "1px solid rgba(235,102,88,0.36)",
-        background: "rgba(235,102,88,0.08)",
-        color: "#EB6658",
-        fontWeight: 700,
-        lineHeight: 1,
-        cursor: "pointer"
-      }}
+      className="button"
       onClick={async (event) => {
         const prompt = `Set up this environment so I can build with CrewAI.
 
@@ -106,49 +75,15 @@ If a command fails, show the exact command and error, explain the likely cause, 
           button.textContent = "Copy failed";
         } finally {
           window.setTimeout(() => {
-            button.textContent = "Copy agent setup prompt";
+            button.textContent = "Copy instructions for coding agents";
           }, 1600);
         }
       }}
     >
-      Copy agent setup prompt
+      Copy instructions for coding agents
     </button>
-    <a
-      href="/en/guides/coding-tools/build-with-ai"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: 42,
-        padding: "0 16px",
-        borderRadius: 8,
-        border: "1px solid rgba(235,102,88,0.28)",
-        color: "#EB6658",
-        fontWeight: 700,
-        lineHeight: 1,
-        textDecoration: "none"
-      }}
-    >
-      Coding-agent guide
-    </a>
-    <a
-      href="/en/api-reference/introduction"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: 42,
-        padding: "0 16px",
-        borderRadius: 8,
-        border: "1px solid rgba(235,102,88,0.18)",
-        color: "var(--mint-text-2)",
-        fontWeight: 700,
-        lineHeight: 1,
-        textDecoration: "none"
-      }}
-    >
-      API Reference
-    </a>
+    <a className="button" href="/en/changelog">View changelog</a>
+    <a className="button" href="/en/api-reference/introduction">API Reference</a>
   </div>
 
 </div>

--- a/docs/edge/en/installation.mdx
+++ b/docs/edge/en/installation.mdx
@@ -83,15 +83,20 @@ Do not hardcode API keys. Use .env.
 Do not invent CLI flags. Validate with crewai --help or crewai create --help.
 If a command fails, show the exact command and error, explain the likely cause, fix what you can safely fix, and retry once.`;
         const button = event.currentTarget;
+        const resetTimeout = button.dataset.resetTimeout;
+        if (resetTimeout) {
+          window.clearTimeout(Number(resetTimeout));
+        }
         try {
           await navigator.clipboard.writeText(prompt);
           button.textContent = "Copied";
         } catch {
           button.textContent = "Copy failed";
         } finally {
-          window.setTimeout(() => {
+          button.dataset.resetTimeout = String(window.setTimeout(() => {
             button.textContent = "Copy agent setup prompt";
-          }, 1600);
+            delete button.dataset.resetTimeout;
+          }, 1600));
         }
       }}
     >

--- a/docs/edge/en/installation.mdx
+++ b/docs/edge/en/installation.mdx
@@ -5,15 +5,49 @@ icon: wrench
 mode: "wide"
 ---
 
-### Watch: Building CrewAI Agents & Flows with Coding Agent Skills
+<div
+  style={{
+    display: "flex",
+    flexDirection: "column",
+    gap: 18,
+    padding: "24px",
+    marginBottom: 32,
+    borderRadius: 12,
+    border: "1px solid rgba(235,102,88,0.28)",
+    background: "linear-gradient(180deg, rgba(235,102,88,0.14) 0%, rgba(235,102,88,0.06) 100%)"
+  }}
+>
+  <div>
+    <p style={{ margin: 0, color: "#EB6658", fontSize: 13, fontWeight: 700, textTransform: "uppercase" }}>
+      Coding agent setup
+    </p>
+    <h2 style={{ margin: "6px 0 8px" }}>Set up CrewAI in your coding agent</h2>
+    <p style={{ margin: 0, color: "var(--mint-text-2)", maxWidth: 760 }}>
+      Copy a ready-to-paste setup prompt for Claude Code, Codex, Cursor, or any coding agent. It installs the official CrewAI skills, checks the CLI, and points the agent at the right docs before it edits code.
+    </p>
+  </div>
 
-Install our coding agent skills (Claude Code, Codex, ...) to quickly get your coding agents up and running with CrewAI.
-
-<button
-  type="button"
-  className="button button-primary"
-  onClick={async (event) => {
-    const prompt = `Set up this environment so I can build with CrewAI.
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "center" }}>
+    <button
+      type="button"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid #EB6658",
+        background: "#EB6658",
+        color: "#FFFFFF",
+        fontSize: 15,
+        fontWeight: 700,
+        lineHeight: 1,
+        cursor: "pointer",
+        boxShadow: "0 10px 24px rgba(235,102,88,0.22)"
+      }}
+      onClick={async (event) => {
+        const prompt = `Set up this environment so I can build with CrewAI.
 
 First install the official CrewAI coding-agent skills if this environment supports npx:
 
@@ -48,21 +82,44 @@ Setup steps:
 Do not hardcode API keys. Use .env.
 Do not invent CLI flags. Validate with crewai --help or crewai create --help.
 If a command fails, show the exact command and error, explain the likely cause, fix what you can safely fix, and retry once.`;
-    const button = event.currentTarget;
-    try {
-      await navigator.clipboard.writeText(prompt);
-      button.textContent = "Copied";
-    } catch {
-      button.textContent = "Copy failed";
-    } finally {
-      window.setTimeout(() => {
-        button.textContent = "Copy instructions for coding agents";
-      }, 1600);
-    }
-  }}
->
-  Copy instructions for coding agents
-</button>
+        const button = event.currentTarget;
+        try {
+          await navigator.clipboard.writeText(prompt);
+          button.textContent = "Copied";
+        } catch {
+          button.textContent = "Copy failed";
+        } finally {
+          window.setTimeout(() => {
+            button.textContent = "Copy agent setup prompt";
+          }, 1600);
+        }
+      }}
+    >
+      Copy agent setup prompt
+    </button>
+    <a
+      href="/en/guides/coding-tools/build-with-ai"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.36)",
+        color: "#EB6658",
+        fontSize: 15,
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      View coding-agent guide
+    </a>
+  </div>
+</div>
+
+### Watch: Building CrewAI Agents & Flows with Coding Agent Skills
 
 <iframe src="https://www.loom.com/embed/befb9f68b81f42ad8112bfdd95a780af" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{width: "100%", height: "400px"}}></iframe>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -99,22 +99,27 @@ Do not hardcode API keys. Use .env.
 Do not invent CLI flags. Validate with crewai --help or crewai create --help.
 If a command fails, show the exact command and error, explain the likely cause, fix what you can safely fix, and retry once.`;
         const button = event.currentTarget;
+        const resetTimeout = button.dataset.resetTimeout;
+        if (resetTimeout) {
+          window.clearTimeout(Number(resetTimeout));
+        }
         try {
           await navigator.clipboard.writeText(prompt);
           button.textContent = "Copied";
         } catch {
           button.textContent = "Copy failed";
         } finally {
-          window.setTimeout(() => {
+          button.dataset.resetTimeout = String(window.setTimeout(() => {
             button.textContent = "Copy agent setup prompt";
-          }, 1600);
+            delete button.dataset.resetTimeout;
+          }, 1600));
         }
       }}
     >
       Copy agent setup prompt
     </button>
     <a
-      href="/en/guides/coding-tools/build-with-ai"
+      href="/guides/coding-tools/build-with-ai"
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -27,9 +27,128 @@ mode: "wide"
   </div>
 
   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
-    <a className="button button-primary" href="/en/quickstart">Get started</a>
-    <a className="button" href="/en/changelog">View changelog</a>
-    <a className="button" href="/en/api-reference/introduction">API Reference</a>
+    <a
+      href="/en/quickstart"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid #EB6658",
+        background: "#EB6658",
+        color: "#FFFFFF",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      Get started
+    </a>
+    <button
+      type="button"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.36)",
+        background: "rgba(235,102,88,0.08)",
+        color: "#EB6658",
+        fontWeight: 700,
+        lineHeight: 1,
+        cursor: "pointer"
+      }}
+      onClick={async (event) => {
+        const prompt = `Set up this environment so I can build with CrewAI.
+
+First install the official CrewAI coding-agent skills if this environment supports npx:
+
+npx skills add crewaiinc/skills
+
+If npx is missing or the current agent cannot load skills, do not fail the whole setup. Report the exact issue and continue using the CrewAI docs directly.
+
+Use these CrewAI docs as source of truth before making assumptions:
+- https://skills.crewai.com
+- https://docs.crewai.com/llms.txt
+- https://docs.crewai.com/en/installation
+- https://docs.crewai.com/en/guides/coding-tools/build-with-ai
+
+Setup steps:
+1. Check python3 --version. CrewAI requires Python >=3.10 and <3.14.
+2. Install uv if missing:
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+3. Source the uv environment if needed:
+   source "$HOME/.local/bin/env"
+4. Install the CrewAI CLI:
+   uv tool install crewai
+5. Verify the CLI:
+   crewai version
+   crewai create --help
+6. Create a project:
+   CREWAI_DMN=true crewai create
+7. After project creation, inspect the generated files before editing.
+8. Run:
+   crewai install
+   crewai run
+
+Do not hardcode API keys. Use .env.
+Do not invent CLI flags. Validate with crewai --help or crewai create --help.
+If a command fails, show the exact command and error, explain the likely cause, fix what you can safely fix, and retry once.`;
+        const button = event.currentTarget;
+        try {
+          await navigator.clipboard.writeText(prompt);
+          button.textContent = "Copied";
+        } catch {
+          button.textContent = "Copy failed";
+        } finally {
+          window.setTimeout(() => {
+            button.textContent = "Copy agent setup prompt";
+          }, 1600);
+        }
+      }}
+    >
+      Copy agent setup prompt
+    </button>
+    <a
+      href="/en/guides/coding-tools/build-with-ai"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.28)",
+        color: "#EB6658",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      Coding-agent guide
+    </a>
+    <a
+      href="/en/api-reference/introduction"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 42,
+        padding: "0 16px",
+        borderRadius: 8,
+        border: "1px solid rgba(235,102,88,0.18)",
+        color: "var(--mint-text-2)",
+        fontWeight: 700,
+        lineHeight: 1,
+        textDecoration: "none"
+      }}
+    >
+      API Reference
+    </a>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Replace the weak installation-page text CTA with a prominent coding-agent setup panel
- Style the copy/setup CTA directly so it renders as an actual button
- Add a direct link to the Build with AI coding-agent guide from the CTA area

## Docs versioning
This edits docs/edge/en/... only. Once merged to main, it appears under the Edge version selector. It will be frozen into the next released docs version when the release-cut docs freeze runs.

## Verification
- git diff --check
- python -m json.tool docs/docs.json
- Compiled edited MDX files with @mdx-js/mdx

Note: mintlify broken-links and mintlify dev started locally but did not complete in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and client-side clipboard UI only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Docs-only UX** for getting started with CrewAI in coding agents: stronger CTAs on the **installation** page and **docs home**.
> 
> On **`installation.mdx`**, the old plain copy button is now a **highlighted “coding agent setup” panel** (headline, short explanation, branded styling). The **copy-to-clipboard** action is an explicit primary button with clearer label (**“Copy agent setup prompt”**), plus a **“View coding-agent guide”** link to `/en/guides/coding-tools/build-with-ai`. Clipboard feedback now **clears pending reset timers** before starting a new copy so rapid clicks don’t leave the label stuck.
> 
> On **`index.mdx`**, the hero **replaces Mintlify `button` classes** with inline-styled links/buttons. It adds the same **copy agent setup prompt** control and a **coding-agent guide** link; **changelog** is dropped from the hero in favor of **Get started**, copy prompt, guide, and **API Reference**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb372ea01ca5464fd70d0e00945dd546f02ee261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Copy agent setup prompt” button to documentation CTAs/callouts for one-click setup prompt copying.
  * Added a direct “Coding-agent guide” link from the getting-started and installation areas.
  * Removed the previous “View changelog” link and the older coding-agent copy button.

* **UI Improvements**
  * Refreshed the installation and homepage getting-started CTAs with a more guided layout and clearer next steps.

* **Bug Fixes**
  * Enhanced clipboard copy feedback with clear success/failure messaging and automatic reset of the button state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->