### PR TITLE
Track TUI button telemetry

### DIFF
--- a/lib/cli/src/crewai_cli/crew_run_tui.py
+++ b/lib/cli/src/crewai_cli/crew_run_tui.py
@@ -10,6 +10,7 @@ import threading
 import time
 from typing import Any, ClassVar, cast
 
+from crewai_core.telemetry import Telemetry
 from rich.text import Text
 from textual import work
 from textual.app import App, ComposeResult
@@ -571,6 +572,7 @@ FooterKey .footer-key--key {
         self._want_deploy: bool = False
         self._trace_url: str | None = None
         self._consent_screen: TraceConsentScreen | None = None
+        self._telemetry: Telemetry | None = None
 
     # ── Layout ──────────────────────────────────────────────
 
@@ -1042,10 +1044,21 @@ FooterKey .footer-key--key {
         self._unsubscribe()
         self.exit(self._crew_result)
 
+    def _record_tui_button_click(self, button_name: str) -> None:
+        try:
+            if self._telemetry is None:
+                self._telemetry = Telemetry()
+                self._telemetry.set_tracer()
+            self._telemetry.tui_button_clicked_span(button_name)
+        except Exception:  # noqa: S110
+            pass
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id in ("btn-traces", "btn-traces-done"):
+            self._record_tui_button_click("view_traces")
             self.action_view_traces()
         elif event.button.id == "btn-deploy":
+            self._record_tui_button_click("deploy")
             self.action_deploy_crew()
 
     def _scroll_to_result(self) -> None:

--- a/lib/cli/src/crewai_cli/crew_run_tui.py
+++ b/lib/cli/src/crewai_cli/crew_run_tui.py
@@ -1049,7 +1049,7 @@ FooterKey .footer-key--key {
             if self._telemetry is None:
                 self._telemetry = Telemetry()
                 self._telemetry.set_tracer()
-            self._telemetry.tui_button_clicked_span(button_name)
+            self._telemetry.feature_usage_span(f"cli_usage:{button_name}")
         except Exception:  # noqa: S110
             pass
 

--- a/lib/cli/tests/test_crew_run_tui.py
+++ b/lib/cli/tests/test_crew_run_tui.py
@@ -139,7 +139,7 @@ def test_view_traces_button_click_records_telemetry(monkeypatch) -> None:
 
     app.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="btn-traces")))
 
-    app._telemetry.tui_button_clicked_span.assert_called_once_with("view_traces")
+    app._telemetry.feature_usage_span.assert_called_once_with("cli_usage:view_traces")
     assert opened_urls == ["https://app.crewai.com/traces/test"]
 
 
@@ -154,7 +154,7 @@ def test_deploy_button_click_records_telemetry() -> None:
 
     app.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="btn-deploy")))
 
-    app._telemetry.tui_button_clicked_span.assert_called_once_with("deploy")
+    app._telemetry.feature_usage_span.assert_called_once_with("cli_usage:deploy")
     assert app._want_deploy is True
     assert exits == [app._crew_result]
 

--- a/lib/cli/tests/test_crew_run_tui.py
+++ b/lib/cli/tests/test_crew_run_tui.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 import time
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -124,6 +126,37 @@ def test_chain_deploy_does_not_login_for_deploy_exit(monkeypatch, capsys) -> Non
     assert create_calls == [{"confirm": True, "skip_validate": True}]
     assert login_calls == []
     assert "Deploy failed with exit code 42" in capsys.readouterr().out
+
+
+def test_view_traces_button_click_records_telemetry(monkeypatch) -> None:
+    app = CrewRunApp()
+    app._status = "completed"
+    app._trace_url = "https://app.crewai.com/traces/test"
+    app._telemetry = Mock()
+    opened_urls: list[str] = []
+
+    monkeypatch.setattr("webbrowser.open", lambda url: opened_urls.append(url))
+
+    app.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="btn-traces")))
+
+    app._telemetry.tui_button_clicked_span.assert_called_once_with("view_traces")
+    assert opened_urls == ["https://app.crewai.com/traces/test"]
+
+
+def test_deploy_button_click_records_telemetry() -> None:
+    app = CrewRunApp()
+    app._status = "completed"
+    app._crew_result = object()
+    app._telemetry = Mock()
+    app._unsubscribe = lambda: None  # type: ignore[method-assign]
+    exits: list[object] = []
+    app.exit = lambda result: exits.append(result)  # type: ignore[method-assign]
+
+    app.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="btn-deploy")))
+
+    app._telemetry.tui_button_clicked_span.assert_called_once_with("deploy")
+    assert app._want_deploy is True
+    assert exits == [app._crew_result]
 
 
 def test_conversation_turn_done_records_assistant_message() -> None:

--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -249,6 +249,17 @@ class Telemetry:
 
         self._safe_telemetry_procedure(_operation)
 
+    def tui_button_clicked_span(self, button_name: str) -> None:
+        """Records when a user clicks a button in the CLI TUI."""
+
+        def _operation() -> None:
+            tracer = trace.get_tracer("crewai.telemetry")
+            span = tracer.start_span("TUI Button Clicked")
+            self._add_attribute(span, "button_name", button_name)
+            close_span(span)
+
+        self._safe_telemetry_procedure(_operation)
+
     def flow_creation_span(self, flow_name: str) -> None:
         """Records the creation of a new flow."""
 

--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -249,13 +249,15 @@ class Telemetry:
 
         self._safe_telemetry_procedure(_operation)
 
-    def tui_button_clicked_span(self, button_name: str) -> None:
-        """Records when a user clicks a button in the CLI TUI."""
+    def feature_usage_span(self, feature: str) -> None:
+        """Records that a feature was used. One span = one count."""
+        from crewai_core.version import get_crewai_version
 
         def _operation() -> None:
             tracer = trace.get_tracer("crewai.telemetry")
-            span = tracer.start_span("TUI Button Clicked")
-            self._add_attribute(span, "button_name", button_name)
+            span = tracer.start_span("Feature Usage")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
+            self._add_attribute(span, "feature", feature)
             close_span(span)
 
         self._safe_telemetry_procedure(_operation)

--- a/lib/crewai-core/tests/test_smoke.py
+++ b/lib/crewai-core/tests/test_smoke.py
@@ -131,7 +131,7 @@ def test_core_telemetry_skips_duplicate_tracer_provider(
     assert telemetry.trace_set is True
 
 
-def test_core_telemetry_records_tui_button_click(
+def test_core_telemetry_records_feature_usage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from crewai_core.telemetry import Telemetry
@@ -150,8 +150,8 @@ def test_core_telemetry_records_tui_button_click(
     )
 
     telemetry = Telemetry()
-    telemetry.tui_button_clicked_span("view_traces")
+    telemetry.feature_usage_span("cli_usage:view_traces")
 
-    tracer.start_span.assert_called_once_with("TUI Button Clicked")
-    span.set_attribute.assert_called_once_with("button_name", "view_traces")
+    tracer.start_span.assert_called_once_with("Feature Usage")
+    span.set_attribute.assert_any_call("feature", "cli_usage:view_traces")
     span.end.assert_called_once()

--- a/lib/crewai-core/tests/test_smoke.py
+++ b/lib/crewai-core/tests/test_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import Mock
 
 from crewai_core import (
     constants,
@@ -128,3 +129,29 @@ def test_core_telemetry_skips_duplicate_tracer_provider(
 
     assert called is False
     assert telemetry.trace_set is True
+
+
+def test_core_telemetry_records_tui_button_click(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from crewai_core.telemetry import Telemetry
+
+    Telemetry._instance = None
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.delenv("CREWAI_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("CREWAI_DISABLE_TRACKING", raising=False)
+
+    tracer = Mock()
+    span = Mock()
+    tracer.start_span.return_value = span
+    monkeypatch.setattr(
+        "crewai_core.telemetry.trace.get_tracer",
+        lambda _name: tracer,
+    )
+
+    telemetry = Telemetry()
+    telemetry.tui_button_clicked_span("view_traces")
+
+    tracer.start_span.assert_called_once_with("TUI Button Clicked")
+    span.set_attribute.assert_called_once_with("button_name", "view_traces")
+    span.end.assert_called_once()


### PR DESCRIPTION
## Summary
- add a sanitized `TUI Button Clicked` telemetry span in `crewai-core`
- emit `view_traces` and `deploy` click events from the completed-run TUI buttons
- add focused tests for the TUI click path and core span shape

## Verification
- `uv run pytest lib/cli/tests/test_crew_run_tui.py lib/crewai-core/tests/test_smoke.py`
- `uv run ruff check lib/cli/src/crewai_cli/crew_run_tui.py lib/cli/tests/test_crew_run_tui.py lib/crewai-core/src/crewai_core/telemetry.py lib/crewai-core/tests/test_smoke.py`
- `uv run ruff format --check lib/cli/src/crewai_cli/crew_run_tui.py lib/cli/tests/test_crew_run_tui.py lib/crewai-core/src/crewai_core/telemetry.py lib/crewai-core/tests/test_smoke.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in style usage telemetry only; errors are caught and telemetry respects existing disable env vars, with no change to auth or deploy logic beyond recording clicks.
> 
> **Overview**
> Adds **anonymous feature-usage telemetry** for post-run TUI sidebar actions.
> 
> **`crewai-core`**: New `Telemetry.feature_usage_span(feature)` emits an OpenTelemetry **Feature Usage** span with `crewai_version` and a `feature` attribute (e.g. `cli_usage:view_traces`), using the same safe/disabled-env behavior as other core spans.
> 
> **CLI TUI**: `CrewRunApp` lazily initializes `Telemetry` and calls `_record_tui_button_click` when **View Traces** (`btn-traces` / `btn-traces-done`) or **Deploy** is pressed, before the existing trace-open and deploy-exit behavior. Failures are swallowed so the UI keeps working.
> 
> **Tests**: Unit tests assert the TUI passes the expected `cli_usage:*` feature strings and that the core span name, `feature` attribute, and `end()` are correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5107624cc49186de68c1377927fd0947ed8abfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry tracking for key CLI TUI actions, including “view traces” and “deploy”.
  * Introduced a feature-usage telemetry span that records the current version and the selected feature name.
* **Tests**
  * Added unit tests covering telemetry spans and expected outcomes for “view traces” and “deploy”.
  * Added a smoke test to verify telemetry span creation, attributes, and proper span termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->