### PR TITLE
fix: update human_input feedback prompt to not reference non-existent result

### DIFF
--- a/lib/crewai/src/crewai/core/providers/human_input.py
+++ b/lib/crewai/src/crewai/core/providers/human_input.py
@@ -343,7 +343,7 @@ class SyncHumanInputProvider(HumanInputProvider):
                 title = "🎓 Training Feedback Required"
             else:
                 prompt_text = (
-                    "Provide feedback on the Final Result above.\n\n"
+                    "The agent has completed its task.\n\n"
                     "• If you are happy with the result, simply hit Enter without typing anything.\n"
                     "• Otherwise, provide specific improvement requests.\n"
                     "• You can provide multiple rounds of feedback until satisfied."
@@ -396,7 +396,7 @@ class SyncHumanInputProvider(HumanInputProvider):
                 title = "🎓 Training Feedback Required"
             else:
                 prompt_text = (
-                    "Provide feedback on the Final Result above.\n\n"
+                    "The agent has completed its task.\n\n"
                     "• If you are happy with the result, simply hit Enter without typing anything.\n"
                     "• Otherwise, provide specific improvement requests.\n"
                     "• You can provide multiple rounds of feedback until satisfied."


### PR DESCRIPTION
## Problem

When  is set on a Task, the feedback prompt says:

> Provide feedback on the Final Result above.

But there's no "Final Result" shown above the prompt at that point in execution. The result exists in memory but isn't displayed to the user before the prompt appears, making the reference confusing.

## Fix

Changed the prompt text from:
- "Provide feedback on the Final Result above."

To:
- "The agent has completed its task."

This is contextually accurate regardless of whether the result is visible to the user.

## Changes

- : Updated prompt text in both  (sync) and  methods

## Testing

All existing human feedback tests pass:
-  (26 tests)
-  
- 
- 
-  (15 tests)

Fixes #6072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the user-facing completion prompt shown after an agent finishes its task in both sync and async flows.
  * The message now starts with clearer language, improving readability and consistency during feedback collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->