### PR TITLE
docs(edge): fix dead Stagehand docs link in stagehandtool (4 langs)

### DIFF
--- a/docs/edge/ar/tools/web-scraping/stagehandtool.mdx
+++ b/docs/edge/ar/tools/web-scraping/stagehandtool.mdx
@@ -8,7 +8,7 @@ mode: "wide"
 
 # نظرة عامة
 
-تدمج أداة `StagehandTool` إطار عمل [Stagehand](https://docs.stagehand.dev/get_started/introduction) مع CrewAI، مما يتيح للوكلاء التفاعل مع المواقع الإلكترونية وأتمتة مهام المتصفح باستخدام تعليمات بلغة طبيعية.
+تدمج أداة `StagehandTool` إطار عمل [Stagehand](https://docs.stagehand.dev/v3/first-steps/introduction) مع CrewAI، مما يتيح للوكلاء التفاعل مع المواقع الإلكترونية وأتمتة مهام المتصفح باستخدام تعليمات بلغة طبيعية.
 
 ## نظرة عامة
 

--- a/docs/edge/en/tools/web-scraping/stagehandtool.mdx
+++ b/docs/edge/en/tools/web-scraping/stagehandtool.mdx
@@ -8,7 +8,7 @@ mode: "wide"
 
 # Overview
 
-The `StagehandTool` integrates the [Stagehand](https://docs.stagehand.dev/get_started/introduction) framework with CrewAI, enabling agents to interact with websites and automate browser tasks using natural language instructions.
+The `StagehandTool` integrates the [Stagehand](https://docs.stagehand.dev/v3/first-steps/introduction) framework with CrewAI, enabling agents to interact with websites and automate browser tasks using natural language instructions.
 
 ## Overview
 

--- a/docs/edge/ko/tools/web-scraping/stagehandtool.mdx
+++ b/docs/edge/ko/tools/web-scraping/stagehandtool.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 # 개요
 
-`StagehandTool`은 [Stagehand](https://docs.stagehand.dev/get_started/introduction) 프레임워크를 CrewAI와 통합하여 에이전트가 자연어 지시를 사용해 웹사이트와 상호작용하고 브라우저 작업을 자동화할 수 있도록 합니다.
+`StagehandTool`은 [Stagehand](https://docs.stagehand.dev/v3/first-steps/introduction) 프레임워크를 CrewAI와 통합하여 에이전트가 자연어 지시를 사용해 웹사이트와 상호작용하고 브라우저 작업을 자동화할 수 있도록 합니다.
 
 ## 개요
 

--- a/docs/edge/pt-BR/tools/web-scraping/stagehandtool.mdx
+++ b/docs/edge/pt-BR/tools/web-scraping/stagehandtool.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 # Visão Geral
 
-A `StagehandTool` integra o framework [Stagehand](https://docs.stagehand.dev/get_started/introduction) com o CrewAI, permitindo que agentes interajam com sites e automatizem tarefas no navegador utilizando instruções em linguagem natural.
+A `StagehandTool` integra o framework [Stagehand](https://docs.stagehand.dev/v3/first-steps/introduction) com o CrewAI, permitindo que agentes interajam com sites e automatizem tarefas no navegador utilizando instruções em linguagem natural.
 
 ## Visão Geral
 


### PR DESCRIPTION
Fixes `docs.stagehand.dev/get_started/introduction` (404) → `docs.stagehand.dev/v3/first-steps/introduction` (200) in ar/en/ko/pt-BR edge docs. Stagehand restructured their docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stagehand tool documentation link to point to the latest getting-started path across all supported languages.
  * Kept the surrounding guidance and description unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->