### PR TITLE
fix: support anthropic-- prefix in model name filtering

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -535,7 +535,8 @@ class LLM(BaseLLM):
 
         if provider == "anthropic" or provider == "claude":
             return any(
-                model_lower.startswith(prefix) for prefix in ["claude-", "anthropic."]
+                model_lower.startswith(prefix)
+                for prefix in ["claude-", "anthropic.", "anthropic--"]
             )
 
         if provider == "gemini" or provider == "google":
@@ -658,6 +659,11 @@ class LLM(BaseLLM):
 
         if model in AZURE_MODELS:
             return "azure"
+
+        # Pattern-based fallback for models not in constants
+        model_lower = model.lower()
+        if model_lower.startswith(("claude-", "anthropic.", "anthropic--")):
+            return "anthropic"
 
         return "openai"
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -887,6 +887,17 @@ def test_prefixed_models_with_valid_patterns_use_native_sdk():
         assert llm2.model == "claude-future-5"
 
 
+def test_anthropic_double_dash_prefix_uses_native_sdk():
+    """Test that models with anthropic-- prefix (e.g. self-hosted) route to native Anthropic SDK."""
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        llm = LLM(
+            model="anthropic/anthropic--claude-3-5-sonnet", is_litellm=False
+        )
+        assert llm.is_litellm is False
+        assert llm.provider == "anthropic"
+        assert llm.model == "anthropic--claude-3-5-sonnet"
+
+
 def test_prefixed_models_with_non_native_providers_use_litellm():
     """Test that models with non-native provider prefixes always use LiteLLM."""
     # Test groq/ prefix (not a native provider) → LiteLLM
@@ -950,6 +961,19 @@ def test_validate_model_in_constants():
     assert (
         LLM._validate_model_in_constants("claude-3-5-sonnet-latest", "claude") is True
     )
+    # Models with non-standard anthropic-- prefix (e.g. self-hosted deployments)
+    assert (
+        LLM._validate_model_in_constants(
+            "anthropic--claude-3-5-sonnet", "anthropic"
+        )
+        is True
+    )
+    assert (
+        LLM._validate_model_in_constants(
+            "anthropic--claude-opus-4-0", "claude"
+        )
+        is True
+    )
     assert LLM._validate_model_in_constants("unknown-model", "claude") is False
 
     # Gemini models
@@ -972,6 +996,16 @@ def test_validate_model_in_constants():
     assert (
         LLM._validate_model_in_constants("anthropic.claude-future-v1:0", "bedrock")
         is True
+    )
+
+
+def test_infer_provider_from_model_anthropic_prefixes():
+    """Test that _infer_provider_from_model recognizes non-standard anthropic prefixes."""
+    # Standard prefixes already in constants
+    assert LLM._infer_provider_from_model("claude-opus-4-0") == "anthropic"
+    # Non-standard prefix not in constants — should still infer anthropic
+    assert (
+        LLM._infer_provider_from_model("anthropic--claude-3-5-sonnet") == "anthropic"
     )
 
 @pytest.mark.vcr(record_mode="once",decode_compressed_response=True)


### PR DESCRIPTION
## Problem

The `_matches_provider_pattern` method only recognizes `claude-` and `anthropic.` prefixes for Anthropic models. Self-hosted deployments using naming conventions like `anthropic--claude-...` are incorrectly rejected or routed to the wrong provider.

Fixes #5893

## Changes

**`lib/crewai/src/crewai/llm.py`** (2 changes):

1. **`_matches_provider_pattern`**: Added `"anthropic--"` to the Anthropic prefix list so models like `anthropic--claude-3-5-sonnet` pass validation.

2. **`_infer_provider_from_model`**: Added a pattern-based fallback after the constants check, so unprefixed models with non-standard Anthropic naming conventions (e.g. `anthropic--claude-3-5-sonnet`) are correctly inferred as Anthropic instead of defaulting to OpenAI.

**`lib/crewai/tests/test_llm.py`** (3 new tests):

- `test_anthropic_double_dash_prefix_uses_native_sdk` — end-to-end routing test
- `test_infer_provider_from_model_anthropic_prefixes` — provider inference test
- Extended `test_validate_model_in_constants` with `anthropic--` prefix assertions

## Testing

All 3 new tests pass, plus all existing anthropic-related tests remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-provider detection for additional Anthropic model name formats, including double-dash prefixes.
  * Better fallback provider inference now recognizes more Anthropic-style model names instead of defaulting incorrectly.
  * Preserved the original model name while using the native Anthropic path when applicable.

* **Tests**
  * Added coverage for Anthropic double-dash model prefixes and provider inference behavior.
  * Expanded validation checks for supported Anthropic model naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->