### PR TITLE
fix: check model support before sending json_schema response_format

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -748,16 +748,19 @@ class OpenAICompletion(BaseLLM):
         if response_model or self.response_format:
             format_model = response_model or self.response_format
             if isinstance(format_model, type) and issubclass(format_model, BaseModel):
-                schema_output = generate_model_description(format_model)
-                json_schema = schema_output.get("json_schema", {})
-                params["text"] = {
-                    "format": {
-                        "type": "json_schema",
-                        "name": json_schema.get("name", format_model.__name__),
-                        "strict": json_schema.get("strict", True),
-                        "schema": json_schema.get("schema", {}),
+                if self._supports_structured_output():
+                    schema_output = generate_model_description(format_model)
+                    json_schema = schema_output.get("json_schema", {})
+                    params["text"] = {
+                        "format": {
+                            "type": "json_schema",
+                            "name": json_schema.get("name", format_model.__name__),
+                            "strict": json_schema.get("strict", True),
+                            "schema": json_schema.get("schema", {}),
+                        }
                     }
-                }
+                else:
+                    params["text"] = {"format": {"type": "json_object"}}
             elif isinstance(format_model, dict):
                 params["text"] = {"format": format_model}
 
@@ -1598,9 +1601,12 @@ class OpenAICompletion(BaseLLM):
             if isinstance(self.response_format, type) and issubclass(
                 self.response_format, BaseModel
             ):
-                params["response_format"] = generate_model_description(
-                    self.response_format
-                )
+                if self._supports_structured_output():
+                    params["response_format"] = generate_model_description(
+                        self.response_format
+                    )
+                else:
+                    params["response_format"] = {"type": "json_object"}
             elif isinstance(self.response_format, dict):
                 params["response_format"] = self.response_format
 
@@ -2401,6 +2407,20 @@ class OpenAICompletion(BaseLLM):
             finish_reason=stream_finish_reason,
             response_id=stream_response_id,
         )
+
+    def _supports_structured_output(self) -> bool:
+        """Whether the model supports json_schema response_format type."""
+        model_lower = self.model.lower() if self.model else ""
+
+        unsupported_prefixes = ("o1-preview", "o1-mini", "gpt-4-base", "gpt-3.5", "gpt-35")
+        if model_lower.startswith(unsupported_prefixes):
+            return False
+
+        supported_prefixes = ("gpt-4o", "gpt-4-turbo", "gpt-4.1", "gpt-5", "o1", "o3", "o4")
+        if model_lower.startswith(supported_prefixes):
+            return True
+
+        return True
 
     def supports_function_calling(self) -> bool:
         """Check if the model supports function calling."""

--- a/lib/crewai/tests/llms/openai/test_openai.py
+++ b/lib/crewai/tests/llms/openai/test_openai.py
@@ -2175,3 +2175,55 @@ def test_openai_no_detail_fields_omitted():
     assert usage["completion_tokens"] == 30
     assert "cached_prompt_tokens" not in usage
     assert "reasoning_tokens" not in usage
+
+
+from pydantic import BaseModel
+
+
+class SampleOutput(BaseModel):
+    name: str
+    value: int
+
+
+def test_structured_output_json_schema_for_supported_models():
+    """Test that json_schema response_format is used for models that support it."""
+    llm = LLM(model="gpt-4o", response_format=SampleOutput, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"]["type"] == "json_schema"
+    assert "json_schema" in params["response_format"]
+
+
+def test_structured_output_fallback_for_unsupported_models():
+    """Test that json_object fallback is used for models that don't support json_schema."""
+    llm = LLM(model="o1-preview", response_format=SampleOutput, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"]["type"] == "json_object"
+
+
+def test_structured_output_fallback_for_o1_mini():
+    """Test that o1-mini falls back to json_object."""
+    llm = LLM(model="o1-mini", response_format=SampleOutput, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"]["type"] == "json_object"
+
+
+def test_structured_output_json_schema_for_o3_mini():
+    """Test that o3-mini supports json_schema (it's a newer reasoning model)."""
+    llm = LLM(model="o3-mini", response_format=SampleOutput, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"]["type"] == "json_schema"
+
+
+def test_structured_output_json_schema_for_gpt4_turbo():
+    """Test that gpt-4-turbo supports json_schema."""
+    llm = LLM(model="gpt-4-turbo", response_format=SampleOutput, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"]["type"] == "json_schema"
+
+
+def test_dict_response_format_passed_through():
+    """Test that dict response_format is passed through unchanged."""
+    custom_format = {"type": "json_object"}
+    llm = LLM(model="o1-preview", response_format=custom_format, api_key="test-key")
+    params = llm._prepare_completion_params(messages=[{"role": "user", "content": "test"}])
+    assert params["response_format"] == custom_format


### PR DESCRIPTION
## Problem

When using structured output with certain models (like `o1-preview`, `o1-mini`), the API call fails with:
```
response_format type is unavailable now
```

This happens because `generate_model_description()` returns `{"type": "json_schema", ...}` which is sent directly to the API, but these models don't support the `json_schema` response_format type.

## Fix

Add `_supports_structured_output()` method to `OpenAICompletion` that checks model capabilities before setting the response_format type. For unsupported models, fall back to `{"type": "json_object"}` which is supported by all models.

### Models that DON'T support json_schema (get json_object fallback):
- `o1-preview`, `o1-mini` (older reasoning models)
- `gpt-4-base`, `gpt-3.5` variants

### Models that DO support json_schema:
- `gpt-4o`, `gpt-4-turbo`, `gpt-4.1`, `gpt-5` variants
- `o1` (newer), `o3-mini`, `o4-mini`

## Changes

- `lib/crewai/src/crewai/llms/providers/openai/completion.py`: Add `_supports_structured_output()` and use it in both `_prepare_completion_params` and `_prepare_responses_params`
- `lib/crewai/tests/llms/openai/test_openai.py`: Add 6 tests covering supported/unsupported models

Fixes #5990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured output handling so compatible models use JSON schema formatting, while unsupported models automatically fall back to a simpler JSON object format.
  * Reduced formatting errors when requesting structured responses from different model families.
  
* **Tests**
  * Added coverage for structured output behavior across supported and unsupported models.
  * Verified that custom response format settings continue to pass through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->