### PR TITLE
fix(agent): implement ExecutorContext protocol on AgentExecutor for human_input support (#6347)

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -3213,6 +3213,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Invoke the agent loop and return the result for HITL feedback processing."""
         self._finalize_called = False
         self.state.is_finished = False
+        self.state.iterations = 0
         self.kickoff()
         result = self.state.current_answer
         if not isinstance(result, AgentFinish):
@@ -3223,11 +3224,13 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """Invoke the agent loop asynchronously and return the result for HITL feedback processing."""
         self._finalize_called = False
         self.state.is_finished = False
+        self.state.iterations = 0
         await self.kickoff_async()
         result = self.state.current_answer
         if not isinstance(result, AgentFinish):
             raise RuntimeError("Agent execution ended without reaching a final answer.")
         return result
+
 
 
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -3196,6 +3196,40 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         """
         return bool(self.crew and self.crew._train)
 
+    def _format_feedback_message(self, feedback: str) -> LLMMessage:
+        """Format feedback as a message for the LLM.
+
+        Args:
+            feedback: User feedback string.
+
+        Returns:
+            Formatted message dict.
+        """
+        return format_message_for_llm(
+            I18N_DEFAULT.slice("feedback_instructions").format(feedback=feedback)
+        )
+
+    def _invoke_loop(self) -> AgentFinish:
+        """Invoke the agent loop and return the result for HITL feedback processing."""
+        self._finalize_called = False
+        self.state.is_finished = False
+        self.kickoff()
+        result = self.state.current_answer
+        if not isinstance(result, AgentFinish):
+            raise RuntimeError("Agent execution ended without reaching a final answer.")
+        return result
+
+    async def _ainvoke_loop(self) -> AgentFinish:
+        """Invoke the agent loop asynchronously and return the result for HITL feedback processing."""
+        self._finalize_called = False
+        self.state.is_finished = False
+        await self.kickoff_async()
+        result = self.state.current_answer
+        if not isinstance(result, AgentFinish):
+            raise RuntimeError("Agent execution ended without reaching a final answer.")
+        return result
+
+
 
 # Backward compatibility alias (deprecated)
 CrewAgentExecutorFlow = AgentExecutor

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -2404,3 +2404,20 @@ class TestAgentExecutorHumanInputProtocolContract:
         assert hasattr(AgentExecutor, "_ainvoke_loop")
         assert hasattr(AgentExecutor, "_is_training_mode")
 
+    def test_agent_executor_format_feedback_message(self, mock_dependencies):
+        executor = _build_executor(**mock_dependencies)
+        msg = executor._format_feedback_message("Please fix the summary")
+        assert msg["role"] == "user"
+        assert "Please fix the summary" in msg["content"]
+
+    def test_agent_executor_invoke_loop_resets_iterations(self, mock_dependencies):
+        executor = _build_executor(**mock_dependencies)
+        executor.state.iterations = 10
+        executor.state.current_answer = AgentFinish(thought="done", output="ok", text="ok")
+        with patch.object(executor, "kickoff") as mock_kickoff:
+            res = executor._invoke_loop()
+            assert executor.state.iterations == 0
+            assert res.output == "ok"
+            mock_kickoff.assert_called_once()
+
+

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -2413,11 +2413,33 @@ class TestAgentExecutorHumanInputProtocolContract:
     def test_agent_executor_invoke_loop_resets_iterations(self, mock_dependencies):
         executor = _build_executor(**mock_dependencies)
         executor.state.iterations = 10
-        executor.state.current_answer = AgentFinish(thought="done", output="ok", text="ok")
-        with patch.object(executor, "kickoff") as mock_kickoff:
+        iterations_at_kickoff = None
+
+        def mock_kickoff_impl():
+            nonlocal iterations_at_kickoff
+            iterations_at_kickoff = executor.state.iterations
+            executor.state.current_answer = AgentFinish(thought="done", output="ok", text="ok")
+
+        with patch.object(executor, "kickoff", side_effect=mock_kickoff_impl):
             res = executor._invoke_loop()
-            assert executor.state.iterations == 0
+            assert iterations_at_kickoff == 0
             assert res.output == "ok"
-            mock_kickoff.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_executor_ainvoke_loop_resets_iterations(self, mock_dependencies):
+        executor = _build_executor(**mock_dependencies)
+        executor.state.iterations = 10
+        iterations_at_kickoff = None
+
+        async def mock_kickoff_async_impl():
+            nonlocal iterations_at_kickoff
+            iterations_at_kickoff = executor.state.iterations
+            executor.state.current_answer = AgentFinish(thought="done", output="ok_async", text="ok_async")
+
+        with patch.object(executor, "kickoff_async", side_effect=mock_kickoff_async_impl):
+            res = await executor._ainvoke_loop()
+            assert iterations_at_kickoff == 0
+            assert res.output == "ok_async"
+
 
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -2391,3 +2391,16 @@ class TestVisionImageFormatContract:
         assert hasattr(AnthropicCompletion, "_convert_image_blocks"), (
             "Anthropic provider must have _convert_image_blocks for auto-conversion"
         )
+
+
+class TestAgentExecutorHumanInputProtocolContract:
+    """AgentExecutor must implement full ExecutorContext and AsyncExecutorContext protocol for human_input=True."""
+
+    def test_agent_executor_implements_human_input_protocol(self):
+        from crewai.experimental.agent_executor import AgentExecutor
+
+        assert hasattr(AgentExecutor, "_format_feedback_message")
+        assert hasattr(AgentExecutor, "_invoke_loop")
+        assert hasattr(AgentExecutor, "_ainvoke_loop")
+        assert hasattr(AgentExecutor, "_is_training_mode")
+


### PR DESCRIPTION
### Summary
Fixes #6347 by implementing the required `ExecutorContext` and `AsyncExecutorContext` protocol methods on `AgentExecutor`.

### Root Cause
In crewAI 1.15.0, `AgentExecutor` became the default agent executor. However, when `Task(human_input=True)` or `ask_for_human_input=True` is enabled, the human input provider (`SyncHumanInputProvider` / `AsyncHumanInputProvider`) casts the executor to `ExecutorContext` / `AsyncExecutorContext` and calls `_format_feedback_message`, `_invoke_loop`, and `_ainvoke_loop`. Because `AgentExecutor` lacked implementations for these methods, execution crashed with an `AttributeError`.

### Fix
Implemented `_format_feedback_message`, `_invoke_loop`, and `_ainvoke_loop` on `AgentExecutor` in `lib/crewai/src/crewai/experimental/agent_executor.py` and added a protocol contract regression test in `test_agent_executor.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced human-in-the-loop feedback handling to format feedback and reliably continue execution in both synchronous and asynchronous runs.
  * When an agent run completes without a final result, the system now raises a clearer error.
  * Feedback is now prepared more consistently before being applied.
* **Tests**
  * Added automated coverage to prevent regressions in the human-feedback execution protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->