### PR TITLE
docs: add app.nz OpenAI-compatible example to LLM connections

### DIFF
--- a/docs/edge/en/learn/llm-connections.mdx
+++ b/docs/edge/en/learn/llm-connections.mdx
@@ -143,6 +143,15 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
         os.environ["OPENAI_API_BASE"] = "https://generativelanguage.googleapis.com/v1beta/openai/"
         os.environ["OPENAI_MODEL_NAME"] = "openai/gemini-2.0-flash"  # Add your Gemini model here, under openai/
         ```
+
+        ```python app.nz
+        import os
+
+        # Example using app.nz's OpenAI-compatible gateway.
+        os.environ["OPENAI_API_KEY"] = "app_live_..."
+        os.environ["OPENAI_API_BASE"] = "https://app.nz/v1"
+        os.environ["OPENAI_MODEL_NAME"] = "openai/app/auto"  # Auto-router; or openai/provider/model
+        ```
         </CodeGroup>
     </Tab>
     <Tab title="Using LLM Class Attributes">
@@ -162,6 +171,16 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
                 model="openai/gemini-2.0-flash",
                 base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
                 api_key="your-gemini-key",  # Should start with AIza...
+            )
+            agent = Agent(llm=llm, ...)
+            ```
+
+            ```python app.nz
+            # Example using app.nz's OpenAI-compatible gateway
+            llm = LLM(
+                model="openai/app/auto",  # Auto-router; or openai/provider/model
+                base_url="https://app.nz/v1",
+                api_key="app_live_...",
             )
             agent = Agent(llm=llm, ...)
             ```


### PR DESCRIPTION
## What
Adds [app.nz](https://app.nz/docs) examples to the "Connecting to OpenAI-Compatible LLMs" section.

## Why
app.nz is a hosted OpenAI-compatible gateway (`https://app.nz/v1`) with an `app/auto` auto-router. It works through CrewAI's existing LiteLLM `base_url` + `api_key` path, so it fits the existing OpenAI-compatible examples.

## Changes
- `docs/edge/en/learn/llm-connections.mdx`: app.nz tab added to both the environment-variable and `LLM(...)` class-attribute CodeGroups, mirroring the existing Gemini example. Model `openai/app/auto`.

Docs-only.

> Note: this PR was prepared with AI assistance and carries the `llm-generated` label per CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenAI-compatible LLM setup guide with new App.nz gateway examples.
  * Added environment variable examples for `OPENAI_API_KEY`, `OPENAI_API_BASE`, and `OPENAI_MODEL_NAME`, including auto-routing support.
  * Added an `LLM(...)` example showing how to connect through App.nz using a custom base URL and API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->