### PR TITLE
docs: update deploy commands in Build with AI guide

### DIFF
--- a/docs/edge/en/guides/coding-tools/build-with-ai.mdx
+++ b/docs/edge/en/guides/coding-tools/build-with-ai.mdx
@@ -140,14 +140,14 @@ Go from a local crew to production on **CrewAI AMP** (Agent Management Platform)
   <Step title="Prepare for deployment">
     Ensure your project structure is ready:
     ```bash
-    crewai deploy --prepare
+    crewai deploy validate
     ```
     See the [preparation guide](/en/enterprise/guides/prepare-for-deployment) for details on project structure and requirements.
   </Step>
   <Step title="Deploy to AMP">
     Push to the CrewAI AMP platform:
     ```bash
-    crewai deploy
+    crewai deploy push
     ```
     You can also deploy via [GitHub integration](/en/enterprise/guides/deploy-to-amp) or [Crew Studio](/en/enterprise/guides/enable-crew-studio).
   </Step>


### PR DESCRIPTION
## Summary

Updates the Build with AI guide to use the current AMP deployment commands:

- `crewai deploy validate` for deployment validation
- `crewai deploy push` for pushing to AMP

This matches the deployment command style used elsewhere in the docs.

## Verification

- `git diff --check HEAD~1..HEAD`
- Confirmed the updated commands appear in other current deployment docs, including `docs/edge/en/quickstart.mdx` and `docs/edge/en/enterprise/guides/deploy-to-amp.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the enterprise deployment guide with the latest CLI commands for checking deployment readiness and pushing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- crewai-require-issue-check -->