### PR TITLE
feat(llm): add Concentrate provider support

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -341,6 +341,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "hosted_vllm",
     "cerebras",
     "dashscope",
+    "concentrate",
     "snowflake",
 ]
 
@@ -430,6 +431,7 @@ class LLM(BaseLLM):
                 "hosted_vllm": "hosted_vllm",
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
+                "concentrate": "concentrate",
                 "snowflake": "snowflake",
             }
 
@@ -550,6 +552,10 @@ class LLM(BaseLLM):
             # OpenRouter uses org/model format but accepts anything
             return True
 
+        if provider == "concentrate":
+            # Concentrate routes to 130+ models from any provider
+            return True
+
         if provider == "snowflake":
             return True
 
@@ -664,6 +670,7 @@ class LLM(BaseLLM):
             "hosted_vllm",
             "cerebras",
             "dashscope",
+            "concentrate",
         }
         if provider in openai_compatible_providers:
             from crewai.llms.providers.openai_compatible.completion import (

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -2,7 +2,7 @@
 
 This module provides a thin subclass of OpenAICompletion that supports
 various OpenAI-compatible APIs like OpenRouter, DeepSeek, Ollama, vLLM,
-Cerebras, and Dashscope (Alibaba/Qwen).
+Cerebras, Dashscope (Alibaba/Qwen), and Concentrate.
 
 Usage:
     llm = LLM(model="deepseek/deepseek-chat")  # Uses DeepSeek API
@@ -89,6 +89,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         base_url_env="DASHSCOPE_BASE_URL",
         api_key_required=True,
     ),
+    "concentrate": ProviderConfig(
+        base_url="https://api.concentrate.ai/v1",
+        api_key_env="CONCENTRATE_API_KEY",
+        base_url_env="CONCENTRATE_BASE_URL",
+        api_key_required=True,
+    ),
 }
 
 
@@ -125,6 +131,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         - hosted_vllm: vLLM server (https://github.com/vllm-project/vllm)
         - cerebras: Cerebras (https://cerebras.ai)
         - dashscope: Alibaba Dashscope/Qwen (https://dashscope.aliyun.com)
+        - concentrate: Concentrate (https://concentrate.ai)
 
     Example:
         # Using provider prefix

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -95,6 +95,14 @@ class TestProviderRegistry:
         assert config.api_key_env == "DASHSCOPE_API_KEY"
         assert config.api_key_required is True
 
+    def test_concentrate_config(self):
+        """Test Concentrate provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["concentrate"]
+        assert config.base_url == "https://api.concentrate.ai/v1"
+        assert config.api_key_env == "CONCENTRATE_API_KEY"
+        assert config.base_url_env == "CONCENTRATE_BASE_URL"
+        assert config.api_key_required is True
+
 
 class TestNormalizeOllamaBaseUrl:
     """Tests for _normalize_ollama_base_url helper."""
@@ -270,6 +278,14 @@ class TestLLMIntegration:
             llm = LLM(model="dashscope/qwen-turbo")
             assert isinstance(llm, OpenAICompatibleCompletion)
             assert llm.provider == "dashscope"
+
+    def test_llm_creates_openai_compatible_for_concentrate(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for Concentrate."""
+        with patch.dict(os.environ, {"CONCENTRATE_API_KEY": "test-key"}):
+            llm = LLM(model="concentrate/gpt-5.4")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "concentrate"
+            assert llm.model == "gpt-5.4"
 
     def test_llm_with_explicit_provider(self):
         """Test LLM with explicit provider parameter."""


### PR DESCRIPTION
## Summary

Adds [Concentrate](https://concentrate.ai) as an OpenAI-compatible LLM provider.

Concentrate is an LLM gateway that gives access to 130+ models from OpenAI, Anthropic, Google, and others through a single API endpoint (`https://api.concentrate.ai/v1`).

## Changes

- Added `"concentrate"` entry to `OPENAI_COMPATIBLE_PROVIDERS` in `openai_compatible/completion.py` with `base_url`, `CONCENTRATE_API_KEY` env var, and `CONCENTRATE_BASE_URL` override
- Added `"concentrate"` to `SUPPORTED_NATIVE_PROVIDERS`, `provider_mapping`, `openai_compatible_providers` set, and `_matches_provider_pattern` in `llm.py`
- Added tests matching the existing pattern for other OpenAI-compatible providers

## Usage

```python
from crewai import LLM

# Via model prefix
llm = LLM(model="concentrate/gpt-5.4")

# Via explicit provider
llm = LLM(model="claude-opus-4-8", provider="concentrate")
```

Set `CONCENTRATE_API_KEY` in your environment. Optionally set `CONCENTRATE_BASE_URL` to override the default endpoint.

## Test plan

- [x] `uv run ruff check lib/` — passed
- [x] `uv run ruff format lib/` — passed
- [x] `uv run mypy lib/crewai/src/crewai/llm.py lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py` — passed
- [x] `uv run pytest lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py` — 37/37 passed

> **Note:** This PR was authored with AI assistance (Claude Code) and should have the `llm-generated` label applied per the contributing guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new `concentrate` model/provider option, including routing from `concentrate/` model names to the compatible completion path.
  * Expanded the list of supported OpenAI-compatible providers to include `concentrate`.

* **Tests**
  * Added coverage to verify provider settings and ensure `concentrate` models are created and routed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->