### PR TITLE
Type tool and app in CrewDefinition

### DIFF
--- a/lib/crewai/src/crewai/project/crew_definition.py
+++ b/lib/crewai/src/crewai/project/crew_definition.py
@@ -74,6 +74,23 @@ class CrewAgentDefinition(BaseModel):
         description="Additional agent settings passed to the loader.",
         examples=[{"llm": "openai/gpt-4o-mini"}],
     )
+    tools: list[str | dict[str, Any]] | None = Field(
+        default=None,
+        description=(
+            "Tool refs or serialized tool definitions available to this agent. "
+            "String refs can use CrewAI tool names, `custom:<name>`, or fully "
+            "qualified `module:Class` references."
+        ),
+        examples=[["crewai_tools:SerperDevTool", "custom:file_read"]],
+    )
+    apps: list[str] | None = Field(
+        default=None,
+        description=(
+            "Platform apps available to this agent. Can contain app names such as "
+            "`gmail` or app/action refs such as `gmail/send_email`."
+        ),
+        examples=[["gmail", "slack/send_message"]],
+    )
 
     @field_validator("settings", mode="before")
     @classmethod

--- a/lib/crewai/src/crewai/project/crew_definition.py
+++ b/lib/crewai/src/crewai/project/crew_definition.py
@@ -91,6 +91,27 @@ class CrewAgentDefinition(BaseModel):
         ),
         examples=[["gmail", "slack/send_message"]],
     )
+    mcps: list[str | dict[str, Any]] | None = Field(
+        default=None,
+        description=(
+            "MCP server refs or serialized MCP server configs available to this "
+            "agent. String refs can use HTTPS URLs, connected MCP integration "
+            "slugs, or refs with a `#tool_name` suffix for specific tools."
+        ),
+        examples=[
+            [
+                "https://api.weather.com/mcp#get_current_weather",
+                "snowflake",
+                "stripe#list_invoices",
+                {
+                    "url": "https://api.example.com/mcp",
+                    "headers": {"Authorization": "Bearer your_token"},
+                    "streamable": True,
+                    "cache_tools_list": True,
+                },
+            ]
+        ],
+    )
 
     @field_validator("settings", mode="before")
     @classmethod

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -1328,6 +1328,9 @@ def test_crew_action_json_schema_describes_inline_crew_definitions():
         "goal",
         "backstory",
         "settings",
+        "tools",
+        "apps",
+        "mcps",
     }
     assert set(schema_defs["CrewTaskDefinition"]["properties"]) >= {
         "description",


### PR DESCRIPTION
This commit fixes a bug in the CrewDefinition class where the tool and app were not being added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only expansion on definition models with optional fields; no loader or runtime behavior changes in this diff.
> 
> **Overview**
> Inline crew agent definitions in **`CrewAgentDefinition`** now declare optional **`tools`**, **`apps`**, and **`mcps`** so YAML/JSON crew configs can specify agent capabilities instead of losing those keys during validation.
> 
> **`tools`** accepts string refs (`crewai_tools:…`, `custom:…`, `module:Class`) or serialized tool dicts. **`apps`** lists platform app names or `app/action` refs. **`mcps`** lists MCP URLs, integration slugs, `#tool` suffixes, or full server config objects.
> 
> Flow definition JSON Schema tests were updated so **`CrewAgentDefinition`** is documented with these properties alongside `role`, `goal`, `backstory`, and `settings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb74dcab763350656481db4ec72af60aa150323c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->