### PR TITLE
Add text helper to flow skill example

### DIFF
--- a/lib/crewai/src/crewai/flow/templates/flow_definition_example.yaml
+++ b/lib/crewai/src/crewai/flow/templates/flow_definition_example.yaml
@@ -57,7 +57,7 @@ methods:
         role: Follow-up router
         goal: 'Return exactly one bare value: followup or done. Do not include explanation.'
         backstory: Skilled at routing reviewed research briefs.
-        input: "${outputs.research_brief.raw}"
+        input: "${'Reviewed research: ' + text(outputs, 'research_brief.raw')}"
   write_followup:
     listen: followup
     do:

--- a/lib/crewai/tests/test_flow_definition.py
+++ b/lib/crewai/tests/test_flow_definition.py
@@ -1333,6 +1333,7 @@ def test_skill_documents_flow_wiring():
     assert isinstance(skill, str)
     assert "```yaml" in skill
     assert "[Method](#method-methods)" in skill
+    assert "input: \"${'Reviewed research: ' + text(outputs, 'research_brief.raw')}\"" in skill
     assert 'text(root, "path", "default")' in skill
 
 


### PR DESCRIPTION
- Add `text(...)` to the flow skill YAML example.
- Assert the rendered skill keeps that interpolation pattern.
