### PR TITLE
docs: add Dakera Storage backend documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -169,6 +169,7 @@
                       "edge/en/concepts/collaboration",
                       "edge/en/concepts/training",
                       "edge/en/concepts/memory",
+                      "edge/en/concepts/dakera-storage",
                       "edge/en/concepts/reasoning",
                       "edge/en/concepts/planning",
                       "edge/en/concepts/testing",

--- a/docs/edge/en/concepts/dakera-storage.mdx
+++ b/docs/edge/en/concepts/dakera-storage.mdx
@@ -1,0 +1,260 @@
+---
+title: Dakera Storage
+description: Use Dakera as a self-hosted, persistent vector memory backend for CrewAI — decay-weighted recall that survives process restarts and scales across agents.
+icon: server
+---
+
+## Overview
+
+[Dakera](https://dakera.ai) is a self-hosted memory server that implements CrewAI's `StorageBackend` protocol. It stores embeddings in a persistent vector index with decay-weighted importance scoring — so older, less-accessed memories fade naturally while relevant context stays sharp across agent runs, deployments, and process restarts.
+
+The `crewai-dakera` package (v0.2.0+) provides `DakeraStorage`, a drop-in backend for `Memory(storage=...)`.
+
+**When to choose Dakera over the default LanceDB backend:**
+
+- You need memory to persist across container restarts or deployments
+- Multiple crew instances or agents share the same memory pool
+- You want decay-weighted recall (importance degrades over time without access)
+- You need a REST API to inspect, inject, or delete memories from outside CrewAI
+
+## Installation
+
+```bash
+pip install crewai-dakera
+```
+
+## Start the Dakera Server
+
+```bash
+docker run -d \
+  --name dakera \
+  -p 3000:3000 \
+  -e DAKERA_API_KEY=your_key \
+  -v dakera_data:/data \
+  dakera/dakera:latest
+```
+
+The server exposes three core endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/memories` | Store a memory with embedding |
+| `POST` | `/v1/memories/search` | Semantic recall with decay scoring |
+| `DELETE` | `/v1/memories` | Forget memories by filter |
+
+## Basic Usage
+
+### With Crews
+
+```python
+from crewai import Crew, Agent, Task, Process
+from crewai_dakera import DakeraStorage
+
+storage = DakeraStorage(
+    base_url="http://localhost:3000",
+    api_key="your_key",
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, writing_task],
+    process=Process.sequential,
+    memory=True,
+    storage=storage,
+)
+
+result = crew.kickoff()
+```
+
+All facts extracted from task outputs are stored in Dakera and recalled automatically before each task — persisted across runs.
+
+### With the Memory Class Directly
+
+```python
+from crewai import Memory
+from crewai_dakera import DakeraStorage
+
+memory = Memory(
+    storage=DakeraStorage(
+        base_url="http://localhost:3000",
+        api_key="your_key",
+    )
+)
+
+memory.remember("The client uses PostgreSQL 15 on AWS RDS.")
+memory.remember("Rate limit: 500 requests/minute per tenant.")
+
+matches = memory.recall("What database does the client use?")
+for m in matches:
+    print(f"[{m.score:.2f}] {m.record.content}")
+```
+
+### With Agents (Scoped Memory)
+
+```python
+from crewai import Agent, Memory
+from crewai_dakera import DakeraStorage
+
+storage = DakeraStorage(
+    base_url="http://localhost:3000",
+    api_key="your_key",
+)
+
+memory = Memory(storage=storage)
+
+# Each agent gets a private scope within the shared Dakera backend
+researcher = Agent(
+    role="Researcher",
+    goal="Find and analyze information",
+    backstory="Expert researcher with attention to detail",
+    memory=memory.scope("/agent/researcher"),
+)
+
+writer = Agent(
+    role="Writer",
+    goal="Produce clear, well-structured content",
+    backstory="Experienced technical writer",
+    memory=memory.scope("/agent/writer"),
+)
+```
+
+## Decay-Weighted Recall
+
+Dakera applies an exponential decay to memory importance over time. Memories accessed frequently remain highly ranked; stale memories fade — matching how human memory works.
+
+```python
+storage = DakeraStorage(
+    base_url="http://localhost:3000",
+    api_key="your_key",
+    # Optional: tune decay parameters
+    half_life_days=14,      # Importance halves every 14 days without access
+    access_boost=0.1,       # Importance boost on each recall
+)
+```
+
+This means a memory about last week's API design decision outranks one about a deprecated endpoint from six months ago — without manual cleanup.
+
+## Cross-Session Persistence
+
+Unlike the default LanceDB backend (which stores to the local filesystem), Dakera persists to its own server. Memories survive:
+
+- Python process restarts
+- Container rebuilds
+- Horizontal scaling (multiple crew instances point to the same server)
+
+```python
+# Run 1 — stores context
+crew_run_1 = Crew(
+    agents=[researcher],
+    tasks=[discovery_task],
+    memory=True,
+    storage=DakeraStorage(base_url="http://dakera:3000", api_key="key"),
+)
+crew_run_1.kickoff()
+
+# Run 2 (next day, new process) — recalls from Run 1 automatically
+crew_run_2 = Crew(
+    agents=[researcher],
+    tasks=[followup_task],
+    memory=True,
+    storage=DakeraStorage(base_url="http://dakera:3000", api_key="key"),
+)
+crew_run_2.kickoff()
+# Agent automatically recalls relevant context from Run 1
+```
+
+## Configuration Reference
+
+```python
+DakeraStorage(
+    base_url="http://localhost:3000",  # Dakera server URL (required)
+    api_key="your_key",               # API key (required)
+    namespace="crewai",               # Isolate memories by crew/project (optional)
+    half_life_days=30,                # Decay half-life in days (default: 30)
+    access_boost=0.05,                # Importance boost per recall (default: 0.05)
+    timeout=10.0,                     # HTTP timeout in seconds (default: 10.0)
+)
+```
+
+## Environment Variables
+
+Set credentials via environment variables to avoid hardcoding:
+
+```bash
+export DAKERA_BASE_URL=http://localhost:3000
+export DAKERA_API_KEY=your_key
+```
+
+```python
+import os
+from crewai_dakera import DakeraStorage
+
+storage = DakeraStorage(
+    base_url=os.environ["DAKERA_BASE_URL"],
+    api_key=os.environ["DAKERA_API_KEY"],
+)
+```
+
+## Inspecting Memories via REST
+
+Because Dakera is a REST server, you can inspect, inject, or delete memories from outside CrewAI:
+
+```bash
+# Store a memory manually
+curl -X POST http://localhost:3000/v1/memories \
+  -H "Authorization: Bearer your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "The project deadline is 2026-09-01.", "namespace": "crewai"}'
+
+# Search memories
+curl -X POST http://localhost:3000/v1/memories/search \
+  -H "Authorization: Bearer your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "project deadline", "namespace": "crewai", "limit": 5}'
+
+# Delete memories by filter
+curl -X DELETE http://localhost:3000/v1/memories \
+  -H "Authorization: Bearer your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"namespace": "crewai", "older_than_days": 90}'
+```
+
+## Production Deployment
+
+For production, use Docker Compose with a named volume:
+
+```yaml
+services:
+  dakera:
+    image: dakera/dakera:latest
+    ports:
+      - "3000:3000"
+    environment:
+      DAKERA_API_KEY: ${DAKERA_API_KEY}
+    volumes:
+      - dakera_data:/data
+    restart: unless-stopped
+
+volumes:
+  dakera_data:
+```
+
+## Troubleshooting
+
+**Connection refused?**
+- Confirm the Dakera server is running: `curl http://localhost:3000/health`
+- Check the `base_url` matches the server address
+
+**Authentication errors?**
+- Verify `DAKERA_API_KEY` matches the value passed to `-e DAKERA_API_KEY=...` in Docker
+
+**Memories not recalled between runs?**
+- Ensure both runs point to the same `base_url` and use the same `namespace`
+- Confirm the Docker volume is mounted (not ephemeral storage)
+
+## Further Resources
+
+- [Dakera documentation](https://dakera.ai/docs)
+- [`crewai-dakera` on PyPI](https://pypi.org/project/crewai-dakera/)
+- [Memory concepts](/concepts/memory)
+- [StorageBackend protocol reference](https://docs.crewai.com/reference/crewai.memory.storage.backend)

--- a/docs/edge/en/concepts/dakera-storage.mdx
+++ b/docs/edge/en/concepts/dakera-storage.mdx
@@ -28,10 +28,10 @@ pip install crewai-dakera
 ```bash
 docker run -d \
   --name dakera \
-  -p 3000:3000 \
+  -p 3300:3300 \
   -e DAKERA_API_KEY=your_key \
   -v dakera_data:/data \
-  dakera/dakera:latest
+  ghcr.io/dakera-ai/dakera:latest
 ```
 
 The server exposes three core endpoints:
@@ -148,7 +148,7 @@ crew_run_1 = Crew(
     agents=[researcher],
     tasks=[discovery_task],
     memory=True,
-    storage=DakeraStorage(base_url="http://dakera:3000", api_key="key"),
+    storage=DakeraStorage(base_url="http://dakera:3300", api_key="key"),
 )
 crew_run_1.kickoff()
 
@@ -157,7 +157,7 @@ crew_run_2 = Crew(
     agents=[researcher],
     tasks=[followup_task],
     memory=True,
-    storage=DakeraStorage(base_url="http://dakera:3000", api_key="key"),
+    storage=DakeraStorage(base_url="http://dakera:3300", api_key="key"),
 )
 crew_run_2.kickoff()
 # Agent automatically recalls relevant context from Run 1
@@ -226,7 +226,7 @@ For production, use Docker Compose with a named volume:
 ```yaml
 services:
   dakera:
-    image: dakera/dakera:latest
+    image: ghcr.io/dakera-ai/dakera:latest
     ports:
       - "3000:3000"
     environment:

--- a/docs/edge/en/concepts/dakera-storage.mdx
+++ b/docs/edge/en/concepts/dakera-storage.mdx
@@ -51,7 +51,7 @@ from crewai import Crew, Agent, Task, Process
 from crewai_dakera import DakeraStorage
 
 storage = DakeraStorage(
-    base_url="http://localhost:3000",
+    base_url="http://localhost:3300",
     api_key="your_key",
 )
 
@@ -76,7 +76,7 @@ from crewai_dakera import DakeraStorage
 
 memory = Memory(
     storage=DakeraStorage(
-        base_url="http://localhost:3000",
+        base_url="http://localhost:3300",
         api_key="your_key",
     )
 )
@@ -96,7 +96,7 @@ from crewai import Agent, Memory
 from crewai_dakera import DakeraStorage
 
 storage = DakeraStorage(
-    base_url="http://localhost:3000",
+    base_url="http://localhost:3300",
     api_key="your_key",
 )
 
@@ -124,7 +124,7 @@ Dakera applies an exponential decay to memory importance over time. Memories acc
 
 ```python
 storage = DakeraStorage(
-    base_url="http://localhost:3000",
+    base_url="http://localhost:3300",
     api_key="your_key",
     # Optional: tune decay parameters
     half_life_days=14,      # Importance halves every 14 days without access
@@ -167,7 +167,7 @@ crew_run_2.kickoff()
 
 ```python
 DakeraStorage(
-    base_url="http://localhost:3000",  # Dakera server URL (required)
+    base_url="http://localhost:3300",  # Dakera server URL (required)
     api_key="your_key",               # API key (required)
     namespace="crewai",               # Isolate memories by crew/project (optional)
     half_life_days=30,                # Decay half-life in days (default: 30)
@@ -181,7 +181,7 @@ DakeraStorage(
 Set credentials via environment variables to avoid hardcoding:
 
 ```bash
-export DAKERA_BASE_URL=http://localhost:3000
+export DAKERA_BASE_URL=http://localhost:3300
 export DAKERA_API_KEY=your_key
 ```
 
@@ -201,19 +201,19 @@ Because Dakera is a REST server, you can inspect, inject, or delete memories fro
 
 ```bash
 # Store a memory manually
-curl -X POST http://localhost:3000/v1/memories \
+curl -X POST http://localhost:3300/v1/memories \
   -H "Authorization: Bearer your_key" \
   -H "Content-Type: application/json" \
   -d '{"content": "The project deadline is 2026-09-01.", "namespace": "crewai"}'
 
 # Search memories
-curl -X POST http://localhost:3000/v1/memories/search \
+curl -X POST http://localhost:3300/v1/memories/search \
   -H "Authorization: Bearer your_key" \
   -H "Content-Type: application/json" \
   -d '{"query": "project deadline", "namespace": "crewai", "limit": 5}'
 
 # Delete memories by filter
-curl -X DELETE http://localhost:3000/v1/memories \
+curl -X DELETE http://localhost:3300/v1/memories \
   -H "Authorization: Bearer your_key" \
   -H "Content-Type: application/json" \
   -d '{"namespace": "crewai", "older_than_days": 90}'
@@ -228,7 +228,7 @@ services:
   dakera:
     image: ghcr.io/dakera-ai/dakera:latest
     ports:
-      - "3000:3000"
+      - "3300:3300"
     environment:
       DAKERA_API_KEY: ${DAKERA_API_KEY}
     volumes:
@@ -242,7 +242,7 @@ volumes:
 ## Troubleshooting
 
 **Connection refused?**
-- Confirm the Dakera server is running: `curl http://localhost:3000/health`
+- Confirm the Dakera server is running: `curl http://localhost:3300/health`
 - Check the `base_url` matches the server address
 
 **Authentication errors?**


### PR DESCRIPTION
## Summary

Adds documentation for `DakeraStorage` from the [`crewai-dakera`](https://pypi.org/project/crewai-dakera/) package (v0.2.0), a custom `StorageBackend` implementation that persists CrewAI memory to a self-hosted [Dakera](https://dakera.ai) server.

Closes #6409

## What Changed

- **New page**: `docs/edge/en/concepts/dakera-storage.mdx`
- **Navigation**: Added entry in `docs/docs.json` after `concepts/memory`

## Quick Start (from the docs)

```python
from crewai import Crew
from crewai_dakera import DakeraStorage

crew = Crew(
    agents=[...],
    tasks=[...],
    memory=True,
    storage=DakeraStorage(
        base_url="http://localhost:3000",
        api_key="your_key"
    )
)
```

The server runs in Docker:
```bash
docker run -p 3000:3000 -e DAKERA_API_KEY=demo -v dakera_data:/data dakera/dakera:latest
```

## Why This Backend

The default LanceDB backend writes to `./.crewai/memory` — coupled to the local filesystem. Dakera offers:

- **Cross-session persistence**: survives container restarts and deployments
- **Shared memory pool**: multiple crew instances point to one server
- **Decay-weighted recall**: memory importance decays over time without access
- **REST-inspectable**: `curl` the server to inspect, inject, or delete memories

## Docs Coverage

The page includes: quick start, usage with Crews/Agents/Memory, decay config, cross-session persistence examples, env var setup, REST API patterns, Docker Compose production setup, and troubleshooting.

## Test Plan

- [ ] Verify `DakeraStorage` imports from `crewai-dakera` (`pip install crewai-dakera`)
- [ ] Spin up Dakera with `docker run -p 3000:3000 -e DAKERA_API_KEY=demo dakera/dakera:latest`
- [ ] Run the crew example in the docs and confirm memories persist across two runs
- [ ] Mintlify renders the MDX page without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crewai-require-issue-check -->