### PR TITLE
fix: include aiobotocore in the bedrock extra

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -92,6 +92,7 @@ litellm = [
 ]
 bedrock = [
     "boto3~=1.42.90",
+    "aiobotocore~=3.5.0",
 ]
 google-genai = [
     "google-genai~=1.65.0",

--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -492,7 +492,7 @@ class BedrockCompletion(BaseLLM):
         if not AIOBOTOCORE_AVAILABLE:
             raise NotImplementedError(
                 "Async support for AWS Bedrock requires aiobotocore. "
-                'Install with: uv add "crewai[bedrock-async]"'
+                'Install with: uv add "crewai[bedrock]"'
             )
 
         with llm_call_context():

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-20T16:46:21.117658Z"
+exclude-newer = "2026-06-28T20:06:34.114646Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1371,6 +1371,7 @@ azure-ai-inference = [
     { name = "azure-identity" },
 ]
 bedrock = [
+    { name = "aiobotocore" },
     { name = "boto3" },
 ]
 docling = [
@@ -1418,6 +1419,7 @@ watson = [
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.5.0" },
+    { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.5.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },
     { name = "aiofiles", specifier = "~=24.1.0" },
     { name = "aiosqlite", specifier = "~=0.21.0" },


### PR DESCRIPTION
### Overview

`BedrockCompletion.acall()` (the async completion path used when a crew is kicked off asynchronously) requires `aiobotocore` to build its async client. The `bedrock` extra, however, only declared `boto3`. Crews configured with an AWS Bedrock model work fine under a synchronous `kickoff()`, since that path only needs `boto3`, but raise `NotImplementedError: Async support for AWS Bedrock requires aiobotocore` as soon as they're kicked off asynchronously, since `aiobotocore` was never installed.

The fix adds `aiobotocore` to the `bedrock` extra, so `crewai[bedrock]` installs both the sync (`boto3`) and async (`aiobotocore`) dependencies the native Bedrock provider needs. The lockfile is regenerated to match. The exception message is also corrected — it previously pointed to a `bedrock-async` extra that never existed in `pyproject.toml`.

### Changes

- `lib/crewai/pyproject.toml`: add `aiobotocore~=3.5.0` to the `bedrock` extra
- `uv.lock`: regenerated to reflect the updated `bedrock` extra
- `lib/crewai/src/crewai/llms/providers/bedrock/completion.py`: fix the install hint in the `NotImplementedError` message to reference the real `bedrock` extra instead of the nonexistent `bedrock-async`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and error-message only; aligns declared dependencies with existing async Bedrock code paths.
> 
> **Overview**
> **Fixes async Bedrock installs** by adding `aiobotocore~=3.5.0` to the `bedrock` optional extra alongside `boto3`, so `uv add "crewai[bedrock]"` pulls in both sync and async AWS clients. Without this, `BedrockCompletion.acall()` could raise `NotImplementedError` after a normal `crewai[bedrock]` install when crews run asynchronously.
> 
> The **`uv.lock`** is updated so the `bedrock` extra resolves `aiobotocore` in package metadata. **`completion.py`** now tells users to install `crewai[bedrock]` instead of the nonexistent `bedrock-async` extra when `aiobotocore` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372728745f0dcff4d24c850fc76abdb8a02de461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->