### PR TITLE
fix: redact directory path validation errors

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/security/safe_path.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_path.py
@@ -117,7 +117,9 @@ def validate_directory_path(path: str, base_dir: str | None = None) -> str:
     """
     validated = validate_file_path(path, base_dir)
     if not os.path.isdir(validated):
-        raise ValueError(f"Path '{validated}' is not a directory.")
+        raise ValueError(
+            f"Path '{format_path_for_display(validated, base_dir)}' is not a directory."
+        )
     return validated
 
 

--- a/lib/crewai-tools/tests/utilities/test_safe_path.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_path.py
@@ -112,6 +112,16 @@ class TestValidateDirectoryPath:
         with pytest.raises(ValueError, match="not a directory"):
             validate_directory_path("file.txt", str(tmp_path))
 
+    def test_rejects_file_as_directory_without_leaking_base_path(self, tmp_path):
+        (tmp_path / "file.txt").touch()
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_directory_path("file.txt", str(tmp_path))
+
+        message = str(exc_info.value)
+        assert "file.txt" in message
+        assert str(tmp_path) not in message
+
     def test_rejects_traversal(self, tmp_path):
         with pytest.raises(ValueError, match="outside the allowed directory"):
             validate_directory_path("../../", str(tmp_path))


### PR DESCRIPTION
## Summary
- Avoid exposing absolute base paths when directory validation receives a file path.
- Add regression coverage for the redacted directory validation error.

## Validation
- git diff --check
- uv run --project /Users/sandog/sandog/code/kaiyuan-space/crewAI --no-sync pytest -p no:cacheprovider work/crewai_safe_path_test.py

Note: attempted the repository test path with uv, but the full environment sync was still running after several minutes. Running the repo test with --no-sync loads the repository conftest, which requires dotenv in this local environment.