### PR TITLE
feat: add pre-tool GuardrailProvider adapter

### DIFF
--- a/lib/crewai/src/crewai/hooks/__init__.py
+++ b/lib/crewai/src/crewai/hooks/__init__.py
@@ -19,14 +19,14 @@ from crewai.hooks.llm_hooks import (
     unregister_before_llm_call_hook,
 )
 from crewai.hooks.tool_hooks import (
-    PolicyDecision,
-    PolicyProvider,
-    PolicyRequest,
+    GuardrailDecision,
+    GuardrailProvider,
+    GuardrailRequest,
     ToolCallHookContext,
     clear_after_tool_call_hooks,
     clear_all_tool_call_hooks,
     clear_before_tool_call_hooks,
-    enable_policy_provider,
+    enable_guardrail,
     get_after_tool_call_hooks,
     get_before_tool_call_hooks,
     register_after_tool_call_hook,
@@ -78,10 +78,10 @@ def clear_all_global_hooks() -> dict[str, tuple[int, int]]:
 
 
 __all__ = [
+    "GuardrailDecision",
+    "GuardrailProvider",
+    "GuardrailRequest",
     "LLMCallHookContext",
-    "PolicyDecision",
-    "PolicyProvider",
-    "PolicyRequest",
     "ToolCallHookContext",
     "after_llm_call",
     "after_tool_call",
@@ -94,7 +94,7 @@ __all__ = [
     "clear_all_tool_call_hooks",
     "clear_before_llm_call_hooks",
     "clear_before_tool_call_hooks",
-    "enable_policy_provider",
+    "enable_guardrail",
     "get_after_llm_call_hooks",
     "get_after_tool_call_hooks",
     "get_before_llm_call_hooks",

--- a/lib/crewai/src/crewai/hooks/__init__.py
+++ b/lib/crewai/src/crewai/hooks/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Mapping, Protocol, runtime_checkable
+
 from crewai.hooks.decorators import (
     after_llm_call,
     after_tool_call,
@@ -30,6 +35,105 @@ from crewai.hooks.tool_hooks import (
     unregister_after_tool_call_hook,
     unregister_before_tool_call_hook,
 )
+from crewai.hooks.types import BeforeToolCallHookType
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRequest:
+    """Detached context for one provider decision before a tool call."""
+
+    tool_name: str
+    tool_alias: str
+    tool_input: Mapping[str, Any]
+    agent_id: str | None = None
+    agent_role: str | None = None
+    task_description: str | None = None
+    crew_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """Provider verdict for one proposed tool call."""
+
+    allow: bool
+    reason: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class PolicyProvider(Protocol):
+    """Contract for pluggable pre-tool-call policy providers."""
+
+    name: str
+
+    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        """Evaluate whether the requested tool call may proceed."""
+        ...
+
+
+def enable_policy_provider(
+    provider: PolicyProvider,
+    *,
+    fail_closed: bool = True,
+) -> BeforeToolCallHookType:
+    """Register a provider through CrewAI's existing before-tool-call hooks.
+
+    Provider failures and invalid results block execution by default. Set
+    ``fail_closed=False`` only when availability is intentionally preferred.
+    The returned hook can be removed with ``unregister_before_tool_call_hook``.
+    """
+
+    def _hook(context: ToolCallHookContext) -> bool | None:
+        try:
+            request = _build_policy_request(context)
+            decision = provider.evaluate(request)
+            if not isinstance(decision, PolicyDecision):
+                raise TypeError("PolicyProvider.evaluate() must return PolicyDecision")
+            if type(decision.allow) is not bool:
+                raise TypeError("PolicyDecision.allow must be a bool")
+        except Exception:
+            logger.exception("PolicyProvider evaluation failed")
+            return False if fail_closed else None
+
+        return None if decision.allow else False
+
+    register_before_tool_call_hook(_hook)
+    return _hook
+
+
+def _build_policy_request(context: ToolCallHookContext) -> PolicyRequest:
+    """Snapshot the mutable tool-call context before provider evaluation."""
+
+    original_tool_name = _optional_text(getattr(context, "tool", None), "name")
+    return PolicyRequest(
+        tool_name=original_tool_name or context.tool_name,
+        tool_alias=context.tool_name,
+        tool_input=deepcopy(context.tool_input),
+        agent_id=_optional_identifier(context.agent, "id"),
+        agent_role=_optional_text(context.agent, "role"),
+        task_description=_optional_text(context.task, "description"),
+        crew_id=_optional_identifier(context.crew, "id"),
+    )
+
+
+def _optional_text(source: Any, attribute: str) -> str | None:
+    if source is None:
+        return None
+    value = getattr(source, attribute, None)
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_identifier(source: Any, attribute: str) -> str | None:
+    if source is None:
+        return None
+    value = getattr(source, attribute, None)
+    if value is None:
+        return None
+    rendered = str(value)
+    return rendered if rendered else None
 
 
 def clear_all_global_hooks() -> dict[str, tuple[int, int]]:
@@ -75,6 +179,9 @@ def clear_all_global_hooks() -> dict[str, tuple[int, int]]:
 
 __all__ = [
     "LLMCallHookContext",
+    "PolicyDecision",
+    "PolicyProvider",
+    "PolicyRequest",
     "ToolCallHookContext",
     "after_llm_call",
     "after_tool_call",
@@ -87,6 +194,7 @@ __all__ = [
     "clear_all_tool_call_hooks",
     "clear_before_llm_call_hooks",
     "clear_before_tool_call_hooks",
+    "enable_policy_provider",
     "get_after_llm_call_hooks",
     "get_after_tool_call_hooks",
     "get_before_llm_call_hooks",

--- a/lib/crewai/src/crewai/hooks/__init__.py
+++ b/lib/crewai/src/crewai/hooks/__init__.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
-from dataclasses import dataclass, field
-import logging
-from typing import Any, Mapping, Protocol, runtime_checkable
-
 from crewai.hooks.decorators import (
     after_llm_call,
     after_tool_call,
@@ -24,10 +19,14 @@ from crewai.hooks.llm_hooks import (
     unregister_before_llm_call_hook,
 )
 from crewai.hooks.tool_hooks import (
+    PolicyDecision,
+    PolicyProvider,
+    PolicyRequest,
     ToolCallHookContext,
     clear_after_tool_call_hooks,
     clear_all_tool_call_hooks,
     clear_before_tool_call_hooks,
+    enable_policy_provider,
     get_after_tool_call_hooks,
     get_before_tool_call_hooks,
     register_after_tool_call_hook,
@@ -35,105 +34,6 @@ from crewai.hooks.tool_hooks import (
     unregister_after_tool_call_hook,
     unregister_before_tool_call_hook,
 )
-from crewai.hooks.types import BeforeToolCallHookType
-
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class PolicyRequest:
-    """Detached context for one provider decision before a tool call."""
-
-    tool_name: str
-    tool_alias: str
-    tool_input: Mapping[str, Any]
-    agent_id: str | None = None
-    agent_role: str | None = None
-    task_description: str | None = None
-    crew_id: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class PolicyDecision:
-    """Provider verdict for one proposed tool call."""
-
-    allow: bool
-    reason: str | None = None
-    metadata: Mapping[str, Any] = field(default_factory=dict)
-
-
-@runtime_checkable
-class PolicyProvider(Protocol):
-    """Contract for pluggable pre-tool-call policy providers."""
-
-    name: str
-
-    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
-        """Evaluate whether the requested tool call may proceed."""
-        ...
-
-
-def enable_policy_provider(
-    provider: PolicyProvider,
-    *,
-    fail_closed: bool = True,
-) -> BeforeToolCallHookType:
-    """Register a provider through CrewAI's existing before-tool-call hooks.
-
-    Provider failures and invalid results block execution by default. Set
-    ``fail_closed=False`` only when availability is intentionally preferred.
-    The returned hook can be removed with ``unregister_before_tool_call_hook``.
-    """
-
-    def _hook(context: ToolCallHookContext) -> bool | None:
-        try:
-            request = _build_policy_request(context)
-            decision = provider.evaluate(request)
-            if not isinstance(decision, PolicyDecision):
-                raise TypeError("PolicyProvider.evaluate() must return PolicyDecision")
-            if type(decision.allow) is not bool:
-                raise TypeError("PolicyDecision.allow must be a bool")
-        except Exception:
-            logger.exception("PolicyProvider evaluation failed")
-            return False if fail_closed else None
-
-        return None if decision.allow else False
-
-    register_before_tool_call_hook(_hook)
-    return _hook
-
-
-def _build_policy_request(context: ToolCallHookContext) -> PolicyRequest:
-    """Snapshot the mutable tool-call context before provider evaluation."""
-
-    original_tool_name = _optional_text(getattr(context, "tool", None), "name")
-    return PolicyRequest(
-        tool_name=original_tool_name or context.tool_name,
-        tool_alias=context.tool_name,
-        tool_input=deepcopy(context.tool_input),
-        agent_id=_optional_identifier(context.agent, "id"),
-        agent_role=_optional_text(context.agent, "role"),
-        task_description=_optional_text(context.task, "description"),
-        crew_id=_optional_identifier(context.crew, "id"),
-    )
-
-
-def _optional_text(source: Any, attribute: str) -> str | None:
-    if source is None:
-        return None
-    value = getattr(source, attribute, None)
-    return value if isinstance(value, str) and value else None
-
-
-def _optional_identifier(source: Any, attribute: str) -> str | None:
-    if source is None:
-        return None
-    value = getattr(source, attribute, None)
-    if value is None:
-        return None
-    rendered = str(value)
-    return rendered if rendered else None
 
 
 def clear_all_global_hooks() -> dict[str, tuple[int, int]]:

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from copy import deepcopy
+from dataclasses import dataclass, field
+import logging
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
 
 from crewai_core.printer import PRINTER
 
@@ -11,6 +14,9 @@ from crewai.hooks.types import (
     BeforeToolCallHookCallable,
     BeforeToolCallHookType,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -316,3 +322,98 @@ def clear_all_tool_call_hooks() -> tuple[int, int]:
     before_count = clear_before_tool_call_hooks()
     after_count = clear_after_tool_call_hooks()
     return (before_count, after_count)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRequest:
+    """Detached context for one provider decision before a tool call."""
+
+    tool_name: str
+    tool_alias: str
+    tool_input: Mapping[str, Any]
+    agent_id: str | None = None
+    agent_role: str | None = None
+    task_description: str | None = None
+    crew_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """Provider verdict for one proposed tool call."""
+
+    allow: bool
+    reason: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class PolicyProvider(Protocol):
+    """Contract for pluggable pre-tool-call policy providers."""
+
+    name: str
+
+    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        """Evaluate whether the requested tool call may proceed."""
+        ...
+
+
+def enable_policy_provider(
+    provider: PolicyProvider,
+    *,
+    fail_closed: bool = True,
+) -> BeforeToolCallHookType:
+    """Register a provider through the existing before-tool-call registry.
+
+    Provider failures and invalid results block execution by default. Set
+    ``fail_closed=False`` only when availability is intentionally preferred.
+    The returned hook can be removed with ``unregister_before_tool_call_hook``.
+    """
+
+    def _hook(context: ToolCallHookContext) -> bool | None:
+        try:
+            request = _build_policy_request(context)
+            decision = provider.evaluate(request)
+            if not isinstance(decision, PolicyDecision):
+                raise TypeError("PolicyProvider.evaluate() must return PolicyDecision")
+            if type(decision.allow) is not bool:
+                raise TypeError("PolicyDecision.allow must be a bool")
+        except Exception:
+            logger.exception("PolicyProvider evaluation failed")
+            return False if fail_closed else None
+
+        return None if decision.allow else False
+
+    register_before_tool_call_hook(_hook)
+    return _hook
+
+
+def _build_policy_request(context: ToolCallHookContext) -> PolicyRequest:
+    """Snapshot the mutable tool-call context before provider evaluation."""
+
+    original_tool_name = _optional_text(getattr(context, "tool", None), "name")
+    return PolicyRequest(
+        tool_name=original_tool_name or context.tool_name,
+        tool_alias=context.tool_name,
+        tool_input=deepcopy(context.tool_input),
+        agent_id=_optional_identifier(context.agent, "id"),
+        agent_role=_optional_text(context.agent, "role"),
+        task_description=_optional_text(context.task, "description"),
+        crew_id=_optional_identifier(context.crew, "id"),
+    )
+
+
+def _optional_text(source: Any, attribute: str) -> str | None:
+    if source is None:
+        return None
+    value = getattr(source, attribute, None)
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_identifier(source: Any, attribute: str) -> str | None:
+    if source is None:
+        return None
+    value = getattr(source, attribute, None)
+    if value is None:
+        return None
+    rendered = str(value)
+    return rendered if rendered else None

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-import logging
-from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from crewai_core.printer import PRINTER
 
@@ -375,7 +376,7 @@ def enable_policy_provider(
             decision = provider.evaluate(request)
             if not isinstance(decision, PolicyDecision):
                 raise TypeError("PolicyProvider.evaluate() must return PolicyDecision")
-            if type(decision.allow) is not bool:
+            if not isinstance(decision.allow, bool):
                 raise TypeError("PolicyDecision.allow must be a bool")
         except Exception:
             logger.exception("PolicyProvider evaluation failed")

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol
 
 from crewai_core.printer import PRINTER
 
@@ -326,7 +326,7 @@ def clear_all_tool_call_hooks() -> tuple[int, int]:
 
 
 @dataclass(frozen=True, slots=True)
-class PolicyRequest:
+class GuardrailRequest:
     """Detached context for one provider decision before a tool call."""
 
     tool_name: str
@@ -334,12 +334,10 @@ class PolicyRequest:
     tool_input: Mapping[str, Any]
     agent_id: str | None = None
     agent_role: str | None = None
-    task_description: str | None = None
-    crew_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
-class PolicyDecision:
+class GuardrailDecision:
     """Provider verdict for one proposed tool call."""
 
     allow: bool
@@ -347,19 +345,16 @@ class PolicyDecision:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
-@runtime_checkable
-class PolicyProvider(Protocol):
-    """Contract for pluggable pre-tool-call policy providers."""
+class GuardrailProvider(Protocol):
+    """Contract for pluggable pre-tool-call guardrail providers."""
 
-    name: str
-
-    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
         """Evaluate whether the requested tool call may proceed."""
         ...
 
 
-def enable_policy_provider(
-    provider: PolicyProvider,
+def enable_guardrail(
+    provider: GuardrailProvider,
     *,
     fail_closed: bool = True,
 ) -> BeforeToolCallHookType:
@@ -372,14 +367,16 @@ def enable_policy_provider(
 
     def _hook(context: ToolCallHookContext) -> bool | None:
         try:
-            request = _build_policy_request(context)
+            request = _build_guardrail_request(context)
             decision = provider.evaluate(request)
-            if not isinstance(decision, PolicyDecision):
-                raise TypeError("PolicyProvider.evaluate() must return PolicyDecision")
+            if not isinstance(decision, GuardrailDecision):
+                raise TypeError(
+                    "GuardrailProvider.evaluate() must return GuardrailDecision"
+                )
             if not isinstance(decision.allow, bool):
-                raise TypeError("PolicyDecision.allow must be a bool")
+                raise TypeError("GuardrailDecision.allow must be a bool")
         except Exception:
-            logger.exception("PolicyProvider evaluation failed")
+            logger.exception("GuardrailProvider evaluation failed")
             return False if fail_closed else None
 
         return None if decision.allow else False
@@ -388,18 +385,16 @@ def enable_policy_provider(
     return _hook
 
 
-def _build_policy_request(context: ToolCallHookContext) -> PolicyRequest:
+def _build_guardrail_request(context: ToolCallHookContext) -> GuardrailRequest:
     """Snapshot the mutable tool-call context before provider evaluation."""
 
     original_tool_name = _optional_text(getattr(context, "tool", None), "name")
-    return PolicyRequest(
+    return GuardrailRequest(
         tool_name=original_tool_name or context.tool_name,
         tool_alias=context.tool_name,
         tool_input=deepcopy(context.tool_input),
         agent_id=_optional_identifier(context.agent, "id"),
         agent_role=_optional_text(context.agent, "role"),
-        task_description=_optional_text(context.task, "description"),
-        crew_id=_optional_identifier(context.crew, "id"),
     )
 
 

--- a/lib/crewai/tests/hooks/test_decorators.py
+++ b/lib/crewai/tests/hooks/test_decorators.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from crewai.hooks import (
-    PolicyDecision,
-    PolicyRequest,
+    GuardrailDecision,
+    GuardrailRequest,
     after_llm_call,
     after_tool_call,
     before_llm_call,
     before_tool_call,
-    enable_policy_provider,
+    enable_guardrail,
     get_after_llm_call_hooks,
     get_after_tool_call_hooks,
     get_before_llm_call_hooks,
@@ -187,7 +187,6 @@ class TestToolHookDecorators:
         """Tool filter should auto-sanitize names so users can pass BaseTool.name directly."""
         execution_log = []
 
-        # User passes the human-readable tool name (e.g. BaseTool.name)
         @before_tool_call(tools=["Delete File", "Execute Code"])
         def filtered_hook(context):
             execution_log.append(context.tool_name)
@@ -197,7 +196,6 @@ class TestToolHookDecorators:
         assert len(hooks) == 1
 
         mock_tool = Mock()
-        # Context uses the sanitized name (as set by the executor)
         context = ToolCallHookContext(
             tool_name="delete_file",
             tool_input={},
@@ -206,7 +204,6 @@ class TestToolHookDecorators:
         hooks[0](context)
         assert execution_log == ["delete_file"]
 
-        # Non-matching tool still filtered out
         context2 = ToolCallHookContext(
             tool_name="read_file",
             tool_input={},
@@ -280,7 +277,7 @@ class TestToolHookDecorators:
         )
         result2 = hooks[0](context2)
 
-        assert result2 is None  # Hook didn't run, returns None
+        assert result2 is None
 
 
 class TestDecoratorAttributes:
@@ -353,28 +350,28 @@ class TestMultipleDecorators:
         assert len(hooks) == 2
 
 
-class RecordingPolicyProvider:
+class RecordingGuardrailProvider:
     """Small provider fixture that records the latest detached request."""
-
-    name = "recording"
 
     def __init__(
         self,
-        decision: PolicyDecision | None = None,
+        decision: GuardrailDecision | None = None,
         error: Exception | None = None,
     ) -> None:
-        self.decision = decision if decision is not None else PolicyDecision(allow=True)
+        self.decision = (
+            decision if decision is not None else GuardrailDecision(allow=True)
+        )
         self.error = error
-        self.request: PolicyRequest | None = None
+        self.request: GuardrailRequest | None = None
 
-    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
         self.request = request
         if self.error is not None:
             raise self.error
         return self.decision
 
 
-class TestPolicyProviderAdapter:
+class TestGuardrailProviderAdapter:
     """Test the provider adapter built on the existing before-tool hook registry."""
 
     @staticmethod
@@ -384,22 +381,16 @@ class TestPolicyProviderAdapter:
         agent = Mock()
         agent.id = "agent-123"
         agent.role = "Support Agent"
-        task = Mock()
-        task.description = "Reply to the customer"
-        crew = Mock()
-        crew.id = "crew-456"
         return ToolCallHookContext(
             tool_name="send_email",
             tool_input={"recipient": "qa@example.com", "body": "Hello"},
             tool=tool,
             agent=agent,
-            task=task,
-            crew=crew,
         )
 
     def test_registers_provider_and_allows(self):
-        provider = RecordingPolicyProvider()
-        hook = enable_policy_provider(provider)
+        provider = RecordingGuardrailProvider()
+        hook = enable_guardrail(provider)
 
         assert get_before_tool_call_hooks() == [hook]
         assert hook(self.context()) is None
@@ -408,38 +399,33 @@ class TestPolicyProviderAdapter:
         assert provider.request.tool_alias == "send_email"
         assert provider.request.agent_id == "agent-123"
         assert provider.request.agent_role == "Support Agent"
-        assert provider.request.task_description == "Reply to the customer"
-        assert provider.request.crew_id == "crew-456"
 
     def test_deny_maps_to_false(self):
-        provider = RecordingPolicyProvider(
-            PolicyDecision(allow=False, reason="policy")
+        provider = RecordingGuardrailProvider(
+            GuardrailDecision(allow=False, reason="policy")
         )
 
-        assert enable_policy_provider(provider)(self.context()) is False
+        assert enable_guardrail(provider)(self.context()) is False
 
     def test_provider_receives_detached_tool_input(self):
         context = self.context()
-        provider = RecordingPolicyProvider()
+        provider = RecordingGuardrailProvider()
 
-        assert enable_policy_provider(provider)(context) is None
+        assert enable_guardrail(provider)(context) is None
         assert provider.request is not None
         provider.request.tool_input["recipient"] = "other@example.com"
 
         assert context.tool_input["recipient"] == "qa@example.com"
 
     def test_provider_failure_is_fail_closed_by_default(self):
-        provider = RecordingPolicyProvider(error=RuntimeError("unavailable"))
+        provider = RecordingGuardrailProvider(error=RuntimeError("unavailable"))
 
-        assert enable_policy_provider(provider)(self.context()) is False
+        assert enable_guardrail(provider)(self.context()) is False
 
     def test_provider_failure_can_fail_open(self):
-        provider = RecordingPolicyProvider(error=RuntimeError("unavailable"))
+        provider = RecordingGuardrailProvider(error=RuntimeError("unavailable"))
 
-        assert (
-            enable_policy_provider(provider, fail_closed=False)(self.context())
-            is None
-        )
+        assert enable_guardrail(provider, fail_closed=False)(self.context()) is None
 
     @pytest.mark.parametrize("fail_closed, expected", [(True, False), (False, None)])
     def test_invalid_provider_result_follows_failure_policy(
@@ -447,17 +433,14 @@ class TestPolicyProviderAdapter:
         fail_closed: bool,
         expected: bool | None,
     ):
-        provider = RecordingPolicyProvider()
+        provider = RecordingGuardrailProvider()
         provider.decision = object()  # type: ignore[assignment]
 
-        assert (
-            enable_policy_provider(provider, fail_closed=fail_closed)(self.context())
-            is expected
-        )
+        assert enable_guardrail(provider, fail_closed=fail_closed)(self.context()) is expected
 
     def test_non_boolean_allow_is_rejected(self):
-        decision = PolicyDecision(allow=True)
+        decision = GuardrailDecision(allow=True)
         object.__setattr__(decision, "allow", 1)
-        provider = RecordingPolicyProvider(decision)
+        provider = RecordingGuardrailProvider(decision)
 
-        assert enable_policy_provider(provider)(self.context()) is False
+        assert enable_guardrail(provider)(self.context()) is False

--- a/lib/crewai/tests/hooks/test_decorators.py
+++ b/lib/crewai/tests/hooks/test_decorators.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from crewai.hooks import (
+    PolicyDecision,
+    PolicyRequest,
     after_llm_call,
     after_tool_call,
     before_llm_call,
     before_tool_call,
+    enable_policy_provider,
     get_after_llm_call_hooks,
     get_after_tool_call_hooks,
     get_before_llm_call_hooks,
@@ -348,3 +351,113 @@ class TestMultipleDecorators:
         hooks = get_before_tool_call_hooks()
 
         assert len(hooks) == 2
+
+
+class RecordingPolicyProvider:
+    """Small provider fixture that records the latest detached request."""
+
+    name = "recording"
+
+    def __init__(
+        self,
+        decision: PolicyDecision | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.decision = decision if decision is not None else PolicyDecision(allow=True)
+        self.error = error
+        self.request: PolicyRequest | None = None
+
+    def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        self.request = request
+        if self.error is not None:
+            raise self.error
+        return self.decision
+
+
+class TestPolicyProviderAdapter:
+    """Test the provider adapter built on the existing before-tool hook registry."""
+
+    @staticmethod
+    def context() -> ToolCallHookContext:
+        tool = Mock()
+        tool.name = "Send Email"
+        agent = Mock()
+        agent.id = "agent-123"
+        agent.role = "Support Agent"
+        task = Mock()
+        task.description = "Reply to the customer"
+        crew = Mock()
+        crew.id = "crew-456"
+        return ToolCallHookContext(
+            tool_name="send_email",
+            tool_input={"recipient": "qa@example.com", "body": "Hello"},
+            tool=tool,
+            agent=agent,
+            task=task,
+            crew=crew,
+        )
+
+    def test_registers_provider_and_allows(self):
+        provider = RecordingPolicyProvider()
+        hook = enable_policy_provider(provider)
+
+        assert get_before_tool_call_hooks() == [hook]
+        assert hook(self.context()) is None
+        assert provider.request is not None
+        assert provider.request.tool_name == "Send Email"
+        assert provider.request.tool_alias == "send_email"
+        assert provider.request.agent_id == "agent-123"
+        assert provider.request.agent_role == "Support Agent"
+        assert provider.request.task_description == "Reply to the customer"
+        assert provider.request.crew_id == "crew-456"
+
+    def test_deny_maps_to_false(self):
+        provider = RecordingPolicyProvider(
+            PolicyDecision(allow=False, reason="policy")
+        )
+
+        assert enable_policy_provider(provider)(self.context()) is False
+
+    def test_provider_receives_detached_tool_input(self):
+        context = self.context()
+        provider = RecordingPolicyProvider()
+
+        assert enable_policy_provider(provider)(context) is None
+        assert provider.request is not None
+        provider.request.tool_input["recipient"] = "other@example.com"
+
+        assert context.tool_input["recipient"] == "qa@example.com"
+
+    def test_provider_failure_is_fail_closed_by_default(self):
+        provider = RecordingPolicyProvider(error=RuntimeError("unavailable"))
+
+        assert enable_policy_provider(provider)(self.context()) is False
+
+    def test_provider_failure_can_fail_open(self):
+        provider = RecordingPolicyProvider(error=RuntimeError("unavailable"))
+
+        assert (
+            enable_policy_provider(provider, fail_closed=False)(self.context())
+            is None
+        )
+
+    @pytest.mark.parametrize("fail_closed, expected", [(True, False), (False, None)])
+    def test_invalid_provider_result_follows_failure_policy(
+        self,
+        fail_closed: bool,
+        expected: bool | None,
+    ):
+        provider = RecordingPolicyProvider()
+        provider.decision = object()  # type: ignore[assignment]
+
+        assert (
+            enable_policy_provider(provider, fail_closed=fail_closed)(self.context())
+            is expected
+        )
+
+    def test_non_boolean_allow_is_rejected(self):
+        decision = PolicyDecision(allow=True)
+        object.__setattr__(decision, "allow", 1)
+        provider = RecordingPolicyProvider(decision)
+
+        assert enable_policy_provider(provider)(self.context()) is False

--- a/lib/crewai/tests/hooks/test_decorators.py
+++ b/lib/crewai/tests/hooks/test_decorators.py
@@ -187,6 +187,7 @@ class TestToolHookDecorators:
         """Tool filter should auto-sanitize names so users can pass BaseTool.name directly."""
         execution_log = []
 
+        # User passes the human-readable tool name (e.g. BaseTool.name)
         @before_tool_call(tools=["Delete File", "Execute Code"])
         def filtered_hook(context):
             execution_log.append(context.tool_name)
@@ -196,6 +197,7 @@ class TestToolHookDecorators:
         assert len(hooks) == 1
 
         mock_tool = Mock()
+        # Context uses the sanitized name (as set by the executor)
         context = ToolCallHookContext(
             tool_name="delete_file",
             tool_input={},
@@ -204,6 +206,7 @@ class TestToolHookDecorators:
         hooks[0](context)
         assert execution_log == ["delete_file"]
 
+        # Non-matching tool still filtered out
         context2 = ToolCallHookContext(
             tool_name="read_file",
             tool_input={},
@@ -277,7 +280,7 @@ class TestToolHookDecorators:
         )
         result2 = hooks[0](context2)
 
-        assert result2 is None
+        assert result2 is None  # Hook didn't run, returns None
 
 
 class TestDecoratorAttributes:
@@ -383,7 +386,11 @@ class TestGuardrailProviderAdapter:
         agent.role = "Support Agent"
         return ToolCallHookContext(
             tool_name="send_email",
-            tool_input={"recipient": "qa@example.com", "body": "Hello"},
+            tool_input={
+                "recipient": "qa@example.com",
+                "body": "Hello",
+                "headers": {"x-trace": "original"},
+            },
             tool=tool,
             agent=agent,
         )
@@ -407,15 +414,17 @@ class TestGuardrailProviderAdapter:
 
         assert enable_guardrail(provider)(self.context()) is False
 
-    def test_provider_receives_detached_tool_input(self):
+    def test_provider_receives_deeply_detached_tool_input(self):
         context = self.context()
         provider = RecordingGuardrailProvider()
 
         assert enable_guardrail(provider)(context) is None
         assert provider.request is not None
         provider.request.tool_input["recipient"] = "other@example.com"
+        provider.request.tool_input["headers"]["x-trace"] = "changed"
 
         assert context.tool_input["recipient"] == "qa@example.com"
+        assert context.tool_input["headers"]["x-trace"] == "original"
 
     def test_provider_failure_is_fail_closed_by_default(self):
         provider = RecordingGuardrailProvider(error=RuntimeError("unavailable"))

--- a/lib/crewai/tests/hooks/test_guardrail_provider.py
+++ b/lib/crewai/tests/hooks/test_guardrail_provider.py
@@ -1,0 +1,44 @@
+"""Focused contract tests for the GuardrailProvider adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from crewai.hooks import (
+    GuardrailDecision,
+    GuardrailRequest,
+    clear_before_tool_call_hooks,
+    enable_guardrail,
+    get_before_tool_call_hooks,
+    register_before_tool_call_hook,
+    unregister_before_tool_call_hook,
+)
+
+
+class AllowProvider:
+    """Minimal provider fixture that always allows the tool call."""
+
+    def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:
+        return GuardrailDecision(allow=True)
+
+
+@pytest.fixture(autouse=True)
+def restore_before_tool_hooks():
+    """Keep the global hook registry unchanged outside this test module."""
+
+    original_hooks = get_before_tool_call_hooks()
+    clear_before_tool_call_hooks()
+    yield
+    clear_before_tool_call_hooks()
+    for hook in original_hooks:
+        register_before_tool_call_hook(hook)
+
+
+def test_enable_guardrail_returns_unregisterable_hook():
+    """The adapter hook can be removed through the existing registry API."""
+
+    hook = enable_guardrail(AllowProvider())
+
+    assert get_before_tool_call_hooks() == [hook]
+    assert unregister_before_tool_call_hook(hook) is True
+    assert get_before_tool_call_hooks() == []


### PR DESCRIPTION
## Summary

Add the minimal provider-agnostic `GuardrailProvider` boundary proposed in #4877 on top of CrewAI's existing global before-tool-call hook registry.

This first PR is intentionally binary and narrow: external providers receive a detached request and return allow/deny. Async suspension, continuation, decision receipts, and executor-side verification remain outside this change.

## Changes

- add frozen `GuardrailRequest` and `GuardrailDecision` records;
- add a minimal `GuardrailProvider` protocol with only `evaluate()`;
- add `enable_guardrail()` as a thin adapter over `register_before_tool_call_hook()`;
- expose the API from `crewai.hooks`;
- add focused regressions for allow, deny, fail-closed, explicit fail-open, detached tool input, invalid provider results, non-boolean verdicts, original tool name vs sanitized alias, stable agent identity, and unregistering the returned hook.

## Minimal request boundary

`GuardrailRequest` contains only:

- original tool name;
- sanitized tool alias;
- detached tool input;
- optional agent ID;
- optional agent role.

It deliberately does not duplicate task, crew, policy-engine identity, continuation, or governance-record fields.

## Safety behavior

- provider input is deep-copied from mutable live tool arguments;
- provider/request failures block by default;
- invalid return types and non-boolean verdicts follow the same failure policy;
- `fail_closed=False` is an explicit availability-over-enforcement opt-out;
- provider exception text is logged internally and is not returned through the hook result;
- `GuardrailProvider.evaluate()` is synchronous; providers that perform I/O must enforce their own finite timeout and return promptly. The adapter does not claim it can safely preempt arbitrary synchronous Python code.

## Compatibility

- no change to the tool execution pipeline;
- no change to existing hook ordering or return semantics;
- providers are optional and register through the current global before-tool-call registry;
- the returned hook can be removed with `unregister_before_tool_call_hook()`.

## Relationship to #6165

#6165 defines a richer runtime hook-result type (`PROCEED`, `NEEDS_REVIEW`, `SILENCE`) and propagates it through execution paths. This PR defines the external provider boundary only.

On current `main`, `GuardrailDecision(allow=True)` maps to `None` and `allow=False` maps to `False`. If #6165 lands first, this adapter can be rebased onto `ToolCallDecision` without duplicating its execution-path changes.

## Out of scope

- `suspend` / `resolve()` / resume semantics;
- human-approval continuation;
- bundled policy engines or RBAC;
- `GovernanceDecision` / `GovernanceOutcome` duplication from #6030;
- executor-side intent or target-state verification;
- signed audit records and durable replay storage;
- changes to task guardrails.

Related to #4877.

<!-- crewai-require-issue-check -->