### PR TITLE
fix(tools): raise tool usage error for invalid arguments

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -849,9 +849,10 @@ class ToolUsage:
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         if not isinstance(arguments, dict):
+            error = ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             if raise_error:
-                raise
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+                raise error
+            return error
 
         return ToolCalling(
             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -465,6 +465,30 @@ def test_validate_tool_input_invalid_input():
 
     arguments = tool_usage._validate_tool_input(None)
     assert arguments == {}
+
+
+def test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments():
+    class TestTool(BaseTool):
+        name: str = "Test Tool"
+        description: str = "A test tool"
+
+        def _run(self) -> str:
+            return "test result"
+
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[TestTool()],
+        task=MagicMock(),
+        function_calling_llm=None,
+        agent=MagicMock(),
+        action=MagicMock(tool="test_tool", tool_input="[]"),
+    )
+    tool_usage._validate_tool_input = MagicMock(return_value=[])
+
+    with pytest.raises(ToolUsageError) as exc_info:
+        tool_usage._original_tool_calling("Action: test_tool", raise_error=True)
+
+    assert "not a valid key, value dictionary" in str(exc_info.value)
 
 
 def test_validate_tool_input_complex_structure():


### PR DESCRIPTION
## Summary

- raise `ToolUsageError` explicitly when parsed tool arguments are not a dictionary
- add regression coverage for the `raise_error=True` path so it no longer falls through to a bare `raise`

Closes #6430.

## Tests

- `UV_CACHE_DIR=/private/tmp/uv-cache-crewai UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python-crewai uv run pytest lib/crewai/tests/tools/test_tool_usage.py::test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments`
- `UV_CACHE_DIR=/private/tmp/uv-cache-crewai UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python-crewai uv run pytest lib/crewai/tests/tools/test_tool_usage.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-crewai UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python-crewai uv run ruff check lib/crewai/src/crewai/tools/tool_usage.py lib/crewai/tests/tools/test_tool_usage.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-crewai UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python-crewai uv run ruff format --check lib/crewai/src/crewai/tools/tool_usage.py lib/crewai/tests/tools/test_tool_usage.py`


<!-- crewai-require-issue-check -->