### PR TITLE
fix(agents): substitute prompt placeholders in a single pass

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -8,6 +8,7 @@ import contextvars
 from datetime import datetime
 import inspect
 import json
+import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 from uuid import uuid4
@@ -3149,6 +3150,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
     def _format_prompt(prompt: str, inputs: dict[str, str]) -> str:
         """Format prompt template with input values.
 
+        Substitutes every placeholder in a single pass so a substituted value
+        that itself contains a placeholder token (e.g. task input mentioning
+        the literal ``{tools}``) is not clobbered by a later replacement.
+
         Args:
             prompt: Template string.
             inputs: Values to substitute.
@@ -3156,9 +3161,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         Returns:
             Formatted prompt.
         """
-        prompt = prompt.replace("{input}", inputs["input"])
-        prompt = prompt.replace("{tool_names}", inputs["tool_names"])
-        return prompt.replace("{tools}", inputs["tools"])
+        return re.sub(
+            r"\{(input|tool_names|tools)\}",
+            lambda match: inputs[match.group(1)],
+            prompt,
+        )
 
     def _handle_human_feedback(self, formatted_answer: AgentFinish) -> AgentFinish:
         """Process human feedback and refine answer.

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -475,6 +475,29 @@ class TestAgentExecutor:
         assert "tool1, tool2" in result
         assert "desc" in result
 
+    def test_format_prompt_preserves_placeholder_tokens_in_values(
+        self, mock_dependencies
+    ):
+        """A value containing a placeholder token must not be re-substituted.
+
+        Regression: sequential ``str.replace`` substituted ``{input}`` first, so
+        task input that legitimately mentioned ``{tools}`` or ``{tool_names}``
+        had those tokens clobbered by the later replacements.
+        """
+        executor = _build_executor(**mock_dependencies)
+        inputs = {
+            "input": "explain the {tools} and {tool_names} placeholders",
+            "tool_names": "search",
+            "tools": "search: web search",
+        }
+
+        result = executor._format_prompt("Task: {input}\nTools: {tools}", inputs)
+
+        assert result == (
+            "Task: explain the {tools} and {tool_names} placeholders\n"
+            "Tools: search: web search"
+        )
+
     def test_is_training_mode_false(self, mock_dependencies):
         """Test training mode detection when not in training."""
         executor = _build_executor(**mock_dependencies)


### PR DESCRIPTION
## Description

`AgentExecutor._format_prompt` (`lib/crewai/src/crewai/experimental/agent_executor.py`) substituted the template placeholders sequentially:

```python
prompt = prompt.replace("{input}", inputs["input"])
prompt = prompt.replace("{tool_names}", inputs["tool_names"])
return prompt.replace("{tools}", inputs["tools"])
```

Because `{input}` is substituted first, any value inserted earlier that itself contains a later placeholder token gets clobbered by the subsequent `replace`. So when a task's input legitimately mentions the literal `{tools}` or `{tool_names}` (for example an agent working on prompt-engineering or template docs), those tokens in the user's text are overwritten with the tool list/names before reaching the LLM:

```python
inputs = {"input": "explain the {tools} placeholder", "tool_names": "search", "tools": "search: web search"}
_format_prompt("Task: {input}", inputs)
# -> "Task: explain the search: web search placeholder"   (user text corrupted)
```

This switches to a single `re.sub` pass that matches only the three known tokens, so substituted values are not re-scanned and user text is preserved. Behavior is unchanged for templates that don't contain this collision, and other `{...}` content in the template is left untouched exactly as before.

The now-deprecated `CrewAgentExecutor` has an identical copy of this method; I left it untouched since it is slated for removal, but happy to mirror the fix there if you'd prefer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Extended `test_agent_executor.py::TestAgentExecutor` with `test_format_prompt_preserves_placeholder_tokens_in_values`. It fails on `main` (the token is clobbered) and passes with this change; the existing `test_format_prompt` still passes, and the full `tests/agents/test_agent_executor.py` file is green (92 passed). `ruff check`, `ruff format --check`, and `mypy` on the changed files are clean.

This bug was found and the patch drafted with AI assistance (Claude Code); I reviewed the change, ran the reproduction above, and validated the tests before and after the fix.

<!-- crewai-require-issue-check -->