### PR TITLE
fix(tools): raise ToolUsageError instead of bare raise in _original_tool_calling

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -849,9 +849,12 @@ class ToolUsage:
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         if not isinstance(arguments, dict):
+            tool_arguments_error = ToolUsageError(
+                f"{I18N_DEFAULT.errors('tool_arguments_error')}"
+            )
             if raise_error:
-                raise
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+                raise tool_arguments_error
+            return tool_arguments_error
 
         return ToolCalling(
             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -687,6 +687,69 @@ def test_tool_validate_input_error_event():
         assert event.agent_role == "test_role"
         assert event.tool_name == "test_tool"
         assert "must be a valid dictionary" in event.error
+
+
+def _build_tool_usage_for_original_calling() -> ToolUsage:
+    """Build a minimal ToolUsage instance for exercising _original_tool_calling."""
+    mock_agent = MagicMock()
+    mock_agent.key = "test_key"
+    mock_agent.role = "test_role"
+    mock_agent.verbose = False
+
+    class TestTool(BaseTool):
+        name: str = "Test Tool"
+        description: str = "A test tool"
+
+        def _run(self, input: dict) -> str:
+            return "test result"
+
+    return ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[TestTool()],
+        task=MagicMock(),
+        function_calling_llm=None,
+        agent=mock_agent,
+        action=MagicMock(tool="test_tool", tool_input='{"key": "value"}'),
+    )
+
+
+def test_original_tool_calling_valid_dict_returns_tool_calling():
+    """A valid dict from _validate_tool_input yields a ToolCalling result."""
+    tool_usage = _build_tool_usage_for_original_calling()
+
+    result = tool_usage._original_tool_calling("tool_string", raise_error=False)
+
+    assert isinstance(result, ToolCalling)
+    assert result.tool_name == "test_tool"
+    assert result.arguments == {"key": "value"}
+
+
+def test_original_tool_calling_non_dict_raises_tool_usage_error():
+    """Non-dict validation result with raise_error=True raises ToolUsageError.
+
+    Regression test: previously this path used a bare ``raise`` outside any
+    ``except`` block, producing ``RuntimeError: No active exception to re-raise``
+    instead of a meaningful error.
+    """
+    tool_usage = _build_tool_usage_for_original_calling()
+
+    with patch.object(
+        ToolUsage, "_validate_tool_input", return_value=["not", "a", "dict"]
+    ):
+        with pytest.raises(ToolUsageError):
+            tool_usage._original_tool_calling("tool_string", raise_error=True)
+
+
+def test_original_tool_calling_non_dict_returns_error_when_not_raising():
+    """Non-dict validation result with raise_error=False returns a ToolUsageError."""
+    tool_usage = _build_tool_usage_for_original_calling()
+
+    with patch.object(
+        ToolUsage, "_validate_tool_input", return_value=["not", "a", "dict"]
+    ):
+        result = tool_usage._original_tool_calling("tool_string", raise_error=False)
+
+    assert isinstance(result, ToolUsageError)
 
 
 def test_tool_usage_finished_event_with_result():


### PR DESCRIPTION
## Problem

`ToolUsage._original_tool_calling` (`lib/crewai/src/crewai/tools/tool_usage.py`) executed a bare `raise` outside any `except` block when `_validate_tool_input` returned a non-dict and `raise_error=True`. Because no exception was active on that path (the preceding `try/except` had completed normally), Python raised `RuntimeError: No active exception to re-raise` instead of a meaningful error. This produced a confusing error message and caused the caller `_tool_calling` to log/retry against a `RuntimeError` rather than a descriptive `ToolUsageError`.

Reported in #6430.

## Solution

Construct a `ToolUsageError` once and `raise` it when `raise_error=True` (or return it when `raise_error=False`), mirroring the existing `raise_error=False` return path. The sole caller `_tool_calling` still catches it via `except Exception` and falls back to `_function_calling` / retry exactly as before, so behavior is backward compatible — the only difference is that the exception now carries a meaningful message instead of `RuntimeError`.

No signature, return-type annotation, or public API change. Minimal and scoped to the bug.

## Changes

- `lib/crewai/src/crewai/tools/tool_usage.py` — in `_original_tool_calling`, replaced the bare `raise` in the non-dict branch with `raise tool_arguments_error` (a constructed `ToolUsageError`); the `raise_error=False` path returns the same object.
- `lib/crewai/tests/tools/test_tool_usage.py` — added `ToolUsageError` import, a small `ToolUsage` builder helper, and 3 tests covering:
  - happy path (valid dict → `ToolCalling`)
  - non-dict + `raise_error=True` → raises `ToolUsageError` (regression: was `RuntimeError`)
  - non-dict + `raise_error=False` → returns `ToolUsageError` (compatibility)

## Testing

- New unit tests pass: `uv run pytest lib/crewai/tests/tools/test_tool_usage.py -k original_tool_calling` → **3 passed**.
- A minimal runtime demo verified all three paths (happy / raise / return).
- `ruff check` and `ruff format --check` are clean on the changed files.
- Note: 5 pre-existing event-bus tests in `test_tool_usage.py` fail locally on a clean `main` checkout (confirmed via `git stash` + re-run) — they are environment/flaky (threading + event bus on Windows) and unrelated to this change.

## Notes for Reviewer

- This is an AI-assisted contribution. Per `.github/CONTRIBUTING.md`, the `llm-generated` label is required — I've attempted to apply it; if the tooling does not permit external contributors to label PRs, please add it.
- Fixes #6430.
- Design choice: I kept the defensive `if not isinstance(arguments, dict)` branch rather than removing it. Since `_validate_tool_input` currently guarantees dict-or-raise, the branch is effectively defensive/dead, but I chose the minimal fix (correct the `raise`) over removing the branch to keep the change scoped to the bug. Happy to remove the branch instead if preferred.
