### PR TITLE
fix(agents): recover real tool call from fabricated Observation continuations

### DIFF
--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -580,11 +580,13 @@ def process_llm_response(
         action_match = ACTION_INPUT_REGEX.search(answer)
         final_answer_idx = answer.find(FINAL_ANSWER_ACTION)
         if action_match and action_match.start() < final_answer_idx:
-            # Without a "\nObservation:" stop sequence the model generates past
+            # Without the "\nObservation:" stop sequence the model generates past
             # the real tool call, fabricating an Observation and Final Answer.
             # Discard the fabricated continuation so the actual Action executes.
+            # Anchor on the newline (the real stop sequence) so an "Observation:"
+            # substring inside the Action Input payload isn't mistaken for it.
             observation_idx = answer.find(
-                "Observation:", action_match.start(), final_answer_idx
+                "\nObservation:", action_match.start(), final_answer_idx
             )
             if observation_idx != -1:
                 answer = answer[:observation_idx].strip()

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -17,7 +17,7 @@ from crewai_core.settings import Settings
 from pydantic import BaseModel
 from rich.console import Console
 
-from crewai.agents.constants import FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE
+from crewai.agents.constants import ACTION_INPUT_REGEX, FINAL_ANSWER_ACTION
 from crewai.agents.parser import (
     AgentAction,
     AgentFinish,
@@ -576,12 +576,18 @@ def process_llm_response(
     Returns:
         Either an AgentAction or AgentFinish
     """
-    if not use_stop_words:
-        try:
-            format_answer(answer)
-        except OutputParserError as e:
-            if FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE in e.error:
-                answer = answer.split("Observation:")[0].strip()
+    if not use_stop_words and FINAL_ANSWER_ACTION in answer:
+        action_match = ACTION_INPUT_REGEX.search(answer)
+        final_answer_idx = answer.find(FINAL_ANSWER_ACTION)
+        if action_match and action_match.start() < final_answer_idx:
+            # Without a "\nObservation:" stop sequence the model generates past
+            # the real tool call, fabricating an Observation and Final Answer.
+            # Discard the fabricated continuation so the actual Action executes.
+            observation_idx = answer.find(
+                "Observation:", action_match.start(), final_answer_idx
+            )
+            if observation_idx != -1:
+                answer = answer[:observation_idx].strip()
 
     return format_answer(answer)
 

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -16,6 +16,7 @@ from crewai.hooks.tool_hooks import (
     clear_before_tool_call_hooks,
     register_after_tool_call_hook,
 )
+from crewai.agents.parser import AgentAction, AgentFinish
 from crewai.tools.base_tool import BaseTool
 from crewai.utilities.agent_utils import (
     _asummarize_chunks,
@@ -27,6 +28,7 @@ from crewai.utilities.agent_utils import (
     execute_single_native_tool_call,
     NativeToolCallResult,
     parse_tool_call_args,
+    process_llm_response,
     summarize_messages,
 )
 
@@ -1256,3 +1258,87 @@ class TestExecuteSingleNativeToolCall:
         assert isinstance(result, NativeToolCallResult)
         assert result.result_as_answer is False
         assert "blocked by hook" in result.result
+
+
+class TestProcessLlmResponse:
+    """Tests for process_llm_response fabricated-Observation recovery.
+
+    Models that do not support stop words (e.g. gpt-5 and o1 family) generate
+    past the point where the "\nObservation:" stop sequence would have cut the
+    completion, fabricating an Observation and Final Answer after a real tool
+    call. process_llm_response must discard the fabricated continuation so the
+    actual Action executes.
+    """
+
+    FABRICATED_TRANSCRIPT = (
+        "Thought: I need to search the web for the latest AI trends.\n"
+        'Action: web_search\nAction Input: {"search_query": "latest AI trends 2026"}\n'
+        "Observation: The top AI trends are multimodal models and agentic workflows.\n"
+        "Thought: I now know the final answer.\n"
+        "Final Answer: The top AI trends are multimodal models and agentic workflows."
+    )
+
+    def test_fabricated_observation_recovers_real_action(self) -> None:
+        """Without stop words, the real Action wins over a fabricated Final Answer."""
+        result = process_llm_response(self.FABRICATED_TRANSCRIPT, use_stop_words=False)
+
+        assert isinstance(result, AgentAction)
+        assert result.tool == "web_search"
+        assert "latest AI trends 2026" in result.tool_input
+        assert "Observation:" not in result.text
+
+    def test_stop_word_models_keep_final_answer(self) -> None:
+        """With stop words supported, existing final-answer semantics are unchanged."""
+        result = process_llm_response(self.FABRICATED_TRANSCRIPT, use_stop_words=True)
+
+        assert isinstance(result, AgentFinish)
+        assert (
+            result.output
+            == "The top AI trends are multimodal models and agentic workflows."
+        )
+
+    @pytest.mark.parametrize("use_stop_words", [True, False])
+    def test_final_answer_only_unchanged(self, use_stop_words: bool) -> None:
+        """A plain final answer parses as AgentFinish regardless of stop words."""
+        text = "Thought: I know this already.\nFinal Answer: Paris is the capital."
+        result = process_llm_response(text, use_stop_words=use_stop_words)
+
+        assert isinstance(result, AgentFinish)
+        assert result.output == "Paris is the capital."
+
+    def test_final_answer_before_action_text_unchanged(self) -> None:
+        """Action-format text quoted after the final answer is not treated as a tool call."""
+        text = (
+            "Thought: I already know this.\n"
+            "Final Answer: To call a tool, respond using:\n"
+            "Action: the tool name\n"
+            "Action Input: the tool arguments\n"
+            "Observation: the tool result"
+        )
+        result = process_llm_response(text, use_stop_words=False)
+
+        assert isinstance(result, AgentFinish)
+
+    def test_action_without_observation_unchanged(self) -> None:
+        """An Action followed directly by a Final Answer keeps current behavior."""
+        text = (
+            "Thought: I need to search.\n"
+            'Action: web_search\nAction Input: {"search_query": "AI trends"}\n'
+            "Final Answer: The top AI trends are multimodal models."
+        )
+        result = process_llm_response(text, use_stop_words=False)
+
+        assert isinstance(result, AgentFinish)
+        assert result.output == "The top AI trends are multimodal models."
+
+    @pytest.mark.parametrize("use_stop_words", [True, False])
+    def test_action_only_returns_agent_action(self, use_stop_words: bool) -> None:
+        """A well-formed tool call parses as AgentAction regardless of stop words."""
+        text = (
+            "Thought: I need to search.\n"
+            'Action: web_search\nAction Input: {"search_query": "AI trends"}'
+        )
+        result = process_llm_response(text, use_stop_words=use_stop_words)
+
+        assert isinstance(result, AgentAction)
+        assert result.tool == "web_search"

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -1319,6 +1319,26 @@ class TestProcessLlmResponse:
 
         assert isinstance(result, AgentFinish)
 
+    def test_observation_substring_in_action_input_preserved(self) -> None:
+        """An 'Observation:' inside the Action Input payload is not a truncation point.
+
+        The fabricated Observation is emitted on its own line, so anchoring the
+        truncation on the "\nObservation:" stop sequence leaves a payload that
+        merely mentions the word intact.
+        """
+        text = (
+            "Thought: I need to look this term up.\n"
+            'Action: web_search\n'
+            'Action Input: {"search_query": "what does Observation: mean in ReAct"}\n'
+            "Observation: It is the tool result step.\n"
+            "Final Answer: Observation is the tool result step in ReAct."
+        )
+        result = process_llm_response(text, use_stop_words=False)
+
+        assert isinstance(result, AgentAction)
+        assert result.tool == "web_search"
+        assert "what does Observation: mean in ReAct" in result.tool_input
+
     def test_action_without_observation_unchanged(self) -> None:
         """An Action followed directly by a Final Answer keeps current behavior."""
         text = (


### PR DESCRIPTION
Closes #6449. Root cause behind the reports collected in #3154.

## Problem

For models that don't support the `stop` parameter (`use_stop_words=False`: gpt-5 family, o1 family, custom `BaseLLM`s), nothing cuts generation at `"\nObservation:"`, so the LLM emits a real `Action` followed by a **fabricated** `Observation` and `Final Answer` in one completion. `parse()` returns the fabricated `AgentFinish`, and the real tool never executes.

`process_llm_response()` contains a recovery block designed for exactly this — but it has been dead code since #2483 (`efe27bd5`, Apr 2025), which removed the parser raise (`FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE`) that the block catches. The recovery worked from #1322 (Oct 2024) until then. Full regression timeline and analysis in #6449.

This explains the correlation users kept reporting in #3154: gpt-4.1 fine, gpt-5/o-series fabricating — `supports_stop_words()` returns `False` for exactly the failing models.

## Fix

Replace the dead `except` block with an explicit position check (no exception plumbing, so it is unaffected by `format_answer()`'s broad `except Exception` — the separate issue #3771):

- Gated to `use_stop_words=False` — behavior for stop-word-supporting models is untouched.
- Requires the exact fabrication shape `Action` < `Observation` < `Final Answer` (bounded `find`), so:
  - "Final Answer first, ReAct format quoted after" still returns the final answer;
  - "Action then Final Answer with no Observation" keeps current behavior;
  - every other shape is unchanged.
- Fixes all four call sites at once (experimental `AgentExecutor`, `CrewAgentExecutor`, `LiteAgent`, `step_executor`) and makes the experimental executor's existing "`Final Answer:` but parsed as AgentAction" warning reachable, giving users visibility when recovery happens.

## Tests

New `TestProcessLlmResponse` class in `lib/crewai/tests/utilities/test_agent_utils.py` (8 tests):

- `test_fabricated_observation_recovers_real_action` — **fails on current `main`** (returns the fabricated `AgentFinish`), passes with this fix:

```
# main (fix stashed):
FAILED tests/utilities/test_agent_utils.py::TestProcessLlmResponse::test_fabricated_observation_recovers_real_action
1 failed, 7 passed

# with fix:
8 passed
```

- The other 7 tests pin the non-fabrication shapes and pass on **both** sides, demonstrating no behavior change outside the targeted case.

`tests/utilities/test_agent_utils.py`, `tests/agents/test_crew_agent_parser.py`, and `tests/agents/test_agent_executor.py` all pass (209 tests). `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

## Disclosure

This fix was developed with AI assistance (Claude); the regression history, reproduction, and red/green results were verified by hand. I don't have permission to add labels — could a maintainer add the `llm-generated` label per the contribution guidelines?


<!-- crewai-require-issue-check -->