### PR TITLE
fix: bare raise in ToolUsage._original_tool_calling causes RuntimeError instead of ToolUsageError

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -850,7 +850,7 @@ class ToolUsage:
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise
+                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         return ToolCalling(

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -344,6 +344,37 @@ def test_validate_tool_input_with_special_characters():
 
     arguments = tool_usage._validate_tool_input(tool_input)
     assert arguments == expected_arguments
+
+
+def test_original_tool_calling_non_dict_arguments_raises_tool_usage_error():
+    """Regression test for #6430.
+
+    The non-dict arguments branch in `_original_tool_calling` used a bare
+    `raise` with no active exception, so hitting it with `raise_error=True`
+    crashed with `RuntimeError: No active exception to re-raise` instead of
+    raising a meaningful `ToolUsageError`.
+    """
+    tool = RandomNumberTool()
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[tool],
+        task=MagicMock(),
+        function_calling_llm=MagicMock(),
+        agent=MagicMock(),
+        action=MagicMock(),
+    )
+
+    with (
+        patch.object(
+            tool_usage, "_validate_tool_input", return_value=["not", "a", "dict"]
+        ),
+        patch.object(tool_usage, "_select_tool", return_value=tool),
+    ):
+        with pytest.raises(ToolUsageError):
+            tool_usage._original_tool_calling("", raise_error=True)
+
+        result = tool_usage._original_tool_calling("")
+        assert isinstance(result, ToolUsageError)
 
 
 def test_validate_tool_input_none_input():


### PR DESCRIPTION
## Description

Fixes #6430.

`ToolUsage._original_tool_calling()` contained a bare `raise` in the `not isinstance(arguments, dict)` branch. A bare `raise` re-raises the exception currently being handled, but on this path no exception is active (the preceding `try/except` completed normally). If that branch were ever hit with `raise_error=True`, Python would crash with `RuntimeError: No active exception to re-raise` instead of the intended tool-arguments error.

This matters because `_tool_calling()` calls this method with `raise_error=True` and relies on catching a meaningful exception to trigger its function-calling/retry fallback.

### Fix

Replace the bare `raise` with an explicit `raise ToolUsageError(...)` using the same `tool_arguments_error` message the branch already returns when `raise_error=False`, keeping error messaging consistent.

### Testing

- Added a regression test that patches `_validate_tool_input` to return a non-dict and asserts `_original_tool_calling(..., raise_error=True)` raises `ToolUsageError` (not `RuntimeError`), and that the non-raise path returns a `ToolUsageError` instance.
- `uv run pytest lib/crewai/tests/tools/test_tool_usage.py` passes (29 tests).
- `ruff check --select PLE0704` no longer flags the file; ruff lint/format clean on changed files.

*(Note: authored with the assistance of an AI coding agent. Please apply the `llm-generated` label.)*

Made with [Cursor](https://cursor.com)

<!-- crewai-require-issue-check -->