### PR TITLE
Fix ToolUsage bare raise for non-dict arguments

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -840,18 +840,21 @@ class ToolUsage:
     ) -> ToolCalling | InstructorToolCalling | ToolUsageError:
         tool_name = self.action.tool
         tool = self._select_tool(tool_name)
+        tool_arguments_error = ToolUsageError(
+            f"{I18N_DEFAULT.errors('tool_arguments_error')}"
+        )
         try:
             arguments = self._validate_tool_input(self.action.tool_input)
 
         except Exception:
             if raise_error:
                 raise
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+            return tool_arguments_error
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+                raise tool_arguments_error
+            return tool_arguments_error
 
         return ToolCalling(
             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -850,7 +850,7 @@ class ToolUsage:
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise
+                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         return ToolCalling(

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -465,6 +465,40 @@ def test_validate_tool_input_invalid_input():
 
     arguments = tool_usage._validate_tool_input(None)
     assert arguments == {}
+
+
+def test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments():
+    class TestTool(BaseTool):
+        name: str = "Test Tool"
+        description: str = "A test tool"
+
+        def _run(self, input: dict) -> str:
+            return "test result"
+
+    action = MagicMock()
+    action.tool = "test_tool"
+    action.tool_input = '["not", "a", "dict"]'
+
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[TestTool()],
+        task=MagicMock(),
+        function_calling_llm=None,
+        agent=MagicMock(),
+        action=action,
+    )
+
+    with (
+        patch.object(
+            tool_usage,
+            "_validate_tool_input",
+            return_value=["not", "a", "dict"],
+        ),
+        pytest.raises(ToolUsageError) as exc_info,
+    ):
+        tool_usage._original_tool_calling(action.tool_input, raise_error=True)
+
+    assert "Action Input is not a valid key, value dictionary" in str(exc_info.value)
 
 
 def test_validate_tool_input_complex_structure():


### PR DESCRIPTION
## Summary
- Replace the bare raise in `ToolUsage._original_tool_calling` with `ToolUsageError` for non-dict arguments.
- Add a regression test for the `raise_error=True` path.

Fixes #6430

## Tests
- `./.venv/Scripts/python.exe -m pytest lib/crewai/tests/tools/test_tool_usage.py::test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments -q`
- `./.venv/Scripts/ruff.exe check lib/crewai/src/crewai/tools/tool_usage.py --select PLE0704`

Note: the full `test_tool_usage.py` file has 5 existing failures on Windows because `pytest-recording` disables socket creation for the event bus; the new regression test passes.


<!-- crewai-require-issue-check -->