### PR TITLE
fix(memory): anchor LanceDB scope matching on path boundary

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -368,6 +368,28 @@ class LanceDBStorage:
             return None
         return self._row_to_record(rows[0])
 
+    @staticmethod
+    def _scope_prefix_clause(scope_prefix: str) -> str:
+        """Build a SQL predicate matching a scope subtree by path boundary.
+
+        A scope such as ``/team`` owns itself and every descendant under
+        ``/team/`` -- but *not* a lexicographic sibling like ``/team-b``.
+        Matching with a bare ``LIKE 'prefix%'`` (or a lexicographic range)
+        leaks into such siblings, so anchor the match on the ``/`` separator:
+        the exact scope, or anything beneath ``prefix + "/"``.
+
+        Args:
+            scope_prefix: The scope path to match (already non-root).
+
+        Returns:
+            A SQL boolean expression selecting the scope and its descendants.
+        """
+        prefix = scope_prefix.rstrip("/")
+        if not prefix.startswith("/"):
+            prefix = "/" + prefix
+        safe = prefix.replace("'", "''")
+        return f"(scope = '{safe}' OR scope LIKE '{safe}/%')"
+
     def search(
         self,
         query_embedding: list[float],
@@ -385,9 +407,7 @@ class LanceDBStorage:
             )
         query = self._table.search(query_embedding)
         if scope_prefix is not None and scope_prefix.strip("/"):
-            prefix = scope_prefix.rstrip("/")
-            like_val = prefix + "%"
-            query = query.where(f"scope LIKE '{like_val}'")
+            query = query.where(self._scope_prefix_clause(scope_prefix))
         results = query.limit(
             limit * 3 if (categories or metadata_filter) else limit
         ).to_list()
@@ -448,10 +468,9 @@ class LanceDBStorage:
                 return before - int(self._table.count_rows())
             conditions = []
             if scope_prefix is not None and scope_prefix.strip("/"):
-                prefix = scope_prefix.rstrip("/")
-                if not prefix.startswith("/"):
-                    prefix = "/" + prefix
-                conditions.append(f"scope LIKE '{prefix}%' OR scope = '/'")
+                conditions.append(
+                    f"({self._scope_prefix_clause(scope_prefix)} OR scope = '/')"
+                )
             if older_than is not None:
                 conditions.append(f"created_at < '{older_than.isoformat()}'")
             if not conditions:
@@ -485,7 +504,7 @@ class LanceDBStorage:
             return []
         q = self._table.search()
         if scope_prefix is not None and scope_prefix.strip("/"):
-            q = q.where(f"scope LIKE '{scope_prefix.rstrip('/')}%'")
+            q = q.where(self._scope_prefix_clause(scope_prefix))
         if columns is not None:
             q = q.select(columns)
         result: list[dict[str, Any]] = q.limit(limit).to_list()
@@ -609,10 +628,9 @@ class LanceDBStorage:
                 return
             if self._table is None:
                 return
-            prefix = scope_prefix.rstrip("/")
-            if prefix:
+            if scope_prefix.rstrip("/"):
                 self._do_write(
-                    "delete", f"scope >= '{prefix}' AND scope < '{prefix}/\uffff'"
+                    "delete", self._scope_prefix_clause(scope_prefix)
                 )
 
     def optimize(self) -> None:

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -374,9 +374,13 @@ class LanceDBStorage:
 
         A scope such as ``/team`` owns itself and every descendant under
         ``/team/`` -- but *not* a lexicographic sibling like ``/team-b``.
-        Matching with a bare ``LIKE 'prefix%'`` (or a lexicographic range)
-        leaks into such siblings, so anchor the match on the ``/`` separator:
-        the exact scope, or anything beneath ``prefix + "/"``.
+        The match is anchored on the ``/`` separator via a half-open range
+        ``[prefix + "/", prefix + "0")``: ``/`` is ``0x2F`` so the next code
+        point is ``0`` (``0x30``), and every descendant ``prefix + "/..."``
+        sorts before ``prefix + "0"``. A range (rather than ``LIKE
+        'prefix/%'``) keeps the scope path a literal -- ``LIKE`` would treat
+        ``%`` and ``_`` inside the path as wildcards and leak into unrelated
+        siblings (e.g. ``/team_x`` matching ``/teamAx``).
 
         Args:
             scope_prefix: The scope path to match (already non-root).
@@ -387,8 +391,10 @@ class LanceDBStorage:
         prefix = scope_prefix.rstrip("/")
         if not prefix.startswith("/"):
             prefix = "/" + prefix
-        safe = prefix.replace("'", "''")
-        return f"(scope = '{safe}' OR scope LIKE '{safe}/%')"
+        exact = prefix.replace("'", "''")
+        lower = (prefix + "/").replace("'", "''")
+        upper = (prefix + "0").replace("'", "''")
+        return f"(scope = '{exact}' OR (scope >= '{lower}' AND scope < '{upper}'))"
 
     def search(
         self,

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -198,11 +198,58 @@ def test_lancedb_scope_prefix_respects_path_boundary(lancedb_path: Path) -> None
     assert storage.count("/team") == 2  # /team and /team/x, NOT /team-b
     assert storage.count("/team-b") == 1
 
+    # search must scope hits to /team + descendants only (not the sibling).
+    hits = {rec.scope for rec, _ in storage.search([0.1] * 4, scope_prefix="/team", limit=100)}
+    assert hits == {"/team", "/team/x"}
+
     # reset must delete only the /team subtree, leaving the sibling intact.
     storage.reset("/team")
     assert storage.count("/team-b") == 1
     surviving = {r.scope for r in storage.list_records(limit=100)}
     assert surviving == {"/team-b"}
+
+
+def test_lancedb_delete_scope_prefix_respects_path_boundary(lancedb_path: Path) -> None:
+    """delete(scope_prefix=...) must remove only the subtree, not siblings."""
+    from crewai.memory.storage.lancedb_storage import LanceDBStorage
+
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    storage.save([
+        MemoryRecord(content="team", scope="/team", embedding=[0.1] * 4),
+        MemoryRecord(content="child", scope="/team/x", embedding=[0.3] * 4),
+        MemoryRecord(content="team-b", scope="/team-b", embedding=[0.2] * 4),
+    ])
+
+    deleted = storage.delete(scope_prefix="/team")
+    assert deleted == 2  # /team and /team/x, NOT /team-b
+    surviving = {r.scope for r in storage.list_records(limit=100)}
+    assert surviving == {"/team-b"}
+
+
+def test_lancedb_scope_prefix_treats_path_as_literal(lancedb_path: Path) -> None:
+    """Scope paths are matched literally, not as SQL LIKE patterns.
+
+    A path segment containing ``_`` (a LIKE single-char wildcard) must not
+    match a sibling subtree that differs only in that position -- e.g. a
+    ``LIKE '/team_x/%'`` predicate wrongly matches ``/teamAx/w`` (``_`` matching
+    ``A``), so ``/team_x`` must not pull in the ``/teamAx`` subtree.
+    """
+    from crewai.memory.storage.lancedb_storage import LanceDBStorage
+
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    storage.save([
+        MemoryRecord(content="a", scope="/team_x", embedding=[0.1] * 4),
+        MemoryRecord(content="b", scope="/team_x/z", embedding=[0.3] * 4),
+        MemoryRecord(content="c", scope="/teamAx/w", embedding=[0.2] * 4),
+    ])
+
+    assert storage.count("/team_x") == 2  # /team_x and /team_x/z, NOT /teamAx/w
+    hits = {rec.scope for rec, _ in storage.search([0.1] * 4, scope_prefix="/team_x", limit=100)}
+    assert hits == {"/team_x", "/team_x/z"}
+
+    storage.reset("/team_x")
+    surviving = {r.scope for r in storage.list_records(limit=100)}
+    assert surviving == {"/teamAx/w"}
 
 
 

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -179,6 +179,32 @@ def test_lancedb_list_scopes_get_scope_info(lancedb_path: Path) -> None:
     assert info.path == "/"
 
 
+def test_lancedb_scope_prefix_respects_path_boundary(lancedb_path: Path) -> None:
+    """Scope operations must not leak into lexicographic sibling scopes.
+
+    ``/team`` owns itself and descendants under ``/team/`` but is a distinct
+    scope from the sibling ``/team-b`` (which merely shares a string prefix).
+    """
+    from crewai.memory.storage.lancedb_storage import LanceDBStorage
+
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    storage.save([
+        MemoryRecord(content="team", scope="/team", embedding=[0.1] * 4),
+        MemoryRecord(content="team-b", scope="/team-b", embedding=[0.2] * 4),
+        MemoryRecord(content="child", scope="/team/x", embedding=[0.3] * 4),
+    ])
+
+    # count/get_scope_info must include the scope + its descendants only.
+    assert storage.count("/team") == 2  # /team and /team/x, NOT /team-b
+    assert storage.count("/team-b") == 1
+
+    # reset must delete only the /team subtree, leaving the sibling intact.
+    storage.reset("/team")
+    assert storage.count("/team-b") == 1
+    surviving = {r.scope for r in storage.list_records(limit=100)}
+    assert surviving == {"/team-b"}
+
+
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Scope filtering in `LanceDBStorage` does not respect the `/` path separator, so operations on a scope leak into **lexicographic sibling** scopes:

- read paths (`search`, `_scan_rows` → `count` / `get_scope_info` / `list_records` / `list_categories`) used `scope LIKE 'prefix%'`
- `delete` used `scope LIKE 'prefix%' OR scope = '/'`
- `reset` used the range `scope >= 'prefix' AND scope < 'prefix/￿'`

Because `-` (0x2D) sorts before `/` (0x2F), a sibling like `/team-b` matches an operation scoped to `/team`.

On read paths this over-counts. On `reset`/`forget` it is **data loss**: `reset("/team")` also deletes every record under the unrelated `/team-b`.

```python
storage.count("/team")   # -> 3  (should be 2: /team and /team/x, NOT /team-b)
storage.reset("/team")   # also wipes /team-b
```

## Fix

Route all four sites through a shared helper that anchors the match on the path boundary — the exact scope, or descendants under `prefix + "/"`:

```python
@staticmethod
def _scope_prefix_clause(scope_prefix: str) -> str:
    prefix = scope_prefix.rstrip("/")
    if not prefix.startswith("/"):
        prefix = "/" + prefix
    safe = prefix.replace("'", "''")
    return f"(scope = '{safe}' OR scope LIKE '{safe}/%')"
```

This matches the hierarchical semantics the qdrant backend (`_build_scope_filter`) and this file's own `get_scope_info` / `list_scopes` already use (`child_prefix = prefix + "/"`). `delete` keeps its explicit `scope = '/'` root-record match, and the existing single-quote escaping is preserved (orthogonal to #5729).

## Tests

Added `test_lancedb_scope_prefix_respects_path_boundary` (in `lib/crewai/tests/memory/test_unified_memory.py`), using explicit embeddings so it needs no network. It asserts `count("/team") == 2`, `count("/team-b") == 1`, and that `reset("/team")` leaves `/team-b` intact.

- Before the fix the test fails: `count("/team")` returns `3` (`assert 3 == 2`).
- After the fix it passes; existing memory tests are unaffected.

---

*Contribution note: AI tooling helped surface and reproduce this scope-boundary bug; I reviewed, verified (before/after unit test), and finalized the fix myself. Tagging as `llm-generated` per the contribution policy.*
