### PR TITLE
Docs: clarify community tool sharing

### DIFF
--- a/docs/edge/en/guides/tools/publish-custom-tools.mdx
+++ b/docs/edge/en/guides/tools/publish-custom-tools.mdx
@@ -303,3 +303,21 @@ agent = Agent(
     # ...
 )
 ```
+
+### Sharing Community Tools
+
+Keep the package README as the primary source of truth for installation, setup, security notes, and usage examples.
+This lets users evaluate the package from PyPI or its source repository without needing a CrewAI docs release.
+
+If you want to propose a CrewAI docs mention for a community-maintained tool, open a docs issue or PR with:
+
+- Package name and PyPI link.
+- Source repository link and license.
+- Supported CrewAI versions.
+- Installation command.
+- Minimal usage snippet that imports the package and attaches the tool to an agent.
+- Required environment variables or external services.
+- Maintenance status, known limitations, and any data handling or security considerations.
+
+Prefer a concise pointer to the external package over duplicating full package documentation in the CrewAI docs.
+If the tool should ship as part of the official `crewai_tools` package instead, follow the repository's normal contribution process.


### PR DESCRIPTION
## Summary
- add guidance for sharing community-maintained CrewAI tool packages after publishing to PyPI
- clarify that the package README should remain the primary source of truth
- list the information maintainers can ask for when evaluating a docs mention

This addresses the documentation path question without adding a third-party tool catalog or documenting any one external package directly.

Closes #6458.

## Validation
- `git diff --check -- docs/edge/en/guides/tools/publish-custom-tools.mdx`

## AI assistance / label note
- AI assistance was used while drafting and reviewing this documentation-only change.
- CrewAI's contributing guide says AI-assisted PRs require the `llm-generated` label. I attempted to apply it, but this account does not have label permission on the upstream repository.

<!-- crewai-require-issue-check -->