### PR TITLE
fix(agent): warn when non-empty `apps` resolve to zero platform tools

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1129,15 +1129,32 @@ class Agent(BaseAgent):
         return agent_tools.tools()
 
     def get_platform_tools(self, apps: list[PlatformAppOrAction]) -> list[BaseTool]:
+        platform_tools: list[BaseTool] = []
         try:
             from crewai_tools import (
                 CrewaiPlatformTools,
             )
 
-            return CrewaiPlatformTools(apps=apps)
+            platform_tools = CrewaiPlatformTools(apps=apps)
         except Exception as e:
             self._logger.log("error", f"Error getting platform tools: {e!s}")
-            return []
+
+        if apps and not platform_tools:
+            # A non-empty `apps` that resolves to zero tools leaves the agent
+            # unable to do what those apps were for — surface it loudly (the
+            # underlying resolver only logs, and Logger.log is verbose-gated) so
+            # it isn't discovered as a mysterious runtime failure.
+            app_names = ", ".join(str(app) for app in apps)
+            warnings.warn(
+                f"Agent '{self.role}' declares apps [{app_names}] but none "
+                "resolved to any tools; the agent will run without them and may "
+                "be unable to complete its goal. Check that these apps exist and "
+                "are connected, and that CREWAI_PLATFORM_INTEGRATION_TOKEN is set.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        return platform_tools
 
     def get_mcp_tools(self, mcps: list[str | MCPServerConfig]) -> list[BaseTool]:
         """Convert MCP server references/configs to CrewAI tools.

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -2595,6 +2595,59 @@ def test_agent_without_apps_no_platform_tools():
     assert tools == []
 
 
+def test_get_platform_tools_warns_when_apps_resolve_to_zero_tools(monkeypatch):
+    """A non-empty `apps` that resolves to no tools must warn loudly."""
+    import crewai_tools
+
+    monkeypatch.setattr(crewai_tools, "CrewaiPlatformTools", lambda apps: [])
+    agent = Agent(
+        role="Empty Apps Agent",
+        goal="Use apps",
+        backstory="b",
+        apps=["gmail", "slack"],
+    )
+
+    with pytest.warns(UserWarning, match="resolved to any tools"):
+        result = agent.get_platform_tools(agent.apps)
+
+    assert result == []
+
+
+def test_get_platform_tools_quiet_when_tools_resolve(monkeypatch):
+    """No warning when the apps resolve to at least one tool."""
+    from crewai.tools import tool
+
+    @tool
+    def platform_tool() -> str:
+        """A resolved platform tool."""
+        return "ok"
+
+    import crewai_tools
+
+    monkeypatch.setattr(crewai_tools, "CrewaiPlatformTools", lambda apps: [platform_tool])
+    agent = Agent(role="A", goal="g", backstory="b", apps=["gmail"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = agent.get_platform_tools(agent.apps)
+
+    assert result == [platform_tool]
+    assert not any("resolved to any tools" in str(w.message) for w in caught)
+
+
+def test_crew_prepare_tools_warns_on_empty_apps(monkeypatch):
+    """The warning also fires through the crew tool-injection path."""
+    import crewai_tools
+
+    monkeypatch.setattr(crewai_tools, "CrewaiPlatformTools", lambda apps: [])
+    agent = Agent(role="A", goal="g", backstory="b", apps=["gmail"])
+    task = Task(description="d", expected_output="o", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+
+    with pytest.warns(UserWarning, match="resolved to any tools"):
+        crew._prepare_tools(agent, task, [])
+
+
 def test_agent_mcps_accepts_slug_with_specific_tool():
     """Agent(mcps=["notion#get_page"]) must pass validation (_SLUG_RE)."""
     agent = Agent(


### PR DESCRIPTION
## Problem

When an agent declares `apps` (enterprise integrations) but they resolve to **zero tools**, the agent silently runs without them — and can't do what those apps were for. `CrewaiPlatformTools(apps=...)` returns an empty list in every such case:

- unknown / misspelled app name (API returns no actions — **fully silent**),
- app not connected / fetch fails (only a module `logging.error`),
- missing `CREWAI_PLATFORM_INTEGRATION_TOKEN` (raises, then swallowed to `[]`).

Both resolution sites dropped the empty result silently — agent kickoff (`agent/core.py` `_prepare_kickoff`, guarded by `if platform_tools:`) and crew task execution (`crew.py` `_inject_platform_tools`, merges the empty list). The only existing signal is a `Logger.log` that is **verbose-gated** (invisible by default). So a misconfigured `apps` surfaces only as a mysterious runtime failure.

## Fix

Emit a loud `UserWarning` from `Agent.get_platform_tools()` — the single shared choke point that **both** call sites (and declarative flows) go through:

- agent kickoff → `_prepare_kickoff` → `get_platform_tools`
- crew task → `_inject_platform_tools` → `get_platform_tools`
- declarative-flow agent action → builds an `Agent` → `kickoff_async` → same path

```
Agent '<role>' declares apps [gmail, slack] but none resolved to any tools;
the agent will run without them and may be unable to complete its goal. Check
that these apps exist and are connected, and that
CREWAI_PLATFORM_INTEGRATION_TOKEN is set.
```

`warnings.warn(UserWarning)` is the framework's established pattern for user-facing config problems (used throughout `agent/core.py`) and, unlike `Logger.log`, shows by default.

## Warning vs. hard error

You noted this is "arguably a hard error." I went with a **loud warning** (the stated floor): a hard error would break agents whose apps legitimately resolve empty in some environments (e.g. not connected in local dev). The check is centralized, so promoting it to an error — or gating that behind an opt-in flag — is a one-line change if we decide the stricter behavior is warranted.

## On "whatever generated this flow.json"

Checked: **no in-repo generator emits concrete `apps`** into a flow definition (scaffolder template, `flow_definition_example.yaml`, json_loader — none write `apps`). Definitions carrying `apps` are authored externally (Studio / an LLM via the flow-definition skill, which correctly documents `apps` as a valid agent-action field). So there's no generator bug — the runtime warning is the right safety net, and it covers the flow path since flow agent actions route through the same agent kickoff.

## Tests

- warns when apps resolve to zero tools (direct `get_platform_tools` + the crew `_prepare_tools` path)
- stays quiet when apps resolve to ≥1 tool

`ruff format --check` + `ruff check` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a user-facing warning only; no change to tool resolution or execution semantics beyond visibility.
> 
> **Overview**
> Agents with **`apps`** set could previously run with **no** platform tools and no obvious signal when `CrewaiPlatformTools` returned an empty list (bad names, disconnected apps, missing token, etc.).
> 
> **`Agent.get_platform_tools()`** now emits a default-visible **`UserWarning`** when `apps` is non-empty but resolution yields zero tools, naming the agent role and listed apps and pointing at connectivity and **`CREWAI_PLATFORM_INTEGRATION_TOKEN`**. That path is shared by agent kickoff and crew tool preparation, so both flows get the same alert without changing runtime behavior (still returns `[]`).
> 
> Tests cover direct **`get_platform_tools`**, the quiet case when at least one tool resolves, and **`Crew._prepare_tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0039376e7b864e48ace0bdd9b20e62a36157277e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->