### PR TITLE
fix(platform-tools): stop silently disabling TLS verification via CREWAI_FACTORY

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
@@ -1,7 +1,6 @@
 """Crewai Enterprise Tools."""
 
 import json
-import os
 from typing import Any
 
 from crewai.tools import BaseTool
@@ -12,6 +11,7 @@ import requests
 from crewai_tools.tools.crewai_platform_tools.misc import (
     get_platform_api_base_url,
     get_platform_integration_token,
+    platform_tls_verify,
 )
 
 
@@ -72,7 +72,7 @@ class CrewAIPlatformActionTool(BaseTool):
                 headers=headers,
                 json=payload,
                 timeout=60,
-                verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
+                verify=platform_tls_verify(),
             )
 
             data = response.json()

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
@@ -1,7 +1,6 @@
 """CrewAI platform tool builder for fetching and creating action tools."""
 
 import logging
-import os
 from types import TracebackType
 from typing import Any
 
@@ -14,6 +13,7 @@ from crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool import
 from crewai_tools.tools.crewai_platform_tools.misc import (
     get_platform_api_base_url,
     get_platform_integration_token,
+    platform_tls_verify,
 )
 
 
@@ -49,7 +49,7 @@ class CrewaiPlatformToolBuilder:
                 headers=headers,
                 timeout=30,
                 params={"apps": ",".join(self._apps)},
-                verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
+                verify=platform_tls_verify(),
             )
             response.raise_for_status()
         except Exception as e:

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/misc.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/misc.py
@@ -1,4 +1,35 @@
 import os
+import warnings
+
+
+def platform_tls_verify() -> bool:
+    """TLS verification setting for CrewAI platform API requests.
+
+    Verification is ON by default and should stay on: these requests carry the
+    platform integration token, so an unverified connection exposes it to
+    man-in-the-middle attacks. It can be disabled only via an explicit opt-out
+    (``CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY``; the legacy ``CREWAI_FACTORY``
+    is still honored for internal builds), and doing so warns loudly. To trust a
+    self-signed endpoint *securely*, leave verification on and point requests at
+    the CA bundle via the standard ``REQUESTS_CA_BUNDLE`` environment variable.
+    """
+    if (
+        os.getenv("CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY", "false").strip().lower()
+        == "true"
+        or os.getenv("CREWAI_FACTORY", "false").strip().lower() == "true"
+    ):
+        warnings.warn(
+            "TLS certificate verification is DISABLED for CrewAI platform API "
+            "requests; the integration token is sent over an unverified connection "
+            "and is exposed to man-in-the-middle attacks. Unset "
+            "CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY (and the legacy CREWAI_FACTORY). "
+            "To trust a self-signed endpoint securely, keep verification on and set "
+            "REQUESTS_CA_BUNDLE to your CA instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return False
+    return True
 
 
 def get_platform_api_base_url() -> str:

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_platform_tls_verify.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_platform_tls_verify.py
@@ -1,0 +1,44 @@
+"""Tests for platform-API TLS verification behavior."""
+
+import warnings
+
+import pytest
+
+from crewai_tools.tools.crewai_platform_tools.misc import platform_tls_verify
+
+
+@pytest.fixture(autouse=True)
+def _clear_tls_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CREWAI_FACTORY", raising=False)
+    monkeypatch.delenv("CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY", raising=False)
+
+
+def test_tls_verify_on_by_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail the test
+        assert platform_tls_verify() is True
+
+
+def test_tls_verify_disabled_by_explicit_flag_warns_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY", "true")
+    with pytest.warns(UserWarning, match="TLS certificate verification is DISABLED"):
+        assert platform_tls_verify() is False
+
+
+def test_tls_verify_disabled_by_legacy_factory_flag_warns_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Back-compat: CREWAI_FACTORY still disables, but now loudly instead of silently.
+    monkeypatch.setenv("CREWAI_FACTORY", "true")
+    with pytest.warns(UserWarning, match="TLS certificate verification is DISABLED"):
+        assert platform_tls_verify() is False
+
+
+def test_tls_verify_only_exact_true_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A stray non-"true" value must not silently drop TLS verification.
+    monkeypatch.setenv("CREWAI_FACTORY", "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert platform_tls_verify() is True


### PR DESCRIPTION
## Problem (security footgun)

Both CrewAI platform API requests set TLS verification like this:

```python
verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true"
```

- `crewai_platform_tool_builder.py` `_fetch_actions` (GET /actions)
- `crewai_platform_action_tool.py` (POST /actions/{name}/execute)

So **`CREWAI_FACTORY=true` disables TLS certificate verification entirely** for requests that carry the platform integration **Bearer token** (and action payloads). `CREWAI_FACTORY` is a vaguely-named flag that gives no hint it touches TLS, it's the *only* thing it does in the codebase, and disabling verification is **silent** — a classic MITM / token-leak footgun if the flag is ever set outside the intended internal build.

## Fix

Centralize the setting into `misc.platform_tls_verify()`:

- **On by default.**
- Disabled **only** via an explicit, self-documenting opt-out `CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY=true` (the legacy `CREWAI_FACTORY=true` is still honored so internal builds don't break).
- Disabling now emits a **loud `UserWarning`** — no longer silent — and points at the secure alternative: keep verification on and set the standard `REQUESTS_CA_BUNDLE` to trust a self-signed endpoint.
- Only the exact value `"true"` disables (unchanged semantics), so a stray value can't accidentally drop verification.

Both request sites now use `verify=platform_tls_verify()`; the now-unused `import os` is removed from each.

## Notes / decisions

- **Kept `CREWAI_FACTORY` back-compat** rather than removing it, so CrewAI's internal factory build (which points `CREWAI_PLUS_URL` at an internal endpoint) keeps working — but it's no longer silent. If you'd rather hard-remove it or drop the insecure path entirely, that's a small follow-up.
- The real secure path for self-signed internal endpoints is `REQUESTS_CA_BUNDLE` (natively honored by `requests` with verification on), which the warning now advertises.

## Tests

`test_platform_tls_verify.py`: on by default (no warning), disabled + loud warning via the explicit flag and the legacy flag, and non-`"true"` values stay verified. Existing `*_factory_true*` tests still pass (behavior preserved). `ruff` + `ruff format --check` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how Bearer-token platform requests validate TLS; behavior change is safer by default but legacy CREWAI_FACTORY still disables verification with a warning only.
> 
> **Overview**
> Platform API HTTP calls (action fetch and execute) no longer tie TLS verification to a silent `CREWAI_FACTORY` check. Both sites now use **`platform_tls_verify()`** from `misc`, which **verifies certificates by default**.
> 
> Opting out requires **`CREWAI_PLATFORM_INSECURE_SKIP_TLS_VERIFY=true`** (or the legacy **`CREWAI_FACTORY=true`** for internal builds). Either path emits a **`UserWarning`** about MITM risk and points users to **`REQUESTS_CA_BUNDLE`** for self-signed CAs. Only the exact value `"true"` disables verification.
> 
> New tests cover default-on behavior, loud warnings for both opt-out flags, and that non-`"true"` env values keep verification enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afc97d1f511bd8831781dfb476208fe813158ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->