### PR TITLE
fix(utilities): stop interpolate_only from re-interpolating substituted values

### DIFF
--- a/lib/crewai/src/crewai/utilities/string_utils.py
+++ b/lib/crewai/src/crewai/utilities/string_utils.py
@@ -133,7 +133,6 @@ def interpolate_only(
         )
 
     variables = _VARIABLE_PATTERN.findall(input_string)
-    result = input_string
 
     missing_vars = [var for var in variables if var not in inputs]
     if missing_vars:
@@ -141,10 +140,8 @@ def interpolate_only(
             f"Template variable '{missing_vars[0]}' not found in inputs dictionary"
         )
 
-    for var in variables:
-        if var in inputs:
-            placeholder = "{" + var + "}"
-            value = str(inputs[var])
-            result = result.replace(placeholder, value)
-
-    return result
+    # Substitute in a single pass so that braces appearing inside a value are
+    # not re-interpreted as placeholders (which would re-interpolate values).
+    return _VARIABLE_PATTERN.sub(
+        lambda match: str(inputs[match.group(1)]), input_string
+    )

--- a/lib/crewai/tests/utilities/test_string_utils.py
+++ b/lib/crewai/tests/utilities/test_string_utils.py
@@ -175,6 +175,22 @@ class TestInterpolateOnly:
         assert '"processed_by": "agent_name"' in result
         assert '"values": [1, 2, 3]' in result
 
+    def test_value_containing_placeholder_is_not_reinterpolated(self):
+        """A brace pattern inside a substituted value must be left untouched.
+
+        Regression: sequential str.replace re-scanned already-substituted values,
+        so a value like "{year} trends" had its {year} wrongly replaced too.
+        """
+        template = "Write about {topic} in {year}"
+        inputs: Dict[str, Union[str, int, float, Dict[str, Any], List[Any]]] = {
+            "topic": "{year} trends",
+            "year": "2024",
+        }
+
+        result = interpolate_only(template, inputs)
+
+        assert result == "Write about {year} trends in 2024"
+
     def test_empty_inputs_dictionary(self):
         """Test that an error is raised with empty inputs dictionary."""
         template = "Hello, {name}!"


### PR DESCRIPTION
## What's broken
`interpolate_only` re-interpolates the values it just substituted. If an input value contains text matching another input's placeholder, that placeholder inside the value gets replaced too.

```python
interpolate_only("Write about {topic} in {year}",
                 {"topic": "{year} trends", "year": "2024"})
# got:      'Write about 2024 trends in 2024'
# expected: 'Write about {year} trends in 2024'
```

This reaches users through `crew.kickoff(inputs=...)`, which feeds task descriptions and agent role/goal/backstory through this function.

## Why it happens
It interpolated via a loop of `str.replace` over the whole string. After `{topic}` is replaced with `"{year} trends"`, the injected `{year}` is still present, so the subsequent `{year}` replacement substitutes it as well. Each substitution re-scans previously-substituted content.

## Fix
Replace all placeholders in a single `re.sub` pass keyed off the existing `_VARIABLE_PATTERN`, so each template placeholder is substituted exactly once and value contents are never re-examined. The missing-variable `KeyError` behavior is unchanged.

## Test
Added `test_value_containing_placeholder_is_not_reinterpolated`. It fails on `main` (returns `...2024 trends in 2024`) and passes with the fix. All existing `interpolate_only` tests still pass.

---
_Disclosure: authored with AI assistance — flagging for the `llm-generated` label per CONTRIBUTING (I can't apply the label as an external contributor)._
