### PR TITLE
fix: add config parameter to BaseTool _run and _arun to resolve LangChain conflict

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -215,7 +215,7 @@ class BaseTool(BaseModel, ABC):
         fields: dict[str, Any] = {}
 
         for param_name, param in run_sig.parameters.items():
-            if param_name in ("self", "return"):
+            if param_name in ("self", "return", "config"):
                 continue
             if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
                 continue
@@ -230,7 +230,7 @@ class BaseTool(BaseModel, ABC):
         if not fields:
             arun_sig = signature(cls._arun)
             for param_name, param in arun_sig.parameters.items():
-                if param_name in ("self", "return"):
+                if param_name in ("self", "return", "config"):
                     continue
                 if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
                     continue
@@ -356,7 +356,7 @@ class BaseTool(BaseModel, ABC):
     async def _arun(
         self,
         *args: Any,
-        config: Optional[Any] = None,
+        config: Any | None = None,
         **kwargs: Any,
     ) -> Any:
         """Async implementation of the tool. Override for async support."""
@@ -377,7 +377,7 @@ class BaseTool(BaseModel, ABC):
     def _run(
         self,
         *args: Any,
-        config: Optional[Any] = None,
+        config: Any | None = None,
         **kwargs: Any,
     ) -> Any:
         """Sync implementation of the tool.

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -463,7 +463,7 @@ class BaseTool(BaseModel, ABC):
             fields: dict[str, Any] = {}
 
             for param_name, param in run_sig.parameters.items():
-                if param_name in ("self", "return"):
+                if param_name in ("self", "return", "config"):
                     continue
                 if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
                     continue

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -356,6 +356,7 @@ class BaseTool(BaseModel, ABC):
     async def _arun(
         self,
         *args: Any,
+        config: Optional[Any] = None,
         **kwargs: Any,
     ) -> Any:
         """Async implementation of the tool. Override for async support."""
@@ -376,6 +377,7 @@ class BaseTool(BaseModel, ABC):
     def _run(
         self,
         *args: Any,
+        config: Optional[Any] = None,
         **kwargs: Any,
     ) -> Any:
         """Sync implementation of the tool.


### PR DESCRIPTION
### Description
This PR addresses an integration issue introduced by recent updates in LangChain's execution flow. LangChain now inspects and passes a `config` keyword argument (containing callbacks and execution metadata) directly to the underlying tool execution methods (`_run` and `_arun`). 

Because CrewAI's `BaseTool` implementation did not explicitly accept this parameter in its signature, tool executions would fail with an unexpected keyword argument error (`TypeError: _run() got an unexpected keyword argument 'config'`).

### Changes
- Updated `BaseTool._run` signature to explicitly include `config: Optional[Any] = None`.
- Updated `BaseTool._arun` signature to explicitly include `config: Optional[Any] = None`.

This safely intercepts the `config` dictionary passed by LangChain, preserving backward compatibility and ensuring smooth tool execution within the crew.

### Related Issue
Closes #86

<!-- crewai-require-issue-check -->