### PR TITLE
fix(agents): exclude sanitized cache-read tool name from tool cache

### DIFF
--- a/lib/crewai/src/crewai/agents/tools_handler.py
+++ b/lib/crewai/src/crewai/agents/tools_handler.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from crewai.agents.cache.cache_handler import CacheHandler
 from crewai.tools.cache_tools.cache_tools import CacheTools
 from crewai.tools.tool_calling import InstructorToolCalling, ToolCalling
+from crewai.utilities.string_utils import sanitize_tool_name
 
 
 class ToolsHandler(BaseModel):
@@ -37,7 +38,9 @@ class ToolsHandler(BaseModel):
             should_cache: Whether to cache the tool output.
         """
         self.last_used_tool = calling
-        if self.cache and should_cache and calling.tool_name != CacheTools().name:
+        if self.cache and should_cache and calling.tool_name != sanitize_tool_name(
+            CacheTools().name
+        ):
             input_str = ""
             if calling.arguments:
                 if isinstance(calling.arguments, dict):

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -24,8 +24,10 @@ from crewai.hooks.tool_hooks import (
     register_after_tool_call_hook,
 )
 from crewai.tools import BaseTool
+from crewai.tools.cache_tools.cache_tools import CacheTools
 from crewai.tools.tool_calling import ToolCalling
 from crewai.tools.tool_usage import ToolUsage
+from crewai.utilities.string_utils import sanitize_tool_name
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -903,3 +905,25 @@ def test_tool_error_does_not_emit_finished_event():
     assert len(finished_events) == 0, (
         "ToolUsageFinishedEvent should NOT be emitted after ToolUsageErrorEvent"
     )
+
+
+def test_cache_tool_result_is_not_cached():
+    """The cache-read tool ('hit_cache') must not be added to the tool cache.
+
+    Regression test: the exclusion guard compared the raw default name
+    'Hit Cache' against the sanitized runtime name 'hit_cache', so the guard
+    was always True and the cache tool's own output got cached anyway.
+    """
+    cache = CacheHandler()
+    tools_handler = ToolsHandler(cache=cache)
+
+    tools_handler.on_tool_use(
+        calling=ToolCalling(
+            tool_name=sanitize_tool_name(CacheTools().name),
+            arguments={},
+        ),
+        output="cached value",
+    )
+
+    cached = cache.read(tool=sanitize_tool_name(CacheTools().name), input="")
+    assert cached is None, "Cache read tool result must not be cached"


### PR DESCRIPTION
## Summary
The guard in `ToolsHandler.on_tool_use` that prevents the built-in cache-read tool ("Hit Cache") from being added to the tool cache compared the raw default name `"Hit Cache"` against the sanitized runtime name `"hit_cache"`. They never match, so the guard was always `True` and the cache tool's own output was written into the cache — polluting it with dead entries and risking stale values.

## Fix
Compare against `sanitize_tool_name(CacheTools().name)` so the sanitized names align.

## Test
Added `test_cache_tool_result_is_not_cached` to `lib/crewai/tests/tools/test_tool_usage.py`. FAILS before the fix, PASSES after. Full `tests/tools/test_tool_usage.py` = 24 passed + new test (5 pre-existing event-bus timing failures are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>