### PR TITLE
fix(tools): raise ToolUsageError instead of bare raise on non-dict args

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -849,9 +849,13 @@ class ToolUsage:
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         if not isinstance(arguments, dict):
+            error = ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+            # A bare ``raise`` here would fail with "No active exception to
+            # re-raise" (this path is outside the except block above), so raise
+            # the intended ToolUsageError explicitly.
             if raise_error:
-                raise
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+                raise error
+            return error
 
         return ToolCalling(
             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -259,6 +259,46 @@ def test_last_raw_result_falls_back_only_until_recorded():
     tool_usage.last_raw_result = None
 
     assert tool_usage.get_last_raw_result("formatted result") is None
+
+
+def _tool_usage_for_calling() -> ToolUsage:
+    return ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[],
+        task=MagicMock(),
+        function_calling_llm=MagicMock(),
+        agent=MagicMock(),
+        action=MagicMock(),
+    )
+
+
+def test_original_tool_calling_non_dict_raises_tool_usage_error():
+    """When validated arguments are not a dict and raise_error=True, a
+    ToolUsageError must be raised — not a RuntimeError from a bare `raise`
+    with no active exception (#6430)."""
+    tool_usage = _tool_usage_for_calling()
+
+    with (
+        patch.object(tool_usage, "_select_tool", return_value=MagicMock()),
+        patch.object(tool_usage, "_validate_tool_input", return_value=[1, 2, 3]),
+    ):
+        with pytest.raises(ToolUsageError):
+            tool_usage._original_tool_calling("some tool string", raise_error=True)
+
+
+def test_original_tool_calling_non_dict_returns_error_when_not_raising():
+    """With raise_error=False, non-dict arguments return a ToolUsageError."""
+    tool_usage = _tool_usage_for_calling()
+
+    with (
+        patch.object(tool_usage, "_select_tool", return_value=MagicMock()),
+        patch.object(tool_usage, "_validate_tool_input", return_value=[1, 2, 3]),
+    ):
+        result = tool_usage._original_tool_calling(
+            "some tool string", raise_error=False
+        )
+
+    assert isinstance(result, ToolUsageError)
 
 
 def test_validate_tool_input_booleans_and_none():


### PR DESCRIPTION
## Problem

`ToolUsage._original_tool_calling` has a bare `raise` on the non-dict path, which sits **outside** the preceding `try/except`:

```python
try:
    arguments = self._validate_tool_input(self.action.tool_input)
except Exception:
    if raise_error:
        raise            # OK — re-raises the active exception
    return ToolUsageError(...)

if not isinstance(arguments, dict):
    if raise_error:
        raise            # BUG — no active exception here
    return ToolUsageError(...)
```

`_tool_calling()` calls this with `raise_error=True`, so if `_validate_tool_input` ever returns a non-dict, the bare `raise` fails with `RuntimeError: No active exception to re-raise` — masking the intended tool-arguments error. It's a latent landmine today (that helper currently always returns a dict or raises), but it's still incorrect.

## Fix

Raise the intended `ToolUsageError` explicitly:

```python
if not isinstance(arguments, dict):
    error = ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
    if raise_error:
        raise error
    return error
```

The bare `raise` at the earlier site (inside `except`) is correct and left unchanged.

## Tests

Added two tests in `test_tool_usage.py` (mock `_validate_tool_input` → non-dict): `raise_error=True` raises `ToolUsageError` (not `RuntimeError`), and `raise_error=False` returns a `ToolUsageError`. Verified failing-without/passing-with the fix; full `test_tool_usage.py` (30) green; `ruff` + `mypy` clean.

Fixes #6430

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->