### PR TITLE
fix: make RAG file-type detection case-insensitive

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/rag/data_types.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/data_types.py
@@ -123,8 +123,9 @@ class DataTypes:
                 ".xml": DataType.XML,
                 ".txt": DataType.TEXT_FILE,
             }
+            lower_path = path.lower()
             for ext, dtype in mapping.items():
-                if path.endswith(ext):
+                if lower_path.endswith(ext):
                     return dtype
             return None
 


### PR DESCRIPTION
Closes #6399

**Problem:** `DataTypes.from_content()` uses case-sensitive `path.endswith(ext)` against a lowercase-only extension map. Files with uppercase/mixed-case extensions (`.PDF`, `.CSV`, `.DOCX`) are silently misrouted to the text loader, causing raw binary bytes to be chunked and embedded into the RAG store instead of parsed document text.

**Fix:** Lowercase the path before extension matching:

```python
lower_path = path.lower()
for ext, dtype in mapping.items():
    if lower_path.endswith(ext):
        return dtype
```

**Before:**
| Input | Detected | Correct |
|---|---|---|
| `report.PDF` | `text_file` | `pdf_file` |
| `data.CSV` | `text_file` | `csv` |
| `doc.DOCX` | `text_file` | `docx` |

**After:** All resolve correctly regardless of case.

This is a single-line change with no behavioral impact for already-correct lowercase paths.

AI-assisted: written with the help of an AI coding agent (OpenClaw/GlM-5.1).