### PR TITLE
fix(reasoning): detect a bare READY marker in text plans

### DIFF
--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 _READY_MARKER: Final[re.Pattern[str]] = re.compile(
-    r"\bNOT\s+READY\b|\bREADY\b", re.IGNORECASE
+    r"^\s*(NOT\s+)?READY\b", re.IGNORECASE | re.MULTILINE
 )
 
 
@@ -41,9 +41,11 @@ def _detect_plan_ready(text: str) -> bool:
     bare ``READY`` rather than the full "READY: I am ready to execute the task."
     sentence, which the previous exact-substring check missed (#6204).
 
-    Matches the LAST readiness marker so a "not ready" mentioned earlier in the
-    plan doesn't override a final "READY", and so "NOT READY" wins over the bare
-    "READY" it contains.
+    The verdict is only recognized when READY / NOT READY is the first
+    non-whitespace on its own line, mirroring how the prompt asks the model to
+    conclude. This avoids treating ordinary prose (e.g. "I am ready to begin")
+    as a verdict, while still accepting "READY", "READY.", "READY: ...", etc.
+    The LAST such marker wins, so a later line overrides an earlier one.
 
     Args:
         text: The raw model response.
@@ -52,10 +54,12 @@ def _detect_plan_ready(text: str) -> bool:
         True if the concluding marker is READY, False for NOT READY or if no
         marker is present.
     """
-    markers = _READY_MARKER.findall(text)
+    # findall returns the optional ``(NOT\\s+)`` group: "" => READY, a non-empty
+    # value (e.g. "NOT ") => NOT READY.
+    markers: list[str] = _READY_MARKER.findall(text)
     if not markers:
         return False
-    return "NOT" not in markers[-1].upper()
+    return markers[-1].strip() == ""
 
 
 class ReasoningPlan(BaseModel):

--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 _READY_MARKER: Final[re.Pattern[str]] = re.compile(
-    r"NOT\s+READY|READY", re.IGNORECASE
+    r"\bNOT\s+READY\b|\bREADY\b", re.IGNORECASE
 )
 
 

--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from pydantic import BaseModel, Field
@@ -25,6 +26,36 @@ if TYPE_CHECKING:
     from crewai.agent import Agent
     from crewai.agent.planning_config import PlanningConfig
     from crewai.task import Task
+
+
+_READY_MARKER: Final[re.Pattern[str]] = re.compile(
+    r"NOT\s+READY|READY", re.IGNORECASE
+)
+
+
+def _detect_plan_ready(text: str) -> bool:
+    """Detect whether a text reasoning plan concludes with READY.
+
+    The reasoning prompts instruct the model to conclude with "READY" or
+    "NOT READY", but models (especially on the text-parsing path) often emit a
+    bare ``READY`` rather than the full "READY: I am ready to execute the task."
+    sentence, which the previous exact-substring check missed (#6204).
+
+    Matches the LAST readiness marker so a "not ready" mentioned earlier in the
+    plan doesn't override a final "READY", and so "NOT READY" wins over the bare
+    "READY" it contains.
+
+    Args:
+        text: The raw model response.
+
+    Returns:
+        True if the concluding marker is READY, False for NOT READY or if no
+        marker is present.
+    """
+    markers = _READY_MARKER.findall(text)
+    if not markers:
+        return False
+    return "NOT" not in markers[-1].upper()
 
 
 class ReasoningPlan(BaseModel):
@@ -409,7 +440,7 @@ class AgentReasoning:
             return (
                 response_str,
                 [],
-                "READY: I am ready to execute the task." in response_str,
+                _detect_plan_ready(response_str),
             )
 
         except Exception as e:
@@ -433,7 +464,7 @@ class AgentReasoning:
                 return (
                     fallback_str,
                     [],
-                    "READY: I am ready to execute the task." in fallback_str,
+                    _detect_plan_ready(fallback_str),
                 )
             except Exception as inner_e:
                 self.logger.error(f"Error during fallback text parsing: {inner_e!s}")
@@ -593,7 +624,7 @@ class AgentReasoning:
             return "No plan was generated.", False
 
         plan = response
-        ready = "READY: I am ready to execute the task." in response
+        ready = _detect_plan_ready(response)
 
         return plan, ready
 

--- a/lib/crewai/tests/utilities/test_structured_planning.py
+++ b/lib/crewai/tests/utilities/test_structured_planning.py
@@ -17,7 +17,39 @@ from crewai.utilities.reasoning_handler import (
     FUNCTION_SCHEMA,
     AgentReasoning,
     ReasoningPlan,
+    _detect_plan_ready,
 )
+
+
+class TestDetectPlanReady:
+    """Readiness detection must accept a bare READY marker, not only the full
+    'READY: I am ready to execute the task.' sentence (#6204)."""
+
+    def test_bare_ready_marker_is_ready(self):
+        assert _detect_plan_ready("1. do X\n2. do Y\n\n---\n\nREADY") is True
+
+    def test_full_sentence_still_ready(self):
+        assert _detect_plan_ready("plan...\nREADY: I am ready to execute the task.")
+
+    def test_not_ready_marker_is_not_ready(self):
+        assert (
+            _detect_plan_ready("plan...\n\nNOT READY: I need more detail.") is False
+        )
+
+    def test_last_marker_wins_over_mid_text_not_ready(self):
+        text = "Step 1 is not ready to run yet without input.\n\nREADY"
+        assert _detect_plan_ready(text) is True
+
+    def test_case_insensitive(self):
+        assert _detect_plan_ready("plan...\n\nready") is True
+        assert _detect_plan_ready("plan...\n\nnot ready") is False
+
+    def test_no_marker_defaults_to_not_ready(self):
+        assert _detect_plan_ready("just a plan with no verdict") is False
+
+    def test_parse_planning_response_detects_bare_ready(self):
+        _plan, ready = AgentReasoning._parse_planning_response("my plan\n\nREADY")
+        assert ready is True
 
 
 class TestFunctionSchema:

--- a/lib/crewai/tests/utilities/test_structured_planning.py
+++ b/lib/crewai/tests/utilities/test_structured_planning.py
@@ -58,6 +58,20 @@ class TestDetectPlanReady:
             _detect_plan_ready("NOT READY. I already have the tools.") is False
         )
 
+    def test_ready_as_ordinary_prose_word_is_not_a_verdict(self):
+        # "ready" mid-sentence is prose, not a verdict marker (line-anchored).
+        assert _detect_plan_ready("I am ready to begin researching.") is False
+        assert _detect_plan_ready("The tool is ready when the file exists.") is False
+
+    def test_verdict_on_its_own_line_after_prose(self):
+        # A concluding marker on its own line is still detected past prose.
+        assert (
+            _detect_plan_ready("I am ready to begin researching.\n\nREADY") is True
+        )
+        assert (
+            _detect_plan_ready("Everything looks ready.\n\nNOT READY: gap") is False
+        )
+
     def test_parse_planning_response_detects_bare_ready(self):
         _plan, ready = AgentReasoning._parse_planning_response("my plan\n\nREADY")
         assert ready is True

--- a/lib/crewai/tests/utilities/test_structured_planning.py
+++ b/lib/crewai/tests/utilities/test_structured_planning.py
@@ -47,6 +47,17 @@ class TestDetectPlanReady:
     def test_no_marker_defaults_to_not_ready(self):
         assert _detect_plan_ready("just a plan with no verdict") is False
 
+    def test_ready_substring_inside_words_is_ignored(self):
+        # "already" contains "ready" but is not a READY marker (word boundaries).
+        assert _detect_plan_ready("I am already prepared") is False
+        assert _detect_plan_ready("The steps are already documented") is False
+
+    def test_trailing_already_does_not_flip_not_ready(self):
+        # A trailing "already" must not override a concluding NOT READY.
+        assert (
+            _detect_plan_ready("NOT READY. I already have the tools.") is False
+        )
+
     def test_parse_planning_response_detects_bare_ready(self):
         _plan, ready = AgentReasoning._parse_planning_response("my plan\n\nREADY")
         assert ready is True


### PR DESCRIPTION
## Problem

With reasoning enabled, the executor asks the model to conclude its plan with **READY** or **NOT READY** and loops "refine plan" until ready. But there's a mismatch between what the prompts request and what the parser accepts:

- `refine_plan_prompt` (and one of the `create_plan_prompt` variants) say: *"Conclude with **READY or NOT READY**"* → models emit a bare `READY`.
- The text parser only accepted the exact sentence:
  ```python
  ready = "READY: I am ready to execute the task." in response
  ```

So a bare `READY` is never detected as ready — the agent stays stuck refining until max attempts. This bites text-parsing models (the reporter used Ollama GLM), where the trace clearly shows `READY` but it's read as not-ready.

## Fix

Add a `_detect_plan_ready` helper and use it at all three text-detection sites:

```python
_READY_MARKER = re.compile(r"NOT\s+READY|READY", re.IGNORECASE)

def _detect_plan_ready(text: str) -> bool:
    markers = _READY_MARKER.findall(text)
    if not markers:
        return False
    return "NOT" not in markers[-1].upper()
```

- Matches the **last** marker, so a "not ready" mentioned mid-plan doesn't override a final `READY`.
- `NOT READY` wins over the bare `READY` it contains.
- The old full sentence (`"READY: I am ready to execute the task."`) still counts as ready — backward compatible.

Only the text-parsing path is affected; the structured/function-calling path already uses a boolean `ready` field.

## Behavior (old → new)
| response ends with | old | new |
|---|---|---|
| `READY` | ❌ not ready | ✅ ready |
| `NOT READY: …` | not ready | not ready |
| `READY: I am ready to execute the task.` | ready | ready |

## Tests
Added `TestDetectPlanReady` (bare/full/none/mid-text/case-insensitive + `_parse_planning_response` integration). Full `test_structured_planning.py` (33) green; `ruff` + `mypy` clean. Branched off latest `main` (v1.15.2).

Fixes #6204

---
This PR was authored with [Claude Code](https://claude.com/claude-code). Per `CONTRIBUTING.md`, AI-generated contributions require the `llm-generated` label — I don't have triage permission to set it, so could a maintainer please add it? 🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->