### PR TITLE
docs: add TokenLab LLM connection example

### DIFF
--- a/docs/edge/en/learn/llm-connections.mdx
+++ b/docs/edge/en/learn/llm-connections.mdx
@@ -143,6 +143,14 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
         os.environ["OPENAI_API_BASE"] = "https://generativelanguage.googleapis.com/v1beta/openai/"
         os.environ["OPENAI_MODEL_NAME"] = "openai/gemini-2.0-flash"  # Add your Gemini model here, under openai/
         ```
+
+        ```python TokenLab
+        import os
+
+        os.environ["OPENAI_API_KEY"] = "your-tokenlab-api-key"
+        os.environ["OPENAI_API_BASE"] = "https://api.tokenlab.sh/v1"
+        os.environ["OPENAI_MODEL_NAME"] = "claude-sonnet-5"
+        ```
         </CodeGroup>
     </Tab>
     <Tab title="Using LLM Class Attributes">
@@ -162,6 +170,16 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
                 model="openai/gemini-2.0-flash",
                 base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
                 api_key="your-gemini-key",  # Should start with AIza...
+            )
+            agent = Agent(llm=llm, ...)
+            ```
+
+            ```python TokenLab
+            # Example using TokenLab's OpenAI-compatible API
+            llm = LLM(
+                model="claude-sonnet-5",
+                base_url="https://api.tokenlab.sh/v1",
+                api_key="your-tokenlab-api-key",
             )
             agent = Agent(llm=llm, ...)
             ```


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible LLM connection option for CrewAI.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check