### PR TITLE
fix(tools): raise ToolUsageError instead of bare raise for non-dict arguments

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -850,7 +850,7 @@ class ToolUsage:
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise
+                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         return ToolCalling(

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -557,6 +557,58 @@ def test_validate_tool_input_large_json_content():
 
     arguments = tool_usage._validate_tool_input(tool_input)
     assert arguments == expected_arguments
+
+
+def test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments():
+    """A non-dict tool input must surface as ToolUsageError, not RuntimeError.
+
+    Regression test for the bare ``raise`` in ``_original_tool_calling``: when
+    the parsed arguments are not a dict, ``raise_error=True`` previously hit a
+    ``raise`` statement outside any active ``except`` block, producing
+    ``RuntimeError: No active exception to reraise`` instead of the intended
+    ``ToolUsageError``.
+    """
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[],
+        task=MagicMock(),
+        function_calling_llm=MagicMock(),
+        agent=MagicMock(),
+        action=MagicMock(),
+    )
+
+    with patch.object(tool_usage, "_select_tool", return_value=MagicMock(name="tool")):
+        with patch.object(
+            ToolUsage,
+            "_validate_tool_input",
+            return_value=["not", "a", "dict"],
+        ):
+            with pytest.raises(ToolUsageError):
+                tool_usage._original_tool_calling("tool_string", raise_error=True)
+
+
+def test_original_tool_calling_returns_tool_usage_error_for_non_dict_without_raise():
+    """When ``raise_error=False`` a non-dict input returns a ToolUsageError."""
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[],
+        task=MagicMock(),
+        function_calling_llm=MagicMock(),
+        agent=MagicMock(),
+        action=MagicMock(),
+    )
+
+    with patch.object(tool_usage, "_select_tool", return_value=MagicMock(name="tool")):
+        with patch.object(
+            ToolUsage,
+            "_validate_tool_input",
+            return_value=["not", "a", "dict"],
+        ):
+            result = tool_usage._original_tool_calling(
+                "tool_string", raise_error=False
+            )
+
+    assert isinstance(result, ToolUsageError)
 
 
 def test_tool_selection_error_event_direct():


### PR DESCRIPTION
## Description

`ToolUsage._original_tool_calling()` used a bare `raise` **outside any active `except` block** when the parsed tool arguments were not a `dict`:

```python
if not isinstance(arguments, dict):
    if raise_error:
        raise          # <- no active exception here
    return ToolUsageError(...)
```

A bare `raise` re-raises the exception currently being handled, but on this path the preceding `try/except` completed **normally**, so no exception is active. Result: with `raise_error=True` the call raised `RuntimeError: No active exception to reraise` instead of the intended `ToolUsageError`, masking the real tool-arguments problem.

Fix: raise the explicit `ToolUsageError`, matching the message already used by the `raise_error=False` branch on the next line.

```python
if not isinstance(arguments, dict):
    if raise_error:
        raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
    return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
```

## Why the bug was latent

`_validate_tool_input()` currently always returns a `dict` or raises, so the non-dict branch was effectively dead code in normal use. The bug surfaces whenever that contract is relaxed — e.g. subclasses overriding `_validate_tool_input`, monkeypatching in tests, or future changes to the validation pipeline. Making the branch raise the correct exception keeps the failure mode meaningful instead of an opaque `RuntimeError`.

## Test plan

- [x] Added regression test `test_original_tool_calling_raises_tool_usage_error_for_non_dict_arguments` — fails with `RuntimeError` on the old code, passes with `ToolUsageError` after the fix.
- [x] Added `test_original_tool_calling_returns_tool_usage_error_for_non_dict_without_raise` covering the `raise_error=False` path.
- [x] `uv run pytest lib/crewai/tests/tools/` → 135 passed.
- [x] `uv run ruff check lib/` → clean.
- [x] `uv run mypy lib/crewai/src/crewai/tools/tool_usage.py` → clean (strict).

Fixes #6430.

> Note: per `.github/CONTRIBUTING.md`, this PR is authored by an AI agent (Claude Code) and carries the `llm-generated` label.