### PR TITLE
[security] Fix verdict-injection via extract_json_from_llm_response

### DIFF
--- a/lib/crewai/src/crewai/experimental/evaluation/json_parser.py
+++ b/lib/crewai/src/crewai/experimental/evaluation/json_parser.py
@@ -21,12 +21,22 @@ def extract_json_from_llm_response(text: str) -> dict[str, Any]:
         r"`([{\\[].*[}\]])`",
     ]
 
+    # Collect ALL parseable JSON from code blocks, then return the LAST one.
+    # The judge's own verdict is the authoritative JSON and appears last;
+    # earlier JSON may have originated from model-under-test output that was
+    # referenced in the judge's reasoning (verdict injection).
+    all_parsed: list[dict[str, Any]] = []
+
     for pattern in json_patterns:
         matches = re.findall(pattern, text, re.IGNORECASE | re.DOTALL)
         for match in matches:
             try:
                 parsed: dict[str, Any] = json.loads(match.strip())
-                return parsed
+                all_parsed.append(parsed)
             except json.JSONDecodeError:  # noqa: PERF203
                 continue
+
+    if all_parsed:
+        return all_parsed[-1]
+
     raise ValueError("No valid JSON found in the response")


### PR DESCRIPTION
## Summary

`extract_json_from_llm_response` returns the **first** matching JSON code block from the LLM judge's response. A model-under-test that embeds JSON in its output can hijack the evaluation verdict when the judge references that output in an early code block.

**Severity:** HIGH
**Class:** Prompt-injection-into-judge → verdict manipulation

## Root cause

`experimental/evaluation/json_parser.py:29`: `return parsed` returns the first code block match.

## Fix

Collect ALL parseable JSON from code blocks, return `all_parsed[-1]` (the last one — the judge's own verdict).

## Cross-framework pattern

Same vulnerability class found in 6 frameworks across 2 languages:

| Framework | Language | PR |
|---|---|---|
| deepeval | Python | [#2868](https://github.com/confident-ai/deepeval/pull/2868) |
| ragas | Python | [#2829](https://github.com/vibrantlabsai/ragas/pull/2829) |
| guardrails-ai | Python | [#1566](https://github.com/guardrails-ai/guardrails/pull/1566) |
| promptfoo | TypeScript | [#10036](https://github.com/promptfoo/promptfoo/pull/10036) |
| instructor | Python | [#2424](https://github.com/567-labs/instructor/pull/2424) |
| **CrewAI** | **Python** | **this PR** |

## Verification

- ruff: clean
- PoC regression: passes (returns LAST JSON)
- Single-file change

## Dedup

Searched issues for "extract_json", "verdict injection", "prompt injection". Zero matches for the JSON parser. Novel.

---

_Generated by redthread. Single-purpose security fix._