### PR TITLE
fix(flow): don't double-append the turn reply when a handler trims history

### DIFF
--- a/lib/crewai/src/crewai/experimental/conversational_mixin.py
+++ b/lib/crewai/src/crewai/experimental/conversational_mixin.py
@@ -133,6 +133,7 @@ class _ConversationalMixin:
         _pending_user_message: str | dict[str, Any] | None
         _pending_intents: Sequence[str] | None
         _pending_intent_llm: str | BaseLLM | None
+        _assistant_reply_appended: bool
 
         def _clear_or_listeners(self) -> None:
             pass
@@ -310,11 +311,11 @@ class _ConversationalMixin:
             if "from_checkpoint" not in kickoff_kwargs:
                 self._reset_turn_execution_state()
 
-            assistant_count = self._assistant_message_count()
+            object.__setattr__(self, "_assistant_reply_appended", False)
             result = self.kickoff(inputs={"id": sid}, **kickoff_kwargs)
             if (
                 result is not None
-                and self._assistant_message_count() == assistant_count
+                and not self._assistant_reply_appended
                 and self._is_public_turn_result(result)
             ):
                 self.append_assistant_message(self._stringify_result(result))
@@ -387,7 +388,7 @@ class _ConversationalMixin:
                 if "from_checkpoint" not in kickoff_kwargs:
                     self._reset_turn_execution_state()
 
-                assistant_count = self._assistant_message_count()
+                object.__setattr__(self, "_assistant_reply_appended", False)
                 original_stream = bool(getattr(self, "stream", False))
                 original_streaming_turn = getattr(
                     self, "_streaming_conversation_turn", False
@@ -403,7 +404,7 @@ class _ConversationalMixin:
                     )
                 if (
                     result is not None
-                    and self._assistant_message_count() == assistant_count
+                    and not self._assistant_reply_appended
                     and self._is_public_turn_result(result)
                 ):
                     self.append_assistant_message(self._stringify_result(result))
@@ -618,6 +619,9 @@ class _ConversationalMixin:
         metadata: dict[str, Any] | None = None,
     ) -> None:
         """Append a final user-visible assistant message."""
+        # Explicit signal for handle_turn's "did the handler reply?" check.
+        # A count heuristic breaks when handlers trim history mid-turn.
+        object.__setattr__(self, "_assistant_reply_appended", True)
         state = cast(ConversationState, self.state)
         state.messages.append(
             ConversationMessage(
@@ -788,6 +792,8 @@ class _ConversationalMixin:
             object.__setattr__(self, "_pending_intent_llm", None)
         if not hasattr(self, "_streaming_conversation_turn"):
             object.__setattr__(self, "_streaming_conversation_turn", False)
+        if not hasattr(self, "_assistant_reply_appended"):
+            object.__setattr__(self, "_assistant_reply_appended", False)
 
     def _create_default_extension_state(self) -> ConversationState | None:
         initial_state_t = getattr(self, "_initial_state_t", None)
@@ -1106,10 +1112,6 @@ class _ConversationalMixin:
         if visible == "all" or (visible is not None and agent_name in visible):
             return "public"
         return "private"
-
-    def _assistant_message_count(self) -> int:
-        state = cast(ConversationState, self.state)
-        return sum(1 for message in state.messages if message.role == "assistant")
 
     def _is_public_turn_result(self, result: Any) -> bool:
         if not isinstance(result, str):

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -1555,6 +1555,71 @@ class TestConversationalFlow:
         )
 
 
+class TestHandleTurnReplyFallback:
+    """Regression tests for EPD-181: ``handle_turn()`` decided "did the
+    handler append its reply?" by comparing assistant-message counts. A
+    handler that appends its reply AND trims history to a cap left the count
+    unchanged, so the fallback appended the reply a second time — every turn,
+    once trimming engaged. The check now uses an explicit appended-this-turn
+    flag.
+    """
+
+    MAX_MESSAGES = 4
+
+    def _make_bot(self) -> ConversationalFlow:
+        max_messages = self.MAX_MESSAGES
+
+        class EchoBot(ConversationalFlow):
+            def route_turn(self, context: dict[str, Any]) -> str | None:
+                return "ECHO"
+
+            @listen("ECHO")
+            def echo(self) -> str:
+                reply = f"echo: {self.state.current_user_message or ''}"
+                self.append_assistant_message(reply)  # handler DOES append
+                if len(self.state.messages) > max_messages:  # ...and trims
+                    self.state.messages = self.state.messages[-max_messages:]
+                return reply
+
+        return EchoBot()
+
+    def test_no_duplicate_reply_when_handler_trims_history(self) -> None:
+        bot = self._make_bot()
+        for i in range(1, 5):
+            bot.handle_turn(f"message {i}")
+            contents = [message.content for message in bot.state.messages]
+            assert len(contents) == len(set(contents)), (
+                f"duplicate reply on turn {i}: {contents}"
+            )
+
+        # The capped window holds the last two full turns, in order.
+        assert [message.content for message in bot.state.messages] == [
+            "message 3",
+            "echo: message 3",
+            "message 4",
+            "echo: message 4",
+        ]
+
+    def test_fallback_still_appends_when_handler_does_not_reply(self) -> None:
+        class SilentBot(ConversationalFlow):
+            def route_turn(self, context: dict[str, Any]) -> str | None:
+                return "WORK"
+
+            @listen("WORK")
+            def work(self) -> str:
+                return "computed reply"  # returns without appending
+
+        bot = SilentBot()
+        bot.handle_turn("hello")
+
+        assistant_messages = [
+            message.content
+            for message in bot.state.messages
+            if message.role == "assistant"
+        ]
+        assert assistant_messages == ["computed reply"]
+
+
 class TestFlowTracingWhenSuppressed:
     def test_flow_started_emitted_when_panel_events_suppressed(self) -> None:
         class QuietFlow(Flow[ChatState]):


### PR DESCRIPTION
## Summary

Fixes [EPD-181](https://linear.app/crewai/issue/EPD-181/conversational-flow-handle-turn-double-appends-the-reply-when-a): in the experimental Conversational Flow, `handle_turn()`'s safety net — "append the handler's return value if the handler didn't append an assistant message itself" — inferred that by **comparing assistant-message counts** before and after kickoff. A handler that appends its reply *and* trims `state.messages` to a cap (a normal bounded-context pattern) leaves the count unchanged, so the fallback appended the reply a **second** time — on every turn once trimming engaged. The duplicates then crowd real turns out of the capped window. Silent, starts mid-conversation, nasty to debug.

## Fix

Replace the count heuristic with an explicit per-turn signal, as the ticket suggests:

- `append_assistant_message()` sets an `_assistant_reply_appended` instance flag.
- `handle_turn()` and `stream_turn()` clear the flag right before kickoff and only run the fallback when no assistant message was appended during the turn — robust to any history mutation (trimming, rewriting, compaction).
- This also covers `append_agent_result(..., visibility="public")` and the built-in handlers, which all append through `append_assistant_message()`.
- The now-unused `_assistant_message_count()` helper is removed.

## Testing

- The ticket's clean-room repro (echo handler with a 4-message cap) now prints `NOT REPRODUCED: no duplicate assistant messages across 4 turns` — where 1.15.2 duplicated from turn 3 onward — and the capped window correctly holds the last two full turns instead of stale echo copies.
- New `TestHandleTurnReplyFallback` regression tests: the trim scenario across 4 turns (no duplicates + exact window contents), and the fallback still appending exactly once for handlers that return without appending.
- Green: full `test_flow_conversation.py` (44), broader flow suites (305: flow, definition, from-definition, persistence, human-input integration), ruff, and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to experimental conversational turn handling with regression tests; behavior change only affects when the return-value fallback runs.
> 
> **Overview**
> Fixes **EPD-181**: experimental conversational `handle_turn()` / `stream_turn()` used to infer “did the handler already reply?” by comparing assistant-message counts before and after kickoff. Handlers that call `append_assistant_message()` and then **trim** `state.messages` can leave the count unchanged, so the fallback appended the same reply again.
> 
> The change replaces that heuristic with a per-turn **`_assistant_reply_appended`** flag: cleared before kickoff, set in `append_assistant_message()`, and used to decide whether to append the kickoff return value. **`_assistant_message_count()`** is removed.
> 
> **`TestHandleTurnReplyFallback`** covers trimming (no duplicates, correct capped window) and silent handlers (fallback still appends once).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b118f6b0af43469919ac9fbbfcea03fe13ffa50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->