### PR TITLE
fix(events): prevent UnicodeEncodeError crash on non-UTF-8 consoles

### DIFF
--- a/lib/crewai/src/crewai/events/utils/console_formatter.py
+++ b/lib/crewai/src/crewai/events/utils/console_formatter.py
@@ -41,6 +41,11 @@ class ConsoleFormatter:
 
     def __init__(self, verbose: bool = False):
         self.console = Console(width=None)
+        if hasattr(self.console.file, "reconfigure"):
+            try:
+                self.console.file.reconfigure(errors="replace")
+            except Exception:  # noqa: S110 - best-effort; stream may not support reconfigure
+                pass
         self.verbose = verbose
         self._streaming_live: Live | None = None
         self._is_streaming: bool = False

--- a/lib/crewai/tests/utilities/test_console_formatter_encoding.py
+++ b/lib/crewai/tests/utilities/test_console_formatter_encoding.py
@@ -1,0 +1,25 @@
+import io
+
+from rich.text import Text
+
+from crewai.events.utils.console_formatter import ConsoleFormatter
+
+
+class TestConsoleFormatterEncoding:
+    """Regression tests: emoji panel titles must not crash on non-UTF-8 streams (e.g. Windows cp1252 console)."""
+
+    def test_reconfigures_stream_errors_to_replace(self):
+        formatter = ConsoleFormatter()
+
+        assert formatter.console.file.errors == "replace"
+
+    def test_emoji_panel_does_not_raise_on_cp1252_stream(self):
+        cp1252_stream = io.TextIOWrapper(
+            io.BytesIO(), encoding="cp1252", write_through=True
+        )
+        formatter = ConsoleFormatter()
+        formatter.console.file = cp1252_stream
+        if hasattr(cp1252_stream, "reconfigure"):
+            cp1252_stream.reconfigure(errors="replace")
+
+        formatter.print_panel(Text("x"), "🌊 Flow Started", "blue", is_flow=True)


### PR DESCRIPTION
On Windows terminals using a legacy codepage (cp1252), printing emoji panel
titles (e.g. "🌊 Flow Started", "🔄 Flow Method Running") raises
UnicodeEncodeError inside ConsoleFormatter's sync event handlers. The event
bus swallows the exception and prints an error line instead, so every Flow
event silently fails to render and spams
"[CrewAIEventsBus] Sync handler error ..." for the whole run.

This is the same root cause behind several previously closed issues
(#3062, #2715, #2708, #823, #772, #755, #713, #665, #603) — each was patched
around a specific emoji/message rather than fixed at the source, so it keeps
recurring whenever a new emoji panel is added.

Fix: reconfigure the console's underlying stream to use errors="replace" on
init, so unencodable characters degrade to "?" instead of crashing.

Reproduced locally on Windows (cp1252 console) with a simple Flow —
confirmed crash before the fix, clean output after. Added regression test
covering both the stream reconfiguration and an emoji panel print against a
cp1252-encoded stream.


<!-- crewai-require-issue-check -->