### PR TITLE
refactor(tools): migrate stagehand example off deprecated crewai.utilities.printer

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/example.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/example.py
@@ -18,7 +18,7 @@ Usage:
 import os
 
 from crewai import Agent, Crew, Process, Task
-from crewai.utilities.printer import Printer
+from crewai_core.printer import Printer
 from dotenv import load_dotenv
 from stagehand.schemas import AvailableModel  # type: ignore[import-not-found]
 


### PR DESCRIPTION
### Summary

The `crewai.utilities.printer` module is a deprecated wrapper that re-exports `Printer` from `crewai_core.printer` and emits a `DeprecationWarning` on every import. The stagehand example script was the only remaining internal caller of the deprecated wrapper.

This PR migrates the single internal import to the supported path, eliminating the spurious `DeprecationWarning` without any behavioral change.

### Deprecation source

`lib/crewai/src/crewai/utilities/printer.py` docstring:
> "Deprecated: use ``crewai_core.printer`` instead."

The same wrapper also emits a `DeprecationWarning` at import time:
> "crewai.utilities.printer is deprecated; import from crewai_core.printer."

### Impact

- **No external behavior change.** `Printer` is the same class at both import paths (the deprecated wrapper re-exports it unchanged).
- **Removes a spurious `DeprecationWarning`** that fired on every import of the stagehand example script.
- **No public API change.** External code that imports from `crewai.utilities.printer` is unaffected; the deprecated wrapper itself is unchanged.

### Files changed

- `lib/crewai-tools/src/crewai_tools/tools/stagehand_tool/example.py` (1 line)

### Verification

- `uv run ruff check` and `uv run ruff format --check` clean on the changed file.
- `uv run mypy` clean on the changed file.
- `uv run pytest lib/crewai-tools/tests` -- no new failures introduced by the change.