### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example

### DIFF
--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1108,6 +1108,33 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="DaoXE">
+    DaoXE is a multi-model multi-protocol API gateway with an OpenAI-compatible Chat Completions endpoint. Prefer an exact model ID from your DaoXE account catalog (`GET /v1/models`) rather than hardcoding example names. Not available in mainland China. Community contribution from a DaoXE maintainer.
+
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    DAOXE_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    from crewai import LLM
+    import os
+
+    llm = LLM(
+        model="openai/YOUR_DAOXE_MODEL_ID",  # exact ID from your DaoXE account catalog
+        custom_openai=True,
+        base_url="https://daoxe.com/v1",
+        api_key=os.getenv("DAOXE_API_KEY"),
+    )
+    ```
+
+    <Info>
+      DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients; CrewAI uses the OpenAI-compatible path above.
+      Docs: https://github.com/seven7763/DaoXE-AI
+    </Info>
+  </Accordion>
+
   <Accordion title="Nebius AI Studio">
     Set the following environment variables in your `.env` file:
     ```toml Code

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1119,13 +1119,12 @@ In this section, you'll find detailed examples that help you select, configure, 
     Example usage in your CrewAI project:
     ```python Code
     from crewai import LLM
-    import os
 
     llm = LLM(
         model="openai/YOUR_DAOXE_MODEL_ID",  # exact ID from your DaoXE account catalog
         custom_openai=True,
         base_url="https://daoxe.com/v1",
-        api_key=os.getenv("DAOXE_API_KEY"),
+        api_key=DAOXE_API_KEY,
     )
     ```
 

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1111,20 +1111,21 @@ In this section, you'll find detailed examples that help you select, configure, 
   <Accordion title="DaoXE">
     DaoXE is a multi-model multi-protocol API gateway with an OpenAI-compatible Chat Completions endpoint. Prefer an exact model ID from your DaoXE account catalog (`GET /v1/models`) rather than hardcoding example names. Not available in mainland China. Community contribution from a DaoXE maintainer.
 
-    Set the following environment variables in your `.env` file:
-    ```toml Code
-    DAOXE_API_KEY=<your-api-key>
+    Export the API key in your shell before running (or ensure your process already loads `.env` — this example does not call `load_dotenv()`):
+    ```bash Code
+    export DAOXE_API_KEY=<your-api-key>
     ```
 
     Example usage in your CrewAI project:
     ```python Code
     from crewai import LLM
+    import os
 
     llm = LLM(
         model="openai/YOUR_DAOXE_MODEL_ID",  # exact ID from your DaoXE account catalog
         custom_openai=True,
         base_url="https://daoxe.com/v1",
-        api_key=DAOXE_API_KEY,
+        api_key=os.getenv("DAOXE_API_KEY"),
     )
     ```
 


### PR DESCRIPTION
## Summary
Adds a **DaoXE** accordion to `docs/edge/en/concepts/llms.mdx` next to other gateway-style OpenAI-compatible providers.

## Why
CrewAI already documents custom OpenAI-compatible endpoints and providers like OpenRouter. DaoXE is a multi-model multi-protocol gateway (`https://daoxe.com/v1`) that some users use as a single OpenAI-compatible base for multi-model access.

## Notes
- Community contribution from a DaoXE maintainer (disclosed in the page).
- Uses `custom_openai=True` + `base_url="https://daoxe.com/v1"`.
- No hardcoded model/price tables — model IDs come from the user's DaoXE account catalog.
- DaoXE is not available in mainland China (noted).
- English `edge` docs only (same pattern as neighboring provider examples).

## Test plan
- [ ] Mintlify/docs preview renders the new Accordion
- [ ] Code sample matches current `LLM(..., custom_openai=True, base_url=...)` API