### PR TITLE
feat: add CrustApiTool for Google search via CrustAPI

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -166,6 +166,7 @@ from crewai_tools.tools.serpapi_tool.serpapi_google_search_tool import (
 from crewai_tools.tools.serpapi_tool.serpapi_google_shopping_tool import (
     SerpApiGoogleShoppingTool,
 )
+from crewai_tools.tools.crustapi_tool.crustapi_tool import CrustApiTool
 from crewai_tools.tools.serper_dev_tool.serper_dev_tool import SerperDevTool
 from crewai_tools.tools.serper_scrape_website_tool.serper_scrape_website_tool import (
     SerperScrapeWebsiteTool,
@@ -303,6 +304,7 @@ __all__ = [
     "SeleniumScrapingTool",
     "SerpApiGoogleSearchTool",
     "SerpApiGoogleShoppingTool",
+    "CrustApiTool",
     "SerperDevTool",
     "SerperScrapeWebsiteTool",
     "SerplyJobSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -154,6 +154,7 @@ from crewai_tools.tools.serpapi_tool.serpapi_google_search_tool import (
 from crewai_tools.tools.serpapi_tool.serpapi_google_shopping_tool import (
     SerpApiGoogleShoppingTool,
 )
+from crewai_tools.tools.crustapi_tool.crustapi_tool import CrustApiTool
 from crewai_tools.tools.serper_dev_tool.serper_dev_tool import SerperDevTool
 from crewai_tools.tools.serper_scrape_website_tool.serper_scrape_website_tool import (
     SerperScrapeWebsiteTool,
@@ -285,6 +286,7 @@ __all__ = [
     "SeleniumScrapingTool",
     "SerpApiGoogleSearchTool",
     "SerpApiGoogleShoppingTool",
+    "CrustApiTool",
     "SerperDevTool",
     "SerperScrapeWebsiteTool",
     "SerplyJobSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/crustapi_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/crustapi_tool/README.md
@@ -1,0 +1,45 @@
+# CrustApiTool
+
+## Description
+
+This tool searches Google through [CrustAPI](https://crustapi.com) and returns clean, structured JSON that drops straight into an agent's context. One endpoint covers web results, Maps, News, Shopping, Images, Videos, Places, Scholar, and Patents. You only pay for results that come back, and there's a free tier with no card.
+
+## Installation
+
+Install the crewai_tools package:
+
+```shell
+pip install 'crewai[tools]'
+```
+
+## Example
+
+```python
+from crewai_tools import CrustApiTool
+
+# Web search (default)
+tool = CrustApiTool()
+
+# Or pick a surface and tune the results
+tool = CrustApiTool(
+    search_type="news",
+    n_results=5,
+    country="us",
+    locale="en",
+)
+```
+
+## Steps to Get Started
+
+1. **Get an API key:** sign up free at [crustapi.com](https://crustapi.com) (3,000 credits per month, no card).
+2. **Set the environment variable:** `export CRUSTAPI_API_KEY="your_key_here"`
+3. **Use the tool:** add `CrustApiTool()` to your agent's tools.
+
+## Parameters
+
+- `search_type`: the Google surface to query. One of `search` (default web), `news`, `maps`, `places`, `shopping`, `images`, `videos`, `scholar`, `patents`.
+- `n_results`: number of results to return (default `10`).
+- `country`: two-letter country code, e.g. `us` (optional).
+- `location`: city or region for local results, e.g. `Austin, TX` (optional).
+- `locale`: two-letter language code, e.g. `en` (optional).
+- `save_file`: set `True` to also write the results to a JSON file (default `False`).

--- a/lib/crewai-tools/src/crewai_tools/tools/crustapi_tool/crustapi_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crustapi_tool/crustapi_tool.py
@@ -1,0 +1,249 @@
+import json
+import logging
+import os
+from typing import Any, List, Optional, Type
+
+import requests
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# CrustAPI returns Google data as clean JSON from one endpoint. The response shape mirrors the
+# common SERP-API schema (organic, knowledgeGraph, peopleAlsoAsk, relatedSearches, news, ...),
+# so results map straight into an agent's context. Get a free key at https://crustapi.com.
+
+ALLOWED_SEARCH_TYPES = [
+    "search",
+    "web",
+    "news",
+    "maps",
+    "places",
+    "shopping",
+    "images",
+    "videos",
+    "scholar",
+    "patents",
+]
+
+
+class CrustApiToolSchema(BaseModel):
+    """Input for CrustApiTool."""
+
+    search_query: str = Field(
+        ..., description="Mandatory search query you want to use to search Google"
+    )
+
+
+class CrustApiTool(BaseTool):
+    name: str = "Search Google with CrustAPI"
+    description: str = (
+        "A tool that searches Google via CrustAPI and returns clean, structured JSON. "
+        "Supports different search types: 'search' (default web results), 'news', 'maps', "
+        "'places', 'shopping', 'images', 'videos', 'scholar', 'patents'."
+    )
+    args_schema: Type[BaseModel] = CrustApiToolSchema
+    base_url: str = "https://crustapi.com/v1"
+    n_results: int = 10
+    save_file: bool = False
+    search_type: str = "search"
+    country: Optional[str] = ""
+    location: Optional[str] = ""
+    locale: Optional[str] = ""
+    env_vars: List[EnvVar] = [
+        EnvVar(name="CRUSTAPI_API_KEY", description="API key for CrustAPI", required=True),
+    ]
+
+    def _normalize_search_type(self, search_type: str) -> str:
+        """Validate the search type and map 'search' to CrustAPI's 'web' surface."""
+        search_type = (search_type or "search").lower()
+        if search_type not in ALLOWED_SEARCH_TYPES:
+            raise ValueError(
+                f"Invalid search type: {search_type}. "
+                f"Must be one of: {', '.join(ALLOWED_SEARCH_TYPES)}"
+            )
+        return "web" if search_type == "search" else search_type
+
+    def _process_knowledge_graph(self, kg: dict) -> dict:
+        """Process knowledge graph data from search results."""
+        return {
+            "title": kg.get("title", ""),
+            "type": kg.get("type", ""),
+            "website": kg.get("website", ""),
+            "imageUrl": kg.get("imageUrl", ""),
+            "description": kg.get("description", ""),
+            "descriptionSource": kg.get("descriptionSource", ""),
+            "descriptionLink": kg.get("descriptionLink", ""),
+            "attributes": kg.get("attributes", {}),
+        }
+
+    def _process_organic_results(self, organic_results: list) -> list:
+        """Process organic search results."""
+        processed_results = []
+        for result in organic_results[: self.n_results]:
+            try:
+                result_data = {
+                    "title": result["title"],
+                    "link": result["link"],
+                    "snippet": result.get("snippet", ""),
+                    "position": result.get("position", ""),
+                }
+                processed_results.append(result_data)
+            except KeyError:
+                logger.warning(f"Skipping malformed organic result: {result}")
+                continue
+        return processed_results
+
+    def _process_people_also_ask(self, paa_results: list) -> list:
+        """Process 'people also ask' results."""
+        processed_results = []
+        for result in paa_results[: self.n_results]:
+            try:
+                result_data = {
+                    "question": result["question"],
+                    "snippet": result.get("snippet", ""),
+                    "title": result.get("title", ""),
+                    "link": result.get("link", ""),
+                }
+                processed_results.append(result_data)
+            except KeyError:
+                logger.warning(f"Skipping malformed PAA result: {result}")
+                continue
+        return processed_results
+
+    def _process_related_searches(self, related_results: list) -> list:
+        """Process related search results."""
+        processed_results = []
+        for result in related_results[: self.n_results]:
+            try:
+                processed_results.append({"query": result["query"]})
+            except KeyError:
+                logger.warning(f"Skipping malformed related search result: {result}")
+                continue
+        return processed_results
+
+    def _process_news_results(self, news_results: list) -> list:
+        """Process news search results."""
+        processed_results = []
+        for result in news_results[: self.n_results]:
+            try:
+                result_data = {
+                    "title": result["title"],
+                    "link": result["link"],
+                    "snippet": result.get("snippet", ""),
+                    "date": result.get("date", ""),
+                    "source": result.get("source", ""),
+                    "imageUrl": result.get("imageUrl", ""),
+                }
+                processed_results.append(result_data)
+            except KeyError:
+                logger.warning(f"Skipping malformed news result: {result}")
+                continue
+        return processed_results
+
+    def _make_api_request(self, search_query: str, search_type: str) -> dict:
+        """Make an API request to CrustAPI."""
+        params = {"type": search_type, "q": search_query, "num": self.n_results}
+
+        if self.country != "":
+            params["gl"] = self.country
+        if self.location != "":
+            params["location"] = self.location
+        if self.locale != "":
+            params["hl"] = self.locale
+
+        headers = {"x-api-key": os.environ["CRUSTAPI_API_KEY"]}
+
+        response = None
+        try:
+            response = requests.get(
+                f"{self.base_url}/search", headers=headers, params=params, timeout=30
+            )
+            response.raise_for_status()
+            results = response.json()
+            if not results:
+                logger.error("Empty response from CrustAPI")
+                raise ValueError("Empty response from CrustAPI")
+            return results
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Error making request to CrustAPI: {e}"
+            if response is not None and hasattr(response, "content"):
+                error_msg += f"\nResponse content: {response.content}"
+            logger.error(error_msg)
+            raise
+        except json.JSONDecodeError as e:
+            if response is not None and hasattr(response, "content"):
+                logger.error(f"Error decoding JSON response: {e}")
+                logger.error(f"Response content: {response.content}")
+            else:
+                logger.error(
+                    f"Error decoding JSON response: {e} (No response content available)"
+                )
+            raise
+
+    def _process_search_results(self, results: dict, search_type: str) -> dict:
+        """Format known result blocks; pass others through untouched."""
+        formatted_results = {}
+
+        if "knowledgeGraph" in results:
+            formatted_results["knowledgeGraph"] = self._process_knowledge_graph(
+                results["knowledgeGraph"]
+            )
+        if "organic" in results:
+            formatted_results["organic"] = self._process_organic_results(
+                results["organic"]
+            )
+        if "peopleAlsoAsk" in results:
+            formatted_results["peopleAlsoAsk"] = self._process_people_also_ask(
+                results["peopleAlsoAsk"]
+            )
+        if "relatedSearches" in results:
+            formatted_results["relatedSearches"] = self._process_related_searches(
+                results["relatedSearches"]
+            )
+        if "news" in results:
+            formatted_results["news"] = self._process_news_results(results["news"])
+
+        # Surfaces like maps, places, shopping, images, videos already come back as clean,
+        # named arrays; forward whichever ones are present so the agent gets everything.
+        for key in ("places", "shopping", "images", "videos", "reviews"):
+            if key in results:
+                formatted_results[key] = results[key][: self.n_results]
+
+        return formatted_results
+
+    def _run(self, **kwargs: Any) -> Any:
+        """Execute the search operation."""
+        search_query = kwargs.get("search_query") or kwargs.get("query")
+        search_type = self._normalize_search_type(
+            kwargs.get("search_type", self.search_type)
+        )
+        save_file = kwargs.get("save_file", self.save_file)
+
+        results = self._make_api_request(search_query, search_type)
+
+        formatted_results = {
+            "searchParameters": {
+                "q": search_query,
+                "type": search_type,
+                **results.get("searchParameters", {}),
+            }
+        }
+        formatted_results.update(self._process_search_results(results, search_type))
+        formatted_results["credits"] = results.get("credits", 1)
+
+        if save_file:
+            import datetime
+
+            filename = (
+                f"crustapi_results_"
+                f"{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
+            )
+            try:
+                with open(filename, "w") as file:
+                    file.write(json.dumps(formatted_results, indent=2))
+                logger.info(f"Results saved to {filename}")
+            except IOError as e:
+                logger.error(f"Failed to save results to file: {e}")
+
+        return formatted_results

--- a/lib/crewai-tools/tests/tools/crustapi_tool_test.py
+++ b/lib/crewai-tools/tests/tools/crustapi_tool_test.py
@@ -1,0 +1,136 @@
+import os
+from unittest.mock import patch
+
+from crewai_tools.tools.crustapi_tool.crustapi_tool import CrustApiTool
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_crustapi_api_key():
+    with patch.dict(os.environ, {"CRUSTAPI_API_KEY": "test_key"}):
+        yield
+
+
+@pytest.fixture
+def crustapi_tool():
+    return CrustApiTool(n_results=2)
+
+
+def test_crustapi_tool_initialization():
+    tool = CrustApiTool()
+    assert tool.n_results == 10
+    assert tool.save_file is False
+    assert tool.search_type == "search"
+    assert tool.country == ""
+    assert tool.location == ""
+    assert tool.locale == ""
+
+
+def test_crustapi_tool_custom_initialization():
+    tool = CrustApiTool(
+        n_results=5,
+        save_file=True,
+        search_type="news",
+        country="US",
+        location="New York",
+        locale="en",
+    )
+    assert tool.n_results == 5
+    assert tool.save_file is True
+    assert tool.search_type == "news"
+    assert tool.country == "US"
+    assert tool.location == "New York"
+    assert tool.locale == "en"
+
+
+def test_crustapi_tool_invalid_search_type():
+    tool = CrustApiTool(search_type="not_a_real_type")
+    with pytest.raises(ValueError, match="Invalid search type"):
+        tool.run(search_query="test query")
+
+
+@patch("requests.get")
+def test_crustapi_tool_search(mock_get):
+    tool = CrustApiTool(n_results=2)
+    mock_response = {
+        "searchParameters": {"q": "test query", "type": "web"},
+        "organic": [
+            {
+                "title": "Test Title 1",
+                "link": "http://test1.com",
+                "snippet": "Test Description 1",
+                "position": 1,
+            },
+            {
+                "title": "Test Title 2",
+                "link": "http://test2.com",
+                "snippet": "Test Description 2",
+                "position": 2,
+            },
+        ],
+        "peopleAlsoAsk": [
+            {
+                "question": "Test Question",
+                "snippet": "Test Answer",
+                "title": "Test Source",
+                "link": "http://test.com",
+            }
+        ],
+    }
+    mock_get.return_value.json.return_value = mock_response
+    mock_get.return_value.status_code = 200
+
+    result = tool.run(search_query="test query")
+
+    assert "searchParameters" in result
+    assert result["searchParameters"]["q"] == "test query"
+    assert result["searchParameters"]["type"] == "web"
+    assert len(result["organic"]) == 2
+    assert result["organic"][0]["title"] == "Test Title 1"
+    assert len(result["peopleAlsoAsk"]) == 1
+
+
+@patch("requests.get")
+def test_crustapi_tool_news_search(mock_get):
+    tool = CrustApiTool(n_results=2, search_type="news")
+    mock_response = {
+        "searchParameters": {"q": "test news", "type": "news"},
+        "news": [
+            {
+                "title": "News Title 1",
+                "link": "http://news1.com",
+                "snippet": "News Description 1",
+                "date": "2024-01-01",
+                "source": "Test Source",
+                "imageUrl": "http://news1.com/image.jpg",
+            }
+        ],
+    }
+    mock_get.return_value.json.return_value = mock_response
+    mock_get.return_value.status_code = 200
+
+    result = tool.run(search_query="test news")
+
+    assert result["searchParameters"]["type"] == "news"
+    assert len(result["news"]) == 1
+    assert result["news"][0]["title"] == "News Title 1"
+
+
+@patch("requests.get")
+def test_crustapi_tool_maps_search(mock_get):
+    tool = CrustApiTool(n_results=2, search_type="maps")
+    mock_response = {
+        "searchParameters": {"q": "coffee austin", "type": "maps"},
+        "places": [
+            {"title": "Cafe One", "rating": 4.8},
+            {"title": "Cafe Two", "rating": 4.6},
+        ],
+    }
+    mock_get.return_value.json.return_value = mock_response
+    mock_get.return_value.status_code = 200
+
+    result = tool.run(search_query="coffee austin")
+
+    assert result["searchParameters"]["type"] == "maps"
+    assert len(result["places"]) == 2
+    assert result["places"][0]["title"] == "Cafe One"


### PR DESCRIPTION
## Summary

Adds a `CrustApiTool` that searches Google through [CrustAPI](https://crustapi.com) and returns clean, structured JSON for agents.

One tool covers multiple Google surfaces via a `search_type` parameter: `search` (default web), `news`, `maps`, `places`, `shopping`, `images`, `videos`, `scholar`, and `patents`. The response schema mirrors the common SERP shape (`organic`, `knowledgeGraph`, `peopleAlsoAsk`, `relatedSearches`, `news`), so it slots in alongside the existing search tools and results map straight into an agent's context.

## Usage

```python
from crewai_tools import CrustApiTool

tool = CrustApiTool()                                    # web search
tool = CrustApiTool(search_type="news", n_results=5, country="us")
```

Auth is a `CRUSTAPI_API_KEY` environment variable. CrustAPI has a free tier (no card), so contributors and users can try it without a paid plan.

## Changes
- `lib/crewai-tools/src/crewai_tools/tools/crustapi_tool/` — the tool, an empty package `__init__.py`, and a README (mirrors the `serper_dev_tool` layout)
- `lib/crewai-tools/tests/tools/crustapi_tool_test.py` — mocked test suite mirroring the `SerperDevTool` tests (init, invalid type, web/news/maps formatting)
- Registered the export in `lib/crewai-tools/src/crewai_tools/__init__.py` and `.../tools/__init__.py`

## Notes
- Follows the same `BaseTool` + `EnvVar` + pydantic `args_schema` pattern as `SerperDevTool`.
- Verified the request and result-formatting logic against the live API and via the mocked tests.