### PR TITLE
feat(tools): add chDB tools for in-process ClickHouse SQL

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -148,6 +148,10 @@ e2b = [
     "e2b-code-interpreter~=2.6.0",
 ]
 
+chdb = [
+    "chdb>=4.2.1",
+]
+
 
 [tool.uv]
 exclude-newer = "3 days"

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -32,6 +32,16 @@ from crewai_tools.tools.brightdata_tool.brightdata_unlocker import (
 from crewai_tools.tools.browserbase_load_tool.browserbase_load_tool import (
     BrowserbaseLoadTool,
 )
+from crewai_tools.tools.chdb_tool.chdb_tool import (
+    ChDBAttachFileTool,
+    ChDBDescribeTableTool,
+    ChDBGetSampleDataTool,
+    ChDBListDatabasesTool,
+    ChDBListFunctionsTool,
+    ChDBListTablesTool,
+    ChDBRunSelectQueryTool,
+    chdb_tools,
+)
 from crewai_tools.tools.code_docs_search_tool.code_docs_search_tool import (
     CodeDocsSearchTool,
 )
@@ -237,6 +247,13 @@ __all__ = [
     "BrightDataWebUnlockerTool",
     "BrowserbaseLoadTool",
     "CSVSearchTool",
+    "ChDBAttachFileTool",
+    "ChDBDescribeTableTool",
+    "ChDBGetSampleDataTool",
+    "ChDBListDatabasesTool",
+    "ChDBListFunctionsTool",
+    "ChDBListTablesTool",
+    "ChDBRunSelectQueryTool",
     "CodeDocsSearchTool",
     "ComposioTool",
     "ContextualAICreateAgentTool",
@@ -328,6 +345,7 @@ __all__ = [
     "YoutubeVideoSearchTool",
     "ZapierActionTool",
     "ZapierActionTools",
+    "chdb_tools",
 ]
 
 __version__ = "1.15.2"

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -21,6 +21,16 @@ from crewai_tools.tools.brightdata_tool import (
 from crewai_tools.tools.browserbase_load_tool.browserbase_load_tool import (
     BrowserbaseLoadTool,
 )
+from crewai_tools.tools.chdb_tool.chdb_tool import (
+    ChDBAttachFileTool,
+    ChDBDescribeTableTool,
+    ChDBGetSampleDataTool,
+    ChDBListDatabasesTool,
+    ChDBListFunctionsTool,
+    ChDBListTablesTool,
+    ChDBRunSelectQueryTool,
+    chdb_tools,
+)
 from crewai_tools.tools.code_docs_search_tool.code_docs_search_tool import (
     CodeDocsSearchTool,
 )
@@ -222,6 +232,13 @@ __all__ = [
     "BrightDataWebUnlockerTool",
     "BrowserbaseLoadTool",
     "CSVSearchTool",
+    "ChDBAttachFileTool",
+    "ChDBDescribeTableTool",
+    "ChDBGetSampleDataTool",
+    "ChDBListDatabasesTool",
+    "ChDBListFunctionsTool",
+    "ChDBListTablesTool",
+    "ChDBRunSelectQueryTool",
     "CodeDocsSearchTool",
     "ComposioTool",
     "ContextualAICreateAgentTool",
@@ -310,4 +327,5 @@ __all__ = [
     "YoutubeChannelSearchTool",
     "YoutubeVideoSearchTool",
     "ZapierActionTools",
+    "chdb_tools",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/README.md
@@ -1,0 +1,84 @@
+# chDB Tools
+
+Give agents analytical SQL over local and remote data with [chDB](https://clickhouse.com/docs/en/chdb), the in-process ClickHouse engine. The engine runs inside the Python process — no server to start, no connection string, no credentials — and queries local files (Parquet/CSV/JSON), object storage, and remote databases through ClickHouse table functions.
+
+Seven tools are provided, mirroring the tool surface chDB ships for agents (`chdb.agents`):
+
+- **`ChDBRunSelectQueryTool`** (`run_select_query`) — read-only ClickHouse SQL with `{name:Type}` parameter binding.
+- **`ChDBListDatabasesTool`** (`list_databases`) — list databases in the session.
+- **`ChDBListTablesTool`** (`list_tables`) — list tables in a database.
+- **`ChDBDescribeTableTool`** (`describe_table`) — columns and types of a table *or* a table-function expression such as `s3('https://bucket/f.parquet','Parquet')`.
+- **`ChDBGetSampleDataTool`** (`get_sample_data`) — a few real rows before querying.
+- **`ChDBListFunctionsTool`** (`list_functions`) — discover the 1000+ ClickHouse SQL functions.
+- **`ChDBAttachFileTool`** (`attach_file`) — register a local file as a named table (writable sessions only).
+
+## Installation
+
+```shell
+uv add "crewai-tools[chdb]"
+# or
+pip install "crewai-tools[chdb]"
+```
+
+No API key or environment variable is needed.
+
+## Quick start
+
+`chdb_tools()` builds the whole suite over **one shared engine**, so what one tool attaches or discovers, the others see:
+
+```python
+from crewai import Agent
+from crewai_tools import chdb_tools
+
+analyst = Agent(
+    role="Data Analyst",
+    goal="Answer questions about the events dataset",
+    backstory="Expert in ClickHouse SQL",
+    tools=chdb_tools(attachments={"events": "data/events.parquet"}),
+)
+```
+
+A single tool works standalone too:
+
+```python
+from crewai_tools import ChDBRunSelectQueryTool
+
+tool = ChDBRunSelectQueryTool()
+print(tool.run(sql="SELECT count() FROM file('data/events.parquet')"))
+```
+
+## Safety defaults
+
+- **Read-only by default.** The session is locked with the ClickHouse setting `readonly=2`: `INSERT`/`CREATE`/`ALTER`/`DROP` are rejected at the engine (not by prompt), while `SELECT` and the `file()`/`s3()`/`url()` table functions keep working. Pass `read_only=False` for a writable session — `chdb_tools()` then also includes `attach_file`.
+- **Capped results.** `max_rows` (default 1000) and `max_bytes` (default 1 MB) bound every payload; truncated results carry a `truncated` flag the agent can react to. `max_execution_time` adds an engine-side wall-clock limit.
+- **Optional source allowlist.** With `file_allowlist=["/data/"]`, file-like sources may only read under the listed prefixes and DSN-based sources (`postgresql()`, `mysql()`, `remote()`, …) are refused.
+- **Errors go to the model, not the run.** Every call returns a JSON envelope — `{"ok": true, "result": …}` or `{"ok": false, "error": {"code", "type", "message"}}` — so a bad query becomes feedback the agent can correct instead of an exception that kills the crew.
+
+## Querying remote data
+
+ClickHouse table functions work inline, subject to the read-only lock and allowlist:
+
+```python
+tools = chdb_tools()
+tools[0].run(
+    sql="SELECT status, count() FROM url('https://example.com/logs.ndjson', 'JSONEachRow') GROUP BY status"
+)
+```
+
+`s3(...)`, `postgresql(...)`, `mysql(...)`, `mongodb(...)`, `remoteSecure(...)`, `iceberg(...)`, and `deltaLake(...)` are available the same way.
+
+## Sharing and lifecycle
+
+Tools built by `chdb_tools()` share one engine. To control the engine's lifetime yourself, create it explicitly and inject it:
+
+```python
+from chdb.agents import ChDBTool
+from crewai_tools import chdb_tools
+
+engine = ChDBTool("analytics_dir", read_only=False)
+tools = chdb_tools(engine=engine)
+...
+engine.close()
+```
+
+Tool names default to the canonical chDB agent-tool names (`run_select_query`, `list_tables`, …). If they collide with another tool suite in your crew, rename at construction: `ChDBRunSelectQueryTool(name="chdb_query")`.

--- a/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/__init__.py
@@ -1,0 +1,24 @@
+from crewai_tools.tools.chdb_tool.chdb_tool import (
+    ChDBAttachFileTool,
+    ChDBBaseTool,
+    ChDBDescribeTableTool,
+    ChDBGetSampleDataTool,
+    ChDBListDatabasesTool,
+    ChDBListFunctionsTool,
+    ChDBListTablesTool,
+    ChDBRunSelectQueryTool,
+    chdb_tools,
+)
+
+
+__all__ = [
+    "ChDBAttachFileTool",
+    "ChDBBaseTool",
+    "ChDBDescribeTableTool",
+    "ChDBGetSampleDataTool",
+    "ChDBListDatabasesTool",
+    "ChDBListFunctionsTool",
+    "ChDBListTablesTool",
+    "ChDBRunSelectQueryTool",
+    "chdb_tools",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/chdb_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/chdb_tool/chdb_tool.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+
+def _import_chdb_tool_class() -> Any:
+    """Import chdb.agents.ChDBTool lazily so crewai-tools imports without chdb."""
+    try:
+        from chdb.agents import ChDBTool
+    except ImportError as exc:
+        raise ImportError(
+            "The 'chdb' package is required for the chDB tools. "
+            "Install it with: uv add chdb  (or) pip install 'crewai-tools[chdb]'"
+        ) from exc
+    return ChDBTool
+
+
+class ChDBBaseTool(BaseTool):
+    """Shared base for tools that run against one in-process chDB engine.
+
+    chDB embeds the ClickHouse engine in the Python process: there is no
+    server to start, no connection string, and no credentials. Each tool
+    lazily creates its own chDB session from the config fields on first use,
+    or reuses an existing ``chdb.agents.ChDBTool`` passed as ``engine``.
+    Tools that must see each other's state (``attach_file`` followed by
+    ``run_select_query``) have to share one engine — build the suite with
+    ``chdb_tools()`` or pass the same ``engine`` instance to each tool.
+
+    Every call returns a JSON envelope string rather than raising:
+    ``{"ok": true, "result": {...}}`` on success, ``{"ok": false, "error":
+    {"code", "type", "message"}}`` on failure, so the agent reads the engine
+    error and can self-correct instead of crashing the run.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    package_dependencies: list[str] = Field(default_factory=lambda: ["chdb"])
+
+    path: str = Field(
+        default=":memory:",
+        description=(
+            "Directory for the chDB session's data; ':memory:' (default) uses "
+            "an ephemeral in-memory session."
+        ),
+    )
+    read_only: bool = Field(
+        default=True,
+        description=(
+            "If True (default), the session is locked with the ClickHouse "
+            "setting readonly=2: INSERT/CREATE/ALTER/DROP are rejected while "
+            "SELECT and the file()/s3()/url() table functions keep working. "
+            "Fixed at construction — chDB cannot lower readonly once set."
+        ),
+    )
+    max_rows: int = Field(
+        default=1000,
+        description=(
+            "Row cap per result; rows beyond it are dropped and the result "
+            "carries a `truncated` flag the agent can react to."
+        ),
+    )
+    max_bytes: int = Field(
+        default=1_000_000,
+        description="UTF-8 byte cap on each serialized result payload.",
+    )
+    max_execution_time: int | None = Field(
+        default=None,
+        description=(
+            "Engine-side wall-clock limit per query, in seconds; a runaway "
+            "query fails with a TIMEOUT_EXCEEDED error instead of hanging."
+        ),
+    )
+    file_allowlist: list[str] | None = Field(
+        default=None,
+        description=(
+            "When set, file-like sources (file/url/s3/...) may only read "
+            "paths under these prefixes, and DSN-based sources (postgresql/"
+            "mysql/remote/...) are refused outright."
+        ),
+    )
+    attachments: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Local files to expose as named tables at construction, as "
+            "{table_name: path} or {table_name: (path, format)}. This is how "
+            "read-only tools get file-backed tables (attach_file needs "
+            "read_only=False)."
+        ),
+    )
+    engine: Any | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "An existing chdb.agents.ChDBTool to reuse; the config fields "
+            "above are ignored when set. Pass the same engine to several "
+            "tools so they share tables and attachments."
+        ),
+    )
+
+    _owned_engine: Any | None = PrivateAttr(default=None)
+    _engine_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+
+    def _get_engine(self) -> Any:
+        if self.engine is not None:
+            return self.engine
+        with self._engine_lock:
+            if self._owned_engine is None:
+                chdb_tool_class = _import_chdb_tool_class()
+                self._owned_engine = chdb_tool_class(
+                    self.path,
+                    read_only=self.read_only,
+                    max_rows=self.max_rows,
+                    max_bytes=self.max_bytes,
+                    max_execution_time=self.max_execution_time,
+                    file_allowlist=self.file_allowlist,
+                    attachments=self.attachments,
+                )
+            return self._owned_engine
+
+    def _dispatch(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        envelope = self._get_engine().call(tool_name, arguments)
+        return json.dumps(envelope)
+
+    async def _adispatch(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        engine = self._get_engine()
+        envelope = await engine.acall(tool_name, arguments)
+        return json.dumps(envelope)
+
+    def close(self) -> None:
+        """Close the engine this tool created; an injected ``engine`` is left to its owner."""
+        with self._engine_lock:
+            engine, self._owned_engine = self._owned_engine, None
+        if engine is not None:
+            engine.close()
+
+
+class ChDBRunSelectQuerySchema(BaseModel):
+    """Input for run_select_query."""
+
+    sql: str = Field(
+        ...,
+        description=(
+            "A complete read-only ClickHouse SQL statement; use {name:Type} "
+            "placeholders for values."
+        ),
+    )
+    params: dict[str, Any] | None = Field(
+        default=None,
+        description="Values bound to the {name:Type} placeholders in `sql`.",
+    )
+
+
+class ChDBRunSelectQueryTool(ChDBBaseTool):
+    """Run read-only ClickHouse SQL in-process with chDB."""
+
+    name: str = "run_select_query"
+    description: str = (
+        "Run a read-only ClickHouse SQL query with chDB, an in-process "
+        "ClickHouse engine (full SQL dialect: 1000+ functions, window "
+        "functions, arrays, JSON). Pass values via `params` as {name:Type} "
+        "placeholders (e.g. WHERE id = {id:Int64}); never concatenate values "
+        "into the SQL. Read external data inline with table functions: "
+        "file('path'[, 'format']), s3('url','format'), url(...), "
+        "postgresql(...), mysql(...). Returns rows plus a `truncated` flag. "
+        "First use list_tables / describe_table to learn the schema."
+    )
+    args_schema: type[BaseModel] = ChDBRunSelectQuerySchema
+
+    def _run(self, sql: str, params: dict[str, Any] | None = None) -> str:
+        return self._dispatch("run_select_query", {"sql": sql, "params": params})
+
+    async def _arun(self, sql: str, params: dict[str, Any] | None = None) -> str:
+        return await self._adispatch("run_select_query", {"sql": sql, "params": params})
+
+
+class ChDBListDatabasesSchema(BaseModel):
+    """Input for list_databases (no arguments)."""
+
+
+class ChDBListDatabasesTool(ChDBBaseTool):
+    """List the databases in the chDB session."""
+
+    name: str = "list_databases"
+    description: str = "List the databases available in the chDB session."
+    args_schema: type[BaseModel] = ChDBListDatabasesSchema
+
+    def _run(self) -> str:
+        return self._dispatch("list_databases", {})
+
+    async def _arun(self) -> str:
+        return await self._adispatch("list_databases", {})
+
+
+class ChDBListTablesSchema(BaseModel):
+    """Input for list_tables."""
+
+    database: str | None = Field(
+        default=None,
+        description="Database to list tables from; current database if omitted.",
+    )
+
+
+class ChDBListTablesTool(ChDBBaseTool):
+    """List the tables in a database of the chDB session."""
+
+    name: str = "list_tables"
+    description: str = (
+        "List the tables in a database (the current database if `database` is omitted)."
+    )
+    args_schema: type[BaseModel] = ChDBListTablesSchema
+
+    def _run(self, database: str | None = None) -> str:
+        return self._dispatch("list_tables", {"database": database})
+
+    async def _arun(self, database: str | None = None) -> str:
+        return await self._adispatch("list_tables", {"database": database})
+
+
+class ChDBDescribeTableSchema(BaseModel):
+    """Input for describe_table."""
+
+    target: str = Field(
+        ...,
+        description=(
+            'A table name or a table-function expression, e.g. "events" or '
+            "\"s3('s3://b/f.parquet','Parquet')\"."
+        ),
+    )
+    database: str | None = Field(
+        default=None,
+        description="Database qualifier for a table name (invalid for a table function).",
+    )
+
+
+class ChDBDescribeTableTool(ChDBBaseTool):
+    """Describe the columns of a table or table-function expression."""
+
+    name: str = "describe_table"
+    description: str = (
+        "Describe the columns and types of a table (optionally "
+        "database-qualified) or a table-function expression, e.g. "
+        "s3('https://bucket/f.parquet','Parquet') or file('data.csv')."
+    )
+    args_schema: type[BaseModel] = ChDBDescribeTableSchema
+
+    def _run(self, target: str, database: str | None = None) -> str:
+        return self._dispatch(
+            "describe_table", {"target": target, "database": database}
+        )
+
+    async def _arun(self, target: str, database: str | None = None) -> str:
+        return await self._adispatch(
+            "describe_table", {"target": target, "database": database}
+        )
+
+
+class ChDBGetSampleDataSchema(BaseModel):
+    """Input for get_sample_data."""
+
+    target: str = Field(
+        ...,
+        description="A table name or a table-function expression.",
+    )
+    database: str | None = Field(
+        default=None,
+        description="Database qualifier for a table name (invalid for a table function).",
+    )
+    limit: int | None = Field(
+        default=None,
+        description="Number of sample rows (default 5).",
+    )
+
+
+class ChDBGetSampleDataTool(ChDBBaseTool):
+    """Fetch a few sample rows from a table or table-function expression."""
+
+    name: str = "get_sample_data"
+    description: str = (
+        "Return a few sample rows from a table or table-function expression, "
+        "to see real values before querying."
+    )
+    args_schema: type[BaseModel] = ChDBGetSampleDataSchema
+
+    def _run(
+        self,
+        target: str,
+        database: str | None = None,
+        limit: int | None = None,
+    ) -> str:
+        return self._dispatch(
+            "get_sample_data",
+            {"target": target, "database": database, "limit": limit},
+        )
+
+    async def _arun(
+        self,
+        target: str,
+        database: str | None = None,
+        limit: int | None = None,
+    ) -> str:
+        return await self._adispatch(
+            "get_sample_data",
+            {"target": target, "database": database, "limit": limit},
+        )
+
+
+class ChDBListFunctionsSchema(BaseModel):
+    """Input for list_functions."""
+
+    like: str | None = Field(
+        default=None,
+        description='ILIKE pattern to filter function names, e.g. "%array%".',
+    )
+    limit: int | None = Field(
+        default=None,
+        description="Max function names to return (default 200).",
+    )
+
+
+class ChDBListFunctionsTool(ChDBBaseTool):
+    """List the ClickHouse SQL functions available in chDB."""
+
+    name: str = "list_functions"
+    description: str = (
+        "List available ClickHouse SQL functions, optionally filtered by an "
+        "ILIKE pattern."
+    )
+    args_schema: type[BaseModel] = ChDBListFunctionsSchema
+
+    def _run(self, like: str | None = None, limit: int | None = None) -> str:
+        return self._dispatch("list_functions", {"like": like, "limit": limit})
+
+    async def _arun(self, like: str | None = None, limit: int | None = None) -> str:
+        return await self._adispatch("list_functions", {"like": like, "limit": limit})
+
+
+class ChDBAttachFileSchema(BaseModel):
+    """Input for attach_file."""
+
+    name: str = Field(
+        ...,
+        description="The table name to register the file under.",
+    )
+    path: str = Field(
+        ...,
+        description="Path to the local file.",
+    )
+    format: str | None = Field(
+        default=None,
+        description=(
+            "chDB/ClickHouse input format (auto-detected from the extension if omitted)."
+        ),
+    )
+
+
+class ChDBAttachFileTool(ChDBBaseTool):
+    """Register a local file as a named queryable table in the chDB session."""
+
+    name: str = "attach_file"
+    description: str = (
+        "Register a local file as a queryable named table (a view over "
+        "file()). Writable tools only; on a read-only tool this returns a "
+        "READONLY error — declare files via the tool's attachments option "
+        "instead."
+    )
+    args_schema: type[BaseModel] = ChDBAttachFileSchema
+
+    def _run(self, name: str, path: str, format: str | None = None) -> str:
+        return self._dispatch(
+            "attach_file", {"name": name, "path": path, "format": format}
+        )
+
+    async def _arun(self, name: str, path: str, format: str | None = None) -> str:
+        return await self._adispatch(
+            "attach_file", {"name": name, "path": path, "format": format}
+        )
+
+
+def chdb_tools(
+    path: str = ":memory:",
+    *,
+    read_only: bool = True,
+    max_rows: int = 1000,
+    max_bytes: int = 1_000_000,
+    max_execution_time: int | None = None,
+    file_allowlist: list[str] | None = None,
+    attachments: dict[str, Any] | None = None,
+    engine: Any | None = None,
+) -> list[BaseTool]:
+    """Build the chDB tool suite over one shared in-process engine.
+
+    All returned tools run against the same chDB session, so a table
+    registered by attach_file (or declared via ``attachments``) is visible to
+    run_select_query, describe_table, and the rest. attach_file is included
+    only for writable suites (``read_only=False``); on a read-only engine it
+    could only ever return a READONLY error, and files should be declared via
+    ``attachments`` instead.
+
+    Pass an existing ``chdb.agents.ChDBTool`` as ``engine`` to control the
+    engine's lifecycle yourself (the other arguments are then ignored);
+    otherwise one is created from the arguments and lives until the process
+    exits or ``engine.close()`` is called on any tool's ``engine`` attribute.
+    """
+    if engine is None:
+        chdb_tool_class = _import_chdb_tool_class()
+        engine = chdb_tool_class(
+            path,
+            read_only=read_only,
+            max_rows=max_rows,
+            max_bytes=max_bytes,
+            max_execution_time=max_execution_time,
+            file_allowlist=file_allowlist,
+            attachments=attachments,
+        )
+    writable = not getattr(engine, "read_only", True)
+
+    tools: list[BaseTool] = [
+        ChDBRunSelectQueryTool(engine=engine),
+        ChDBListDatabasesTool(engine=engine),
+        ChDBListTablesTool(engine=engine),
+        ChDBDescribeTableTool(engine=engine),
+        ChDBGetSampleDataTool(engine=engine),
+        ChDBListFunctionsTool(engine=engine),
+    ]
+    if writable:
+        tools.append(ChDBAttachFileTool(engine=engine))
+
+    return tools

--- a/lib/crewai-tools/tests/tools/chdb_tool_test.py
+++ b/lib/crewai-tools/tests/tools/chdb_tool_test.py
@@ -1,0 +1,264 @@
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from crewai_tools import (
+    ChDBAttachFileTool,
+    ChDBDescribeTableTool,
+    ChDBGetSampleDataTool,
+    ChDBListDatabasesTool,
+    ChDBListFunctionsTool,
+    ChDBListTablesTool,
+    ChDBRunSelectQueryTool,
+    chdb_tools,
+)
+
+
+OK_ENVELOPE = {
+    "ok": True,
+    "result": {"rows": [{"x": 1}], "row_count": 1, "truncated": False},
+}
+ERROR_ENVELOPE = {
+    "ok": False,
+    "error": {"code": 62, "type": "SYNTAX_ERROR", "message": "Syntax error"},
+}
+
+
+# --- unit tests against a mocked engine (no chdb install required) ----------
+
+
+def _mock_engine(envelope=OK_ENVELOPE, read_only=True):
+    engine = MagicMock()
+    engine.read_only = read_only
+    engine.call.return_value = envelope
+
+    async def acall(name, arguments):
+        return envelope
+
+    engine.acall = acall
+    return engine
+
+
+def test_query_tool_dispatches_canonical_call():
+    engine = _mock_engine()
+    tool = ChDBRunSelectQueryTool(engine=engine)
+
+    out = tool.run(sql="SELECT 1 AS x")
+
+    engine.call.assert_called_once_with(
+        "run_select_query", {"sql": "SELECT 1 AS x", "params": None}
+    )
+    assert json.loads(out) == OK_ENVELOPE
+
+
+def test_query_tool_passes_params():
+    engine = _mock_engine()
+    tool = ChDBRunSelectQueryTool(engine=engine)
+
+    tool.run(sql="SELECT {id:Int64}", params={"id": 42})
+
+    engine.call.assert_called_once_with(
+        "run_select_query", {"sql": "SELECT {id:Int64}", "params": {"id": 42}}
+    )
+
+
+def test_error_envelope_is_returned_not_raised():
+    tool = ChDBRunSelectQueryTool(engine=_mock_engine(ERROR_ENVELOPE))
+
+    out = json.loads(tool.run(sql="SELEC bad"))
+
+    assert out["ok"] is False
+    assert out["error"]["type"] == "SYNTAX_ERROR"
+
+
+def test_arun_uses_async_engine_path():
+    tool = ChDBRunSelectQueryTool(engine=_mock_engine())
+
+    out = asyncio.run(tool.arun(sql="SELECT 1"))
+
+    assert json.loads(out) == OK_ENVELOPE
+
+
+@pytest.mark.parametrize(
+    ("tool_class", "canonical_name", "kwargs", "expected_arguments"),
+    [
+        (ChDBListDatabasesTool, "list_databases", {}, {}),
+        (ChDBListTablesTool, "list_tables", {"database": "db1"}, {"database": "db1"}),
+        (
+            ChDBDescribeTableTool,
+            "describe_table",
+            {"target": "events"},
+            {"target": "events", "database": None},
+        ),
+        (
+            ChDBGetSampleDataTool,
+            "get_sample_data",
+            {"target": "events", "limit": 3},
+            {"target": "events", "database": None, "limit": 3},
+        ),
+        (
+            ChDBListFunctionsTool,
+            "list_functions",
+            {"like": "%array%"},
+            {"like": "%array%", "limit": None},
+        ),
+        (
+            ChDBAttachFileTool,
+            "attach_file",
+            {"name": "t", "path": "/tmp/t.csv"},
+            {"name": "t", "path": "/tmp/t.csv", "format": None},
+        ),
+    ],
+)
+def test_each_tool_dispatches_its_canonical_name(
+    tool_class, canonical_name, kwargs, expected_arguments
+):
+    engine = _mock_engine()
+    tool = tool_class(engine=engine)
+
+    assert tool.name == canonical_name
+    tool.run(**kwargs)
+    engine.call.assert_called_once_with(canonical_name, expected_arguments)
+
+
+def test_close_does_not_close_injected_engine():
+    engine = _mock_engine()
+    tool = ChDBRunSelectQueryTool(engine=engine)
+
+    tool.close()
+
+    engine.close.assert_not_called()
+
+
+def test_suite_shares_injected_engine_and_gates_attach_file():
+    read_only_suite = chdb_tools(engine=_mock_engine(read_only=True))
+    writable_engine = _mock_engine(read_only=False)
+    writable_suite = chdb_tools(engine=writable_engine)
+
+    assert [t.name for t in read_only_suite] == [
+        "run_select_query",
+        "list_databases",
+        "list_tables",
+        "describe_table",
+        "get_sample_data",
+        "list_functions",
+    ]
+    assert [t.name for t in writable_suite][-1] == "attach_file"
+    assert all(t.engine is writable_engine for t in writable_suite)
+
+
+def test_import_error_message_mentions_extra(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("chdb"):
+            raise ImportError("No module named 'chdb'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    tool = ChDBRunSelectQueryTool()
+
+    with pytest.raises(ImportError, match=r"crewai-tools\[chdb\]"):
+        tool.run(sql="SELECT 1")
+
+
+# --- integration tests against the real engine -------------------------------
+
+chdb = pytest.importorskip("chdb")
+
+
+def test_end_to_end_select():
+    tool = ChDBRunSelectQueryTool()
+    try:
+        out = json.loads(tool.run(sql="SELECT 1 + 1 AS answer"))
+        assert out["ok"] is True
+        assert out["result"]["rows"] == [{"answer": 2}]
+    finally:
+        tool.close()
+
+
+def test_param_binding_end_to_end():
+    tool = ChDBRunSelectQueryTool()
+    try:
+        out = json.loads(
+            tool.run(sql="SELECT {n:Int64} * 2 AS doubled", params={"n": 21})
+        )
+        assert out["ok"] is True
+        # 64-bit integers are serialized as strings so exact values survive JSON.
+        assert out["result"]["rows"] == [{"doubled": "42"}]
+    finally:
+        tool.close()
+
+
+def test_read_only_rejects_writes_with_envelope():
+    tool = ChDBRunSelectQueryTool()
+    try:
+        out = json.loads(
+            tool.run(sql="CREATE TABLE t (x Int64) ENGINE = MergeTree ORDER BY x")
+        )
+        assert out["ok"] is False
+        assert "readonly" in out["error"]["message"].lower()
+    finally:
+        tool.close()
+
+
+def test_writable_suite_attach_then_query(tmp_path):
+    csv = tmp_path / "people.csv"
+    csv.write_text("name,age\nada,36\ngrace,45\n")
+
+    tools = {t.name: t for t in chdb_tools(read_only=False)}
+    try:
+        attached = json.loads(
+            tools["attach_file"].run(name="people", path=str(csv))
+        )
+        assert attached["ok"] is True
+
+        queried = json.loads(
+            tools["run_select_query"].run(
+                sql="SELECT max(age) AS oldest FROM people"
+            )
+        )
+        assert queried["ok"] is True
+        # 64-bit integers are serialized as strings so exact values survive JSON.
+        assert queried["result"]["rows"] == [{"oldest": "45"}]
+    finally:
+        tools["run_select_query"].engine.close()
+
+
+def test_read_only_suite_with_attachments(tmp_path):
+    csv = tmp_path / "cities.csv"
+    csv.write_text("city,pop\nparis,2100000\n")
+
+    tools = chdb_tools(attachments={"cities": str(csv)})
+    try:
+        out = json.loads(tools[0].run(sql="SELECT city FROM cities"))
+        assert out["ok"] is True
+        assert out["result"]["rows"] == [{"city": "paris"}]
+    finally:
+        tools[0].engine.close()
+
+
+def test_introspection_tools_end_to_end():
+    engine_owner = ChDBListDatabasesTool()
+    try:
+        databases = json.loads(engine_owner.run())
+        assert databases["ok"] is True
+
+        shared = engine_owner._get_engine()
+        described = json.loads(
+            ChDBDescribeTableTool(engine=shared).run(
+                target="numbers(3)",
+            )
+        )
+        assert described["ok"] is True
+
+        functions = json.loads(
+            ChDBListFunctionsTool(engine=shared).run(like="%arrayJoin%")
+        )
+        assert functions["ok"] is True
+    finally:
+        engine_owner.close()

--- a/lib/crewai-tools/tests/tools/chdb_tool_test.py
+++ b/lib/crewai-tools/tests/tools/chdb_tool_test.py
@@ -167,10 +167,21 @@ def test_import_error_message_mentions_extra(monkeypatch):
 
 
 # --- integration tests against the real engine -------------------------------
+# Guarded per-test rather than with a module-level importorskip, which would
+# skip the whole file — including the mocked unit tests above — when chdb is
+# not installed.
 
-chdb = pytest.importorskip("chdb")
+try:
+    import chdb  # noqa: F401
+
+    HAS_CHDB = True
+except ImportError:
+    HAS_CHDB = False
+
+requires_chdb = pytest.mark.skipif(not HAS_CHDB, reason="chdb is not installed")
 
 
+@requires_chdb
 def test_end_to_end_select():
     tool = ChDBRunSelectQueryTool()
     try:
@@ -181,6 +192,7 @@ def test_end_to_end_select():
         tool.close()
 
 
+@requires_chdb
 def test_param_binding_end_to_end():
     tool = ChDBRunSelectQueryTool()
     try:
@@ -194,6 +206,7 @@ def test_param_binding_end_to_end():
         tool.close()
 
 
+@requires_chdb
 def test_read_only_rejects_writes_with_envelope():
     tool = ChDBRunSelectQueryTool()
     try:
@@ -206,6 +219,7 @@ def test_read_only_rejects_writes_with_envelope():
         tool.close()
 
 
+@requires_chdb
 def test_writable_suite_attach_then_query(tmp_path):
     csv = tmp_path / "people.csv"
     csv.write_text("name,age\nada,36\ngrace,45\n")
@@ -229,6 +243,7 @@ def test_writable_suite_attach_then_query(tmp_path):
         tools["run_select_query"].engine.close()
 
 
+@requires_chdb
 def test_read_only_suite_with_attachments(tmp_path):
     csv = tmp_path / "cities.csv"
     csv.write_text("city,pop\nparis,2100000\n")
@@ -242,6 +257,7 @@ def test_read_only_suite_with_attachments(tmp_path):
         tools[0].engine.close()
 
 
+@requires_chdb
 def test_introspection_tools_end_to_end():
     engine_owner = ChDBListDatabasesTool()
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,8 @@ info = "Commits must follow Conventional Commits 1.0.0."
 [tool.uv]
 exclude-newer = "3 days"
 # These security fixes are newer than the global supply-chain cutoff.
-exclude-newer-package = { pypdf = "2026-06-18T00:00:00Z", msgpack = "2026-06-20T00:00:00Z", pydantic-settings = "2026-06-20T00:00:00Z", langsmith = "2026-06-20T00:00:00Z" }
+# chdb 4.2.1 (crewai-tools[chdb] minimum) released 2026-07-13, inside the rolling window.
+exclude-newer-package = { pypdf = "2026-06-18T00:00:00Z", msgpack = "2026-06-20T00:00:00Z", pydantic-settings = "2026-06-20T00:00:00Z", langsmith = "2026-06-20T00:00:00Z", chdb = "2026-07-14T00:00:00Z" }
 
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.


### PR DESCRIPTION
> **AI disclosure**: this PR was authored with AI assistance (Claude Code), per the contributing guide it should carry the `llm-generated` label — I don't have permission to add labels on this repo, so please apply it. The design, testing, and review of every line were done by a ClickHouse engineer (chDB team).

## What

Seven tools that give agents analytical SQL over local and remote data with [chDB](https://clickhouse.com/docs/en/chdb), the in-process ClickHouse engine, wrapping `chdb.agents.ChDBTool` (the agent-tool surface the `chdb` package ships and conformance-tests):

- `ChDBRunSelectQueryTool` (`run_select_query`) — read-only ClickHouse SQL with `{name:Type}` parameter binding
- `ChDBListDatabasesTool`, `ChDBListTablesTool`, `ChDBDescribeTableTool`, `ChDBGetSampleDataTool`, `ChDBListFunctionsTool` — schema discovery, including describing table-function expressions like `s3('…','Parquet')`
- `ChDBAttachFileTool` (`attach_file`) — register a local file as a named table (writable sessions only)
- `chdb_tools()` — builds the suite over **one shared engine**, so a table one tool attaches is visible to the others

## Why (vs existing SQL tools)

- **In-process**: no server, no connection string, no credentials, no env vars — the engine runs inside the Python process and reads Parquet/CSV/JSON files, S3/URLs, and remote databases through ClickHouse table functions.
- **Engine-level safety, not prompt-level**: sessions default to ClickHouse `readonly=2` (INSERT/CREATE/ALTER/DROP rejected by the engine while SELECT and `file()`/`s3()`/`url()` keep working — same direction as the NL2SQLTool read-only hardening); `max_rows`/`max_bytes` cap every payload with an explicit `truncated` flag; optional `file_allowlist` confines file-like sources to listed prefixes and refuses DSN-based sources.
- **Errors feed the model**: every call returns a JSON envelope (`{"ok": true, "result": …}` / `{"ok": false, "error": {code, type, message}}`), so a wrong query becomes feedback the agent corrects instead of an exception that kills the crew run.

## Notes for reviewers

- `chdb` is an optional dependency (`crewai-tools[chdb]`). `import crewai_tools` works without it; tools raise a descriptive ImportError at first use.
- chdb 4.2.1 (the extra's minimum) was released 2026-07-13, inside the rolling 3-day `exclude-newer` window, so the second commit adds it to the existing `exclude-newer-package` overrides. From 2026-07-16 the entry is no longer needed and can be dropped whenever convenient. `uv.lock` is intentionally untouched (CI re-resolves; happy to include the regenerated lock if you prefer).
- `tool.specs.json` is intentionally untouched — the Generate Tool Specifications workflow doesn't run for fork PRs; happy to include the regenerated file instead.
- Async is native: `_arun` delegates to the engine's `acall()` rather than blocking the loop.
- `ChDBBaseTool` is importable from the subpackage but not exported at the top level, mirroring `DaytonaBaseTool`.
- Tool names default to chDB's agent-tool names (`run_select_query`, …); they can be renamed at construction if a crew combines multiple SQL suites.

## Testing

- 19 tests in `tests/tools/chdb_tool_test.py`: unit tests against a mocked engine (no chdb needed) plus integration tests (`pytest.importorskip("chdb")`) covering parameter binding, the readonly=2 write rejection envelope, attach-then-query engine sharing, read-only attachments, and the introspection tools.
- `ruff check` / `ruff format` and strict `mypy` (repo config, pydantic plugin) clean.
- Verified `import crewai_tools` succeeds and tools construct with chdb absent (import blocked via a meta-path hook), with the lazy ImportError pointing at `crewai-tools[chdb]`.
