### PR TITLE
fix(types): distinguish a legitimate None result from never-set in streaming

### DIFF
--- a/lib/crewai/src/crewai/types/streaming.py
+++ b/lib/crewai/src/crewai/types/streaming.py
@@ -342,7 +342,7 @@ class StreamingOutputBase(Generic[T]):
         async_iterator: AsyncIterator[StreamChunk] | None = None,
     ) -> None:
         """Initialize streaming output base."""
-        self._result: T | None = None
+        self._result: T | object = _MISSING
         self._completed: bool = False
         self._chunks: list[StreamChunk] = []
         self._error: Exception | None = None
@@ -370,9 +370,9 @@ class StreamingOutputBase(Generic[T]):
             )
         if self._error is not None:
             raise self._error
-        if self._result is None:
+        if self._result is _MISSING:
             raise RuntimeError("No result available")
-        return self._result
+        return self._result  # type: ignore[return-value]
 
     @property
     def is_completed(self) -> bool:
@@ -553,8 +553,8 @@ class CrewStreamingOutput(StreamingOutputBase["CrewOutput"]):
             raise self._error
         if self._results is not None:
             return self._results
-        if self._result is not None:
-            return [self._result]
+        if self._result is not _MISSING:
+            return [self._result]  # type: ignore[list-item]
         raise RuntimeError("No results available")
 
     def _set_results(self, results: list[CrewOutput]) -> None:

--- a/lib/crewai/tests/test_streaming.py
+++ b/lib/crewai/tests/test_streaming.py
@@ -179,6 +179,18 @@ class TestFlowStreamingOutput:
         list(streaming)
         assert streaming.is_completed is True
 
+    def test_result_can_legitimately_be_none(self) -> None:
+        """Test that a flow result that is legitimately None (e.g. a final
+        method with no return value) does not raise, distinguishing 'never
+        set' from 'set to None'."""
+
+        def empty_gen() -> Generator[StreamChunk, None, None]:
+            yield StreamChunk(content="test")
+
+        streaming = FlowStreamingOutput(sync_iterator=empty_gen())
+        streaming._set_result(None)
+        assert streaming.result is None
+
 
 class TestCrewKickoffStreaming:
     """Tests for Crew(stream=True).kickoff() method."""


### PR DESCRIPTION
## AI-generated contribution disclosure

I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I reviewed the diff, wrote/verified the regression test in both red and green states, traced every other read site of the affected field to check for related issues, and ran the full local test suite + ruff + mypy before opening this PR. Per CONTRIBUTING.md I understand this should carry the `llm-generated` label — as an external contributor I don't have permission to apply labels myself, so flagging it here explicitly; happy for a maintainer to add it.

## Problem

`StreamingOutputBase` (the base class behind `FlowStreamingOutput`/`CrewStreamingOutput`) initializes `self._result` to `None` and treats `None` as "no result was ever set":

```python
if self._result is None:
    raise RuntimeError("No result available")
```

This misfires whenever the actual streamed result legitimately *is* `None` — e.g. a `Flow` whose final method has no return value — even though streaming completed successfully with no error.

The sibling `StreamSessionBase` class in the same file already solves exactly this problem correctly, using a module-level `_MISSING = object()` sentinel instead of comparing to `None`.

## Fix

Apply the same `_MISSING` sentinel pattern to `StreamingOutputBase`. While tracing every read site of `self._result` in the file to make sure I wasn't missing a related spot, I found one more: `CrewStreamingOutput.results`' fallback branch (`if self._result is not None: return [self._result]`) made the same None-means-unset assumption and needed the same fix, or it would have silently broken (returning `[_MISSING]`) once the default changed.

## Testing

- Added `test_result_can_legitimately_be_none` to `TestFlowStreamingOutput` in `tests/test_streaming.py`, confirming `.result` returns `None` (rather than raising) after `_set_result(None)`. Verified it fails against the pre-fix code and passes after.
- Ran the full `tests/test_streaming.py` suite (38 passed).
- `ruff check`/`ruff format --check` clean; `mypy` clean on the changed file.