### PR TITLE
fix(memory): scope-prefix delete no longer leaks root-scope records or ignores older_than

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -451,7 +451,7 @@ class LanceDBStorage:
                 prefix = scope_prefix.rstrip("/")
                 if not prefix.startswith("/"):
                     prefix = "/" + prefix
-                conditions.append(f"scope LIKE '{prefix}%' OR scope = '/'")
+                conditions.append(f"(scope LIKE '{prefix}%')")
             if older_than is not None:
                 conditions.append(f"created_at < '{older_than.isoformat()}'")
             if not conditions:

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -451,7 +451,8 @@ class LanceDBStorage:
                 prefix = scope_prefix.rstrip("/")
                 if not prefix.startswith("/"):
                     prefix = "/" + prefix
-                conditions.append(f"(scope LIKE '{prefix}%')")
+                safe_prefix = prefix.replace("'", "''")
+                conditions.append(f"(scope LIKE '{safe_prefix}%')")
             if older_than is not None:
                 conditions.append(f"created_at < '{older_than.isoformat()}'")
             if not conditions:

--- a/lib/crewai/tests/memory/test_lancedb_delete_scope.py
+++ b/lib/crewai/tests/memory/test_lancedb_delete_scope.py
@@ -1,0 +1,66 @@
+"""LanceDBStorage.delete() scope filtering must not leak unrelated records.
+
+The scope-prefix delete condition was previously built as
+``scope LIKE '{prefix}%' OR scope = '/'`` and joined with an ``older_than``
+condition via ``" AND ".join(conditions)``. Because SQL ``AND`` binds tighter
+than ``OR``, this parsed as
+``scope LIKE 'X%' OR (scope = '/' AND created_at < Y)`` -- every record under
+the target prefix was deleted unconditionally (the age filter never applied
+to it), and every unrelated root-scope (``/``) record was deleted regardless
+of prefix.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from crewai.memory.storage.lancedb_storage import LanceDBStorage
+from crewai.memory.types import MemoryRecord
+
+
+@pytest.fixture
+def lancedb_path(tmp_path: Path) -> Path:
+    return tmp_path / "mem"
+
+
+def _record(scope: str, content: str, created_at: datetime | None = None) -> MemoryRecord:
+    kwargs: dict[str, object] = {
+        "content": content,
+        "scope": scope,
+        "embedding": [0.1, 0.2, 0.3, 0.4],
+    }
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    return MemoryRecord(**kwargs)  # type: ignore[arg-type]
+
+
+def test_delete_by_scope_prefix_does_not_delete_unrelated_root_scope_record(
+    lancedb_path: Path,
+) -> None:
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    storage.save([_record("/", "root memory"), _record("/project", "project memory")])
+
+    deleted = storage.delete(scope_prefix="/project")
+
+    assert deleted == 1
+    assert storage._table.count_rows() == 1
+
+
+def test_delete_by_scope_prefix_and_older_than_only_deletes_old_records(
+    lancedb_path: Path,
+) -> None:
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    old_record = _record(
+        "/project", "old memory", created_at=datetime.utcnow() - timedelta(days=100)
+    )
+    new_record = _record("/project", "new memory", created_at=datetime.utcnow())
+    storage.save([old_record, new_record])
+
+    cutoff = datetime.utcnow() - timedelta(days=1)
+    deleted = storage.delete(scope_prefix="/project", older_than=cutoff)
+
+    assert deleted == 1
+    assert storage._table.count_rows() == 1

--- a/lib/crewai/tests/memory/test_lancedb_delete_scope.py
+++ b/lib/crewai/tests/memory/test_lancedb_delete_scope.py
@@ -64,3 +64,20 @@ def test_delete_by_scope_prefix_and_older_than_only_deletes_old_records(
 
     assert deleted == 1
     assert storage._table.count_rows() == 1
+
+
+def test_delete_by_scope_prefix_containing_single_quote_does_not_break_query(
+    lancedb_path: Path,
+) -> None:
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    storage.save(
+        [
+            _record("/o'brien", "quoted-scope memory"),
+            _record("/other", "unrelated memory"),
+        ]
+    )
+
+    deleted = storage.delete(scope_prefix="/o'brien")
+
+    assert deleted == 1
+    assert storage._table.count_rows() == 1


### PR DESCRIPTION
## AI-generated contribution disclosure

I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I reproduced both failure modes against a real local `LanceDBStorage` table, wrote/verified the regression tests in both red and green states, cross-checked the fix against two other correctly-implemented sibling methods in the same file, and ran the full local test suite + ruff + mypy before opening this PR. Per CONTRIBUTING.md this should carry the `llm-generated` label — as an external contributor I don't have permission to apply labels myself (confirmed via `gh pr edit --add-label`, which returned a GraphQL permission error on my prior PR #6534), so flagging it here for a maintainer to add.

## Problem

`LanceDBStorage.delete()`'s scope-prefix branch builds the SQL condition as:

```python
conditions.append(f"scope LIKE '{prefix}%' OR scope = '/'")
...
where_expr = " AND ".join(conditions)
```

SQL `AND` binds tighter than `OR`, so when combined with an `older_than` condition this parses as:

```
scope LIKE 'X%' OR (scope = '/' AND created_at < Y)
```

Two bugs follow from this:
1. Every record under the target prefix is deleted **unconditionally** — the `older_than` age filter never actually applies to it.
2. Every unrelated record at the root scope (`/`) is deleted **regardless of prefix**, as long as it happens to also satisfy the age condition (or if there's no age condition, essentially always).

## Fix

Parenthesize the scope clause and drop the unconditional root-scope inclusion:

```python
conditions.append(f"(scope LIKE '{prefix}%')")
```

I checked whether the root-scope inclusion might be intentional design, but two sibling code paths in the same file argue against that: `reset()` (a few lines below) does prefix-scoped deletion via `scope >= '{prefix}' AND scope < '{prefix}/￿'` with no root-scope carve-out, and `_scan_rows()` filters with a plain `scope LIKE '{prefix}%'`, also with no such clause. This confirms the `OR scope = '/'` was an implementation defect, not intentional.

## Testing

Added `tests/memory/test_lancedb_delete_scope.py` with two regression tests against a real local `LanceDBStorage` table (no network/embedder required):

- `test_delete_by_scope_prefix_does_not_delete_unrelated_root_scope_record`: saves one root-scope record and one `/project`-scope record, deletes by `scope_prefix="/project"`, confirms only 1 record is deleted (not both).
- `test_delete_by_scope_prefix_and_older_than_only_deletes_old_records`: saves an old and a new record both under `/project`, deletes with `scope_prefix="/project", older_than=<1 day ago>`, confirms only the old one is deleted.

Both fail against the pre-fix code (2 records deleted instead of 1 in each case, verified via `git stash`) and pass after. Ran the full `tests/memory/` suite (149 passed), `ruff check`/`ruff format --check`, and `mypy` — all clean.