### PR TITLE
fix(deps): stop capping chromadb at 1.1.x so the CVE-2026-45829 patch can land

### DIFF
--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "opentelemetry-sdk~=1.42.0",
     "opentelemetry-exporter-otlp-proto-http~=1.42.0",
     # Data Handling
-    "chromadb~=1.1.0",
+    "chromadb>=1.1.0,<2.0.0",
     "tokenizers>=0.21,<1",
     "openpyxl~=3.1.5",
     # Authentication and Security

--- a/lib/crewai/tests/security/test_chromadb_pin.py
+++ b/lib/crewai/tests/security/test_chromadb_pin.py
@@ -1,0 +1,47 @@
+"""Guardrail for the chromadb requirement specifier (OSS-90).
+
+CVE-2026-45829 is a pre-auth code injection in the ChromaDB server with no
+patched release yet (vulnerable range >=1.0.0, <=1.5.9). A compatible-release
+pin like ~=1.1.0 would silently block the 1.6+ patch the moment it ships, so
+the requirement must keep the 1.x line open.
+"""
+
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PYPROJECT_PATH = Path(__file__).parents[2] / "pyproject.toml"
+
+
+def _get_requirement(name: str) -> Requirement:
+    data = tomllib.loads(PYPROJECT_PATH.read_text())
+    for spec in data["project"]["dependencies"]:
+        requirement = Requirement(spec)
+        if requirement.name == name:
+            return requirement
+    raise AssertionError(f"{name} not found in [project.dependencies]")
+
+
+class TestChromadbPin:
+    def test_requirement_does_not_block_future_1x_patch(self) -> None:
+        requirement = _get_requirement("chromadb")
+        for candidate in ("1.6.0", "1.9.0"):
+            assert requirement.specifier.contains(candidate), (
+                f"chromadb requirement '{requirement}' blocks {candidate}; a "
+                "CVE-2026-45829 patch release (>1.5.9) must be installable "
+                "without waiting for a crewai release"
+            )
+
+    def test_requirement_keeps_known_compatible_floor(self) -> None:
+        requirement = _get_requirement("chromadb")
+        assert requirement.specifier.contains("1.1.0"), (
+            f"chromadb requirement '{requirement}' dropped the 1.1.0 floor"
+        )
+        assert not requirement.specifier.contains("2.0.0"), (
+            f"chromadb requirement '{requirement}' admits an untested major"
+        )

--- a/lib/crewai/tests/security/test_chromadb_pin.py
+++ b/lib/crewai/tests/security/test_chromadb_pin.py
@@ -19,7 +19,7 @@ PYPROJECT_PATH = Path(__file__).parents[2] / "pyproject.toml"
 
 
 def _get_requirement(name: str) -> Requirement:
-    data = tomllib.loads(PYPROJECT_PATH.read_text())
+    data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
     for spec in data["project"]["dependencies"]:
         requirement = Requirement(spec)
         if requirement.name == name:

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T15:35:51.457693Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -985,7 +985,7 @@ wheels = [
 
 [[package]]
 name = "chromadb"
-version = "1.1.1"
+version = "1.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
@@ -1004,9 +1004,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "orjson" },
     { name = "overrides" },
-    { name = "posthog" },
     { name = "pybase64" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pypika" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1017,13 +1017,13 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/48/11851dddeadad6abe36ee071fedc99b5bdd2c324df3afa8cb952ae02798b/chromadb-1.1.1.tar.gz", hash = "sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223", size = 1338109, upload-time = "2025-10-05T02:49:14.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/d1/5e33b26985f0c7046a0be1cee2158ada1748ee700d2545057fde1468d74d/chromadb-1.5.9.tar.gz", hash = "sha256:5c20e62a455c28bacac927f26116a73fd8e1799e0d908be8e8a4f02197a54731", size = 2595635, upload-time = "2026-05-05T05:54:51.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/59/0d881a9b7eb63d8d2446cf67fcbb53fb8ae34991759d2b6024a067e90a9a/chromadb-1.1.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27fe0e25ef0f83fb09c30355ab084fe6f246808a7ea29e8c19e85cf45785b90d", size = 19175479, upload-time = "2025-10-05T02:49:12.525Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4f/5a9fa317c84c98e70af48f74b00aa25589626c03a0428b4381b2095f3d73/chromadb-1.1.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:95aed58869683f12e7dcbf68b039fe5f576dbe9d1b86b8f4d014c9d077ccafd2", size = 18267188, upload-time = "2025-10-05T02:49:09.236Z" },
-    { url = "https://files.pythonhosted.org/packages/45/1a/02defe2f1c8d1daedb084bbe85f5b6083510a3ba192ed57797a3649a4310/chromadb-1.1.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06776dad41389a00e7d63d936c3a15c179d502becaf99f75745ee11b062c9b6a", size = 18855754, upload-time = "2025-10-05T02:49:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0d/80be82717e5dc19839af24558494811b6f2af2b261a8f21c51b872193b09/chromadb-1.1.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bba0096a7f5e975875ead23a91c0d41d977fbd3767f60d3305a011b0ace7afd3", size = 19893681, upload-time = "2025-10-05T02:49:06.481Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6e/956e62975305a4e31daf6114a73b3b0683a8f36f8d70b20aabd466770edb/chromadb-1.1.1-cp39-abi3-win_amd64.whl", hash = "sha256:a77aa026a73a18181fd89bbbdb86191c9a82fd42aa0b549ff18d8cae56394c8b", size = 19844042, upload-time = "2025-10-05T02:49:16.925Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5b/3cced915244f43ed14b53fe9f63a37f05f865064f4e4fe7d9448d3f2a352/chromadb-1.5.9-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60701011b5e6409647fa40d12c7c5a66b2b0bfcf33a52db2ad53a30a2abc4957", size = 22564540, upload-time = "2026-05-05T05:54:48.906Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4c/adcef1f4e82a2ef69ccd3711d55fc289193d54c4c0ff7a0292a3631db46f/chromadb-1.5.9-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:814b9c95617377f6501e5757d63dfddb554a283a7739c87b9fa573850174e6f3", size = 21699698, upload-time = "2026-05-05T05:54:45.078Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/937bc4d2e6f8ab9664ec79931fbbd69efff47e513ec2924b071e4b0ff774/chromadb-1.5.9-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9192d111bd662241625867962333d99369a00769a50f8b2f58cb388731274d7e", size = 22680924, upload-time = "2026-05-05T05:54:36.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ec/0c42039e80b9acc534f67b73b7a42471948042859b3a64867b50a4a77fa3/chromadb-1.5.9-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc09b3df76e5a5cb386aed2715a2eea152e3949f9e1ba93c7119505377749929", size = 23316203, upload-time = "2026-05-05T05:54:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/0f7be6e5d0feafa2cda54b12e6542afeea7dea89d2d411e14da90f8abb96/chromadb-1.5.9-cp39-abi3-win_amd64.whl", hash = "sha256:4fd0b560e56761b7f3cb4d5c6205fd5f20814484b4a3e4e9af9038c2b428fc6c", size = 23542454, upload-time = "2026-05-05T05:54:54.942Z" },
 ]
 
 [[package]]
@@ -1430,7 +1430,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'aws'", specifier = "~=1.42.90" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "~=1.42.90" },
     { name = "cel-python", specifier = ">=0.5.0,<0.6" },
-    { name = "chromadb", specifier = "~=1.1.0" },
+    { name = "chromadb", specifier = ">=1.1.0,<2.0.0" },
     { name = "click", specifier = ">=8.1.7,<9" },
     { name = "crewai-cli", editable = "lib/cli" },
     { name = "crewai-core", editable = "lib/crewai-core" },


### PR DESCRIPTION
## Summary

Addresses the actionable part of [OSS-90](https://linear.app/crewai/issue/OSS-90): crewai mandatorily pins `chromadb~=1.1.0` while CVE-2026-45829 (pre-auth code injection in the ChromaDB server, CRITICAL) has **no patched release yet** — the entire 1.x line through 1.5.9 is vulnerable. The `~=1.1.0` compatible-release pin would silently block the 1.6+ patch the moment it ships, leaving users unable to remediate without a crewai release.

## Changes

- Relax the requirement to `chromadb>=1.1.0,<2.0.0` so a patched 1.6+ release is installable the day it ships.
- Lock the workspace to the current top of the range (1.5.9) so CI validates the widened ceiling.
- Add `tests/security/test_chromadb_pin.py` asserting the specifier keeps the 1.x line open (and keeps the tested floor/major cap).

## What this does NOT do (deliberately)

- It does **not** fix the CVE — nothing to bump to yet. The moment a patched chromadb ships, users can adopt it without waiting on crewai; a follow-up should still bump the floor then.
- The ticket's larger ask — making chromadb an **optional extra** so non-Memory/RAG users don't carry it at all — is a breaking packaging/architecture change (~25 modules import chromadb, including default Memory paths) that needs a product decision; flagged back on the Linear ticket rather than bundled here.

## Validation

- New pin test fails against `~=1.1.0` (reproduces the blocked-patch problem) and passes after the relaxation.
- `lib/crewai/tests/rag`, `memory`, `knowledge`, `security` run against chromadb **1.5.9**: 353 passed; the remaining failures are pre-existing on main with chromadb 1.1.1 (missing optional deps: qdrant, docling, vertex), verified against an unmodified baseline — no new failures across the full allowed range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and lockfile-only change with a regression test; runtime behavior follows whatever chromadb version resolves, still bounded to 1.x.
> 
> **Overview**
> Relaxes the mandatory **chromadb** dependency from `~=1.1.0` to `>=1.1.0,<2.0.0` so a future **1.6+** security fix for CVE-2026-45829 can be installed without a new **crewai** release. The compatible-release pin would have capped installs at the 1.1.x line even after a patched ChromaDB ships.
> 
> The lockfile is refreshed to resolve **chromadb 1.5.9** (current top of the allowed 1.x range) so CI exercises the widened ceiling. A new **`tests/security/test_chromadb_pin.py`** guard asserts the specifier still admits **1.1.0**, allows hypothetical **1.6+** patch versions, and rejects **2.0.0**.
> 
> This does **not** remediate the CVE (no fixed release yet) and does **not** make chromadb optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97da603375b3edaa215d789dd46f411edfffcef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->