### PR TITLE
[EPD-194] Make missing OPENAI_API_KEY error actionable (env var / api_key / AMP scope)

### DIFF
--- a/lib/cli/tests/deploy/test_validate.py
+++ b/lib/cli/tests/deploy/test_validate.py
@@ -383,7 +383,11 @@ def test_classify_missing_openai_key_is_warning(tmp_path: Path) -> None:
     v._classify_import_error(
         "ImportError",
         "Error importing native provider: 1 validation error for OpenAICompletion\n"
-        "  Value error, OPENAI_API_KEY is required",
+        "  Value error, OPENAI_API_KEY is required. Set the OPENAI_API_KEY "
+        "environment variable or pass api_key to LLM(). On CrewAI AMP, "
+        "code-first deployments read API keys from deployment environment "
+        "variables — org-wide LLM Connections do not apply to code-first "
+        "deployments.",
         tb="",
     )
     assert len(v.results) == 1

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -387,7 +387,13 @@ class OpenAICompletion(BaseLLM):
         if self.api_key is None:
             self.api_key = os.getenv("OPENAI_API_KEY")
             if self.api_key is None:
-                raise ValueError("OPENAI_API_KEY is required")
+                raise ValueError(
+                    "OPENAI_API_KEY is required. Set the OPENAI_API_KEY "
+                    "environment variable or pass api_key to LLM(). On CrewAI "
+                    "AMP, code-first deployments read API keys from deployment "
+                    "environment variables — org-wide LLM Connections do not "
+                    "apply to code-first deployments."
+                )
 
         base_params = {
             "api_key": self.api_key,

--- a/lib/crewai/tests/llms/openai/test_openai.py
+++ b/lib/crewai/tests/llms/openai/test_openai.py
@@ -618,6 +618,25 @@ def test_openai_get_client_params_no_base_url(monkeypatch):
     assert "base_url" not in client_params or client_params.get("base_url") is None
 
 
+def test_openai_missing_api_key_error_is_actionable(monkeypatch):
+    """
+    Test that the missing-API-key error explains how to fix it: set the
+    OPENAI_API_KEY environment variable or pass api_key, and clarifies that
+    org-wide LLM Connections do not apply to code-first CrewAI AMP deployments.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    llm = OpenAICompletion(model="gpt-4o")
+    with pytest.raises(ValueError) as exc_info:
+        llm._get_client_params()
+
+    message = str(exc_info.value)
+    assert "OPENAI_API_KEY environment variable" in message
+    assert "api_key" in message
+    assert "org-wide LLM Connections do not apply to code-first deployments" in message
+    assert "deployment environment variables" in message
+
+
 def test_openai_streaming_with_response_model():
     """
     Test that streaming with response_model works correctly and doesn't call invalid API methods.


### PR DESCRIPTION
- Rewrites the bare `ValueError("OPENAI_API_KEY is required")` in the OpenAI provider (`lib/crewai/src/crewai/llms/providers/openai/completion.py`) to explain the remediation: set the `OPENAI_API_KEY` environment variable or pass `api_key` to `LLM()`, and that org-wide LLM Connections do not apply to code-first CrewAI AMP deployments (which read keys from deployment environment variables).
- Adds `test_openai_missing_api_key_error_is_actionable` asserting the new message content.
- Updates the CLI deploy-validate test's simulated provider error to the new shipped string; the `llm_init_missing_key` classifier regex still matches.
- Linear: https://linear.app/crewai/issue/EPD-194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text and test fixtures only; no auth or runtime behavior changes beyond clearer failures when the key is missing.
> 
> **Overview**
> Replaces the bare **`OPENAI_API_KEY is required`** `ValueError` in **`OpenAICompletion._get_client_params`** with guidance to set **`OPENAI_API_KEY`**, pass **`api_key`** to **`LLM()`**, and a note that **org-wide LLM Connections do not apply** to **code-first CrewAI AMP** deployments (keys come from **deployment environment variables**).
> 
> Adds **`test_openai_missing_api_key_error_is_actionable`** to lock in that message. Updates the deploy validator test’s simulated import error to the new provider string; **`llm_init_missing_key`** classification is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47bbb8ab445534de0734525957aea79bdb0905b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->