### PR TITLE
[EPD-198] Document restoreFromStateId in kickoff API reference + migration guide operational notes

### DIFF
--- a/docs/edge/en/guides/flows/inputs-id-deprecation.mdx
+++ b/docs/edge/en/guides/flows/inputs-id-deprecation.mdx
@@ -137,6 +137,50 @@ Migrating to `restoreFromStateId` keeps every kickoff as its own execution — w
 its own status, traces, and row in the list — while still hydrating state from a
 previous run.
 
+### Operational notes
+
+A few current behaviors to be aware of when chaining runs over the AMP REST API:
+
+- **The API does not return the new run's state id yet.** A `restoreFromStateId`
+  kickoff mints a fresh `state.id` for the new run, but neither the `/kickoff`
+  response (which returns `kickoff_id`) nor the `/status` payload currently
+  surfaces it, so there is no way to read back the id you would need for the next
+  turn. Until the API exposes the minted state id (this gap is being tracked), the
+  working approach for multi-turn chains is to generate a UUID client-side and pin
+  it as the new run's id via `inputs.id` alongside `restoreFromStateId`:
+
+  ```bash
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer YOUR_CREW_TOKEN" \
+    -d '{
+          "inputs": {"id": "NEW-CLIENT-GENERATED-UUID", "topic": "AI Agent Frameworks"},
+          "restoreFromStateId": "STATE-ID-FROM-PREVIOUS-TURN"
+        }' \
+    https://your-crew-url.crewai.com/kickoff
+  ```
+
+  This deliberately leans on the deprecated `inputs.id` parameter — today it is the
+  only way to know the new run's state id ahead of time. Keep the pinned UUID on
+  your side for the next turn's `restoreFromStateId`, and plan to drop `inputs.id`
+  once the API returns the minted state id.
+
+- **An unknown `restoreFromStateId` silently starts a fresh session.** If the
+  referenced state id does not exist (typo, deleted state, wrong deployment), the
+  kickoff does not fail — the run proceeds with a brand-new state, and nothing in
+  the kickoff response or status payload signals that hydration was skipped.
+  Validate state ids client-side before sending them.
+
+- **`inputs.id` must be a valid UUID on AMP.** The local SDK accepts arbitrary
+  strings, but AMP rejects non-UUID values with a `422`:
+
+  ```json
+  {
+    "error": "Validation Error",
+    "message": "'inputs.id' must be a valid UUID when provided; got 'test 1'."
+  }
+  ```
+
 <Card title="Need Help?" icon="headset" href="mailto:support@crewai.com">
   Contact our support team if you're unsure which mode your flow needs or hit issues
   during the migration.

--- a/docs/edge/en/guides/flows/inputs-id-deprecation.mdx
+++ b/docs/edge/en/guides/flows/inputs-id-deprecation.mdx
@@ -150,12 +150,14 @@ A few current behaviors to be aware of when chaining runs over the AMP REST API:
   it as the new run's id via `inputs.id` alongside `restoreFromStateId`:
 
   ```bash
+  # Example UUIDs: "inputs.id" is a fresh UUID you generated for this turn;
+  # "restoreFromStateId" is the UUID you pinned on the previous turn.
   curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer YOUR_CREW_TOKEN" \
     -d '{
-          "inputs": {"id": "NEW-CLIENT-GENERATED-UUID", "topic": "AI Agent Frameworks"},
-          "restoreFromStateId": "STATE-ID-FROM-PREVIOUS-TURN"
+          "inputs": {"id": "7f9c24e5-3a61-42b0-9c8b-2f1a5d6e8c33", "topic": "AI Agent Frameworks"},
+          "restoreFromStateId": "123e4567-e89b-42d3-a456-426614174000"
         }' \
     https://your-crew-url.crewai.com/kickoff
   ```

--- a/docs/edge/enterprise-api.base.yaml
+++ b/docs/edge/enterprise-api.base.yaml
@@ -149,7 +149,7 @@ paths:
                     silently starts as a fresh session — no error is returned. See the
                     [inputs.id deprecation guide](/en/guides/flows/inputs-id-deprecation)
                     for migration details and operational notes.
-                  example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+                  example: "123e4567-e89b-42d3-a456-426614174000"
                 taskWebhookUrl:
                   type: string
                   format: uri
@@ -194,7 +194,7 @@ paths:
                 value:
                   inputs:
                     topic: "AI Agent Frameworks"
-                  restoreFromStateId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+                  restoreFromStateId: "123e4567-e89b-42d3-a456-426614174000"
       responses:
         "200":
           description: Crew execution started successfully

--- a/docs/edge/enterprise-api.base.yaml
+++ b/docs/edge/enterprise-api.base.yaml
@@ -138,6 +138,18 @@ paths:
                   example:
                     requestId: "user-request-12345"
                     source: "mobile-app"
+                restoreFromStateId:
+                  type: string
+                  format: uuid
+                  description: |
+                    State id of a previous `@persist` flow execution to hydrate from.
+                    The new run **forks** from the referenced snapshot: state is restored,
+                    then the execution proceeds under a fresh state id (the source run's
+                    history is preserved). If the referenced state id is unknown, the run
+                    silently starts as a fresh session — no error is returned. See the
+                    [inputs.id deprecation guide](/en/guides/flows/inputs-id-deprecation)
+                    for migration details and operational notes.
+                  example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
                 taskWebhookUrl:
                   type: string
                   format: uri
@@ -177,6 +189,12 @@ paths:
                     linkedin_url: "https://linkedin.com/in/johnsmith"
                   taskWebhookUrl: "https://api.example.com/webhooks/task"
                   crewWebhookUrl: "https://api.example.com/webhooks/crew"
+              flow_state_restore:
+                summary: Flow kickoff restored from a previous state
+                value:
+                  inputs:
+                    topic: "AI Agent Frameworks"
+                  restoreFromStateId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
       responses:
         "200":
           description: Crew execution started successfully
@@ -199,11 +217,26 @@ paths:
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "422":
-          description: Validation error - ensure all required inputs are provided
+          description: |
+            Validation error. Returned when required inputs are missing, or when
+            `inputs.id` is provided but is not a valid UUID.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidationError"
+              examples:
+                missing_inputs:
+                  summary: Required inputs missing
+                  value:
+                    error: "Validation Error"
+                    message: "Missing required inputs"
+                    details:
+                      missing_inputs: ["budget", "interests"]
+                invalid_inputs_id:
+                  summary: inputs.id is not a valid UUID
+                  value:
+                    error: "Validation Error"
+                    message: "'inputs.id' must be a valid UUID when provided; got 'test 1'."
         "500":
           $ref: "#/components/responses/ServerError"
 

--- a/docs/edge/enterprise-api.en.yaml
+++ b/docs/edge/enterprise-api.en.yaml
@@ -149,7 +149,7 @@ paths:
                     silently starts as a fresh session — no error is returned. See the
                     [inputs.id deprecation guide](/en/guides/flows/inputs-id-deprecation)
                     for migration details and operational notes.
-                  example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+                  example: "123e4567-e89b-42d3-a456-426614174000"
                 taskWebhookUrl:
                   type: string
                   format: uri
@@ -194,7 +194,7 @@ paths:
                 value:
                   inputs:
                     topic: "AI Agent Frameworks"
-                  restoreFromStateId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+                  restoreFromStateId: "123e4567-e89b-42d3-a456-426614174000"
       responses:
         "200":
           description: Crew execution started successfully

--- a/docs/edge/enterprise-api.en.yaml
+++ b/docs/edge/enterprise-api.en.yaml
@@ -138,6 +138,18 @@ paths:
                   example:
                     requestId: "user-request-12345"
                     source: "mobile-app"
+                restoreFromStateId:
+                  type: string
+                  format: uuid
+                  description: |
+                    State id of a previous `@persist` flow execution to hydrate from.
+                    The new run **forks** from the referenced snapshot: state is restored,
+                    then the execution proceeds under a fresh state id (the source run's
+                    history is preserved). If the referenced state id is unknown, the run
+                    silently starts as a fresh session — no error is returned. See the
+                    [inputs.id deprecation guide](/en/guides/flows/inputs-id-deprecation)
+                    for migration details and operational notes.
+                  example: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
                 taskWebhookUrl:
                   type: string
                   format: uri
@@ -177,6 +189,12 @@ paths:
                     linkedin_url: "https://linkedin.com/in/johnsmith"
                   taskWebhookUrl: "https://api.example.com/webhooks/task"
                   crewWebhookUrl: "https://api.example.com/webhooks/crew"
+              flow_state_restore:
+                summary: Flow kickoff restored from a previous state
+                value:
+                  inputs:
+                    topic: "AI Agent Frameworks"
+                  restoreFromStateId: "abcd1234-5678-90ef-ghij-klmnopqrstuv"
       responses:
         "200":
           description: Crew execution started successfully
@@ -199,11 +217,26 @@ paths:
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "422":
-          description: Validation error - ensure all required inputs are provided
+          description: |
+            Validation error. Returned when required inputs are missing, or when
+            `inputs.id` is provided but is not a valid UUID.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidationError"
+              examples:
+                missing_inputs:
+                  summary: Required inputs missing
+                  value:
+                    error: "Validation Error"
+                    message: "Missing required inputs"
+                    details:
+                      missing_inputs: ["budget", "interests"]
+                invalid_inputs_id:
+                  summary: inputs.id is not a valid UUID
+                  value:
+                    error: "Validation Error"
+                    message: "'inputs.id' must be a valid UUID when provided; got 'test 1'."
         "500":
           $ref: "#/components/responses/ServerError"
 


### PR DESCRIPTION
- Add `restoreFromStateId` (optional string, uuid format) to the POST /kickoff request schema in `docs/edge/enterprise-api.en.yaml` (and the in-sync `enterprise-api.base.yaml`): documents fork semantics (hydrates from the referenced state, the new run gets a fresh state id), the silent fresh-session fallback when the id is unknown, and links to the migration guide
- Add a `flow_state_restore` request example and document the 422 variant where a non-UUID `inputs.id` is rejected (`"'inputs.id' must be a valid UUID when provided; got 'test 1'."`) alongside the existing missing_inputs case
- Add an "Operational notes" section to `docs/edge/en/guides/flows/inputs-id-deprecation.mdx` covering: the API does not yet return the minted state id (chain turns today by pinning a client-generated UUID via `inputs.id` alongside `restoreFromStateId`; gap is tracked), unknown `restoreFromStateId` silently starts a fresh session with no failure signal, and AMP's UUID format requirement for `inputs.id`
- Edge-only per AGENTS.md: frozen `docs/v*/` snapshots and non-English locales untouched
- Linear: https://linear.app/crewai/issue/EPD-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Edge guides and OpenAPI YAML; no runtime or API implementation changes.
> 
> **Overview**
> Documents **`restoreFromStateId`** on **POST `/kickoff`** in the Edge OpenAPI specs (`enterprise-api.en.yaml` / `enterprise-api.base.yaml`): optional UUID to hydrate from a prior `@persist` flow with **fork** semantics, silent fresh session when the id is unknown, plus a **`flow_state_restore`** example. **422** is expanded to cover invalid **`inputs.id`** (non-UUID) with concrete response examples alongside missing inputs.
> 
> The **`inputs.id` deprecation** guide gains an **Operational notes** section for AMP REST chaining: the API still does not return the new run’s minted state id (interim pattern of client UUID via **`inputs.id`** + **`restoreFromStateId`**), unknown restore ids fail open with no signal, and AMP requires UUID-shaped **`inputs.id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90f73515a9539d9eaea8a504328c068b73d9a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->