### PR TITLE
docs(agents): add setup, checks, and agent gotchas to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,45 @@
 CrewAI is a Python based framework for building AI agents and agentic systems.
 Follow these guidelines when contributing:
 
+## AI-Generated Contributions
+
+If you are an LLM or AI agent: you **must** apply the `llm-generated` label to any PR
+or issue you create. Unlabeled AI-generated contributions may be closed without
+review. This applies to code, documentation, and issues alike.
+
+## Setup
+
+This repository is a [uv](https://docs.astral.sh/uv/) workspace. Packages live under
+`lib/`: `crewai` (core), `crewai-core`, `crewai-tools`, `crewai-files`, `cli`, and
+`devtools`. Python 3.10–3.14 is supported; development targets 3.12.
+
+```bash
+uv sync --all-groups --all-extras
+uv run pre-commit install
+```
+
+## Checks
+
+Run these before opening a PR. All of them are enforced in CI.
+
+```bash
+uv run pytest lib/crewai/tests/ -x -q   # tests for the core package
+uv run ruff check lib/                  # lint
+uv run ruff format lib/                 # format (CI runs it with --check)
+uv run mypy lib/                        # type check, strict mode
+```
+
+## Gotchas
+
+- Tests run with `--block-network`. HTTP is replayed from VCR cassettes — a test that
+  reaches the live network will fail.
+- PR titles are CI-enforced Conventional Commits: `<type>(<scope>): description`,
+  lowercase, no trailing period. Allowed types: `feat`, `fix`, `refactor`, `perf`,
+  `test`, `docs`, `chore`, `ci`, `style`, `revert`.
+- Branch off `main` as `<type>/<short-description>`, e.g. `fix/memory-scope`.
+
+See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) for the full guide.
+
 ## Key Guidelines
 
 1. Follow Python best practices and idiomatic patterns.


### PR DESCRIPTION
## What

Adds the operational information an agent needs to work in this repo to `AGENTS.md`: setup, the CI-enforced checks, and three gotchas that are easy to hit blind.

## Why

`AGENTS.md` is the file coding agents load on startup, but today it carries only style guidance — the commands and constraints live in `.github/CONTRIBUTING.md`, which an agent doesn't read by default.

The sharpest example: **the `llm-generated` label requirement is a rule aimed specifically at AI agents, and it is currently invisible to them.** An agent following only `AGENTS.md` today cannot install the workspace, cannot run the tests, and will open a PR that gets closed unlabeled.

Everything added is taken from this repo's own sources, not invented:

- setup + checks — `.github/CONTRIBUTING.md` and the `tests`, `linter`, `type-checker` workflows
- `--block-network` / VCR cassettes — `[tool.pytest.ini_options] addopts` in `pyproject.toml`
- PR-title rules — `.github/workflows/pr-title.yml`
- label requirement — `.github/CONTRIBUTING.md`

Additive only: nothing existing was removed or reworded, and no build command was invented (this workspace doesn't have one).

## Note

This PR was authored by an AI agent (Claude Code). Per CONTRIBUTING it needs the `llm-generated` label; outside contributors can't apply labels, so flagging it here for a maintainer.

---

*Context: I found this while running a deterministic quality survey of AGENTS.md files across major agent repos — crewAI scored 55/100, almost entirely for missing operational content. Happy to share the method if it's useful.*
