### PR TITLE
fix: preserve negative sign when parsing float fields in TrainingConverter

### DIFF
--- a/lib/crewai/src/crewai/utilities/training_converter.py
+++ b/lib/crewai/src/crewai/utilities/training_converter.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ValidationError
 from crewai.utilities.converter import Converter, ConverterError
 
 
-_FLOAT_PATTERN: Final[re.Pattern[str]] = re.compile(r"(\d+(?:\.\d+)?)")
+_FLOAT_PATTERN: Final[re.Pattern[str]] = re.compile(r"(-?\d+(?:\.\d+)?)")
 
 
 class TrainingConverter(Converter):

--- a/lib/crewai/tests/utilities/test_training_converter.py
+++ b/lib/crewai/tests/utilities/test_training_converter.py
@@ -95,3 +95,12 @@ class TestTrainingConverter:
         response = "The quality score is 8.5 out of 10"
         result = self.converter._process_field_value(response, float)
         assert result == 8.5
+
+    def test_process_field_value_float_negative(self):
+        response = "The temperature delta is -3.2 degrees"
+        result = self.converter._process_field_value(response, float)
+        assert result == -3.2
+
+    def test_parse_float_preserves_negative_sign(self):
+        assert TrainingConverter._parse_float("-5.2") == -5.2
+        assert TrainingConverter._parse_float("-3 degrees") == -3.0


### PR DESCRIPTION
## What

`_FLOAT_PATTERN` had no `-?`, so `_parse_float('-5.2')` returned `5.2` — silently flipping the sign of any negative value parsed during `TrainingConverter`'s field-by-field fallback extraction (used when a smaller LLM's direct-to-Pydantic conversion fails).

This is reachable for any Pydantic model field typed `float` via `_process_field_value` -> `_parse_float`, e.g. text like `"-3 degrees"` parses to `3.0` instead of `-3.0`.

## Fix

Add the missing `-?` to the pattern.

## How I verified this

- Added 2 new test cases to `test_training_converter.py` covering negative-value parsing; confirmed they fail (sign dropped) before the fix, pass after.
- Ran the full `test_training_converter.py` suite: 8/8 passed.
- Ran the broader `tests/utilities/` suite: 541 passed.
- ruff + mypy clean.

## Disclosure

AI-Generated PR: Yes, drafted with Claude Code and personally reviewed/tested before submission. Per CONTRIBUTING.md's `llm-generated` label requirement: as an external contributor I don't have permission to self-apply GitHub labels (confirmed via `gh pr edit --add-label`, GraphQL permission error) — disclosing here instead; happy to have a maintainer apply the label if needed.