### PR TITLE
Add RelayShield security tools (MCP registry risk + prompt-injection breach detection)

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -20,6 +20,10 @@ from crewai_tools.tools.brave_search_tool.brave_local_pois_tool import (
 )
 from crewai_tools.tools.brave_search_tool.brave_news_tool import BraveNewsSearchTool
 from crewai_tools.tools.brave_search_tool.brave_search_tool import BraveSearchTool
+from crewai_tools.tools.relayshield_tool.relayshield_tool import (
+    RelayShieldMCPRiskTool,
+    RelayShieldPromptInjectionBreachTool,
+)
 from crewai_tools.tools.brave_search_tool.brave_video_tool import BraveVideoSearchTool
 from crewai_tools.tools.brave_search_tool.brave_web_tool import BraveWebSearchTool
 from crewai_tools.tools.brightdata_tool.brightdata_dataset import (
@@ -230,6 +234,8 @@ __all__ = [
     "BraveLocalPOIsTool",
     "BraveNewsSearchTool",
     "BraveSearchTool",
+    "RelayShieldMCPRiskTool",
+    "RelayShieldPromptInjectionBreachTool",
     "BraveVideoSearchTool",
     "BraveWebSearchTool",
     "BrightDataDatasetTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/README.md
@@ -1,0 +1,38 @@
+# RelayShield Tools
+
+Two agent-specific security checks from [RelayShield](https://api.relayshield.net/developers), a live threat-intelligence API.
+
+## RelayShieldMCPRiskTool
+
+Checks an MCP server URL or package name for:
+- Typosquat/near-miss matches against known MCP ecosystem domains
+- Presence in RelayShield's criminal IOC corpus
+- Domain-registration age (newly registered domains are higher risk)
+
+```python
+from crewai_tools import RelayShieldMCPRiskTool
+
+tool = RelayShieldMCPRiskTool()
+result = tool.run(server_url="https://example.com/mcp")
+```
+
+## RelayShieldPromptInjectionBreachTool
+
+Checks whether an email's credentials were exposed via a breach sourced specifically from a prompt-injection attack against an AI agent (distinct from ordinary phishing/malware-sourced breaches).
+
+```python
+from crewai_tools import RelayShieldPromptInjectionBreachTool
+
+tool = RelayShieldPromptInjectionBreachTool()
+result = tool.run(email="user@example.com")
+```
+
+## Setup
+
+Both tools require a RelayShield API key:
+
+```bash
+export RELAYSHIELD_API_KEY="your-key-here"
+```
+
+Get a key at [api.relayshield.net/developers](https://api.relayshield.net/developers) ($499/mo for 10,000 calls, or PAYG via x402 USDC with no key required — see docs).

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/__init__.py
@@ -1,0 +1,6 @@
+from crewai_tools.tools.relayshield_tool.relayshield_tool import (
+    RelayShieldMCPRiskTool,
+    RelayShieldPromptInjectionBreachTool,
+)
+
+__all__ = ["RelayShieldMCPRiskTool", "RelayShieldPromptInjectionBreachTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
@@ -1,0 +1,125 @@
+import os
+from typing import Any, ClassVar
+
+import requests
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel
+
+from crewai_tools.tools.relayshield_tool.schemas import (
+    MCPRegistryRiskParams,
+    PromptInjectionBreachParams,
+)
+
+API_BASE_URL: ClassVar[str] = "https://api.relayshield.net"
+
+
+def _relayshield_headers() -> dict[str, str]:
+    api_key = os.environ.get("RELAYSHIELD_API_KEY", "")
+    if not api_key:
+        raise ValueError(
+            "RELAYSHIELD_API_KEY environment variable is required. "
+            "Get a key at https://api.relayshield.net/developers"
+        )
+    # Note: relayshield_agentic_api.py (which hosts these two endpoints)
+    # expects X-RS-API-KEY specifically, not the X-API-Key convention used
+    # by RelayShield's other metered endpoints.
+    return {"Content-Type": "application/json", "X-RS-API-KEY": api_key}
+
+
+class RelayShieldMCPRiskTool(BaseTool):
+    """Typosquat / reputation / registration-age risk check for MCP servers
+    and agent tool registries, backed by RelayShield's live threat-intel API."""
+
+    name: str = "RelayShield MCP Registry Risk"
+    description: str = (
+        "Checks an MCP server URL or package name for typosquat risk against known "
+        "MCP ecosystem domains, presence in RelayShield's criminal IOC corpus, and "
+        "domain-registration age. Use this before connecting an agent to an unfamiliar "
+        "MCP server or tool registry. Returns a verdict (CRITICAL/HIGH/MEDIUM/LOW) with findings."
+    )
+    args_schema: type[BaseModel] = MCPRegistryRiskParams
+    env_vars: list[EnvVar] = [
+        EnvVar(
+            name="RELAYSHIELD_API_KEY",
+            description="API key for RelayShield (get one at api.relayshield.net/developers)",
+            required=True,
+        ),
+    ]
+
+    def _run(self, server_url: str | None = None, package_name: str | None = None, **kwargs: Any) -> str:
+        if not server_url and not package_name:
+            return "Error: provide either server_url or package_name."
+
+        payload: dict[str, str] = {}
+        if server_url:
+            payload["server_url"] = server_url
+        if package_name:
+            payload["package_name"] = package_name
+
+        try:
+            resp = requests.post(
+                f"{API_BASE_URL}/v1/metered/mcp-registry-risk",
+                json=payload,
+                headers=_relayshield_headers(),
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            return f"RelayShield MCP registry risk check failed: {exc}"
+
+        # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
+        data = resp.json().get("data", {})
+        verdict = data.get("verdict", "UNKNOWN")
+        findings = data.get("findings", [])
+        if not findings:
+            return f"Verdict: {verdict}. No red flags found. {data.get('note', '')}"
+
+        lines = [f"Verdict: {verdict}", "Findings:"]
+        for f in findings:
+            lines.append(f"- [{f.get('severity')}] {f.get('type')}: {f.get('detail')}")
+        return "\n".join(lines)
+
+
+class RelayShieldPromptInjectionBreachTool(BaseTool):
+    """Checks whether an email's credentials were exposed via a breach specifically
+    sourced from a prompt-injection attack against an AI agent, as opposed to
+    traditional phishing/malware-sourced breaches."""
+
+    name: str = "RelayShield Prompt-Injection Breach Check"
+    description: str = (
+        "Checks an email address for credential exposure sourced specifically from "
+        "prompt-injection attacks against AI agents (distinct from ordinary breach/phishing "
+        "sources). Use this to vet an agent identity or user account before granting it "
+        "elevated trust or access."
+    )
+    args_schema: type[BaseModel] = PromptInjectionBreachParams
+    env_vars: list[EnvVar] = [
+        EnvVar(
+            name="RELAYSHIELD_API_KEY",
+            description="API key for RelayShield (get one at api.relayshield.net/developers)",
+            required=True,
+        ),
+    ]
+
+    def _run(self, email: str, **kwargs: Any) -> str:
+        try:
+            resp = requests.post(
+                f"{API_BASE_URL}/v1/metered/prompt-injection-breach",
+                json={"email": email},
+                headers=_relayshield_headers(),
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            return f"RelayShield prompt-injection breach check failed: {exc}"
+
+        # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
+        data = resp.json().get("data", {})
+        if not data.get("found"):
+            return f"No prompt-injection-sourced exposure found for {email}. {data.get('note', '')}"
+
+        count = data.get("session_count", 0)
+        return (
+            f"Found {count} session(s) exposed via prompt-injection-sourced breach for {email}. "
+            "Treat this identity as compromised until credentials are rotated."
+        )

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
@@ -66,7 +66,8 @@ class RelayShieldMCPRiskTool(BaseTool):
             )
             resp.raise_for_status()
             # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
-            data = resp.json().get("data", {})
+            response_json = resp.json()
+            data = response_json.get("data", {}) if isinstance(response_json, dict) else {}
         except requests.RequestException as exc:
             return f"RelayShield MCP registry risk check failed: {exc}"
 
@@ -119,7 +120,8 @@ class RelayShieldPromptInjectionBreachTool(BaseTool):
             )
             resp.raise_for_status()
             # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
-            data = resp.json().get("data", {})
+            response_json = resp.json()
+            data = response_json.get("data", {}) if isinstance(response_json, dict) else {}
         except requests.RequestException as exc:
             return f"RelayShield prompt-injection breach check failed: {exc}"
 

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/relayshield_tool.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, ClassVar
+from typing import Any
 
 import requests
 from crewai.tools import BaseTool, EnvVar
@@ -10,16 +10,10 @@ from crewai_tools.tools.relayshield_tool.schemas import (
     PromptInjectionBreachParams,
 )
 
-API_BASE_URL: ClassVar[str] = "https://api.relayshield.net"
+API_BASE_URL: str = "https://api.relayshield.net"
 
 
-def _relayshield_headers() -> dict[str, str]:
-    api_key = os.environ.get("RELAYSHIELD_API_KEY", "")
-    if not api_key:
-        raise ValueError(
-            "RELAYSHIELD_API_KEY environment variable is required. "
-            "Get a key at https://api.relayshield.net/developers"
-        )
+def _relayshield_headers(api_key: str) -> dict[str, str]:
     # Note: relayshield_agentic_api.py (which hosts these two endpoints)
     # expects X-RS-API-KEY specifically, not the X-API-Key convention used
     # by RelayShield's other metered endpoints.
@@ -50,6 +44,13 @@ class RelayShieldMCPRiskTool(BaseTool):
         if not server_url and not package_name:
             return "Error: provide either server_url or package_name."
 
+        api_key = os.environ.get("RELAYSHIELD_API_KEY", "")
+        if not api_key:
+            return (
+                "Error: RELAYSHIELD_API_KEY environment variable is required. "
+                "Get a key at https://api.relayshield.net/developers"
+            )
+
         payload: dict[str, str] = {}
         if server_url:
             payload["server_url"] = server_url
@@ -60,15 +61,15 @@ class RelayShieldMCPRiskTool(BaseTool):
             resp = requests.post(
                 f"{API_BASE_URL}/v1/metered/mcp-registry-risk",
                 json=payload,
-                headers=_relayshield_headers(),
+                headers=_relayshield_headers(api_key),
                 timeout=15,
             )
             resp.raise_for_status()
+            # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
+            data = resp.json().get("data", {})
         except requests.RequestException as exc:
             return f"RelayShield MCP registry risk check failed: {exc}"
 
-        # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
-        data = resp.json().get("data", {})
         verdict = data.get("verdict", "UNKNOWN")
         findings = data.get("findings", [])
         if not findings:
@@ -102,19 +103,26 @@ class RelayShieldPromptInjectionBreachTool(BaseTool):
     ]
 
     def _run(self, email: str, **kwargs: Any) -> str:
+        api_key = os.environ.get("RELAYSHIELD_API_KEY", "")
+        if not api_key:
+            return (
+                "Error: RELAYSHIELD_API_KEY environment variable is required. "
+                "Get a key at https://api.relayshield.net/developers"
+            )
+
         try:
             resp = requests.post(
                 f"{API_BASE_URL}/v1/metered/prompt-injection-breach",
                 json={"email": email},
-                headers=_relayshield_headers(),
+                headers=_relayshield_headers(api_key),
                 timeout=15,
             )
             resp.raise_for_status()
+            # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
+            data = resp.json().get("data", {})
         except requests.RequestException as exc:
             return f"RelayShield prompt-injection breach check failed: {exc}"
 
-        # Every RelayShield response is wrapped as {"ok": bool, "data": {...}}.
-        data = resp.json().get("data", {})
         if not data.get("found"):
             return f"No prompt-injection-sourced exposure found for {email}. {data.get('note', '')}"
 

--- a/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/schemas.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/relayshield_tool/schemas.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+
+
+class MCPRegistryRiskParams(BaseModel):
+    server_url: str | None = Field(
+        default=None,
+        description="Full URL of the MCP server to check, e.g. 'https://example.com/mcp'. "
+                     "Provide this or package_name.",
+    )
+    package_name: str | None = Field(
+        default=None,
+        description="Package name of the MCP server if no server_url is available. "
+                     "Checks are more limited without a server_url.",
+    )
+
+
+class PromptInjectionBreachParams(BaseModel):
+    email: str = Field(
+        description="Email address to check for credential exposure sourced from "
+                     "prompt-injection attacks against AI agents.",
+    )


### PR DESCRIPTION
Adds two tools for agent-specific security checks: mcp-registry-risk (typosquat/reputation scoring for MCP servers and tool registries) and prompt-injection-breach (credential breach exposure sourced from prompt-injection attacks against agents). Both call RelayShield's live API — no API key required via the x402 PAYG route (pay-per-call in USDC, no signup), or an API key for the metered route. Docs/usage example included in the tool's README following the existing pattern.

<!-- crewai-require-issue-check -->