### PR TITLE
fix: CrewOutput.json raises IndexError instead of ValueError on empty tasks_output

### DIFF
--- a/lib/crewai/src/crewai/crews/crew_output.py
+++ b/lib/crewai/src/crewai/crews/crew_output.py
@@ -43,7 +43,10 @@ class CrewOutput(BaseModel):
 
     @property
     def json(self) -> str | None:  # type: ignore[override]
-        if self.tasks_output[-1].output_format != OutputFormat.JSON:
+        if (
+            not self.tasks_output
+            or self.tasks_output[-1].output_format != OutputFormat.JSON
+        ):
             raise ValueError(
                 "No JSON output found in the final task. Please make sure to set the output_json property in the final task in your crew."
             )

--- a/lib/crewai/tests/test_crew_output.py
+++ b/lib/crewai/tests/test_crew_output.py
@@ -1,0 +1,40 @@
+import pytest
+
+from crewai.crews.crew_output import CrewOutput
+from crewai.tasks.output_format import OutputFormat
+from crewai.tasks.task_output import TaskOutput
+from crewai.types.usage_metrics import UsageMetrics
+
+
+def test_json_raises_value_error_on_empty_tasks_output():
+    """CrewOutput.json should raise the documented ValueError when there is no
+    JSON output -- including when tasks_output is empty, which is a real,
+    reachable state (constructed directly elsewhere in this test suite, e.g.
+    test_crew.py's kickoff_for_each_async mocks), not just an empty-input
+    contrivance."""
+    crew_output = CrewOutput(
+        raw="",
+        tasks_output=[],
+        token_usage=UsageMetrics(),
+    )
+
+    with pytest.raises(ValueError, match="No JSON output found"):
+        _ = crew_output.json
+
+
+def test_json_returns_dumped_output_when_final_task_is_json():
+    task_output = TaskOutput(
+        description="task",
+        agent="tester",
+        raw='{"answer": 42}',
+        json_dict={"answer": 42},
+        output_format=OutputFormat.JSON,
+    )
+    crew_output = CrewOutput(
+        raw="",
+        tasks_output=[task_output],
+        token_usage=UsageMetrics(),
+        json_dict={"answer": 42},
+    )
+
+    assert crew_output.json == '{"answer": 42}'


### PR DESCRIPTION
## Problem

`CrewOutput.json` does `self.tasks_output[-1].output_format != ...` before checking whether the list is empty, so an empty `tasks_output` (a genuine, reachable state — constructed directly elsewhere in this test suite, e.g. `test_crew.py`'s `kickoff_for_each_async` mocks) raises a raw `IndexError` instead of the intended, documented `ValueError` one line below.

## Fix

Guard with `not self.tasks_output or ...` before indexing.

## Testing

- New file `lib/crewai/tests/test_crew_output.py`: asserts the empty-`tasks_output` case raises `ValueError` (not `IndexError`), plus a sanity check that a non-empty, JSON-output final task still returns the dumped JSON.
- Confirmed red→green: reverting only `crew_output.py` reproduces `IndexError: list index out of range`; reapplying passes.
- Full `test_crew_output.py` + `test_crew.py`: 133 passed, 1 skipped (unrelated).
- `ruff check` and `mypy` — clean.
- xref: no open PR touches `crew_output.py`.

## AI-Generated disclosure

Drafted with Claude Code and personally reviewed/tested before submission. Per CONTRIBUTING.md's llm-generated label requirement: as an external contributor I don't have permission to self-apply GitHub labels (confirmed via `gh pr edit --add-label`, GraphQL permission error) — disclosing here instead; happy to have a maintainer apply the label if needed.