### PR TITLE
fix: reject chunk_overlap >= chunk_size in knowledge sources instead of crashing/dropping content

### DIFF
--- a/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
 
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
 from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
@@ -27,6 +28,21 @@ class BaseKnowledgeSource(BaseModel, ABC):
     storage: BaseKnowledgeStorage | None = Field(default=None)
     metadata: dict[str, Any] = Field(default_factory=dict)  # Currently unused
     collection_name: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_chunk_overlap(self) -> Self:
+        """Reject a chunk_overlap that would break _chunk_text's slicing step.
+
+        step = chunk_size - chunk_overlap: zero raises ValueError("range() arg 3
+        must not be zero"); negative silently makes range() empty, dropping all
+        content with no error at all.
+        """
+        if self.chunk_overlap >= self.chunk_size:
+            raise ValueError(
+                f"chunk_overlap ({self.chunk_overlap}) must be smaller than "
+                f"chunk_size ({self.chunk_size})."
+            )
+        return self
 
     @abstractmethod
     def validate_content(self) -> Any:

--- a/lib/crewai/tests/knowledge/test_base_knowledge_source_chunk_overlap.py
+++ b/lib/crewai/tests/knowledge/test_base_knowledge_source_chunk_overlap.py
@@ -1,0 +1,24 @@
+"""Test BaseKnowledgeSource rejects a chunk_overlap that would break _chunk_text's slicing step."""
+
+import pytest
+from crewai.knowledge.source.string_knowledge_source import StringKnowledgeSource
+
+
+def test_chunk_overlap_equal_to_chunk_size_is_rejected():
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        StringKnowledgeSource(content="hello world", chunk_size=50, chunk_overlap=50)
+
+
+def test_chunk_overlap_greater_than_chunk_size_is_rejected():
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        StringKnowledgeSource(content="hello world", chunk_size=50, chunk_overlap=60)
+
+
+def test_chunk_overlap_smaller_than_chunk_size_is_accepted():
+    source = StringKnowledgeSource(content="hello world", chunk_size=50, chunk_overlap=10)
+    assert source.chunk_overlap == 10
+
+
+def test_default_chunk_size_and_overlap_are_valid():
+    source = StringKnowledgeSource(content="hello world")
+    assert source.chunk_overlap < source.chunk_size


### PR DESCRIPTION
## Summary

`BaseKnowledgeSource._chunk_text()` — and 6 byte-for-byte identical copies of
it duplicated across `StringKnowledgeSource`, `JSONKnowledgeSource`,
`PDFKnowledgeSource`, `TextFileKnowledgeSource`, `CSVKnowledgeSource`, and
`ExcelKnowledgeSource` — compute the slicing step with no validation:

```python
range(0, len(text), self.chunk_size - self.chunk_overlap)
```

- `chunk_overlap == chunk_size` → step is `0` → `ValueError("range() arg 3
  must not be zero")`, a confusing error with no indication it's a
  chunk_size/chunk_overlap misconfiguration.
- `chunk_overlap > chunk_size` → step is negative → `range(0, len(text),
  negative)` with `start(0) < stop(len(text))` silently yields nothing →
  `_chunk_text` returns `[]` → the entire source content is dropped, no
  error, no warning, nothing gets indexed.

Verified both independently with a real `StringKnowledgeSource` instance
(no mocking) before this fix — confirmed the exact `ValueError` message for
the equal case, and confirmed zero chunks / no exception at all for the
greater-than case.

## Fix

Added a single `@model_validator(mode="after")` on `BaseKnowledgeSource`
that rejects `chunk_overlap >= chunk_size` at construction time with a clear
message. Every one of the 7 duplicated `_chunk_text` implementations reads
`self.chunk_size` / `self.chunk_overlap` from the same inherited Pydantic
fields, and Pydantic validators are inherited by subclasses — so this one
change on the base class protects all 7 call sites without touching each
file's duplicated method individually. Confirmed by direct instantiation:
`StringKnowledgeSource(..., chunk_size=50, chunk_overlap=50)` and
`chunk_overlap=60` both now raise `ValidationError` immediately, before any
chunking is attempted.

## Testing

Added `tests/knowledge/test_base_knowledge_source_chunk_overlap.py`:
- `chunk_overlap == chunk_size` → rejected
- `chunk_overlap > chunk_size` → rejected
- `chunk_overlap < chunk_size` → accepted
- library defaults (`chunk_size=4000`, `chunk_overlap=200`) → accepted

Confirmed red→green: reverting the source change reproduces "DID NOT RAISE
ValueError" for both bad-config tests; reapplying passes all 4.

Full `tests/knowledge/` suite: 58 passed, no regressions. `ruff check` +
`ruff format --check` + `mypy` all clean.

## Note on overlap

Open PR #5899 also touches `base_knowledge_source.py` (adds a
`description=` to the `metadata` field and threads `metadata` through
`_save_documents`/`_asave_documents`) — different lines, no functional
overlap with this change, but flagging it since both touch the same file.

## AI-Generated disclosure

Implemented with Claude Code (Anthropic) — I independently reproduced both
failure modes with a real (non-mocked) knowledge source instance, verified
the fix protects all 7 duplicated call sites via Pydantic's validator
inheritance, and ran the full test suite before submitting.

Per CONTRIBUTING.md, AI-assisted PRs should carry the `llm-generated` label.
As an external contributor I don't have permission to self-apply labels
(confirmed via `gh pr edit --add-label`, GraphQL permission error) — happy
for a maintainer to apply it.