### PR TITLE
fix(tasks): rename json property to json_output to avoid BaseModel method conflict

### DIFF
--- a/lib/crewai/src/crewai/crews/crew_output.py
+++ b/lib/crewai/src/crewai/crews/crew_output.py
@@ -57,7 +57,15 @@ class CrewOutput(BaseModel):
         return self.token_usage.model_dump()
 
     @property
-    def json(self) -> str | None:  # type: ignore[override]
+    def json_output(self) -> str | None:
+        """Get the JSON string representation of the crew output.
+
+        Returns:
+            JSON string representation of the crew output.
+
+        Raises:
+            ValueError: If the final task output format is not JSON.
+        """
         if self.tasks_output[-1].output_format != OutputFormat.JSON:
             raise ValueError(
                 "No JSON output found in the final task. Please make sure to set the output_json property in the final task in your crew."

--- a/lib/crewai/src/crewai/tasks/task_output.py
+++ b/lib/crewai/src/crewai/tasks/task_output.py
@@ -72,7 +72,7 @@ class TaskOutput(BaseModel):
         return self
 
     @property
-    def json(self) -> str | None:  # type: ignore[override]
+    def json_output(self) -> str | None:
         """Get the JSON string representation of the task output.
 
         Returns:
@@ -80,9 +80,6 @@ class TaskOutput(BaseModel):
 
         Raises:
             ValueError: If output format is not JSON.
-
-        Notes:
-            TODO: Refactor to use model_dump_json() to avoid BaseModel method conflict
         """
         if self.output_format != OutputFormat.JSON:
             raise ValueError(

--- a/lib/crewai/tests/test_task.py
+++ b/lib/crewai/tests/test_task.py
@@ -368,7 +368,7 @@ def test_output_json_sequential():
 
     crew = Crew(agents=[scorer], tasks=[task], process=Process.sequential)
     result = crew.kickoff()
-    assert '{"score": 4}' == result.json
+    assert '{"score": 4}' == result.json_output
     assert result.to_dict() == {"score": 4}
 
     if os.path.exists(output_file):
@@ -401,7 +401,7 @@ def test_output_json_hierarchical():
         manager_llm="gpt-4o",
     )
     result = crew.kickoff()
-    assert result.json == '{"score": 4}'
+    assert result.json_output == '{"score": 4}'
     assert result.to_dict() == {"score": 4}
 
 
@@ -482,7 +482,7 @@ def test_no_inject_date():
 
 
 @pytest.mark.vcr()
-def test_json_property_without_output_json():
+def test_json_output_property_without_output_json():
     class ScoreOutput(BaseModel):
         score: int
 
@@ -504,7 +504,7 @@ def test_json_property_without_output_json():
     result = crew.kickoff()
 
     with pytest.raises(ValueError) as excinfo:
-        _ = result.json  # Attempt to access the json property
+        _ = result.json_output  # Attempt to access the json_output property
 
     assert "No JSON output found in the final task." in str(excinfo.value)
 
@@ -630,7 +630,7 @@ def test_output_json_to_another_task():
 
     crew = Crew(agents=[scorer], tasks=[task1, task2])
     result = crew.kickoff()
-    assert '{"score": 3}' == result.json
+    assert '{"score": 3}' == result.json_output
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

Both `TaskOutput` and `CrewOutput` inherit from Pydantic's `BaseModel`, which provides a built-in `.json()` method. Both classes defined a `@property` named `json` which shadowed `BaseModel.json()`, causing serialization conflicts.

This was acknowledged by a TODO comment in `task_output.py`.

## Changes

- **task_output.py**: Renamed `@property def json` to `@property def json_output`, removed the TODO comment and `# type: ignore[override]`
- **crew_output.py**: Renamed `@property def json` to `@property def json_output`, removed the `# type: ignore[override]`, added a docstring
- **test_task.py**: Updated 4 references from `result.json` to `result.json_output`, renamed test for consistency

## Testing

- All existing tests pass with the updated property name
- The renamed property still returns the same JSON string as before
- Pydantic's native `BaseModel.json()` method is now accessible again

<!-- crewai-require-issue-check -->