### PR TITLE
feat(tools): add Hlido agent trust tools (trust check + recommend)

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -95,6 +95,10 @@ from crewai_tools.tools.generate_crewai_automation_tool.generate_crewai_automati
     GenerateCrewaiAutomationTool,
 )
 from crewai_tools.tools.github_search_tool.github_search_tool import GithubSearchTool
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import (
+    HlidoRecommendTool,
+    HlidoTrustCheckTool,
+)
 from crewai_tools.tools.hyperbrowser_load_tool.hyperbrowser_load_tool import (
     HyperbrowserLoadTool,
 )
@@ -267,6 +271,8 @@ __all__ = [
     "FirecrawlSearchTool",
     "GenerateCrewaiAutomationTool",
     "GithubSearchTool",
+    "HlidoRecommendTool",
+    "HlidoTrustCheckTool",
     "HyperbrowserLoadTool",
     "InvokeCrewAIAutomationTool",
     "JSONSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -84,6 +84,10 @@ from crewai_tools.tools.generate_crewai_automation_tool.generate_crewai_automati
     GenerateCrewaiAutomationTool,
 )
 from crewai_tools.tools.github_search_tool.github_search_tool import GithubSearchTool
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import (
+    HlidoRecommendTool,
+    HlidoTrustCheckTool,
+)
 from crewai_tools.tools.hyperbrowser_load_tool.hyperbrowser_load_tool import (
     HyperbrowserLoadTool,
 )

--- a/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/README.md
@@ -1,0 +1,70 @@
+# HlidoTrustTool
+
+Independent, evidence-backed trust checks on AI agents — so a crew can vet a
+collaborator or tool **before** delegating work to it.
+
+[Hlido](https://hlido.eu) publishes independent reviews of AI agents (score,
+tier, verified claim audits, strengths and red flags). This module exposes two
+tools:
+
+- **`HlidoTrustCheckTool`** — given an agent slug (e.g. `aider`), returns its
+  Hlido score (0-100), tier (`VITAL`/`STEADY`/`FADING`/`FLATLINE`), a `PASS`/`FAIL`
+  gate against a `min_score`, and the reviewed strengths / red flags.
+- **`HlidoRecommendTool`** — given a free-text need (e.g. "AI coding agent"),
+  returns matching Hlido-reviewed agents ranked by trust score.
+
+Both call the **public** Hlido API — **no API key required**, and no new
+dependencies beyond `requests` (already a CrewAI dependency).
+
+## Installation
+
+`HlidoTrustTool` ships with `crewai-tools`; no extra install is needed.
+
+## Example
+
+```python
+from crewai import Agent, Crew, Task
+from crewai_tools import HlidoRecommendTool, HlidoTrustCheckTool
+
+router = Agent(
+    role="Delegation Router",
+    goal="Only delegate coding work to agents that pass an independent Hlido trust check.",
+    backstory="You refuse to rely on any agent Hlido has not vetted to STEADY tier or above.",
+    tools=[HlidoRecommendTool(), HlidoTrustCheckTool()],
+)
+
+task = Task(
+    description=(
+        "Find a reliable AI coding agent with Hlido Recommend, then run Hlido Trust "
+        "Check on it with min_score=70. Only approve it if the gate PASSES."
+    ),
+    expected_output="The chosen agent's name, its Hlido verdict, and APPROVE or REJECT.",
+    agent=router,
+)
+
+Crew(agents=[router], tasks=[task]).kickoff()
+```
+
+## Tool inputs
+
+### `HlidoTrustCheckTool`
+
+| Argument    | Type    | Default | Description                                             |
+| ----------- | ------- | ------- | ------------------------------------------------------- |
+| `slug`      | `str`   | —       | Hlido agent slug (e.g. `aider`, `crewai`, `langchain`). |
+| `min_score` | `float` | `70.0`  | Minimum acceptable Hlido score; sets the PASS/FAIL gate. |
+
+### `HlidoRecommendTool`
+
+| Argument    | Type    | Default | Description                                        |
+| ----------- | ------- | ------- | -------------------------------------------------- |
+| `need`      | `str`   | —       | Free-text description of what you need an agent for. |
+| `min_score` | `float` | `70.0`  | Only recommend agents at or above this score.       |
+| `limit`     | `int`   | `5`     | Maximum number of agents to return.                 |
+
+## Notes
+
+- Data source: the public Hlido reviews API (`hlido.eu/data/scorecards/<slug>.json`
+  and `hlido.eu/data/review-registry.json`).
+- Errors (unknown slug, network issues) are returned as plain, actionable strings
+  rather than raised, so an agent can react to them.

--- a/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/__init__.py
@@ -1,0 +1,3 @@
+from .hlido_trust_tool import HlidoRecommendTool, HlidoTrustCheckTool
+
+__all__ = ["HlidoRecommendTool", "HlidoTrustCheckTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/hlido_trust_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/hlido_trust_tool.py
@@ -1,0 +1,213 @@
+"""Hlido trust tools for CrewAI.
+
+Give a CrewAI agent independent, evidence-backed trust checks on other AI agents
+before delegating work to them, using Hlido's public reviews API (https://hlido.eu).
+
+* ``Hlido Trust Check`` — verdict (score, tier, PASS/FAIL gate) for a known agent slug.
+* ``Hlido Recommend``   — find a Hlido-reviewed agent for a free-text need.
+
+No API key required — both tools call the public Hlido API and add no new
+dependencies beyond ``requests`` (already a CrewAI dependency).
+
+Usage::
+
+    from crewai_tools import HlidoTrustCheckTool, HlidoRecommendTool
+
+    router = Agent(
+        role="Delegation Router",
+        goal="Only delegate to agents that pass an independent Hlido trust check.",
+        tools=[HlidoTrustCheckTool(), HlidoRecommendTool()],
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+HLIDO_BASE_URL = "https://hlido.eu"
+
+# Hlido tier bands (public): VITAL >= 90, STEADY >= 70, FADING >= 40, else FLATLINE.
+_TIER_BANDS = [(90, "VITAL"), (70, "STEADY"), (40, "FADING")]
+
+
+def _tier_for_score(score: float) -> str:
+    for threshold, tier in _TIER_BANDS:
+        if score >= threshold:
+            return tier
+    return "FLATLINE"
+
+
+class HlidoTrustCheckInput(BaseModel):
+    """Input for HlidoTrustCheckTool."""
+
+    slug: str = Field(
+        ...,
+        description=(
+            "Hlido agent slug to check, e.g. 'aider', 'crewai', 'langchain'. "
+            "Lowercase and hyphenated — the identifier in a Hlido review URL "
+            "(hlido.eu/reviews/<slug>/)."
+        ),
+    )
+    min_score: float = Field(
+        70.0,
+        ge=0,
+        le=100,
+        description="Minimum acceptable Hlido score (0-100). 70 = STEADY tier or above.",
+    )
+
+
+class HlidoTrustCheckTool(BaseTool):
+    """Independent trust verdict for a known AI agent, from Hlido's public reviews."""
+
+    name: str = "Hlido Trust Check"
+    description: str = (
+        "Check an AI agent's independent Hlido trust verdict before relying on it. "
+        "Given an agent slug (e.g. 'aider'), returns its Hlido score (0-100), tier "
+        "(VITAL/STEADY/FADING/FLATLINE), a PASS/FAIL gate against min_score, and the "
+        "reviewed strengths and red flags. Uses the public, evidence-backed Hlido API; "
+        "no API key required."
+    )
+    args_schema: type[BaseModel] = HlidoTrustCheckInput
+    base_url: str = HLIDO_BASE_URL
+    timeout: int = 15
+
+    def _run(self, slug: str, min_score: float = 70.0, **_: Any) -> str:
+        slug = (slug or "").strip().lower()
+        if not slug:
+            return "Error: a Hlido agent slug is required (e.g. 'aider')."
+
+        url = f"{self.base_url}/data/scorecards/{slug}.json"
+        try:
+            resp = requests.get(
+                url, timeout=self.timeout, headers={"Accept": "application/json"}
+            )
+            if resp.status_code == 404:
+                return (
+                    f"No Hlido review found for '{slug}'. Hlido has not reviewed this "
+                    "agent (or the slug differs). Use Hlido Recommend to find a "
+                    "reviewed alternative."
+                )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as e:
+            return f"Error querying Hlido for '{slug}': {e}"
+        except ValueError as e:
+            return f"Error parsing Hlido response for '{slug}': {e}"
+
+        score = data.get("score")
+        if score is None:
+            return f"Hlido returned no score for '{slug}'."
+
+        resolved_slug = data.get("slug", slug)
+        tier = data.get("tier") or _tier_for_score(score)
+        passed = score >= min_score
+        result = {
+            "slug": resolved_slug,
+            "name": data.get("name", slug),
+            "score": score,
+            "tier": tier,
+            "min_score": min_score,
+            "gate": "PASS" if passed else "FAIL",
+            "verdict": "APPROVE" if passed else "REJECT",
+            "strengths": data.get("what_it_does_well") or [],
+            "red_flags": data.get("red_flags") or [],
+            "review_url": f"{self.base_url}/reviews/{resolved_slug}/",
+        }
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+class HlidoRecommendInput(BaseModel):
+    """Input for HlidoRecommendTool."""
+
+    need: str = Field(
+        ...,
+        description=(
+            "Free-text description of what you need an agent for, "
+            "e.g. 'AI coding assistant' or 'web scraping agent'."
+        ),
+    )
+    min_score: float = Field(
+        70.0,
+        ge=0,
+        le=100,
+        description="Only recommend agents scoring at or above this (0-100).",
+    )
+    limit: int = Field(
+        5, ge=1, le=25, description="Maximum number of agents to return."
+    )
+
+
+class HlidoRecommendTool(BaseTool):
+    """Find Hlido-reviewed AI agents matching a free-text need, ranked by trust score."""
+
+    name: str = "Hlido Recommend"
+    description: str = (
+        "Find independently-reviewed AI agents for a described need, ranked by Hlido "
+        "trust score. Given a free-text need (e.g. 'AI coding agent'), returns matching "
+        "agents from Hlido's public review registry with their score, tier and review "
+        "URL. Uses the public Hlido API; no API key required."
+    )
+    args_schema: type[BaseModel] = HlidoRecommendInput
+    base_url: str = HLIDO_BASE_URL
+    timeout: int = 15
+
+    def _run(self, need: str, min_score: float = 70.0, limit: int = 5, **_: Any) -> str:
+        need = (need or "").strip().lower()
+        if not need:
+            return "Error: describe what you need an agent for."
+
+        url = f"{self.base_url}/data/review-registry.json"
+        try:
+            resp = requests.get(
+                url, timeout=self.timeout, headers={"Accept": "application/json"}
+            )
+            resp.raise_for_status()
+            registry = resp.json()
+        except requests.RequestException as e:
+            return f"Error querying Hlido registry: {e}"
+        except ValueError as e:
+            return f"Error parsing Hlido registry: {e}"
+
+        items = registry.get("items", []) if isinstance(registry, dict) else registry
+        terms = [t for t in need.replace("/", " ").split() if len(t) > 2]
+
+        matches: list[tuple] = []
+        for item in items:
+            if item.get("lane") != "reviewed":
+                continue
+            score = item.get("score")
+            if score is None or score < min_score:
+                continue
+            haystack = " ".join(
+                str(item.get(k, "")) for k in ("name", "slug", "category", "summary")
+            ).lower()
+            hits = sum(1 for t in terms if t in haystack)
+            if hits:
+                matches.append((hits, score, item))
+
+        if not matches:
+            return (
+                f"No Hlido-reviewed agents scoring >= {min_score} matched '{need}'. "
+                "Try a broader need or a lower min_score."
+            )
+
+        matches.sort(key=lambda m: (m[0], m[1]), reverse=True)
+        out = []
+        for _hits, score, item in matches[:limit]:
+            slug = item.get("slug")
+            out.append(
+                {
+                    "slug": slug,
+                    "name": item.get("name", slug),
+                    "score": score,
+                    "tier": item.get("tier") or _tier_for_score(score),
+                    "category": item.get("category"),
+                    "review_url": f"{self.base_url}/reviews/{slug}/",
+                }
+            )
+        return json.dumps(out, ensure_ascii=False, indent=2)

--- a/lib/crewai-tools/tests/tools/hlido_trust_tool_test.py
+++ b/lib/crewai-tools/tests/tools/hlido_trust_tool_test.py
@@ -1,0 +1,123 @@
+from unittest.mock import MagicMock, patch
+
+from crewai_tools.tools.hlido_trust_tool.hlido_trust_tool import (
+    HlidoRecommendTool,
+    HlidoTrustCheckTool,
+    _tier_for_score,
+)
+
+
+def _mock_response(status_code=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_tier_for_score():
+    assert _tier_for_score(95) == "VITAL"
+    assert _tier_for_score(70) == "STEADY"
+    assert _tier_for_score(40) == "FADING"
+    assert _tier_for_score(10) == "FLATLINE"
+
+
+def test_trust_check_defaults():
+    tool = HlidoTrustCheckTool()
+    assert tool.name == "Hlido Trust Check"
+    assert tool.base_url == "https://hlido.eu"
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.requests.get")
+def test_trust_check_pass(mock_get):
+    mock_get.return_value = _mock_response(
+        json_data={
+            "slug": "aider",
+            "name": "Aider",
+            "score": 88,
+            "tier": "STEADY",
+            "what_it_does_well": ["Surgical diff edits"],
+            "red_flags": [],
+        }
+    )
+    result = HlidoTrustCheckTool().run(slug="aider", min_score=70)
+    assert '"gate": "PASS"' in result
+    assert '"verdict": "APPROVE"' in result
+    assert "Aider" in result
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.requests.get")
+def test_trust_check_fail(mock_get):
+    mock_get.return_value = _mock_response(
+        json_data={"slug": "weak", "name": "Weak", "score": 45, "tier": "FADING"}
+    )
+    result = HlidoTrustCheckTool().run(slug="weak", min_score=70)
+    assert '"gate": "FAIL"' in result
+    assert '"verdict": "REJECT"' in result
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.requests.get")
+def test_trust_check_unknown_slug(mock_get):
+    mock_get.return_value = _mock_response(status_code=404)
+    result = HlidoTrustCheckTool().run(slug="does-not-exist")
+    assert "No Hlido review found" in result
+
+
+def test_trust_check_empty_slug():
+    result = HlidoTrustCheckTool().run(slug="  ")
+    assert "slug is required" in result
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.requests.get")
+def test_recommend_ranks_by_score(mock_get):
+    mock_get.return_value = _mock_response(
+        json_data={
+            "items": [
+                {
+                    "slug": "a",
+                    "name": "A",
+                    "category": "AI coding agent",
+                    "score": 82,
+                    "tier": "STEADY",
+                    "lane": "reviewed",
+                },
+                {
+                    "slug": "b",
+                    "name": "B",
+                    "category": "AI coding agent",
+                    "score": 91,
+                    "tier": "VITAL",
+                    "lane": "reviewed",
+                },
+                {
+                    "slug": "c",
+                    "name": "C",
+                    "category": "Voice",
+                    "score": 95,
+                    "tier": "VITAL",
+                    "lane": "reviewed",
+                },
+                {
+                    "slug": "d",
+                    "name": "D",
+                    "category": "AI coding agent",
+                    "score": 60,
+                    "tier": "FADING",
+                    "lane": "reviewed",
+                },
+            ]
+        }
+    )
+    result = HlidoRecommendTool().run(need="coding agent", min_score=70, limit=5)
+    # Highest-scoring matching reviewed agent first; below-threshold and
+    # non-matching-category excluded.
+    assert result.index('"slug": "b"') < result.index('"slug": "a"')
+    assert '"slug": "d"' not in result
+    assert '"slug": "c"' not in result
+
+
+@patch("crewai_tools.tools.hlido_trust_tool.hlido_trust_tool.requests.get")
+def test_recommend_no_match(mock_get):
+    mock_get.return_value = _mock_response(json_data={"items": []})
+    result = HlidoRecommendTool().run(need="nonexistent category")
+    assert "No Hlido-reviewed agents" in result

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -11598,6 +11598,184 @@
       }
     },
     {
+      "description": "Find independently-reviewed AI agents for a described need, ranked by Hlido trust score. Given a free-text need (e.g. 'AI coding agent'), returns matching agents from Hlido's public review registry with their score, tier and review URL. Uses the public Hlido API; no API key required.",
+      "env_vars": [],
+      "humanized_name": "Hlido Recommend",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "description": "Find Hlido-reviewed AI agents matching a free-text need, ranked by trust score.",
+        "properties": {
+          "base_url": {
+            "default": "https://hlido.eu",
+            "title": "Base Url",
+            "type": "string"
+          },
+          "timeout": {
+            "default": 15,
+            "title": "Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "title": "HlidoRecommendTool",
+        "type": "object"
+      },
+      "name": "HlidoRecommendTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for HlidoRecommendTool.",
+        "properties": {
+          "limit": {
+            "default": 5,
+            "description": "Maximum number of agents to return.",
+            "maximum": 25,
+            "minimum": 1,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "min_score": {
+            "default": 70.0,
+            "description": "Only recommend agents scoring at or above this (0-100).",
+            "maximum": 100,
+            "minimum": 0,
+            "title": "Min Score",
+            "type": "number"
+          },
+          "need": {
+            "description": "Free-text description of what you need an agent for, e.g. 'AI coding assistant' or 'web scraping agent'.",
+            "title": "Need",
+            "type": "string"
+          }
+        },
+        "required": [
+          "need"
+        ],
+        "title": "HlidoRecommendInput",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Check an AI agent's independent Hlido trust verdict before relying on it. Given an agent slug (e.g. 'aider'), returns its Hlido score (0-100), tier (VITAL/STEADY/FADING/FLATLINE), a PASS/FAIL gate against min_score, and the reviewed strengths and red flags. Uses the public, evidence-backed Hlido API; no API key required.",
+      "env_vars": [],
+      "humanized_name": "Hlido Trust Check",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "description": "Independent trust verdict for a known AI agent, from Hlido's public reviews.",
+        "properties": {
+          "base_url": {
+            "default": "https://hlido.eu",
+            "title": "Base Url",
+            "type": "string"
+          },
+          "timeout": {
+            "default": 15,
+            "title": "Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "title": "HlidoTrustCheckTool",
+        "type": "object"
+      },
+      "name": "HlidoTrustCheckTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for HlidoTrustCheckTool.",
+        "properties": {
+          "min_score": {
+            "default": 70.0,
+            "description": "Minimum acceptable Hlido score (0-100). 70 = STEADY tier or above.",
+            "maximum": 100,
+            "minimum": 0,
+            "title": "Min Score",
+            "type": "number"
+          },
+          "slug": {
+            "description": "Hlido agent slug to check, e.g. 'aider', 'crewai', 'langchain'. Lowercase and hyphenated \u2014 the identifier in a Hlido review URL (hlido.eu/reviews/<slug>/).",
+            "title": "Slug",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug"
+        ],
+        "title": "HlidoTrustCheckInput",
+        "type": "object"
+      }
+    },
+    {
       "description": "Scrape or crawl a website using Hyperbrowser and return the contents in properly formatted markdown or html",
       "env_vars": [
         {


### PR DESCRIPTION
## What

Adds two CrewAI tools under `lib/crewai-tools/src/crewai_tools/tools/hlido_trust_tool/` that let a crew vet other AI agents against independent, evidence-backed reviews **before** delegating work to them:

- **`HlidoTrustCheckTool`** — given an agent slug (e.g. `aider`), returns its Hlido score (0-100), tier (VITAL/STEADY/FADING/FLATLINE), a `PASS`/`FAIL` gate against a `min_score`, and the reviewed strengths / red flags.
- **`HlidoRecommendTool`** — given a free-text need (e.g. "AI coding agent"), returns matching reviewed agents ranked by trust score.

## Why

Agents increasingly delegate to other agents/tools with no independent signal of reliability. These tools give a routing/orchestration agent a machine-readable trust check at decision time — a natural fit for CrewAI's delegation model.

## Notes

- **No API key required** — both tools call the public Hlido API (`hlido.eu`).
- **No new dependencies** — uses `requests` (already a CrewAI dependency).
- Pydantic `args_schema`, graceful error strings (no exceptions leaking to the agent), README, and mocked unit tests (no network).
- Registered in `crewai_tools/tools/__init__.py` and `crewai_tools/__init__.py`; `tool.specs.json` regenerated (only the two new entries added).
- `uv run pytest tests/tools/hlido_trust_tool_test.py` — 8 passed; `black`/`isort` clean.

## Disclosure

I'm the founder of Hlido. This integration is opt-in, uses only the public Hlido API, and adds no new dependencies. Happy to adjust naming/placement to match maintainer preferences.