### PR TITLE
fix: replace bare raise in _original_tool_calling to prevent RuntimeError

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -850,7 +850,9 @@ class ToolUsage:
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise
+                raise ToolUsageError(
+                    f"{I18N_DEFAULT.errors('tool_arguments_error')}"
+                )
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         return ToolCalling(

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -557,6 +557,36 @@ def test_validate_tool_input_large_json_content():
 
     arguments = tool_usage._validate_tool_input(tool_input)
     assert arguments == expected_arguments
+
+
+def test_original_tool_calling_non_dict_arguments_raises_tool_usage_error():
+    """Regression test: a bare `raise` outside an except block would surface as
+    `RuntimeError: No active exception to re-raise` instead of ToolUsageError."""
+    tool = RandomNumberTool()
+    action = MagicMock()
+    action.tool = "Random Number Generator"
+    action.tool_input = '["not", "a", "dict"]'
+
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[tool],
+        task=MagicMock(),
+        function_calling_llm=None,
+        agent=MagicMock(),
+        action=action,
+    )
+
+    with (
+        patch.object(tool_usage, "_select_tool", return_value=tool),
+        patch.object(
+            tool_usage, "_validate_tool_input", return_value=["not", "a", "dict"]
+        ),
+    ):
+        with pytest.raises(ToolUsageError):
+            tool_usage._original_tool_calling(action.tool_input, raise_error=True)
+
+        result = tool_usage._original_tool_calling(action.tool_input)
+        assert isinstance(result, ToolUsageError)
 
 
 def test_tool_selection_error_event_direct():


### PR DESCRIPTION
Fixes #6430

Bare `raise` in `ToolUsage._original_tool_calling()` causes `RuntimeError: No active exception to re-raise` when the non-dict-arguments path is reached with `raise_error=True`, because no exception is active on that path (the preceding try/except completed normally). This is a latent landmine that triggers when the model struggles with parameter formatting, and it breaks the fallback logic in `_tool_calling()`, which relies on catching a meaningful exception.

Also flagged by `ruff check --select PLE0704`.

**Fix**: Replace the bare `raise` with `raise ToolUsageError(...)` using the existing i18n `tool_arguments_error` message, mirroring the `raise_error=False` branch.

**Test**: Added a regression test (`test_original_tool_calling_non_dict_arguments_raises_tool_usage_error`) that forces `_validate_tool_input` to return a non-dict and asserts `ToolUsageError` is raised with `raise_error=True` (and returned with `raise_error=False`) instead of a cryptic `RuntimeError`.

Note: this contribution was made with AI assistance — per CONTRIBUTING.md it needs the `llm-generated` label, which I can't set myself.

<!-- crewai-require-issue-check -->