### PR TITLE
fix(tools): raise ToolUsageError instead of bare raise for non-dict args

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -849,9 +849,13 @@ class ToolUsage:
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         if not isinstance(arguments, dict):
+            # Bare `raise` is invalid here: there is no active exception context
+            # (the preceding try/except completed normally). Re-raise a meaningful
+            # ToolUsageError so `_tool_calling` can fall back to the LLM path.
+            error = ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             if raise_error:
-                raise
-            return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
+                raise error
+            return error
 
         return ToolCalling(
             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -25,7 +25,7 @@ from crewai.hooks.tool_hooks import (
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
-from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_usage import ToolUsage, ToolUsageError
 from crewai.utilities.tool_utils import execute_tool_and_check_finality
 from pydantic import BaseModel, Field
 import pytest
@@ -903,3 +903,82 @@ def test_tool_error_does_not_emit_finished_event():
     assert len(finished_events) == 0, (
         "ToolUsageFinishedEvent should NOT be emitted after ToolUsageErrorEvent"
     )
+
+
+def _make_tool_usage_for_args_test(tool_input: str = '["not", "a", "dict"]') -> ToolUsage:
+    """Build a minimal ToolUsage for argument-validation unit tests."""
+
+    class DummyTool(BaseTool):
+        name: str = "dummy_tool"
+        description: str = "A dummy tool."
+
+        def _run(self, x: str = "") -> str:
+            return x
+
+    action = MagicMock()
+    action.tool = "dummy_tool"
+    action.tool_input = tool_input
+
+    agent = MagicMock()
+    agent.verbose = False
+    agent.role = "tester"
+    agent._original_role = "tester"
+    agent.fingerprint = None
+
+    task = MagicMock()
+    task.name = "test"
+    task.description = "test"
+    task.id = "test-id"
+    task.delegations = 0
+
+    return ToolUsage(
+        tools_handler=MagicMock(cache=None, last_used_tool=None),
+        tools=[DummyTool()],
+        task=task,
+        function_calling_llm=None,
+        agent=agent,
+        action=action,
+    )
+
+
+class TestOriginalToolCallingNonDictArguments:
+    """Regression tests for #6430: bare raise on non-dict tool arguments."""
+
+    def test_raise_error_true_raises_tool_usage_error_not_runtime_error(self) -> None:
+        """Non-dict arguments with raise_error=True must raise ToolUsageError."""
+        tu = _make_tool_usage_for_args_test()
+
+        with (
+            patch.object(tu, "_select_tool", return_value=tu.tools[0]),
+            patch.object(tu, "_validate_tool_input", return_value=["not", "a", "dict"]),
+            pytest.raises(ToolUsageError) as exc_info,
+        ):
+            tu._original_tool_calling(tu.action.tool_input, raise_error=True)
+
+        assert not isinstance(exc_info.value, RuntimeError)
+        assert "No active exception" not in str(exc_info.value)
+
+    def test_raise_error_false_returns_tool_usage_error(self) -> None:
+        """Non-dict arguments with raise_error=False must return ToolUsageError."""
+        tu = _make_tool_usage_for_args_test()
+
+        with (
+            patch.object(tu, "_select_tool", return_value=tu.tools[0]),
+            patch.object(tu, "_validate_tool_input", return_value=["not", "a", "dict"]),
+        ):
+            result = tu._original_tool_calling(tu.action.tool_input, raise_error=False)
+
+        assert isinstance(result, ToolUsageError)
+
+    def test_tool_calling_fallback_does_not_crash_on_non_dict_args(self) -> None:
+        """_tool_calling should catch ToolUsageError and take the non-raise path."""
+        tu = _make_tool_usage_for_args_test()
+
+        with (
+            patch.object(tu, "_select_tool", return_value=tu.tools[0]),
+            patch.object(tu, "_validate_tool_input", return_value=["not", "a", "dict"]),
+        ):
+            result = tu._tool_calling(tu.action.tool_input)
+
+        assert isinstance(result, ToolUsageError)
+        assert not isinstance(result, RuntimeError)


### PR DESCRIPTION
## Summary

Fixes a latent bug in `ToolUsage._original_tool_calling()` where a bare `raise` is used **outside** any exception handler when tool arguments are not a `dict`.

On that path Python raises `RuntimeError: No active exception to re-raise` instead of a meaningful `ToolUsageError`. Today `_validate_tool_input` usually returns a dict or raises, so this is a landmine — but `_tool_calling()` calls this with `raise_error=True` and relies on catching a meaningful exception to trigger its LLM fallback.

Closes #6430

## Changes

- Replace bare `raise` with explicit `raise ToolUsageError(...)` when `raise_error=True`
- Keep the existing `return ToolUsageError(...)` behavior when `raise_error=False` (same message, shared instance path)
- Also clears ruff `PLE0704` (bare raise not inside exception handler)

## Test plan

- [x] Unit tests for `_original_tool_calling(raise_error=True)` → `ToolUsageError` (not `RuntimeError`)
- [x] Unit tests for `_original_tool_calling(raise_error=False)` → returns `ToolUsageError`
- [x] Unit test that `_tool_calling` fallback path survives non-dict args
- [ ] CI: `pytest lib/crewai/tests/tools/test_tool_usage.py -q`

## Notes

This contribution was authored with AI assistance. Per CONTRIBUTING.md, please apply the `llm-generated` label (I cannot set labels on this repository).