### PR TITLE
fix(files): raise PermanentUploadError instead of bare raise in get_uploader

### DIFF
--- a/lib/crewai-files/src/crewai_files/uploaders/factory.py
+++ b/lib/crewai-files/src/crewai_files/uploaders/factory.py
@@ -7,6 +7,7 @@ from typing import Any as AnyType, Literal, TypeAlias, TypedDict, overload
 
 from typing_extensions import NotRequired, Unpack
 
+from crewai_files.processing.exceptions import PermanentUploadError
 from crewai_files.uploaders.anthropic import AnthropicFileUploader
 from crewai_files.uploaders.bedrock import BedrockFileUploader
 from crewai_files.uploaders.gemini import GeminiFileUploader
@@ -192,11 +193,12 @@ def get_uploader(
             not os.environ.get("CREWAI_BEDROCK_S3_BUCKET")
             and "bucket_name" not in kwargs
         ):
-            logger.debug(
+            message = (
                 "Bedrock S3 uploader not configured. "
                 "Set CREWAI_BEDROCK_S3_BUCKET environment variable to enable."
             )
-            raise
+            logger.debug(message)
+            raise PermanentUploadError(message)
         try:
             from crewai_files.uploaders.bedrock import BedrockFileUploader
 
@@ -212,5 +214,6 @@ def get_uploader(
             logger.warning("boto3 not installed. Install with: pip install boto3")
             raise
 
-    logger.debug(f"No file uploader available for provider: {provider}")
-    raise
+    message = f"No file uploader available for provider: {provider}"
+    logger.debug(message)
+    raise PermanentUploadError(message)

--- a/lib/crewai-files/tests/test_factory.py
+++ b/lib/crewai-files/tests/test_factory.py
@@ -1,0 +1,21 @@
+"""Tests for the file uploader factory."""
+
+from crewai_files.processing.exceptions import PermanentUploadError
+from crewai_files.uploaders.factory import get_uploader
+import pytest
+
+
+def test_get_uploader_raises_for_unconfigured_bedrock(monkeypatch):
+    monkeypatch.delenv("CREWAI_BEDROCK_S3_BUCKET", raising=False)
+
+    with pytest.raises(
+        PermanentUploadError, match="Bedrock S3 uploader not configured"
+    ):
+        get_uploader("bedrock")
+
+
+def test_get_uploader_raises_for_unsupported_provider():
+    with pytest.raises(
+        PermanentUploadError, match="No file uploader available for provider"
+    ):
+        get_uploader("totally-not-a-real-provider")


### PR DESCRIPTION
Closes #6568

## Summary
Two bare `raise` statements in `get_uploader()` (lib/crewai-files/src/crewai_files/uploaders/factory.py)
were outside any exception handler, causing `RuntimeError: No active exception to re-raise` instead of
a meaningful error:

1. Line 199 — Bedrock requested without CREWAI_BEDROCK_S3_BUCKET configured
2. Line 216 — unsupported provider string passed

## Fix
Both now raise `PermanentUploadError` (already defined in `crewai_files/processing/exceptions.py`
for exactly this kind of non-retryable config/input error), using the same message that was already
being logged via `logger.debug()`.

## Testing
Added `lib/crewai-files/tests/test_factory.py` with two regression tests covering both paths.
Verified locally:
- `uv run pytest lib/crewai-files/tests/test_factory.py -v` — 2 passed
- `uv run ruff check lib/crewai-files/ --select PLE0704` — no issues (confirmed it flagged both
  lines on the pre-fix file, and passes after)
- `uv run mypy lib/crewai-files/src/crewai_files/` — no issues found in 33 source files

## Disclosure
Found via AI-assisted static analysis (ruff's PLE0704 rule run across the codebase), same
defect pattern as #6430 in a different file. Per CONTRIBUTING.md this needs the `llm-generated`
label — I can't apply it myself, could a maintainer add it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
