### PR TITLE
fix: sync kickoff-completed event with OUTPUT hook result

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1928,6 +1928,11 @@ class Crew(FlowTrackable, BaseModel):
         dispatch(InterceptionPoint.EXECUTION_END, end_ctx)
         crew_output = cast(CrewOutput, end_ctx.payload)
 
+        # Keep KickoffCompletedEvent in sync with post-hook output so AMP /
+        # OTEL consumers see OUTPUT mutations (mirrors FlowFinishedEvent).
+        if isinstance(crew_output, CrewOutput):
+            final_task_output.raw = crew_output.raw
+
         # Ensure background memory saves finish (and emit their
         # completed/failed events) before the kickoff-completed event below
         # triggers listener teardown/finalization.

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1928,8 +1928,6 @@ class Crew(FlowTrackable, BaseModel):
         dispatch(InterceptionPoint.EXECUTION_END, end_ctx)
         crew_output = cast(CrewOutput, end_ctx.payload)
 
-        # Keep KickoffCompletedEvent in sync with post-hook output so AMP /
-        # OTEL consumers see OUTPUT mutations (mirrors FlowFinishedEvent).
         if isinstance(crew_output, CrewOutput):
             final_task_output.raw = crew_output.raw
 

--- a/lib/crewai/tests/hooks/test_interception_conformance.py
+++ b/lib/crewai/tests/hooks/test_interception_conformance.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from crewai.agent import Agent
+from crewai.crew import Crew
+from crewai.events.event_bus import crewai_event_bus
+from crewai.events.types.crew_events import CrewKickoffCompletedEvent
 from crewai.flow.flow import Flow, listen, start
 from crewai.hooks.dispatch import (
     HookAborted,
@@ -147,3 +150,36 @@ class TestTaskStepPoints:
 
         assert result.raw == "sanitized output"
         assert (tmp_path / "output.txt").read_text() == "sanitized output"
+
+
+class TestCrewExecutionBoundaries:
+    """execution_start / input / output / execution_end on a crew."""
+
+    def test_output_modification_reaches_kickoff_completed_event(self):
+        @on(InterceptionPoint.OUTPUT)
+        def append_notice(ctx):
+            if hasattr(ctx.payload, "raw") and isinstance(ctx.payload.raw, str):
+                ctx.payload.raw += "\nchanged by hook"
+            return None
+
+        completed_raw: list[str] = []
+
+        @crewai_event_bus.on(CrewKickoffCompletedEvent)
+        def capture_completed(_source, event: CrewKickoffCompletedEvent):
+            completed_raw.append(event.output.raw)
+
+        agent = Agent(role="Writer", goal="Write", backstory="Writes things.")
+        task = Task(
+            description="Write something",
+            expected_output="Some text",
+            agent=agent,
+        )
+        crew = Crew(agents=[agent], tasks=[task], verbose=False)
+
+        with patch.object(Agent, "execute_task", return_value="original output"):
+            result = crew.kickoff()
+        crewai_event_bus.flush()
+
+        assert result.raw.endswith("changed by hook")
+        assert completed_raw
+        assert completed_raw[-1].endswith("changed by hook")

--- a/lib/crewai/tests/hooks/test_interception_conformance.py
+++ b/lib/crewai/tests/hooks/test_interception_conformance.py
@@ -152,9 +152,7 @@ class TestTaskStepPoints:
         assert (tmp_path / "output.txt").read_text() == "sanitized output"
 
 
-class TestCrewExecutionBoundaries:
-    """execution_start / input / output / execution_end on a crew."""
-
+class TestCrewOutput:
     def test_output_modification_reaches_kickoff_completed_event(self):
         @on(InterceptionPoint.OUTPUT)
         def append_notice(ctx):


### PR DESCRIPTION
Crew `OUTPUT` hooks already mutated the returned `CrewOutput`, but `CrewKickoffCompletedEvent` still emitted the pre-hook `TaskOutput`, so AMP/OTEL never showed those changes even though Flow already honors post-hook results via `FlowFinishedEvent`. This syncs `final_task_output.raw` from the post-hook payload before the completed event is emitted so crew OUTPUT mutations surface the same way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change at crew completion; only syncs the `raw` field on the existing final task output before event emission.
> 
> **Overview**
> **Crew `OUTPUT` hooks could change the `CrewOutput` returned from `kickoff()`, but `CrewKickoffCompletedEvent` still carried the pre-hook final `TaskOutput`, so telemetry listeners (e.g. AMP/OTEL) did not see hook edits.**
> 
> After `OUTPUT` and `EXECUTION_END` interception, `_create_crew_output` now copies the post-hook `crew_output.raw` onto `final_task_output` before emitting the kickoff-completed event, so event subscribers see the same text as the returned crew output.
> 
> A conformance test asserts that an `OUTPUT` hook that appends to `raw` is reflected in both `crew.kickoff()` and `CrewKickoffCompletedEvent.output.raw`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0fc106c918fb62fdbd6250b72b10cafd70b751a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->