### PR TITLE
fix(project): resolve skills paths against project root

### DIFF
--- a/lib/crewai/src/crewai/project/json_loader.py
+++ b/lib/crewai/src/crewai/project/json_loader.py
@@ -1013,6 +1013,10 @@ def _agent_kwargs_from_definition(
     if resolve_tools:
         _resolve_tool_fields(agent_kwargs, path, project_root=project_root)
         _resolve_agent_python_refs(agent_kwargs, path, project_root)
+        if "skills" in agent_kwargs:
+            agent_kwargs["skills"] = _normalize_skills(
+                agent_kwargs["skills"], project_root
+            )
     else:
         # Validation/deploy mode: check tool declarations structurally without
         # importing or instantiating anything — custom:<name> tools execute
@@ -1117,6 +1121,8 @@ def _crew_kwargs_from_definition(
         crew_kwargs["manager_agent"] = agents_map[manager_agent]
 
     _resolve_crew_python_refs(crew_kwargs, source, project_root)
+    if "skills" in crew_kwargs:
+        crew_kwargs["skills"] = _normalize_skills(crew_kwargs["skills"], project_root)
 
     return crew_kwargs
 
@@ -1709,6 +1715,67 @@ def _normalize_input_files(
             continue
         normalized[name] = file_spec
     return normalized
+
+
+def _is_skill_path_ref(item: Any) -> bool:
+    """Return True when a skill entry denotes a filesystem path.
+
+    Mirrors the string dispatch order of ``crewai.skills.loader.load_skill``:
+    registry references (``@org/name``) and inline SKILL.md documents are not
+    paths and must reach the loader untouched.
+
+    Args:
+        item: A single entry from a ``skills`` definition list.
+
+    Returns:
+        True if the entry should be resolved against the project root.
+    """
+    if not isinstance(item, str) or not item.strip():
+        return False
+    if item.startswith("@"):
+        return False
+    return not item.lstrip().startswith("---\n")
+
+
+def _anchor_skill_path(value: str, root: Path) -> str:
+    """Anchor a relative skill path to the project root.
+
+    Absolute inputs are returned verbatim, including Windows drive and UNC
+    paths seen from a POSIX host, so a definition that loads today keeps
+    loading. Only cwd-dependent relative paths are rewritten.
+
+    Args:
+        value: A skill entry already known to denote a filesystem path.
+        root: Resolved project root.
+
+    Returns:
+        The anchored path, or the original value when it is absolute.
+    """
+    if Path(value).is_absolute() or _looks_like_windows_absolute_path(value):
+        return value
+    return str((root / value).resolve())
+
+
+def _normalize_skills(value: Any, project_root: Path | None) -> Any:
+    """Resolve relative filesystem skill paths against the project root.
+
+    Registry references, inline SKILL.md content, absolute paths and
+    already-resolved ``Skill`` objects are returned unchanged.
+
+    Args:
+        value: The ``skills`` value from an agent or crew definition.
+        project_root: Root the relative paths are resolved against.
+
+    Returns:
+        The skills value with relative filesystem paths anchored.
+    """
+    if not isinstance(value, list):
+        return value
+    root = _project_root(project_root)
+    return [
+        _anchor_skill_path(item, root) if _is_skill_path_ref(item) else item
+        for item in value
+    ]
 
 
 def _input_files_definition_errors(

--- a/lib/crewai/tests/project/test_crew_loader.py
+++ b/lib/crewai/tests/project/test_crew_loader.py
@@ -6,12 +6,14 @@ import json
 from pathlib import Path
 import sys
 import types
+from unittest.mock import patch
 
 import pytest
 
 from crewai.llms.base_llm import BaseLLM
 from crewai.project.json_loader import JSONProjectError, JSONProjectValidationError
 from crewai.project.crew_loader import load_crew, load_crew_from_definition
+from crewai.skills.models import Skill, SkillFrontmatter
 
 
 def _write_python_defs(tmp_path: Path) -> None:
@@ -69,6 +71,16 @@ def _input_file_path(value) -> Path:
         source = getattr(value, "source", value)
     path = getattr(source, "path", source)
     return Path(str(path))
+
+
+def _write_skill(skills_dir: Path, name: str) -> Path:
+    """Create a discoverable skill directory containing a minimal SKILL.md."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} description\n---\n\nDo the thing.\n"
+    )
+    return skill_dir
 
 
 class TestLoadCrew:
@@ -963,3 +975,184 @@ class TestLoadCrew:
 
         crew, _ = load_crew(crew_file)
         assert crew.verbose is True
+
+    def test_crew_loads_agent_skill_path_relative_to_project_root(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Agent skill paths resolve against project_root, not the process cwd."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        _write_agent(agents_dir, "helper", skills=["skills"])
+        skill_dir = _write_skill(tmp_path / "skills", "pdf-report")
+
+        monkeypatch.chdir(tmp_path_factory.mktemp("elsewhere_agent"))
+
+        crew_def = {
+            "name": "skills_crew",
+            "agents": ["helper"],
+            "tasks": [
+                {
+                    "name": "write",
+                    "description": "Write a report",
+                    "expected_output": "A report",
+                    "agent": "helper",
+                }
+            ],
+        }
+        crew_file = _write_crew(tmp_path, crew_def)
+
+        crew, _ = load_crew(crew_file)
+        loaded = crew.agents[0].skills
+
+        assert loaded, "Expected the agent skill to be discovered from the project root"
+        assert [s.name for s in loaded] == ["pdf-report"]
+        assert Path(loaded[0].path) == skill_dir
+
+    def test_crew_loads_crew_level_skill_path_relative_to_project_root(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Crew-level skill paths resolve against project_root, not the process cwd."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        _write_agent(agents_dir, "helper")
+        _write_skill(tmp_path / "skills", "shared-skill")
+
+        monkeypatch.chdir(tmp_path_factory.mktemp("elsewhere_crew"))
+
+        crew_def = {
+            "name": "crew_skills_crew",
+            "agents": ["helper"],
+            "skills": ["skills"],
+            "tasks": [
+                {
+                    "name": "write",
+                    "description": "Write a report",
+                    "expected_output": "A report",
+                    "agent": "helper",
+                }
+            ],
+        }
+        crew_file = _write_crew(tmp_path, crew_def)
+
+        crew, _ = load_crew(crew_file)
+
+        # Crew-level skills are loaded per agent at kickoff, so the loader's
+        # contract is that the stored path is already rooted at project_root.
+        assert crew.skills == [str(tmp_path / "skills")]
+
+    def test_crew_leaves_registry_skill_reference_unresolved(self, tmp_path: Path):
+        """Registry refs reach the resolver verbatim instead of being path-resolved."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        _write_agent(agents_dir, "helper", skills=["@acme/research"])
+
+        crew_def = {
+            "name": "registry_skills_crew",
+            "agents": ["helper"],
+            "tasks": [
+                {
+                    "name": "write",
+                    "description": "Write a report",
+                    "expected_output": "A report",
+                    "agent": "helper",
+                }
+            ],
+        }
+        crew_file = _write_crew(tmp_path, crew_def)
+
+        captured: list[str] = []
+
+        def _fake_resolve(ref, source=None, activate=True):
+            captured.append(ref)
+            return Skill(
+                frontmatter=SkillFrontmatter(
+                    name="research", description="research description"
+                ),
+                path=Path("."),
+            )
+
+        with patch("crewai.skills.registry.resolve_registry_ref", _fake_resolve):
+            load_crew(crew_file)
+
+        assert captured == ["@acme/research"]
+
+    def test_crew_anchors_agent_skill_path_pointing_above_project_root(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A skill path above the project root anchors to it instead of being rejected."""
+        project_root = tmp_path / "project"
+        agents_dir = project_root / "agents"
+        agents_dir.mkdir(parents=True)
+        _write_agent(agents_dir, "helper", skills=["../shared_skills"])
+        skill_dir = _write_skill(tmp_path / "shared_skills", "shared-lookup")
+
+        monkeypatch.chdir(tmp_path_factory.mktemp("elsewhere_above"))
+
+        crew_def = {
+            "name": "shared_skills_crew",
+            "agents": ["helper"],
+            "tasks": [
+                {
+                    "name": "write",
+                    "description": "Write a report",
+                    "expected_output": "A report",
+                    "agent": "helper",
+                }
+            ],
+        }
+        crew_file = _write_crew(project_root, crew_def)
+
+        crew, _ = load_crew(crew_file)
+        loaded = crew.agents[0].skills
+
+        assert [s.name for s in loaded] == ["shared-lookup"], (
+            f"Expected the sibling skill directory to load, got {loaded}"
+        )
+        assert Path(loaded[0].path) == skill_dir
+
+    def test_crew_leaves_absolute_agent_skill_path_untouched(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Absolute skill paths outside the project root keep loading unchanged."""
+        project_root = tmp_path / "project"
+        agents_dir = project_root / "agents"
+        agents_dir.mkdir(parents=True)
+        outside_skills = tmp_path / "outside_skills"
+        skill_dir = _write_skill(outside_skills, "external-lookup")
+        _write_agent(agents_dir, "helper", skills=[str(outside_skills)])
+
+        monkeypatch.chdir(tmp_path_factory.mktemp("elsewhere_absolute"))
+
+        crew_def = {
+            "name": "absolute_skills_crew",
+            "agents": ["helper"],
+            "tasks": [
+                {
+                    "name": "write",
+                    "description": "Write a report",
+                    "expected_output": "A report",
+                    "agent": "helper",
+                }
+            ],
+        }
+        crew_file = _write_crew(project_root, crew_def)
+
+        crew, _ = load_crew(crew_file)
+        loaded = crew.agents[0].skills
+
+        assert [s.name for s in loaded] == ["external-lookup"], (
+            f"Expected the absolute skill path to load, got {loaded}"
+        )
+        assert Path(loaded[0].path) == skill_dir


### PR DESCRIPTION
## Problem

Every relative path field in a JSON crew definition is resolved against `project_root`: `custom:` tools, `output_pydantic` / `response_model` python refs, and `input_files`. The `skills` field is the one exception.

It is passed through unresolved in `_agent_kwargs_from_definition` and `_crew_kwargs_from_definition`, and reaches `crewai.skills.loader.load_skill`, whose final branch calls `discover_skills(Path(skill))`. That resolves against the process working directory at call time.

The result is that the same crew definition succeeds or fails purely based on where the process was launched from. Running a script from its own directory works; running the identical code under uvicorn, in a container, or from an IDE run configuration raises:

```
FileNotFoundError: Skill search path does not exist or is not a directory: skills
```

## Root cause

`skills` is listed in `_AGENT_OBJECT_REF_FIELDS` and `_CREW_OBJECT_REF_FIELDS`, so `python:` reference dicts are converted to `Skill` objects. Plain path strings, however, are left untouched and never normalized against `project_root`.

## Change

Anchor `skills` entries that denote *relative* filesystem paths to `project_root`.

`_is_skill_path_ref` mirrors the string dispatch order of `load_skill` so the two stay in sync:

| Entry | Handling |
| --- | --- |
| `@org/name` | registry reference, left untouched |
| `---\n...` | inline SKILL.md document, left untouched |
| `Skill` object | already resolved, left untouched |
| absolute path | left untouched |
| relative path | anchored to `project_root` |

Normalization runs after `_resolve_agent_python_refs` / `_resolve_crew_python_refs`, so `python:` refs are already `Skill` instances by that point and only genuine strings remain. It is confined to the `resolve_tools=True` branch, leaving validation and deploy mode free of any project code execution.

## Compatibility

No definition that loads today stops loading.

- Absolute paths — including Windows drive and UNC forms seen from a POSIX host — are passed through verbatim.
- Relative paths escaping the root (`../shared_skills`) are anchored rather than rejected, which is exactly what they already resolved to whenever the process ran from the project directory.

Unlike `input_files`, no containment rule is introduced: the skills loader has never had one, and adding it here would reject working monorepo layouts that keep a shared skills directory next to the project.

## Tests

Five cases in `lib/crewai/tests/project/test_crew_loader.py`, alongside the existing `input_files` path tests. Every path case chdirs elsewhere first, so each one fails without this change:

- agent-level `skills` resolves against `project_root`
- crew-level `skills` stores the project-rooted path
- `@acme/research` reaches the registry resolver verbatim, guarding the Skills Repository path
- `../shared_skills` loads a sibling directory above the project root
- an absolute path outside the project root loads unchanged

Fixes #6585


<!-- crewai-require-issue-check -->