### PR TITLE
feat(crewai-tools): add SerpdiveSearchTool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -252,6 +252,7 @@
                           "edge/en/tools/search-research/tavilysearchtool",
                           "edge/en/tools/search-research/tavilyextractortool",
                           "edge/en/tools/search-research/tavilyresearchtool",
+                          "edge/en/tools/search-research/serpdivesearchtool",
                           "edge/en/tools/search-research/arxivpapertool",
                           "edge/en/tools/search-research/serpapi-googlesearchtool",
                           "edge/en/tools/search-research/serpapi-googleshoppingtool",

--- a/docs/edge/en/tools/search-research/overview.mdx
+++ b/docs/edge/en/tools/search-research/overview.mdx
@@ -62,6 +62,10 @@ These tools enable your agents to search the web, research topics, and find info
     Retrieve the status and results of an existing Tavily research task.
   </Card>
 
+  <Card title="SERPdive Search Tool" icon="water" href="/en/tools/search-research/serpdivesearchtool">
+    Web search that returns extracted, answer-ready page content using the SERPdive API.
+  </Card>
+
   <Card title="Arxiv Paper Tool" icon="box-archive" href="/en/tools/search-research/arxivpapertool">
     Search arXiv and optionally download PDFs.
   </Card>

--- a/docs/edge/en/tools/search-research/serpdivesearchtool.mdx
+++ b/docs/edge/en/tools/search-research/serpdivesearchtool.mdx
@@ -1,0 +1,84 @@
+---
+title: SERPdive Search Tool
+description: The `SerpdiveSearchTool` performs web searches that return answer-ready page content using the SERPdive API.
+icon: water
+mode: "wide"
+---
+
+# `SerpdiveSearchTool`
+
+## Description
+
+The `SerpdiveSearchTool` connects your agents to [SERPdive](https://serpdive.com), an AI search API that returns answer-ready web content: every result carries the actual text of the page (url, title, date, content), already extracted, cleaned, and sized for LLM consumption, so agents can quote and cite straight from the tool output. On a [public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark), SERPdive runs at the same speed as Tavily, feeds your LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels.
+
+## Installation
+
+To use this tool, you need to install the SERPdive SDK:
+
+```shell
+uv add serpdive
+```
+
+## Steps to Get Started
+
+1. **API Key**: Get a free API key (no card required) at [serpdive.com/dashboard/keys](https://serpdive.com/dashboard/keys).
+2. **Environment Setup**: Set the key as the `SERPDIVE_API_KEY` environment variable.
+3. **Install SDK**: Install the SERPdive SDK using the command above.
+
+## Example
+
+The following example demonstrates how to initialize the tool and use it in an agent:
+
+```python Code
+from crewai import Agent
+from crewai_tools import SerpdiveSearchTool
+
+# Reads the SERPDIVE_API_KEY environment variable
+serpdive_tool = SerpdiveSearchTool()
+
+researcher = Agent(
+    role="Market Researcher",
+    goal="Find current information about the solid state battery market",
+    backstory="An expert market researcher specializing in energy technology.",
+    tools=[serpdive_tool],
+)
+```
+
+## Parameters
+
+### Constructor Parameters
+
+- **model**: Optional. Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"moby"` returns the full readable text of each page, for deep research.
+- **answer**: Optional. When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`). Default is `False`.
+- **max_results**: Optional. Hard cap on delivered results (1-10). By default the engine picks its calibrated mix.
+- **api_key**: Optional. Your SERPdive API key. If not provided, it is read from the `SERPDIVE_API_KEY` environment variable.
+
+### Run Parameters
+
+- **query**: Required. The search query, in any language.
+
+There is no country or locale parameter to configure: the language of the query picks where the search runs, automatically. Failed searches are never billed.
+
+## Return Format
+
+The tool returns a JSON string in the following format:
+
+```json
+{
+  "query": "latest developments in solid state batteries",
+  "results": [
+    {
+      "url": "https://example.com/article",
+      "title": "Article title",
+      "date": "2026-07-11",
+      "content": "The fact-carrying text of the page, extracted and cleaned..."
+    }
+  ],
+  "answer": "Only present when the answer option is enabled."
+}
+```
+
+## Links
+
+- [API reference](https://serpdive.com/docs)
+- [Public benchmark](https://github.com/edendalexis/serpdive-benchmark) (replayable end to end: same questions, same judge, your machine)

--- a/docs/edge/en/tools/search-research/serpdivesearchtool.mdx
+++ b/docs/edge/en/tools/search-research/serpdivesearchtool.mdx
@@ -48,8 +48,8 @@ researcher = Agent(
 
 ### Constructor Parameters
 
-- **model**: Optional. Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"moby"` returns the full readable text of each page, for deep research.
-- **answer**: Optional. When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`). Default is `False`.
+- **model**: Optional. Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"krill"` is the free tier: unlimited under fair use, a smaller set of the same sentences, one request at a time, at low priority. `"moby"` returns the full readable text of each page, for deep research.
+- **answer**: Optional. When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`; unavailable on `krill`). Default is `False`.
 - **max_results**: Optional. Hard cap on delivered results (1-10). By default the engine picks its calibrated mix.
 - **api_key**: Optional. Your SERPdive API key. If not provided, it is read from the `SERPDIVE_API_KEY` environment variable.
 

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -53,6 +53,9 @@ patronus = [
 serpapi = [
     "serpapi>=0.1.5",
 ]
+serpdive = [
+    "serpdive>=0.1.1",
+]
 beautifulsoup4 = [
     "beautifulsoup4>=4.12.3",
 ]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -166,6 +166,9 @@ from crewai_tools.tools.serpapi_tool.serpapi_google_search_tool import (
 from crewai_tools.tools.serpapi_tool.serpapi_google_shopping_tool import (
     SerpApiGoogleShoppingTool,
 )
+from crewai_tools.tools.serpdive_search_tool.serpdive_search_tool import (
+    SerpdiveSearchTool,
+)
 from crewai_tools.tools.serper_dev_tool.serper_dev_tool import SerperDevTool
 from crewai_tools.tools.serper_scrape_website_tool.serper_scrape_website_tool import (
     SerperScrapeWebsiteTool,
@@ -303,6 +306,7 @@ __all__ = [
     "SeleniumScrapingTool",
     "SerpApiGoogleSearchTool",
     "SerpApiGoogleShoppingTool",
+    "SerpdiveSearchTool",
     "SerperDevTool",
     "SerperScrapeWebsiteTool",
     "SerplyJobSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -154,6 +154,9 @@ from crewai_tools.tools.serpapi_tool.serpapi_google_search_tool import (
 from crewai_tools.tools.serpapi_tool.serpapi_google_shopping_tool import (
     SerpApiGoogleShoppingTool,
 )
+from crewai_tools.tools.serpdive_search_tool.serpdive_search_tool import (
+    SerpdiveSearchTool,
+)
 from crewai_tools.tools.serper_dev_tool.serper_dev_tool import SerperDevTool
 from crewai_tools.tools.serper_scrape_website_tool.serper_scrape_website_tool import (
     SerperScrapeWebsiteTool,
@@ -285,6 +288,7 @@ __all__ = [
     "SeleniumScrapingTool",
     "SerpApiGoogleSearchTool",
     "SerpApiGoogleShoppingTool",
+    "SerpdiveSearchTool",
     "SerperDevTool",
     "SerperScrapeWebsiteTool",
     "SerplyJobSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/README.md
@@ -1,0 +1,80 @@
+# SERPdive Search Tool
+
+## Description
+
+The `SerpdiveSearchTool` connects CrewAI agents to [SERPdive](https://serpdive.com), an AI search API that returns answer-ready web content: every result carries the actual text of the page (url, title, date, content), already extracted, cleaned, and sized for LLM consumption, so agents can quote and cite straight from the tool output. On a [public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark), SERPdive runs at the same speed as Tavily, feeds your LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels.
+
+The tool returns the search results as a JSON string.
+
+## Installation
+
+To use the `SerpdiveSearchTool`, you need to install the `serpdive` library:
+
+```shell
+pip install 'crewai[tools]' serpdive
+```
+
+## Environment Variables
+
+Get a free API key (no card required) at [serpdive.com/dashboard/keys](https://serpdive.com/dashboard/keys) and set it as an environment variable:
+
+```bash
+export SERPDIVE_API_KEY='sd_live_...'
+```
+
+## Example
+
+Here's how to initialize and use the `SerpdiveSearchTool` within a CrewAI agent:
+
+```python
+from crewai import Agent, Task, Crew
+from crewai_tools import SerpdiveSearchTool
+
+# Initialize the tool
+serpdive_tool = SerpdiveSearchTool()
+
+# Create an agent that uses the tool
+researcher = Agent(
+    role='Market Researcher',
+    goal='Find current information about the solid state battery market',
+    backstory='An expert market researcher specializing in energy technology.',
+    tools=[serpdive_tool],
+    verbose=True,
+)
+
+# Create a task for the agent
+research_task = Task(
+    description='Search for the main obstacles to mass production of solid state batteries.',
+    expected_output='A short report citing the sources found.',
+    agent=researcher,
+)
+
+# Form the crew and kick it off
+crew = Crew(
+    agents=[researcher],
+    tasks=[research_task],
+)
+
+result = crew.kickoff()
+print(result)
+```
+
+## Arguments
+
+Initialization arguments:
+
+- `model` (str, optional): Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"moby"` returns the full readable text of each page, for deep research.
+- `answer` (bool, optional): When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`). Defaults to `False`.
+- `max_results` (int, optional): Hard cap on delivered results (1-10). By default the engine picks its calibrated mix.
+- `api_key` (str, optional): Your SERPdive API key. If not provided, it's read from the `SERPDIVE_API_KEY` environment variable.
+
+Run argument:
+
+- `query` (str): **Required**. The search query, in any language.
+
+There is no country or locale parameter to configure: the language of the query picks where the search runs, automatically. Failed searches are never billed.
+
+## Links
+
+- [API reference](https://serpdive.com/docs)
+- [Public benchmark](https://github.com/edendalexis/serpdive-benchmark) (replayable end to end: same questions, same judge, your machine)

--- a/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/README.md
@@ -63,8 +63,8 @@ print(result)
 
 Initialization arguments:
 
-- `model` (str, optional): Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"moby"` returns the full readable text of each page, for deep research.
-- `answer` (bool, optional): When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`). Defaults to `False`.
+- `model` (str, optional): Retrieval depth. `"mako"` (default) returns the fact-carrying sentences of each page, fast. `"krill"` is the free tier: unlimited under fair use, a smaller set of the same sentences, one request at a time, at low priority. `"moby"` returns the full readable text of each page, for deep research.
+- `answer` (bool, optional): When `True`, the output also carries an `answer` field: a direct answer synthesized from the sources (concise on `mako`, cited on `moby`; unavailable on `krill`). Defaults to `False`.
 - `max_results` (int, optional): Hard cap on delivered results (1-10). By default the engine picks its calibrated mix.
 - `api_key` (str, optional): Your SERPdive API key. If not provided, it's read from the `SERPDIVE_API_KEY` environment variable.
 

--- a/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/serpdive_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/serpdive_search_tool.py
@@ -1,0 +1,158 @@
+import json
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, ConfigDict, Field
+
+try:
+    from serpdive import AsyncSerpDive, SerpDive  # type: ignore[import-untyped]
+
+    SERPDIVE_AVAILABLE = True
+except ImportError:
+    SERPDIVE_AVAILABLE = False
+
+
+class SerpdiveSearchToolSchema(BaseModel):
+    """Input schema for SerpdiveSearchTool."""
+
+    query: str = Field(
+        ...,
+        description="The search query, in any language, phrased like a real web search.",
+    )
+
+
+class SerpdiveSearchTool(BaseTool):
+    """Tool that uses the SERPdive Search API to perform web searches.
+
+    Every result carries the actual text of the page (url, title, date,
+    content), already extracted and cleaned for LLM consumption, so agents
+    can quote and cite straight from the tool output.
+
+    Attributes:
+        client: An instance of SerpDive (sync client).
+        async_client: An instance of AsyncSerpDive.
+        name: The name of the tool.
+        description: A description of the tool's purpose.
+        args_schema: The schema for the tool's arguments.
+        api_key: The SERPdive API key.
+        model: Retrieval depth, "mako" (key sentences, fast) or "moby"
+            (full page text, deep research).
+        answer: Whether to also return a direct answer synthesized from
+            the sources.
+        max_results: Hard cap on delivered results (1-10).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    client: Any | None = None
+    async_client: Any | None = None
+    name: str = "SERPdive Search"
+    description: str = (
+        "Search the live web and get back answer-ready page content, not a list "
+        "of links. Each result carries the actual text of the page (url, title, "
+        "date, content), already extracted and cleaned, so facts can be quoted "
+        "and cited straight from the response. Use it for anything that needs "
+        "current or post-training information: news, prices, releases, docs, "
+        "niche facts. Write the query the way a person would type it, in any "
+        "language: localization is automatic."
+    )
+    args_schema: type[BaseModel] = SerpdiveSearchToolSchema
+    api_key: str | None = Field(
+        default_factory=lambda: os.getenv("SERPDIVE_API_KEY"),
+        description="The SERPdive API key. If not provided, it is read from the SERPDIVE_API_KEY environment variable.",
+    )
+    model: str = Field(
+        default="mako",
+        description='Retrieval depth: "mako" (default) returns the fact-carrying sentences of each page, fast; "moby" returns the full readable text, for deep research.',
+    )
+    answer: bool = Field(
+        default=False,
+        description='When True, the output also carries an "answer" field: a direct answer synthesized from the sources (concise on mako, cited on moby).',
+    )
+    max_results: int | None = Field(
+        default=None,
+        description="Hard cap on delivered results (1-10). None lets the engine pick its calibrated mix.",
+    )
+    package_dependencies: list[str] = Field(default_factory=lambda: ["serpdive"])
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="SERPDIVE_API_KEY",
+                description="API key for SERPdive, free at https://serpdive.com/dashboard/keys",
+                required=True,
+            ),
+        ]
+    )
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        if not SERPDIVE_AVAILABLE:
+            raise ImportError(
+                "The 'serpdive' package is required to use the SerpdiveSearchTool. "
+                "Please install it with: uv add serpdive (or pip install serpdive)"
+            )
+        self.client = SerpDive(api_key=self.api_key)
+        self.async_client = AsyncSerpDive(api_key=self.api_key)
+
+    def _search_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"model": self.model}
+        if self.answer:
+            kwargs["answer"] = True
+        if self.max_results is not None:
+            kwargs["max_results"] = self.max_results
+        return kwargs
+
+    def _payload(self, response: Any) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "query": response.query,
+            "results": [
+                {
+                    "url": result.url,
+                    "title": result.title,
+                    **({"date": result.date} if result.date else {}),
+                    "content": result.content,
+                }
+                for result in response.results
+            ],
+        }
+        if response.answer is not None:
+            payload["answer"] = response.answer
+        if response.extra_info is not None:
+            payload["extra_info"] = response.extra_info
+        return payload
+
+    def _run(self, query: str) -> str:
+        """Synchronously performs a search using the SERPdive API.
+
+        Args:
+            query: The search query string.
+
+        Returns:
+            A JSON string with the query, the results (url, title, date,
+            content) and, when enabled, the synthesized answer.
+        """
+        if not self.client:
+            raise ValueError(
+                "SERPdive client is not initialized. Ensure 'serpdive' is "
+                "installed and the API key is set."
+            )
+        response = self.client.search(query, **self._search_kwargs())
+        return json.dumps(self._payload(response), indent=2)
+
+    async def _arun(self, query: str) -> str:
+        """Asynchronously performs a search using the SERPdive API.
+
+        Args:
+            query: The search query string.
+
+        Returns:
+            A JSON string with the query, the results (url, title, date,
+            content) and, when enabled, the synthesized answer.
+        """
+        if not self.async_client:
+            raise ValueError(
+                "SERPdive async client is not initialized. Ensure 'serpdive' is "
+                "installed and the API key is set."
+            )
+        response = await self.async_client.search(query, **self._search_kwargs())
+        return json.dumps(self._payload(response), indent=2)

--- a/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/serpdive_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/serpdive_search_tool.py
@@ -36,7 +36,9 @@ class SerpdiveSearchTool(BaseTool):
         description: A description of the tool's purpose.
         args_schema: The schema for the tool's arguments.
         api_key: The SERPdive API key.
-        model: Retrieval depth, "mako" (key sentences, fast) or "moby"
+        model: Retrieval depth, "mako" (key sentences, fast), "krill" (the
+            free tier: unlimited under fair use, smallest payload, one
+            request at a time, low priority, no written answer) or "moby"
             (full page text, deep research).
         answer: Whether to also return a direct answer synthesized from
             the sources.
@@ -63,11 +65,11 @@ class SerpdiveSearchTool(BaseTool):
     )
     model: str = Field(
         default="mako",
-        description='Retrieval depth: "mako" (default) returns the fact-carrying sentences of each page, fast; "moby" returns the full readable text, for deep research.',
+        description='Retrieval depth: "mako" (default) returns the fact-carrying sentences of each page, fast; "krill" is free and unlimited under fair use, returning a smaller set of them at low priority, one request at a time, with no written answer; "moby" returns the full readable text, for deep research.',
     )
     answer: bool = Field(
         default=False,
-        description='When True, the output also carries an "answer" field: a direct answer synthesized from the sources (concise on mako, cited on moby).',
+        description='When True, the output also carries an "answer" field: a direct answer synthesized from the sources (concise on mako, cited on moby; unavailable on krill).',
     )
     max_results: int | None = Field(
         default=None,

--- a/lib/crewai-tools/tests/tools/serpdive_search_tool_test.py
+++ b/lib/crewai-tools/tests/tools/serpdive_search_tool_test.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from serpdive import SearchResponse
+
+from crewai_tools.tools.serpdive_search_tool.serpdive_search_tool import (
+    SerpdiveSearchTool,
+)
+
+PAYLOAD = {
+    "query": "seine temperature",
+    "results": [
+        {
+            "url": "https://a.example",
+            "title": "T",
+            "date": "2026-07-01",
+            "content": "C1",
+        },
+        {"url": "https://b.example", "title": "U", "content": "C2"},
+    ],
+}
+
+
+def make_tool(**kwargs):
+    tool = SerpdiveSearchTool(api_key="sd_live_TEST", **kwargs)
+    tool.client = MagicMock()
+    tool.client.search.return_value = SearchResponse.from_dict(PAYLOAD)
+    tool.async_client = MagicMock()
+    tool.async_client.search = AsyncMock(
+        return_value=SearchResponse.from_dict(PAYLOAD)
+    )
+    return tool
+
+
+def test_tool_initialization_defaults():
+    tool = SerpdiveSearchTool(api_key="sd_live_TEST")
+    assert tool.name == "SERPdive Search"
+    assert tool.model == "mako"
+    assert tool.answer is False
+    assert tool.max_results is None
+
+
+def test_run_returns_json_payload():
+    tool = make_tool()
+    out = json.loads(tool._run(query="seine temperature"))
+    assert out["query"] == "seine temperature"
+    assert out["results"][0] == {
+        "url": "https://a.example",
+        "title": "T",
+        "date": "2026-07-01",
+        "content": "C1",
+    }
+    # no date key when the API returned none
+    assert "date" not in out["results"][1]
+    # answer key absent when not requested
+    assert "answer" not in out
+
+
+def test_params_travel_to_the_sdk():
+    tool = make_tool(model="moby", answer=True, max_results=3)
+    tool._run(query="q")
+    tool.client.search.assert_called_once_with(
+        "q", model="moby", answer=True, max_results=3
+    )
+
+
+@pytest.mark.asyncio
+async def test_arun_returns_json_payload():
+    tool = make_tool()
+    out = json.loads(await tool._arun(query="seine temperature"))
+    assert [r["url"] for r in out["results"]] == [
+        "https://a.example",
+        "https://b.example",
+    ]

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -20501,6 +20501,139 @@
       }
     },
     {
+      "description": "Search the live web and get back answer-ready page content, not a list of links. Each result carries the actual text of the page (url, title, date, content), already extracted and cleaned, so facts can be quoted and cited straight from the response. Use it for anything that needs current or post-training information: news, prices, releases, docs, niche facts. Write the query the way a person would type it, in any language: localization is automatic.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for SERPdive, free at https://serpdive.com/dashboard/keys",
+          "name": "SERPDIVE_API_KEY",
+          "required": true
+        }
+      ],
+      "humanized_name": "SERPdive Search",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          }
+        },
+        "description": "Tool that uses the SERPdive Search API to perform web searches.\n\nEvery result carries the actual text of the page (url, title, date,\ncontent), already extracted and cleaned for LLM consumption, so agents\ncan quote and cite straight from the tool output.\n\nAttributes:\n    client: An instance of SerpDive (sync client).\n    async_client: An instance of AsyncSerpDive.\n    name: The name of the tool.\n    description: A description of the tool's purpose.\n    args_schema: The schema for the tool's arguments.\n    api_key: The SERPdive API key.\n    model: Retrieval depth, \"mako\" (key sentences, fast) or \"moby\"\n        (full page text, deep research).\n    answer: Whether to also return a direct answer synthesized from\n        the sources.\n    max_results: Hard cap on delivered results (1-10).",
+        "properties": {
+          "answer": {
+            "default": false,
+            "description": "When True, the output also carries an \"answer\" field: a direct answer synthesized from the sources (concise on mako, cited on moby).",
+            "title": "Answer",
+            "type": "boolean"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The SERPdive API key. If not provided, it is read from the SERPDIVE_API_KEY environment variable.",
+            "title": "Api Key"
+          },
+          "async_client": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Async Client"
+          },
+          "client": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client"
+          },
+          "max_results": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Hard cap on delivered results (1-10). None lets the engine pick its calibrated mix.",
+            "title": "Max Results"
+          },
+          "model": {
+            "default": "mako",
+            "description": "Retrieval depth: \"mako\" (default) returns the fact-carrying sentences of each page, fast; \"moby\" returns the full readable text, for deep research.",
+            "title": "Model",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "title": "SerpdiveSearchTool",
+        "type": "object"
+      },
+      "name": "SerpdiveSearchTool",
+      "package_dependencies": [
+        "serpdive"
+      ],
+      "run_params_schema": {
+        "description": "Input schema for SerpdiveSearchTool.",
+        "properties": {
+          "query": {
+            "description": "The search query, in any language, phrased like a real web search.",
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "SerpdiveSearchToolSchema",
+        "type": "object"
+      }
+    },
+    {
       "description": "A tool that can be used to search the internet with a search_query. Supports different search types: 'search' (default), 'news'",
       "env_vars": [
         {

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -20553,7 +20553,7 @@
         "properties": {
           "answer": {
             "default": false,
-            "description": "When True, the output also carries an \"answer\" field: a direct answer synthesized from the sources (concise on mako, cited on moby).",
+            "description": "When True, the output also carries an \"answer\" field: a direct answer synthesized from the sources (concise on mako, cited on moby; unavailable on krill).",
             "title": "Answer",
             "type": "boolean"
           },
@@ -20604,7 +20604,7 @@
           },
           "model": {
             "default": "mako",
-            "description": "Retrieval depth: \"mako\" (default) returns the fact-carrying sentences of each page, fast; \"moby\" returns the full readable text, for deep research.",
+            "description": "Retrieval depth: \"mako\" (default) returns the fact-carrying sentences of each page, fast; \"krill\" is free and unlimited under fair use, returning a smaller set of them at low priority, one request at a time, with no written answer; \"moby\" returns the full readable text, for deep research.",
             "title": "Model",
             "type": "string"
           }


### PR DESCRIPTION
# Add SerpdiveSearchTool

Adds a search tool for [SERPdive](https://serpdive.com), an AI search API that returns answer-ready web content: every result carries the actual text of the page (url, title, date, content), already extracted, cleaned, and sized for LLM consumption, so agents can quote and cite straight from the tool output. On a [public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark), SERPdive runs at the same speed as Tavily, feeds your LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels.

## What's included

- `lib/crewai-tools/src/crewai_tools/tools/serpdive_search_tool/`: `SerpdiveSearchTool` (sync `_run` + async `_arun`) over the official [`serpdive`](https://pypi.org/project/serpdive/) SDK, following the structure and current style of the existing search tools (import guard, `package_dependencies`, `env_vars`, JSON string output) + tool README
- Exports in `crewai_tools/__init__.py` and `crewai_tools/tools/__init__.py` (imports and `__all__`), `serpdive` optional dependency group in `lib/crewai-tools/pyproject.toml`
- `lib/crewai-tools/tests/tools/serpdive_search_tool_test.py`: 4 stubbed unit tests (no network), passing locally; the tool was also run live against the production API
- Docs page `docs/edge/en/tools/search-research/serpdivesearchtool.mdx` + overview card + `docs/docs.json` nav entry (edge only, no frozen `docs/v*` touched)
- `lib/crewai-tools/tool.specs.json` regenerated with `generate_tool_specs.py`: the diff is additive only (the new tool's entry), no existing entry changed

## Notes

- Auth via `SERPDIVE_API_KEY` (free key, no card required). No country or locale parameter: the language of the query picks where the search runs automatically.
- Heads-up on `exclude-newer = "3 days"`: the `serpdive` SDK's latest release was published on 2026-07-18, so `uv sync --all-extras` resolves it once the release is more than 3 days old. No config change is included; if CI runs before then and you prefer, we can add a temporary `exclude-newer-package` override instead.


<!-- crewai-require-issue-check -->