### PR TITLE
fix: resolve agent/crew skills paths against project_root, not cwd

### DIFF
--- a/lib/crewai/src/crewai/project/json_loader.py
+++ b/lib/crewai/src/crewai/project/json_loader.py
@@ -1383,6 +1383,10 @@ def _resolve_agent_python_refs(
     _resolve_object_reference_fields(
         kwargs, source, _AGENT_OBJECT_REF_FIELDS, project_root
     )
+    if "skills" in kwargs:
+        kwargs["skills"] = _resolve_skill_path_strings(
+            kwargs["skills"], f"{source}: skills", project_root
+        )
 
 
 def _resolve_task_python_refs(
@@ -1442,6 +1446,44 @@ def _resolve_crew_python_refs(
     _resolve_object_reference_fields(
         kwargs, source, _CREW_OBJECT_REF_FIELDS, project_root
     )
+    if "skills" in kwargs:
+        kwargs["skills"] = _resolve_skill_path_strings(
+            kwargs["skills"], f"{source}: skills", project_root
+        )
+
+
+def _is_skill_registry_ref(value: str) -> bool:
+    return value.startswith("@")
+
+
+def _is_skill_inline_definition(value: str) -> bool:
+    return value.lstrip().startswith("---\n")
+
+
+def _resolve_skill_path_strings(
+    value: Any,
+    source: str | Path,
+    project_root: Path | None,
+) -> Any:
+    """Resolve filesystem 'skills' path strings against project_root.
+
+    Mirrors how 'tools' and 'output_pydantic' resolve relative paths against
+    project_root instead of the process cwd, so the same crew definition
+    behaves the same way regardless of the cwd at load time. Registry
+    references ('@org/name'), inline SKILL.md content, and any item already
+    resolved to a non-string object (e.g. via a Python reference) are passed
+    through unchanged.
+    """
+    if not isinstance(value, list):
+        return value
+    return [
+        Path(_resolve_project_path(item, project_root, f"{source}[{index}]"))
+        if isinstance(item, str)
+        and not _is_skill_registry_ref(item)
+        and not _is_skill_inline_definition(item)
+        else item
+        for index, item in enumerate(value)
+    ]
 
 
 def _resolve_object_reference_fields(

--- a/lib/crewai/tests/project/test_json_loader.py
+++ b/lib/crewai/tests/project/test_json_loader.py
@@ -401,6 +401,33 @@ class TestLoadAgentFromDefinition:
         assert issubclass(response_format, BaseModel)
         assert response_format.__name__ == "AnswerModel"
 
+    def test_skills_resolve_relative_to_project_root_not_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        project_root = tmp_path / "project"
+        skill_dir = project_root / "skills" / "greeting"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: greeting\ndescription: Greets the user.\n---\nSay hello.\n"
+        )
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        agent, _ = load_agent_from_definition(
+            {
+                "role": "Greeter",
+                "goal": "Greet people",
+                "backstory": "Friendly greeter.",
+                "input": "Greet the user",
+                "skills": ["./skills"],
+            },
+            source="agent action",
+            project_root=project_root,
+        )
+
+        assert [skill.name for skill in agent.skills or []] == ["greeting"]
+
 
 class TestResolveTools:
     def test_import_ref_tool_resolves(self, tmp_path, monkeypatch):
@@ -673,3 +700,56 @@ class TestCustomToolPathSafety:
 
         assert len(tools) == 1
         assert tools[0].name == "echo"
+
+
+class TestResolveSkillPathStrings:
+    def test_resolves_relative_to_project_root_not_cwd(self, tmp_path, monkeypatch):
+        from crewai.project.json_loader import _resolve_skill_path_strings
+
+        project_root = tmp_path / "project"
+        (project_root / "skills").mkdir(parents=True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        resolved = _resolve_skill_path_strings(
+            ["./skills"], "agent: skills", project_root
+        )
+
+        assert resolved == [(project_root / "skills").resolve()]
+
+    def test_registry_ref_passes_through_unchanged(self):
+        from crewai.project.json_loader import _resolve_skill_path_strings
+
+        resolved = _resolve_skill_path_strings(
+            ["@acme/greeting"], "agent: skills", None
+        )
+
+        assert resolved == ["@acme/greeting"]
+
+    def test_inline_skill_definition_passes_through_unchanged(self):
+        from crewai.project.json_loader import _resolve_skill_path_strings
+
+        inline = "---\nname: greeting\ndescription: Greets.\n---\nSay hi.\n"
+
+        resolved = _resolve_skill_path_strings([inline], "agent: skills", None)
+
+        assert resolved == [inline]
+
+    def test_non_string_items_pass_through_unchanged(self):
+        from crewai.project.json_loader import _resolve_skill_path_strings
+        from crewai.skills.models import Skill, SkillFrontmatter
+
+        preloaded = Skill(
+            frontmatter=SkillFrontmatter(name="greeting", description="Greets."),
+            path=Path("."),
+        )
+
+        resolved = _resolve_skill_path_strings([preloaded], "agent: skills", None)
+
+        assert resolved == [preloaded]
+
+    def test_non_list_value_passes_through_unchanged(self):
+        from crewai.project.json_loader import _resolve_skill_path_strings
+
+        assert _resolve_skill_path_strings(None, "agent: skills", None) is None


### PR DESCRIPTION
## Summary

Fixes #6585.

When loading a crew from JSONC (`load_crew`, `load_crew_from_definition`,
`load_agent_from_definition`), every relative path field (`tools` with the
`custom:` prefix, `output_pydantic`/`response_format` Python refs, etc.) is
resolved against `project_root`. The agent/crew `skills` field was the one
exception: it was passed through unresolved in
`crewai/project/json_loader.py`, and ultimately reached
`crewai/skills/loader.py::discover_skills(Path(skill))`, which resolves the
path against `Path.cwd()` at call time instead of `project_root`.

This meant the same crew definition would succeed or fail purely based on
the process's current working directory at import/call time — e.g. it
works when running a script directly from its own directory, but fails
with `FileNotFoundError: Skill search path does not exist or is not a
directory: skills` when the same code runs as part of a server process
launched from a different cwd (uvicorn, docker, IDE run configs, etc.).

- Adds `_resolve_skill_path_strings()` in `crewai/project/json_loader.py`,
  called for the `skills` field in both `_resolve_agent_python_refs` (agent
  definitions) and `_resolve_crew_python_refs` (crew-level `skills`).
- Filesystem path strings (e.g. `"./skills"`) are rewritten to absolute
  paths resolved against `project_root`, reusing the existing
  `_resolve_project_path` helper (same containment rules already applied to
  `input_files`).
- Registry references (`@org/name`), inline `SKILL.md` string content, and
  values already resolved to non-string objects (e.g. via a `{"python":
  ...}` reference, or a pre-loaded `Skill` instance) are left unchanged.
- Only affects JSON/JSONC loading; direct Python `Agent(skills=...)` /
  `Crew(skills=...)` usage is unaffected.

## Test plan

- [x] Added `TestResolveSkillPathStrings` unit tests covering: relative
      path resolution against `project_root` (not cwd), registry refs
      passed through, inline SKILL.md content passed through, pre-loaded
      `Skill` objects passed through, and non-list values passed through.
- [x] Added `test_skills_resolve_relative_to_project_root_not_cwd` to
      `TestLoadAgentFromDefinition`, reproducing the issue's repro case
      end-to-end: agent loaded via `load_agent_from_definition` with
      `skills: ["./skills"]` from a cwd other than `project_root` correctly
      discovers the skill.
- [x] `uv run pytest lib/crewai/tests/project/test_json_loader.py` — 61
      passed.
- [x] `uv run ruff check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crewai-require-issue-check -->