### PR TITLE
fix(openai): match longest model prefix for context window size

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -2445,7 +2445,11 @@ class OpenAICompletion(BaseLLM):
             "o4-mini": 200000,
         }
 
-        for model_prefix, size in context_windows.items():
+        # Match the most specific (longest) prefix first so that, e.g.,
+        # "gpt-4o" is not shadowed by the shorter "gpt-4" entry.
+        for model_prefix, size in sorted(
+            context_windows.items(), key=lambda x: len(x[0]), reverse=True
+        ):
             if self.model.startswith(model_prefix):
                 return int(size * CONTEXT_WINDOW_USAGE_RATIO)
 

--- a/lib/crewai/tests/llms/openai/test_openai.py
+++ b/lib/crewai/tests/llms/openai/test_openai.py
@@ -35,6 +35,32 @@ def test_openai_completion_is_used_when_no_provider_prefix():
     assert llm.model == "gpt-4o"
 
 
+def test_openai_context_window_uses_longest_prefix_match():
+    """Model prefixes must resolve to the most specific match.
+
+    Regression test: ``gpt-4o`` (and other ``gpt-4*`` models) must not be
+    shadowed by the shorter ``gpt-4`` prefix, which would collapse their
+    context window to 8192. This mirrors the Azure provider, which already
+    matches the longest prefix first.
+    """
+    from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+        llm_gpt4 = LLM(model="gpt-4")
+        llm_gpt4o = LLM(model="gpt-4o")
+        llm_gpt4o_mini = LLM(model="gpt-4o-mini")
+
+    assert isinstance(llm_gpt4o, OpenAICompletion)
+    assert llm_gpt4.get_context_window_size() == int(8192 * CONTEXT_WINDOW_USAGE_RATIO)
+    assert llm_gpt4o.get_context_window_size() == int(
+        128000 * CONTEXT_WINDOW_USAGE_RATIO
+    )
+    assert llm_gpt4o_mini.get_context_window_size() == int(
+        200000 * CONTEXT_WINDOW_USAGE_RATIO
+    )
+    assert llm_gpt4o.get_context_window_size() > llm_gpt4.get_context_window_size()
+
+
 def test_custom_openai_flag_uses_native_openai_without_provider_prefix():
     """Custom OpenAI-compatible endpoints can serve arbitrary model ids."""
     with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):


### PR DESCRIPTION
## Summary

`OpenAICompletion.get_context_window_size()` iterates the model-prefix table in **insertion order** and returns on the **first** `startswith` match:

```python
context_windows = {
    "gpt-4": 8192,
    "gpt-4o": 128000,
    "gpt-4o-mini": 200000,
    "gpt-4-turbo": 128000,
    "gpt-4.1": 1047576,
    ...
}
for model_prefix, size in context_windows.items():
    if self.model.startswith(model_prefix):
        return int(size * CONTEXT_WINDOW_USAGE_RATIO)
```

Because `"gpt-4"` comes first and `"gpt-4o".startswith("gpt-4")` is `True`, every `gpt-4*` model collapses to gpt-4's **8192**-token window before its own, more-specific entry is ever reached. The more specific keys (`gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4.1`, ...) are effectively dead code.

This hits the **default model** `gpt-4o` (`model: str = "gpt-4o"`), so out of the box `get_context_window_size()` returns `int(8192 * 0.85) = 6963` instead of `int(128000 * 0.85) = 108800` — making summarization/truncation far too aggressive and causing spurious context-window-exceeded handling.

| model | before | after |
|-------|-------:|------:|
| gpt-4 | 6963 | 6963 |
| gpt-4o | **6963** | **108800** |
| gpt-4o-mini | **6963** | **170000** |
| gpt-4-turbo | **6963** | **108800** |
| gpt-4.1 | **6963** | **890439** |

## Fix

Sort the prefixes by length (longest first) before matching, so the most specific prefix wins. This mirrors `AzureCompletion.get_context_window_size()`, which already does exactly this:

```python
for model_prefix, size in sorted(
    context_windows.items(), key=lambda x: len(x[0]), reverse=True
):
```

## Test

Adds `test_openai_context_window_uses_longest_prefix_match`, asserting `gpt-4o` -> 128k and `gpt-4o-mini` -> 200k windows while `gpt-4` stays at 8k. It fails on `main` (`6963 == 108800` AssertionError) and passes with this change. Existing behavior for models without a shorter conflicting prefix (e.g. `o3-mini` -> 200k) is unchanged.

<!-- crewai-require-issue-check -->