### PR TITLE
fix: handle async get_agent in load_agent_from_repository

### DIFF
--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1137,7 +1137,7 @@ def load_agent_from_repository(from_repository: str) -> dict[str, Any]:
         _print_current_organization()
         response = client.get_agent(from_repository)
         if inspect.isawaitable(response):
-            coro = response  # type: ignore[assignment]
+            coro = response
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1137,6 +1137,7 @@ def load_agent_from_repository(from_repository: str) -> dict[str, Any]:
         _print_current_organization()
         response = client.get_agent(from_repository)
         if inspect.isawaitable(response):
+            coro = response  # type: ignore[assignment]
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
@@ -1144,9 +1145,9 @@ def load_agent_from_repository(from_repository: str) -> dict[str, Any]:
 
             if loop and loop.is_running():
                 with concurrent.futures.ThreadPoolExecutor() as pool:
-                    response = pool.submit(asyncio.run, response).result()
+                    response = pool.submit(asyncio.run, coro).result()  # type: ignore[arg-type]
             else:
-                response = asyncio.run(response)
+                response = asyncio.run(coro)  # type: ignore[arg-type]
         if response.status_code == 404:
             raise AgentRepositoryError(
                 f"Agent {from_repository} does not exist, make sure the name is correct or the agent is available on your organization."

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1136,6 +1136,17 @@ def load_agent_from_repository(from_repository: str) -> dict[str, Any]:
             client = PlusAPI(api_key=get_auth_token())
         _print_current_organization()
         response = client.get_agent(from_repository)
+        if inspect.isawaitable(response):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop and loop.is_running():
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    response = pool.submit(asyncio.run, response).result()
+            else:
+                response = asyncio.run(response)
         if response.status_code == 404:
             raise AgentRepositoryError(
                 f"Agent {from_repository} does not exist, make sure the name is correct or the agent is available on your organization."


### PR DESCRIPTION
## Problem

Deployed flows built in Studio that use `from_repository` to load agents fail at runtime with:

```
agent action: failed to load agent: 'coroutine' object has no attribute 'status_code'
```

## Root Cause

`load_agent_from_repository()` in `agent_utils.py` calls `client.get_agent(from_repository)` synchronously. This works fine with the OSS `PlusAPI` client (sync), but the enterprise `PlusClient`/`PlusV2Client` defines `get_agent` as `async def`. When the enterprise client is hooked in via `_create_plus_client_hook`, the call returns a coroutine object instead of an HTTP response, and the subsequent `.status_code` access crashes.

**Why it works in Studio but not deployed:** Studio uses the sync `PlusAPI`. Deployed mode injects the async enterprise client.

## Fix

After calling `client.get_agent()`, check if the result is awaitable via `inspect.isawaitable()`. If so, resolve it:
- If no event loop is running → `asyncio.run()`
- If an event loop is already running → run in a thread-pool executor to avoid nested loop errors

This is a minimal, backwards-compatible change — sync clients are completely unaffected.