### PR TITLE
fix: adapt _safe_repair_json to json-repair 0.60 semantics

### DIFF
--- a/lib/crewai/src/crewai/agents/parser.py
+++ b/lib/crewai/src/crewai/agents/parser.py
@@ -173,7 +173,12 @@ def _safe_repair_json(tool_input: str) -> str:
     tool_input = tool_input.replace('"""', '"')
 
     result = repair_json(tool_input)
-    if result in UNABLE_TO_REPAIR_JSON_RESULTS:
+    if not result or result in UNABLE_TO_REPAIR_JSON_RESULTS:
+        return tool_input
+
+    # json-repair >= 0.60 wraps non-JSON input in a single-element list;
+    # treat that as unrepairable and return the original.
+    if result.startswith("[") and not tool_input.lstrip().startswith("["):
         return tool_input
 
     return str(result)


### PR DESCRIPTION
## Summary
Stacked on #6612 (json-repair 0.60.1 bump).

json-repair 0.60.x changed how it handles non-JSON input:
- plain text now repairs to `''` (previously `'""'`/`'{}'` sentinels)
- brace-enclosed junk like `{temperature in SF}` now repairs to a single-element list `["temperature in SF}"]`

Both cases broke `_safe_repair_json`'s unrepairable-detection in `lib/crewai/src/crewai/agents/parser.py`, mangling plain-text tool inputs. This treats empty results and list results (for non-array input) as unrepairable, preserving the original input.

## Tests
- `test_crew_agent_parser.py` (15 previously failing) and `test_tool_usage.py` now pass.
- Remaining local failures are environmental only (missing optional extras: litellm, anthropic, google-genai, a2a) and unrelated to this change.