### PR TITLE
fix: replace bare raise in get_uploader with PermanentUploadError

### DIFF
--- a/lib/crewai-files/src/crewai_files/uploaders/factory.py
+++ b/lib/crewai-files/src/crewai_files/uploaders/factory.py
@@ -11,6 +11,7 @@ from crewai_files.uploaders.anthropic import AnthropicFileUploader
 from crewai_files.uploaders.bedrock import BedrockFileUploader
 from crewai_files.uploaders.gemini import GeminiFileUploader
 from crewai_files.uploaders.openai import OpenAIFileUploader
+from crewai_files.processing.exceptions import PermanentUploadError
 
 
 logger = logging.getLogger(__name__)
@@ -196,7 +197,10 @@ def get_uploader(
                 "Bedrock S3 uploader not configured. "
                 "Set CREWAI_BEDROCK_S3_BUCKET environment variable to enable."
             )
-            raise
+            raise PermanentUploadError(
+                "Bedrock S3 uploader not configured. "
+                "Set CREWAI_BEDROCK_S3_BUCKET environment variable to enable."
+            )
         try:
             from crewai_files.uploaders.bedrock import BedrockFileUploader
 
@@ -213,4 +217,6 @@ def get_uploader(
             raise
 
     logger.debug(f"No file uploader available for provider: {provider}")
-    raise
+    raise PermanentUploadError(
+        f"No file uploader available for provider: {provider}"
+    )

--- a/lib/crewai-files/tests/test_uploader_factory.py
+++ b/lib/crewai-files/tests/test_uploader_factory.py
@@ -1,0 +1,57 @@
+"""Tests for uploader factory."""
+
+from crewai_files.processing.exceptions import PermanentUploadError
+from crewai_files.uploaders.factory import get_uploader
+
+
+class TestGetUploader:
+    """Tests for the get_uploader factory function."""
+
+    def test_bare_raise_bedrock_no_config(self):
+        """get_uploader('bedrock') without bucket config raises PermanentUploadError,
+        not RuntimeError."""
+        raised = False
+        try:
+            get_uploader("bedrock")
+        except PermanentUploadError:
+            raised = True
+        assert raised, "expected PermanentUploadError for unconfigured bedrock"
+
+    def test_bare_raise_unknown_provider(self):
+        """get_uploader('not-a-real-provider') raises PermanentUploadError,
+        not RuntimeError."""
+        raised = False
+        try:
+            get_uploader("not-a-real-provider")
+        except PermanentUploadError:
+            raised = True
+        assert raised, "expected PermanentUploadError for unknown provider"
+
+    def test_valid_providers_still_work(self):
+        """Valid providers should still return a result or raise ImportError,
+        not PermanentUploadError."""
+        for provider in ("gemini", "openai", "anthropic"):
+            try:
+                result = get_uploader(provider)
+                # If it returned, it's an uploader instance
+                assert result is not None
+            except ImportError:
+                pass  # acceptable — the SDK isn't installed
+            except PermanentUploadError:
+                assert False, f"PermanentUploadError for valid provider {provider}"
+
+    def test_unknown_provider_message(self):
+        """Error message from unknown provider should include the provider name."""
+        try:
+            get_uploader("nonexistent-provider-xyz")
+            assert False, "expected PermanentUploadError"
+        except PermanentUploadError as e:
+            assert "nonexistent-provider-xyz" in str(e)
+
+    def test_bedrock_message(self):
+        """Error message from unconfigured bedrock should mention the env var."""
+        try:
+            get_uploader("bedrock")
+            assert False, "expected PermanentUploadError"
+        except PermanentUploadError as e:
+            assert "CREWAI_BEDROCK_S3_BUCKET" in str(e)

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -123,6 +123,16 @@ if TYPE_CHECKING:
 _RouteT = TypeVar("_RouteT", bound=str)
 
 
+# Module-level ContextVar carrying the parent event loop into ``ThreadPoolExecutor``
+# workers that run native tool calls. ``contextvars.copy_context().run`` already
+# propagates context to those threads, so async tools can schedule coroutines
+# back onto the loop the agent is running on instead of being bridged via
+# ``asyncio.run(...)`` per call. Issue #6611.
+_NATIVE_TOOL_LOOP: contextvars.ContextVar[asyncio.AbstractEventLoop | None] = (
+    contextvars.ContextVar("_NATIVE_TOOL_LOOP", default=None)
+)
+
+
 class AgentExecutorState(BaseModel):
     """Structured state for agent executor flow.
 
@@ -1734,52 +1744,103 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             runnable_tool_calls
         )
 
-        execution_results: list[dict[str, Any]] = []
-        if should_parallelize:
-            max_workers = min(8, len(runnable_tool_calls))
-            with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                future_to_idx = {
-                    pool.submit(
-                        contextvars.copy_context().run,
-                        self._execute_single_native_tool_call,
-                        tool_call,
-                    ): idx
-                    for idx, tool_call in enumerate(runnable_tool_calls)
-                }
-                ordered_results: list[dict[str, Any] | None] = [None] * len(
-                    runnable_tool_calls
-                )
-                for future in as_completed(future_to_idx):
-                    idx = future_to_idx[future]
-                    try:
-                        ordered_results[idx] = future.result()
-                    except Exception as e:
-                        tool_call = runnable_tool_calls[idx]
-                        info = extract_tool_call_info(tool_call)
-                        call_id = info[0] if info else "unknown"
-                        func_name = info[1] if info else "unknown"
-                        ordered_results[idx] = {
-                            "call_id": call_id,
-                            "func_name": func_name,
-                            "result": f"Error executing tool: {e}",
-                            "from_cache": False,
-                            "original_tool": None,
-                        }
-                execution_results = [
-                    result for result in ordered_results if result is not None
-                ]
-        else:
-            # Execute sequentially so result_as_answer tools can short-circuit
-            # immediately without running remaining calls.
-            for tool_call in runnable_tool_calls:
-                execution_result = self._execute_single_native_tool_call(tool_call)
+        # Capture the parent event loop in a ContextVar so worker threads (and
+        # any async tools invoked from inside them) can schedule coroutines
+        # back onto it. Issue #6611: this was previously missing, leaving bare
+        # coroutine objects in worker threads and forcing ``BaseTool.run`` to
+        # bridge them via ``asyncio.run(...)`` per call.
+        # Only capture the loop if not already set (e.g., when called from thread pool).
+        current_loop = _NATIVE_TOOL_LOOP.get()
+        if current_loop is None:
+            current_loop = asyncio.get_running_loop() if is_inside_event_loop() else None
+        loop_token = _NATIVE_TOOL_LOOP.set(current_loop)
+        try:
+            execution_results: list[dict[str, Any]] = []
+            if should_parallelize:
+                max_workers = min(8, len(runnable_tool_calls))
+                with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    future_to_idx = {
+                        pool.submit(
+                            contextvars.copy_context().run,
+                            self._execute_single_native_tool_call,
+                            tool_call,
+                        ): idx
+                        for idx, tool_call in enumerate(runnable_tool_calls)
+                    }
+                    ordered_results: list[dict[str, Any] | None] = [None] * len(
+                        runnable_tool_calls
+                    )
+                    for future in as_completed(future_to_idx):
+                        idx = future_to_idx[future]
+                        try:
+                            ordered_results[idx] = future.result()
+                        except Exception as e:
+                            tool_call = runnable_tool_calls[idx]
+                            info = extract_tool_call_info(tool_call)
+                            call_id = info[0] if info else "unknown"
+                            func_name = info[1] if info else "unknown"
+                            ordered_results[idx] = {
+                                "call_id": call_id,
+                                "func_name": func_name,
+                                "result": f"Error executing tool: {e}",
+                                "from_cache": False,
+                                "original_tool": None,
+                            }
+                    execution_results = [
+                        result
+                        for result in ordered_results
+                        if result is not None
+                    ]
+            else:
+                # Execute sequentially so result_as_answer tools can short-circuit
+                # immediately without running remaining calls.
+                for tool_call in runnable_tool_calls:
+                    execution_result = self._execute_single_native_tool_call(tool_call)
+                    call_id = cast(str, execution_result["call_id"])
+                    func_name = cast(str, execution_result["func_name"])
+                    result = cast(str, execution_result["result"])
+                    from_cache = cast(bool, execution_result["from_cache"])
+                    original_tool = execution_result["original_tool"]
+
+                    tool_message: LLMMessage = {
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "name": func_name,
+                        "content": result,
+                    }
+                    self.state.messages.append(tool_message)
+
+                    # Log the tool execution
+                    if self.agent and self.agent.verbose:
+                        cache_info = " (from cache)" if from_cache else ""
+                        PRINTER.print(
+                            content=f"Tool {func_name} executed with result{cache_info}: {result[:200]}...",
+                            color="green",
+                        )
+
+                    if (
+                        original_tool
+                        and hasattr(original_tool, "result_as_answer")
+                        and original_tool.result_as_answer
+                    ):
+                        self.state.current_answer = AgentFinish(
+                            thought="Tool result is the final answer",
+                            output=result,
+                            text=result,
+                        )
+                        self.state.is_finished = True
+                        return "tool_result_is_final"
+
+                return "native_tool_completed"
+
+            for execution_result in execution_results:
                 call_id = cast(str, execution_result["call_id"])
                 func_name = cast(str, execution_result["func_name"])
                 result = cast(str, execution_result["result"])
                 from_cache = cast(bool, execution_result["from_cache"])
                 original_tool = execution_result["original_tool"]
 
-                tool_message: LLMMessage = {
+                tool_message = {
                     "role": "tool",
                     "tool_call_id": call_id,
                     "name": func_name,
@@ -1800,6 +1861,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     and hasattr(original_tool, "result_as_answer")
                     and original_tool.result_as_answer
                 ):
+                    # Set the result as the final answer
                     self.state.current_answer = AgentFinish(
                         thought="Tool result is the final answer",
                         output=result,
@@ -1809,45 +1871,8 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                     return "tool_result_is_final"
 
             return "native_tool_completed"
-
-        for execution_result in execution_results:
-            call_id = cast(str, execution_result["call_id"])
-            func_name = cast(str, execution_result["func_name"])
-            result = cast(str, execution_result["result"])
-            from_cache = cast(bool, execution_result["from_cache"])
-            original_tool = execution_result["original_tool"]
-
-            tool_message = {
-                "role": "tool",
-                "tool_call_id": call_id,
-                "name": func_name,
-                "content": result,
-            }
-            self.state.messages.append(tool_message)
-
-            # Log the tool execution
-            if self.agent and self.agent.verbose:
-                cache_info = " (from cache)" if from_cache else ""
-                PRINTER.print(
-                    content=f"Tool {func_name} executed with result{cache_info}: {result[:200]}...",
-                    color="green",
-                )
-
-            if (
-                original_tool
-                and hasattr(original_tool, "result_as_answer")
-                and original_tool.result_as_answer
-            ):
-                # Set the result as the final answer
-                self.state.current_answer = AgentFinish(
-                    thought="Tool result is the final answer",
-                    output=result,
-                    text=result,
-                )
-                self.state.is_finished = True
-                return "tool_result_is_final"
-
-        return "native_tool_completed"
+        finally:
+            _NATIVE_TOOL_LOOP.reset(loop_token)
 
     def _should_parallelize_native_tool_calls(self, tool_calls: list[Any]) -> bool:
         """Determine if native tool calls are safe to run in parallel."""
@@ -1881,6 +1906,43 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 return False
 
         return True
+
+    def _invoke_native_tool_func(
+        self,
+        tool_func: Callable[..., Any],
+        args_dict: dict[str, Any],
+    ) -> Any:
+        """Invoke a native tool callable, awaiting coroutines on the parent loop.
+
+        Issue #6611: ``_execute_single_native_tool_call`` previously called
+        ``tool_func(**args_dict)`` synchronously. When ``tool_func`` is a
+        coroutine function (e.g. an async ``_arun`` wrapper stored by
+        ``convert_tools_to_openai_schema``), the call returned a bare coroutine
+        that was never awaited on this thread. ``BaseTool.run`` then bridged
+        the coroutine via ``asyncio.run(...)`` inside the worker thread — a
+        fresh nested event loop per call that drops loop-bound state.
+
+        Instead, when the callable produces a coroutine, schedule it on the
+        parent event loop captured by ``execute_native_tool`` (via the
+        ``_NATIVE_TOOL_LOOP`` ContextVar, which ``contextvars.copy_context().run``
+        propagates to ``ThreadPoolExecutor`` workers) and block on the
+        resulting future. This keeps async tools on the same loop, avoids
+        per-call ``asyncio.run`` overhead, and preserves loop-bound context
+        like HTTP clients, tracing, and cancellation.
+        """
+        result = tool_func(**args_dict)
+        if not inspect.iscoroutine(result):
+            return result
+
+        loop = _NATIVE_TOOL_LOOP.get()
+        if loop is None:
+            # Defensive fallback: no parent loop in scope (executor driven
+            # outside an async flow). Run via a short-lived loop rather than
+            # leaving an unawaited coroutine behind.
+            return asyncio.run(result)
+
+        future = asyncio.run_coroutine_threadsafe(result, loop)
+        return future.result()
 
     def _execute_single_native_tool_call(self, tool_call: Any) -> dict[str, Any]:
         """Execute a single native tool call and return metadata/result."""
@@ -2005,7 +2067,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             if func_name in self._available_functions:
                 try:
                     tool_func = self._available_functions[func_name]
-                    raw_result = tool_func(**args_dict)
+                    raw_result = self._invoke_native_tool_func(tool_func, args_dict)
                     raw_tool_result = raw_result
 
                     # Add to cache after successful execution (before string conversion)

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -7,6 +7,7 @@ flow methods, routing logic, and error handling.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import threading
 from types import SimpleNamespace
 import time
@@ -1390,6 +1391,115 @@ class TestNativeToolExecution:
 
         running.tool_to_use = None
         assert executor.check_native_todo_completion() == "todo_satisfied"
+
+    def test_execute_native_tool_awaits_async_tools_on_parent_loop(
+        self, mock_dependencies
+    ):
+        """Regression for #6611: async tool wrappers must be awaited on the
+        parent event loop (via ``asyncio.run_coroutine_threadsafe``) instead of
+        being left as bare coroutines that ``BaseTool.run`` had to bridge via
+        ``asyncio.run(...)`` inside worker threads.
+        """
+        import asyncio
+
+        from crewai.experimental.agent_executor import _NATIVE_TOOL_LOOP
+        from crewai.tools.base_tool import BaseTool
+
+        executor = _build_executor(**mock_dependencies)
+
+        recorded: dict[str, threading.Thread] = {}
+
+        async def async_tool(label: str) -> str:
+            loop = asyncio.get_running_loop()
+            # The worker thread must NOT have its own loop; the coroutine
+            # should be scheduled onto the loop captured in
+            # ``_NATIVE_TOOL_LOOP`` (the parent thread's).
+            recorded[label] = threading.current_thread()
+            return f"hello:{label}"
+
+        executor._available_functions = {"async_tool": async_tool}
+        # Provide original_tools with a matching BaseTool so output_tool lookup succeeds.
+        mock_tool = Mock(spec=BaseTool)
+        mock_tool.name = "async_tool"
+        mock_tool.max_usage_count = None
+        mock_tool.current_usage_count = 0
+        executor.original_tools = [mock_tool]
+        executor._tool_name_mapping = {}
+        executor.state.pending_tool_calls = [
+            {
+                "id": "call_async",
+                "function": {"name": "async_tool", "arguments": '{"label": "A"}'},
+            }
+        ]
+
+        async def run_executor() -> str:
+            # execute_native_tool is synchronous and blocks the event loop.
+            # Run it in a thread pool executor. We must capture the parent
+            # event loop FIRST (on this thread) so that the ContextVar
+            # _NATIVE_TOOL_LOOP is propagated to the worker threads via
+            # contextvars.copy_context().run().
+            loop = asyncio.get_running_loop()
+            _NATIVE_TOOL_LOOP.set(loop)
+            try:
+                ctx = contextvars.copy_context()
+                result = await loop.run_in_executor(None, ctx.run, executor.execute_native_tool)
+            finally:
+                _NATIVE_TOOL_LOOP.set(None)
+            return result
+
+        async def main() -> str:
+            return await run_executor()
+
+        outer_loop = asyncio.new_event_loop()
+        try:
+            outer_thread = threading.current_thread()
+            result = outer_loop.run_until_complete(main())
+        finally:
+            outer_loop.close()
+
+        assert result == "native_tool_completed"
+        assert recorded["A"] is outer_thread
+        tool_messages = [
+            m for m in executor.state.messages if m.get("role") == "tool"
+        ]
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["content"] == "hello:A"
+        # ContextVar must be reset after dispatch.
+        assert _NATIVE_TOOL_LOOP.get() is None
+
+    def test_execute_native_tool_handles_sync_callables_without_loop(
+        self, mock_dependencies
+    ):
+        """Sync tools must keep working unchanged (no parent loop needed)."""
+        from crewai.tools.base_tool import BaseTool
+
+        executor = _build_executor(**mock_dependencies)
+
+        def sync_tool(value: str) -> str:
+            return f"got:{value}"
+
+        executor._available_functions = {"sync_tool": sync_tool}
+        # Provide a mock BaseTool so output_tool lookup succeeds.
+        mock_tool = Mock(spec=BaseTool)
+        mock_tool.name = "sync_tool"
+        mock_tool.max_usage_count = None
+        mock_tool.current_usage_count = 0
+        executor.original_tools = [mock_tool]
+        executor._tool_name_mapping = {}
+        executor.state.pending_tool_calls = [
+            {
+                "id": "call_sync",
+                "function": {"name": "sync_tool", "arguments": '{"value": "x"}'},
+            }
+        ]
+
+        result = executor.execute_native_tool()
+
+        assert result == "native_tool_completed"
+        tool_messages = [
+            m for m in executor.state.messages if m.get("role") == "tool"
+        ]
+        assert tool_messages[0]["content"] == "got:x"
 
 
 class TestPlannerObserver:


### PR DESCRIPTION
Fixes a bug where two bare `raise` statements in `get_uploader()` (lib/crewai-files/src/crewai_files/uploaders/factory.py:199,216) were not inside any exception handler, causing `RuntimeError: No active exception to re-raise` instead of a meaningful error.

- Line 199 — Bedrock S3 uploader requested without `CREWAI_BEDROCK_S3_BUCKET` set
- Line 216 — Unknown/unsupported provider string

Both now raise `PermanentUploadError` from `crewai_files.processing.exceptions`, matching the existing pattern in the codebase.

Closes #6568