### PR TITLE
fix(agents): await native async tools on caller loop

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -121,6 +121,9 @@ if TYPE_CHECKING:
     from crewai.tools.tool_types import ToolResult
 
 _RouteT = TypeVar("_RouteT", bound=str)
+_native_tool_event_loop: contextvars.ContextVar[asyncio.AbstractEventLoop | None] = (
+    contextvars.ContextVar("native_tool_event_loop", default=None)
+)
 
 
 class AgentExecutorState(BaseModel):
@@ -1675,7 +1678,6 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         return "tool_completed"
 
-    @router("native_tool_calls")
     def execute_native_tool(
         self,
     ) -> Literal["native_tool_completed", "tool_result_is_final"]:
@@ -1849,6 +1851,17 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         return "native_tool_completed"
 
+    @router("native_tool_calls")
+    async def execute_native_tool_async(
+        self,
+    ) -> Literal["native_tool_completed", "tool_result_is_final"]:
+        """Run native tool calls while keeping coroutine tools on this event loop."""
+        token = _native_tool_event_loop.set(asyncio.get_running_loop())
+        try:
+            return await asyncio.to_thread(self.execute_native_tool)
+        finally:
+            _native_tool_event_loop.reset(token)
+
     def _should_parallelize_native_tool_calls(self, tool_calls: list[Any]) -> bool:
         """Determine if native tool calls are safe to run in parallel."""
         if len(tool_calls) <= 1:
@@ -1991,8 +2004,11 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         elif not from_cache and not max_usage_reached and output_tool is not None:
             if func_name in self._available_functions:
                 try:
-                    tool_func = self._available_functions[func_name]
-                    raw_result = tool_func(**args_dict)
+                    if isinstance(original_tool, BaseTool):
+                        raw_result = self._run_native_tool(original_tool, args_dict)
+                    else:
+                        tool_func = self._available_functions[func_name]
+                        raw_result = tool_func(**args_dict)
                     raw_tool_result = raw_result
 
                     # Add to cache after successful execution (before string conversion)
@@ -2074,6 +2090,25 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             "original_tool": original_tool,
         }
 
+    def _run_native_tool(self, tool: BaseTool, args_dict: dict[str, Any]) -> Any:
+        """Run a native tool without creating an event loop for awaitable results."""
+        validated_args = tool._validate_kwargs(args_dict)
+        limit_error = tool._claim_usage()
+        if limit_error:
+            return limit_error
+
+        raw_result = tool._run(**validated_args)
+        if not inspect.isawaitable(raw_result):
+            return raw_result
+
+        async def await_result() -> Any:
+            return await raw_result
+
+        event_loop = _native_tool_event_loop.get()
+        if event_loop is None:
+            return asyncio.run(await_result())
+        return asyncio.run_coroutine_threadsafe(await_result(), event_loop).result()
+
     def _extract_tool_name(self, tool_call: Any) -> str:
         """Extract tool name from various tool call formats."""
         if hasattr(tool_call, "function"):
@@ -2089,7 +2124,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             )
         return "unknown"
 
-    @router(execute_native_tool)
+    @router(execute_native_tool_async)
     def check_native_todo_completion(
         self,
     ) -> Literal["todo_satisfied", "todo_not_satisfied"]:

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -75,6 +75,7 @@ from crewai.events.types.tool_usage_events import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
+from crewai.tools.base_tool import BaseTool, Tool
 from crewai.tools.tool_types import ToolResult
 from crewai.utilities.step_execution_context import StepExecutionContext
 from crewai.utilities.planning_types import TodoItem, TodoList
@@ -1198,6 +1199,16 @@ class TestFlowInvoke:
 class TestNativeToolExecution:
     """Test native tool execution behavior."""
 
+    def test_async_native_tool_router_is_registered_with_the_flow(
+        self, mock_dependencies
+    ):
+        """The async dispatch entry point must remain reachable from the flow."""
+        executor = _build_executor(**mock_dependencies)
+        methods = type(executor).flow_definition().methods
+
+        assert methods["execute_native_tool_async"].listen == "native_tool_calls"
+        assert methods["check_native_todo_completion"].listen == "execute_native_tool_async"
+
     @pytest.fixture
     def mock_dependencies(self):
         llm = Mock()
@@ -1275,6 +1286,116 @@ class TestNativeToolExecution:
         assert len(tool_messages) == 2
         assert tool_messages[0]["tool_call_id"] == "call_1"
         assert tool_messages[1]["tool_call_id"] == "call_2"
+
+    @pytest.mark.asyncio
+    async def test_async_native_tool_runs_on_the_caller_event_loop(
+        self, mock_dependencies
+    ):
+        """Coroutine BaseTools must not be bridged with asyncio.run in a worker."""
+        executor = _build_executor(**mock_dependencies)
+        observed_thread_ids: list[int] = []
+
+        class AsyncTool(BaseTool):
+            name: str = "async_tool"
+            description: str = "Record the event-loop thread."
+
+            async def _run(self) -> str:
+                observed_thread_ids.append(threading.get_ident())
+                await asyncio.sleep(0)
+                return "async result"
+
+        tool = AsyncTool()
+        executor.original_tools = [tool]
+        executor._available_functions = {"async_tool": tool.run}
+        executor.state.pending_tool_calls = [
+            {
+                "id": "call_async",
+                "function": {"name": "async_tool", "arguments": "{}"},
+            }
+        ]
+
+        result = await executor.execute_native_tool_async()
+
+        assert result == "native_tool_completed"
+        assert observed_thread_ids == [threading.get_ident()]
+        assert executor.state.messages[-1]["content"] == "async result"
+
+    @pytest.mark.asyncio
+    async def test_async_function_tool_runs_on_the_caller_event_loop(
+        self, mock_dependencies
+    ):
+        """Tools wrapping an async function must not create a worker event loop."""
+        executor = _build_executor(**mock_dependencies)
+        observed_thread_ids: list[int] = []
+
+        async def async_function() -> str:
+            observed_thread_ids.append(threading.get_ident())
+            await asyncio.sleep(0)
+            return "function result"
+
+        tool = Tool(
+            name="async_function_tool",
+            description="Record the event-loop thread.",
+            func=async_function,
+        )
+        executor.original_tools = [tool]
+        executor._available_functions = {tool.name: tool.run}
+        executor.state.pending_tool_calls = [
+            {
+                "id": "call_async_function",
+                "function": {"name": tool.name, "arguments": "{}"},
+            }
+        ]
+
+        result = await executor.execute_native_tool_async()
+
+        assert result == "native_tool_completed"
+        assert observed_thread_ids == [threading.get_ident()]
+        assert executor.state.messages[-1]["content"] == "function result"
+
+    @pytest.mark.asyncio
+    async def test_parallel_async_native_tools_run_on_the_caller_event_loop(
+        self, mock_dependencies
+    ):
+        """Parallel native calls keep every coroutine on the caller loop."""
+        executor = _build_executor(**mock_dependencies)
+        observed_thread_ids: list[int] = []
+
+        class AsyncTool(BaseTool):
+            name: str
+            description: str = "Record the event-loop thread."
+
+            async def _run(self) -> str:
+                observed_thread_ids.append(threading.get_ident())
+                await asyncio.sleep(0)
+                return self.name
+
+        first_tool = AsyncTool(name="first_async_tool")
+        second_tool = AsyncTool(name="second_async_tool")
+        executor.original_tools = [first_tool, second_tool]
+        executor._available_functions = {
+            first_tool.name: first_tool.run,
+            second_tool.name: second_tool.run,
+        }
+        executor.state.pending_tool_calls = [
+            {
+                "id": "call_first",
+                "function": {"name": first_tool.name, "arguments": "{}"},
+            },
+            {
+                "id": "call_second",
+                "function": {"name": second_tool.name, "arguments": "{}"},
+            },
+        ]
+
+        result = await executor.execute_native_tool_async()
+
+        assert result == "native_tool_completed"
+        assert observed_thread_ids == [threading.get_ident()] * 2
+        assert [message["content"] for message in executor.state.messages[-2:]] == [
+            "first_async_tool",
+            "second_async_tool",
+        ]
 
     def test_execute_native_tool_falls_back_to_sequential_for_result_as_answer(
         self, mock_dependencies


### PR DESCRIPTION
## Summary

- dispatch awaitable native-tool results back to the active flow event loop instead of creating a per-call worker loop
- preserve synchronous native-tool execution, argument validation, usage limits, hooks, caching, and ordering
- cover async `BaseTool._run`, wrapped async functions, parallel calls, and flow-route registration

Closes #6611

## Validation

- `pytest lib/crewai/tests/agents/test_agent_executor.py -q -n 0 --timeout=60 --block-network --import-mode=importlib -k "not anthropic_provider_has_image_block_converter and not kickoff_response_format_with_planning_and_tools"` (98 passed, 2 deselected because optional Anthropic/Exa dependencies are unavailable)
- `pytest lib/crewai/tests/agents/test_agent_executor.py::TestNativeToolExecution -q -n 0 --timeout=60 --block-network --import-mode=importlib` (8 passed)
- `mypy lib/crewai/src/crewai/experimental/agent_executor.py`
- `ruff check` and `ruff format --check` on changed files

<!-- crewai-require-issue-check -->