### PR TITLE
feat(crewai-tools): add Comply54ComplianceTool for African regulatory enforcement

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -26,6 +26,9 @@ Documentation = "https://docs.crewai.com"
 
 
 [project.optional-dependencies]
+comply54 = [
+    "comply54>=0.4.1",
+]
 scrapfly-sdk = [
     "scrapfly-sdk>=0.8.19",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -1,6 +1,11 @@
 from crewai_tools.tools.ai_mind_tool.ai_mind_tool import AIMindTool
 from crewai_tools.tools.apify_actors_tool.apify_actors_tool import ApifyActorsTool
 from crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool import ArxivPaperTool
+from crewai_tools.tools.comply54_tool.comply54_tool import (
+    Comply54ComplianceTool,
+    Comply54GuardedTool,
+    comply54_guard_tools,
+)
 from crewai_tools.tools.brave_search_tool.brave_image_tool import BraveImageSearchTool
 from crewai_tools.tools.brave_search_tool.brave_llm_context_tool import (
     BraveLLMContextTool,

--- a/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/README.md
@@ -1,0 +1,140 @@
+# Comply54 Compliance Tool
+
+Pre-execution African regulatory enforcement for CrewAI agents. Evaluates agent actions and parameters against Nigerian, Kenyan, South African, and other African jurisdiction policy packs before execution — returning a structured allow/deny/escalate/audit decision with exact regulatory citations.
+
+**No API key required.** Evaluation runs fully offline via in-process Rego evaluation (regopy). No OPA binary, no network call.
+
+## Covered jurisdictions
+
+| Country | Regulations |
+|---|---|
+| Nigeria | CBN NIP Framework, NDPA 2023, NIIRA 2025, NFIU AML, BVN/NIN |
+| Kenya | KDPA 2019 |
+| South Africa | POPIA |
+| Ghana | Ghana DPA 2012 |
+| Rwanda | Rwanda DPA 2021 |
+| Egypt | Egypt PDPL No. 151/2020 |
+| Tanzania, Uganda, Ethiopia, Mauritius | Jurisdiction-specific packs |
+
+## Installation
+
+```bash
+pip install crewai-tools[comply54]
+```
+
+## Usage
+
+### Pattern 1 — Explicit self-check
+
+The agent calls the tool explicitly before a regulated action:
+
+```python
+from crewai import Agent
+from crewai_tools import Comply54ComplianceTool
+from comply54.sectors import NigeriaFintechCompliance
+
+tool = Comply54ComplianceTool(compliance=NigeriaFintechCompliance())
+
+agent = Agent(
+    role="Fintech Payment Agent",
+    tools=[transfer_funds_tool, tool],
+    ...
+)
+```
+
+The tool returns a JSON decision:
+
+```json
+{
+  "overall": "deny",
+  "blocked": true,
+  "audit_id": "c54-20260701-abc123",
+  "violations": [
+    {
+      "regulation": "CBN NIP Framework",
+      "jurisdiction": "NG",
+      "messages": ["Transaction of ₦15,000,000 exceeds single-transfer cap of ₦10,000,000"],
+      "rule_triggered": "cbn_nip_single_transfer_cap",
+      "citations": [
+        {
+          "document": "CBN NIP Framework",
+          "section": "Section 4.2",
+          "authority": "Central Bank of Nigeria",
+          "year": 2021
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Pattern 2 — Automatic pre-execution guard
+
+Wrap existing tools so compliance runs transparently before each call:
+
+```python
+from crewai_tools import comply54_guard_tools
+from comply54.sectors import NigeriaFintechCompliance
+
+guarded = comply54_guard_tools(
+    NigeriaFintechCompliance(),
+    [transfer_funds_tool, approve_loan_tool],
+    context={"kyc_tier": 3, "customer_verified": True},
+)
+
+agent = Agent(role="Fintech Agent", tools=guarded, ...)
+```
+
+Or wrap a single tool with `Comply54GuardedTool`:
+
+```python
+from crewai_tools import Comply54GuardedTool
+
+guarded = Comply54GuardedTool(
+    TransferFundsTool(),
+    NigeriaFintechCompliance(),
+    context={"kyc_tier": 3},
+    block_on_escalate=True,
+)
+```
+
+### Pattern 3 — Output-level task guardrail
+
+Block PII leakage (BVN, NIN, account numbers) in task output before delivery:
+
+```python
+from comply54.crewai import Comply54TaskGuardrail
+from comply54.sectors import NigeriaFintechCompliance
+
+guardrail = Comply54TaskGuardrail(NigeriaFintechCompliance())
+
+task = Task(
+    description="Summarise the customer account",
+    expected_output="Plain text summary",
+    guardrail=guardrail,
+    agent=agent,
+)
+```
+
+## Available sector packs
+
+```python
+from comply54.sectors import (
+    NigeriaFintechCompliance,   # CBN, NDPA 2023, NFIU AML, NIIRA 2025
+    NigeriaHealthCompliance,    # NHA, NDPA 2023
+    NigeriaInsuranceCompliance, # NAICOM, NDPA 2023
+    KenyaCompliance,            # KDPA 2019
+    SouthAfricaCompliance,      # POPIA
+    PanAfricanCompliance,       # All 21 packs across 12 jurisdictions
+)
+```
+
+## Environment variables
+
+None required. Comply54 is fully self-contained.
+
+## Links
+
+- [comply54 on PyPI](https://pypi.org/project/comply54/)
+- [comply54 docs](https://comply54.io)
+- [comply54 on GitHub](https://github.com/kingztech2019/comply54)

--- a/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/README.md
@@ -4,7 +4,7 @@ Pre-execution African regulatory enforcement for CrewAI agents. Evaluates agent 
 
 **No API key required.** Evaluation runs fully offline via in-process Rego evaluation (regopy). No OPA binary, no network call.
 
-## Covered jurisdictions
+## Covered jurisdictions (21 policy packs, 10 countries)
 
 | Country | Regulations |
 |---|---|
@@ -14,7 +14,10 @@ Pre-execution African regulatory enforcement for CrewAI agents. Evaluates agent 
 | Ghana | Ghana DPA 2012 |
 | Rwanda | Rwanda DPA 2021 |
 | Egypt | Egypt PDPL No. 151/2020 |
-| Tanzania, Uganda, Ethiopia, Mauritius | Jurisdiction-specific packs |
+| Tanzania | Tanzania Personal Data Protection Act |
+| Uganda | Uganda Data Protection and Privacy Act |
+| Ethiopia | Ethiopia Data Protection Proclamation No. 1321/2024 |
+| Mauritius | Mauritius Data Protection Act 2017 |
 
 ## Installation
 
@@ -103,6 +106,7 @@ guarded = Comply54GuardedTool(
 Block PII leakage (BVN, NIN, account numbers) in task output before delivery:
 
 ```python
+from crewai import Task
 from comply54.crewai import Comply54TaskGuardrail
 from comply54.sectors import NigeriaFintechCompliance
 
@@ -125,7 +129,7 @@ from comply54.sectors import (
     NigeriaInsuranceCompliance, # NAICOM, NDPA 2023
     KenyaCompliance,            # KDPA 2019
     SouthAfricaCompliance,      # POPIA
-    PanAfricanCompliance,       # All 21 packs across 12 jurisdictions
+    PanAfricanCompliance,       # All 21 packs across 10 jurisdictions
 )
 ```
 

--- a/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/__init__.py
@@ -1,0 +1,3 @@
+from .comply54_tool import Comply54ComplianceTool, Comply54GuardedTool, comply54_guard_tools
+
+__all__ = ["Comply54ComplianceTool", "Comply54GuardedTool", "comply54_guard_tools"]

--- a/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/comply54_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/comply54_tool.py
@@ -44,6 +44,18 @@ from pydantic import BaseModel, Field
 from crewai.tools import BaseTool
 
 
+def _ensure_comply54_installed() -> None:
+    try:
+        from comply54.sectors._base import SectorCompliance  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "Missing optional dependency 'comply54'. Install with:\n"
+            "  pip install crewai-tools[comply54]\n"
+            "or\n"
+            "  pip install comply54"
+        ) from exc
+
+
 class _ComplianceInput(BaseModel):
     """Input schema for Comply54ComplianceTool."""
 
@@ -111,16 +123,7 @@ class Comply54ComplianceTool(BaseTool):
     model_config = {"arbitrary_types_allowed": True}
 
     def __init__(self, compliance: Any, **kwargs: Any) -> None:
-        try:
-            from comply54.sectors._base import SectorCompliance  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(
-                "Missing optional dependency 'comply54'. Install with:\n"
-                "  pip install crewai-tools[comply54]\n"
-                "or\n"
-                "  pip install comply54"
-            ) from exc
-
+        _ensure_comply54_installed()
         super().__init__(
             compliance=compliance,
             name=f"comply54_{type(compliance).__name__.lower()}",
@@ -201,16 +204,7 @@ class Comply54GuardedTool(BaseTool):
         block_on_escalate: bool = False,
         **kwargs: Any,
     ) -> None:
-        try:
-            from comply54.sectors._base import SectorCompliance  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(
-                "Missing optional dependency 'comply54'. Install with:\n"
-                "  pip install crewai-tools[comply54]\n"
-                "or\n"
-                "  pip install comply54"
-            ) from exc
-
+        _ensure_comply54_installed()
         inner_schema = getattr(inner_tool, "args_schema", _FallbackInput)
 
         super().__init__(
@@ -232,6 +226,7 @@ class Comply54GuardedTool(BaseTool):
         result = self.compliance.check(
             action=self.inner_tool.name,
             params=kwargs,
+            output="",
             context=self.guard_context,
         )
         is_blocked = result.overall == "deny" or (

--- a/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/comply54_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/comply54_tool/comply54_tool.py
@@ -1,0 +1,341 @@
+"""
+comply54 compliance tools for CrewAI agents.
+
+Provides pre-execution African regulatory enforcement (CBN, NDPA 2023,
+POPIA, KDPA, NFIU AML, and 18 other jurisdiction packs) with zero runtime
+dependencies beyond comply54 itself — no OPA binary, no API calls, fully
+offline in-process Rego evaluation via regopy.
+
+Three integration patterns:
+
+1. Explicit self-check (agent decides when to call):
+
+    from crewai_tools import Comply54ComplianceTool
+    from comply54.sectors import NigeriaFintechCompliance
+
+    tool = Comply54ComplianceTool(compliance=NigeriaFintechCompliance())
+    agent = Agent(role="Fintech Agent", tools=[tool], ...)
+
+2. Automatic pre-execution guard (transparent to the agent):
+
+    from crewai_tools import comply54_guard_tools
+    from comply54.sectors import NigeriaFintechCompliance
+
+    guarded = comply54_guard_tools(
+        NigeriaFintechCompliance(),
+        [transfer_funds_tool, approve_payment_tool],
+        context={"kyc_tier": 3},
+    )
+    agent = Agent(role="Fintech Agent", tools=guarded, ...)
+
+3. Output-level task guardrail (blocks PII leakage before delivery):
+
+    from comply54.crewai import Comply54TaskGuardrail
+    guardrail = Comply54TaskGuardrail(NigeriaFintechCompliance())
+    task = Task(..., guardrail=guardrail, agent=agent)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List, Optional, Type
+
+from pydantic import BaseModel, Field
+from crewai.tools import BaseTool
+
+
+class _ComplianceInput(BaseModel):
+    """Input schema for Comply54ComplianceTool."""
+
+    action: str = Field(
+        description=(
+            "The action or tool name the agent intends to perform "
+            "(e.g. 'transfer_funds', 'approve_loan', 'send_sms')."
+        )
+    )
+    params: dict = Field(
+        default_factory=dict,
+        description="Parameters for the action (e.g. amount, recipient, account number).",
+    )
+    output: str = Field(
+        default="",
+        description="Proposed output text to check for PII leakage or policy violations.",
+    )
+    context: dict = Field(
+        default_factory=dict,
+        description=(
+            "Session context used to evaluate dynamic rules "
+            "(e.g. {'kyc_tier': 3, 'customer_verified': True})."
+        ),
+    )
+
+
+class Comply54ComplianceTool(BaseTool):
+    """
+    Check an agent action against African financial regulations before executing.
+
+    Returns a JSON decision — ``allow``, ``deny``, ``escalate``, or ``audit`` —
+    with the triggered rule, exact regulatory citation, and a stable audit ID.
+
+    Covers Nigeria (CBN, NDPA 2023, NIIRA 2025, NFIU AML, BVN/NIN),
+    Kenya (KDPA), South Africa (POPIA), Ghana, Rwanda, Egypt, Tanzania,
+    Uganda, Ethiopia, Mauritius — 21 policy packs across 12 jurisdictions.
+
+    No API key required. Evaluation runs fully offline via in-process Rego
+    (regopy); no OPA binary or network call needed.
+
+    Args:
+        compliance: A ``SectorCompliance`` instance from comply54
+                    (e.g. ``NigeriaFintechCompliance()``).
+
+    Usage::
+
+        from crewai_tools import Comply54ComplianceTool
+        from comply54.sectors import NigeriaFintechCompliance
+
+        tool = Comply54ComplianceTool(compliance=NigeriaFintechCompliance())
+        agent = Agent(role="Fintech Agent", tools=[tool], ...)
+    """
+
+    name: str = "comply54_compliance_check"
+    description: str = (
+        "Check whether an agent action complies with applicable African regulatory "
+        "requirements before executing it. Returns a JSON decision: allow / deny / "
+        "escalate / audit — with the triggered rule and exact regulatory citation. "
+        "Call this tool before any regulated financial, health, or data-processing action."
+    )
+    args_schema: Type[BaseModel] = _ComplianceInput
+    package_dependencies: List[str] = ["comply54"]
+
+    compliance: Any = None
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __init__(self, compliance: Any, **kwargs: Any) -> None:
+        try:
+            from comply54.sectors._base import SectorCompliance  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "Missing optional dependency 'comply54'. Install with:\n"
+                "  pip install crewai-tools[comply54]\n"
+                "or\n"
+                "  pip install comply54"
+            ) from exc
+
+        super().__init__(
+            compliance=compliance,
+            name=f"comply54_{type(compliance).__name__.lower()}",
+            description=(
+                f"comply54 compliance check — {compliance.name}. "
+                f"Jurisdictions: {', '.join(compliance.jurisdictions)}. "
+                "Returns JSON with overall decision (allow/deny/escalate/audit), "
+                "triggered rule, and exact regulatory citations."
+            ),
+            **kwargs,
+        )
+
+    def _run(
+        self,
+        action: str,
+        params: Optional[dict] = None,
+        output: str = "",
+        context: Optional[dict] = None,
+    ) -> str:
+        result = self.compliance.check(
+            action=action,
+            params=params or {},
+            output=output,
+            context=context or {},
+        )
+        return json.dumps(_result_to_dict(result))
+
+
+class _FallbackInput(BaseModel):
+    """Generic input for tools without a defined args_schema."""
+
+    input: str = Field(default="", description="Tool input.")
+
+
+class Comply54GuardedTool(BaseTool):
+    """
+    Wrap any CrewAI BaseTool with automatic pre-execution comply54 enforcement.
+
+    The original tool's name, description, and args_schema are preserved —
+    the agent's interface is unchanged. If comply54 returns ``deny`` (or
+    ``escalate`` when ``block_on_escalate=True``), the inner tool is not called
+    and a structured error JSON is returned instead.
+
+    Args:
+        inner_tool:        The CrewAI ``BaseTool`` to wrap.
+        compliance:        A ``SectorCompliance`` instance.
+        context:           Default session context applied to every evaluation.
+        block_on_escalate: Treat ``escalate`` decisions as blocks. Default ``False``.
+
+    Usage::
+
+        from crewai_tools import Comply54GuardedTool
+        from comply54.sectors import NigeriaFintechCompliance
+
+        guarded = Comply54GuardedTool(
+            TransferFundsTool(),
+            NigeriaFintechCompliance(),
+            context={"kyc_tier": 3},
+        )
+        agent = Agent(role="Fintech Agent", tools=[guarded], ...)
+    """
+
+    name: str = ""
+    description: str = ""
+    package_dependencies: List[str] = ["comply54"]
+
+    inner_tool: Any = None
+    compliance: Any = None
+    guard_context: dict = Field(default_factory=dict)
+    block_on_escalate: bool = False
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __init__(
+        self,
+        inner_tool: Any,
+        compliance: Any,
+        context: Optional[dict] = None,
+        block_on_escalate: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        try:
+            from comply54.sectors._base import SectorCompliance  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "Missing optional dependency 'comply54'. Install with:\n"
+                "  pip install crewai-tools[comply54]\n"
+                "or\n"
+                "  pip install comply54"
+            ) from exc
+
+        inner_schema = getattr(inner_tool, "args_schema", _FallbackInput)
+
+        super().__init__(
+            name=inner_tool.name,
+            description=(
+                f"[comply54 guarded] {inner_tool.description} "
+                f"— enforces {compliance.name} "
+                f"({', '.join(compliance.jurisdictions)})"
+            ),
+            inner_tool=inner_tool,
+            compliance=compliance,
+            guard_context=context or {},
+            block_on_escalate=block_on_escalate,
+            args_schema=inner_schema,
+            **kwargs,
+        )
+
+    def _run(self, **kwargs: Any) -> str:
+        result = self.compliance.check(
+            action=self.inner_tool.name,
+            params=kwargs,
+            context=self.guard_context,
+        )
+        is_blocked = result.overall == "deny" or (
+            self.block_on_escalate and result.overall == "escalate"
+        )
+
+        if is_blocked:
+            violation = result.primary_violation
+            reason = (
+                violation.messages[0]
+                if violation and violation.messages
+                else "Compliance check failed"
+            )
+            return json.dumps({
+                "blocked": True,
+                "decision": result.overall,
+                "reason": reason,
+                "regulation": violation.regulation if violation else self.compliance.name,
+                "rule_triggered": violation.rule_triggered if violation else None,
+                "citations": [
+                    {
+                        "document": c.document,
+                        "section": c.section,
+                        "authority": c.authority,
+                        "year": c.year,
+                    }
+                    for c in (violation.citations if violation else [])
+                ],
+                "audit_id": result.audit_id,
+                "jurisdictions": self.compliance.jurisdictions,
+            })
+
+        return self.inner_tool._run(**kwargs)
+
+
+def comply54_guard_tools(
+    compliance: Any,
+    tools: list,
+    context: Optional[dict] = None,
+    block_on_escalate: bool = False,
+) -> list:
+    """
+    Wrap a list of CrewAI tools with comply54 pre-execution enforcement.
+
+    Each tool's original name, description, and args_schema are preserved.
+    Compliance is checked before every execution; denied calls return a
+    structured error JSON without calling the inner tool.
+
+    Args:
+        compliance:        A ``SectorCompliance`` instance.
+        tools:             List of CrewAI ``BaseTool`` instances to guard.
+        context:           Default session context applied to every evaluation
+                           (e.g. ``{"kyc_tier": 3, "customer_verified": True}``).
+        block_on_escalate: Treat ``escalate`` decisions as blocks. Default ``False``.
+
+    Returns:
+        List of ``Comply54GuardedTool`` instances, one per input tool.
+
+    Usage::
+
+        from crewai_tools import comply54_guard_tools
+        from comply54.sectors import NigeriaFintechCompliance
+
+        guarded = comply54_guard_tools(
+            NigeriaFintechCompliance(),
+            [transfer_funds_tool, approve_payment_tool],
+            context={"kyc_tier": 3},
+        )
+        agent = Agent(role="Fintech Agent", tools=guarded, ...)
+    """
+    return [
+        Comply54GuardedTool(
+            inner_tool=tool,
+            compliance=compliance,
+            context=context,
+            block_on_escalate=block_on_escalate,
+        )
+        for tool in tools
+    ]
+
+
+def _result_to_dict(result: Any) -> dict:
+    return {
+        "overall": result.overall,
+        "blocked": result.blocked,
+        "audit_id": result.audit_id,
+        "violations": [
+            {
+                "pack": d.pack,
+                "regulation": d.regulation,
+                "jurisdiction": d.jurisdiction,
+                "action": d.action,
+                "messages": d.messages,
+                "rule_triggered": d.rule_triggered,
+                "citations": [
+                    {
+                        "document": c.document,
+                        "section": c.section,
+                        "authority": c.authority,
+                        "year": c.year,
+                    }
+                    for c in d.citations
+                ],
+            }
+            for d in result.violations
+        ],
+    }

--- a/lib/crewai-tools/tests/tools/test_comply54_tool.py
+++ b/lib/crewai-tools/tests/tools/test_comply54_tool.py
@@ -1,0 +1,239 @@
+"""
+Unit tests for Comply54ComplianceTool and Comply54GuardedTool.
+
+All tests mock the comply54 library so no real Rego evaluation or
+comply54 installation is required in CI.
+"""
+
+import json
+from typing import Any, Optional, Type
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, Field
+from crewai.tools import BaseTool
+
+from crewai_tools.tools.comply54_tool.comply54_tool import (
+    Comply54ComplianceTool,
+    Comply54GuardedTool,
+    comply54_guard_tools,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_compliance(overall: str = "allow", blocked: bool = False) -> MagicMock:
+    """Build a minimal SectorCompliance mock."""
+    violation = MagicMock()
+    violation.messages = ["Transaction exceeds cap"]
+    violation.regulation = "CBN NIP Framework"
+    violation.rule_triggered = "cbn_nip_single_transfer_cap"
+    violation.citations = []
+
+    result = MagicMock()
+    result.overall = overall
+    result.blocked = blocked
+    result.audit_id = "c54-test-001"
+    result.violations = [violation] if blocked else []
+    result.primary_violation = violation if blocked else None
+
+    compliance = MagicMock()
+    compliance.name = "Nigeria Fintech Compliance"
+    compliance.jurisdictions = ["NG"]
+    compliance.check.return_value = result
+    return compliance
+
+
+class _TransferInput(BaseModel):
+    amount: float = Field(description="Amount in NGN.")
+    recipient: str = Field(description="Recipient account number.")
+
+
+class _MockInnerTool(BaseTool):
+    name: str = "transfer_funds"
+    description: str = "Transfer funds between accounts."
+    args_schema: Type[BaseModel] = _TransferInput
+
+    def _run(self, amount: float, recipient: str) -> str:
+        return json.dumps({"status": "ok", "amount": amount, "recipient": recipient})
+
+
+# ── Comply54ComplianceTool ────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_sector_compliance_import():
+    """Patch the comply54 import check inside the tool constructors."""
+    with patch(
+        "crewai_tools.tools.comply54_tool.comply54_tool.__import__",
+        side_effect=lambda name, *a, **kw: MagicMock() if "comply54" in name else __import__(name, *a, **kw),
+    ):
+        yield
+
+
+def _build_compliance_tool(overall: str = "allow", blocked: bool = False):
+    compliance = _make_compliance(overall=overall, blocked=blocked)
+    with patch("crewai_tools.tools.comply54_tool.comply54_tool.__builtins__"):
+        pass
+    # Patch only the import guard inside __init__
+    with patch(
+        "crewai_tools.tools.comply54_tool.comply54_tool.importlib",
+        create=True,
+    ):
+        pass
+
+    with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+        tool = Comply54ComplianceTool.__new__(Comply54ComplianceTool)
+        tool.compliance = compliance
+        tool.name = f"comply54_{type(compliance).__name__.lower()}"
+        tool.description = "comply54 compliance check"
+        tool.guard_context = {}
+        tool.block_on_escalate = False
+        return tool, compliance
+
+
+class TestComply54ComplianceTool:
+    def test_allow_decision_returns_json(self):
+        compliance = _make_compliance(overall="allow", blocked=False)
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            tool = Comply54ComplianceTool(compliance=compliance)
+
+        result = json.loads(tool._run(action="transfer_funds", params={"amount": 5000}))
+
+        assert result["overall"] == "allow"
+        assert result["blocked"] is False
+        assert result["audit_id"] == "c54-test-001"
+        compliance.check.assert_called_once_with(
+            action="transfer_funds",
+            params={"amount": 5000},
+            output="",
+            context={},
+        )
+
+    def test_deny_decision_returns_json(self):
+        compliance = _make_compliance(overall="deny", blocked=True)
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            tool = Comply54ComplianceTool(compliance=compliance)
+
+        result = json.loads(tool._run(action="transfer_funds", params={"amount": 15_000_000}))
+
+        assert result["overall"] == "deny"
+        assert result["blocked"] is True
+        assert len(result["violations"]) == 1
+        assert result["violations"][0]["regulation"] == "CBN NIP Framework"
+
+    def test_missing_comply54_raises_import_error(self):
+        with patch.dict("sys.modules", {"comply54": None, "comply54.sectors._base": None}):
+            with pytest.raises(ImportError, match="comply54"):
+                Comply54ComplianceTool(compliance=MagicMock())
+
+    def test_name_derived_from_compliance_class(self):
+        compliance = _make_compliance()
+        compliance.__class__.__name__ = "NigeriaFintechCompliance"
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            tool = Comply54ComplianceTool(compliance=compliance)
+        assert "nigeria" in tool.name.lower() or "compliance" in tool.name.lower()
+
+
+# ── Comply54GuardedTool ───────────────────────────────────────────────────────
+
+class TestComply54GuardedTool:
+    def _make_guarded(self, overall: str = "allow", blocked: bool = False, block_on_escalate: bool = False):
+        compliance = _make_compliance(overall=overall, blocked=blocked)
+        inner = _MockInnerTool()
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            guarded = Comply54GuardedTool(
+                inner,
+                compliance,
+                context={"kyc_tier": 3},
+                block_on_escalate=block_on_escalate,
+            )
+        return guarded, compliance, inner
+
+    def test_allow_passes_through_to_inner_tool(self):
+        guarded, compliance, _ = self._make_guarded(overall="allow", blocked=False)
+
+        result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
+
+        assert result["status"] == "ok"
+        assert result["amount"] == 5000.0
+
+    def test_deny_blocks_inner_tool(self):
+        guarded, compliance, inner = self._make_guarded(overall="deny", blocked=True)
+
+        result = json.loads(guarded._run(amount=15_000_000.0, recipient="0123456789"))
+
+        assert result["blocked"] is True
+        assert result["decision"] == "deny"
+        assert "CBN NIP Framework" in result["regulation"]
+        assert result["audit_id"] == "c54-test-001"
+
+    def test_escalate_passes_through_by_default(self):
+        guarded, _, _ = self._make_guarded(overall="escalate", blocked=False, block_on_escalate=False)
+
+        result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
+
+        assert result["status"] == "ok"
+
+    def test_escalate_blocked_when_block_on_escalate_true(self):
+        compliance = _make_compliance(overall="escalate", blocked=False)
+        # Primary violation still set for escalate case
+        violation = MagicMock()
+        violation.messages = ["Requires manual review"]
+        violation.regulation = "NFIU AML"
+        violation.rule_triggered = "nfiu_high_risk_flag"
+        violation.citations = []
+        compliance.check.return_value.primary_violation = violation
+        compliance.check.return_value.overall = "escalate"
+
+        inner = _MockInnerTool()
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            guarded = Comply54GuardedTool(inner, compliance, block_on_escalate=True)
+
+        result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
+
+        assert result["blocked"] is True
+        assert result["decision"] == "escalate"
+
+    def test_preserves_inner_tool_name(self):
+        guarded, _, inner = self._make_guarded()
+        assert guarded.name == inner.name
+
+    def test_preserves_inner_tool_args_schema(self):
+        guarded, _, inner = self._make_guarded()
+        assert guarded.args_schema is _TransferInput
+
+    def test_missing_comply54_raises_import_error(self):
+        with patch.dict("sys.modules", {"comply54": None, "comply54.sectors._base": None}):
+            with pytest.raises(ImportError, match="comply54"):
+                Comply54GuardedTool(_MockInnerTool(), MagicMock())
+
+
+# ── comply54_guard_tools ──────────────────────────────────────────────────────
+
+class TestComply54GuardTools:
+    def test_returns_one_guarded_tool_per_input(self):
+        compliance = _make_compliance()
+        tools = [_MockInnerTool(), _MockInnerTool()]
+        tools[1].name = "approve_loan"
+
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            guarded = comply54_guard_tools(compliance, tools, context={"kyc_tier": 3})
+
+        assert len(guarded) == 2
+        assert all(isinstance(t, Comply54GuardedTool) for t in guarded)
+
+    def test_empty_list_returns_empty(self):
+        compliance = _make_compliance()
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            guarded = comply54_guard_tools(compliance, [])
+        assert guarded == []
+
+    def test_context_propagated_to_all_tools(self):
+        compliance = _make_compliance()
+        ctx = {"kyc_tier": 3, "customer_verified": True}
+        tools = [_MockInnerTool()]
+
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            guarded = comply54_guard_tools(compliance, tools, context=ctx)
+
+        assert guarded[0].guard_context == ctx

--- a/lib/crewai-tools/tests/tools/test_comply54_tool.py
+++ b/lib/crewai-tools/tests/tools/test_comply54_tool.py
@@ -121,6 +121,17 @@ class TestComply54ComplianceTool:
         assert len(result["violations"]) == 1
         assert result["violations"][0]["regulation"] == "CBN NIP Framework"
 
+    def test_audit_decision_returns_json(self):
+        compliance = _make_compliance(overall="audit", blocked=False)
+        with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
+            tool = Comply54ComplianceTool(compliance=compliance)
+
+        result = json.loads(tool._run(action="transfer_funds", params={"amount": 5000}))
+
+        assert result["overall"] == "audit"
+        assert result["blocked"] is False
+        assert result["audit_id"] == "c54-test-001"
+
     def test_missing_comply54_raises_import_error(self):
         with patch.dict("sys.modules", {"comply54": None, "comply54.sectors._base": None}):
             with pytest.raises(ImportError, match="comply54"):
@@ -150,28 +161,38 @@ class TestComply54GuardedTool:
         return guarded, compliance, inner
 
     def test_allow_passes_through_to_inner_tool(self):
-        guarded, compliance, _ = self._make_guarded(overall="allow", blocked=False)
+        guarded, compliance, inner = self._make_guarded(overall="allow", blocked=False)
 
         result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
 
         assert result["status"] == "ok"
         assert result["amount"] == 5000.0
+        compliance.check.assert_called_once_with(
+            action=inner.name,
+            params={"amount": 5000.0, "recipient": "0123456789"},
+            output="",
+            context={"kyc_tier": 3},
+        )
 
     def test_deny_blocks_inner_tool(self):
         guarded, compliance, inner = self._make_guarded(overall="deny", blocked=True)
 
-        result = json.loads(guarded._run(amount=15_000_000.0, recipient="0123456789"))
+        with patch.object(inner, "_run", wraps=inner._run) as inner_run:
+            result = json.loads(guarded._run(amount=15_000_000.0, recipient="0123456789"))
 
+        inner_run.assert_not_called()
         assert result["blocked"] is True
         assert result["decision"] == "deny"
         assert "CBN NIP Framework" in result["regulation"]
         assert result["audit_id"] == "c54-test-001"
 
     def test_escalate_passes_through_by_default(self):
-        guarded, _, _ = self._make_guarded(overall="escalate", blocked=False, block_on_escalate=False)
+        guarded, compliance, inner = self._make_guarded(overall="escalate", blocked=False, block_on_escalate=False)
 
-        result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
+        with patch.object(inner, "_run", wraps=inner._run) as inner_run:
+            result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
 
+        inner_run.assert_called_once()
         assert result["status"] == "ok"
 
     def test_escalate_blocked_when_block_on_escalate_true(self):
@@ -189,8 +210,10 @@ class TestComply54GuardedTool:
         with patch.dict("sys.modules", {"comply54": MagicMock(), "comply54.sectors._base": MagicMock()}):
             guarded = Comply54GuardedTool(inner, compliance, block_on_escalate=True)
 
-        result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
+        with patch.object(inner, "_run", wraps=inner._run) as inner_run:
+            result = json.loads(guarded._run(amount=5000.0, recipient="0123456789"))
 
+        inner_run.assert_not_called()
         assert result["blocked"] is True
         assert result["decision"] == "escalate"
 

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -2907,7 +2907,7 @@
       }
     },
     {
-      "description": "Check whether an agent action complies with applicable African regulatory requirements before executing it. Returns a JSON decision: allow / deny / escalate / audit \u2014 with the triggered rule and exact regulatory citation. Covers Nigeria (CBN, NDPA 2023, NIIRA 2025, NFIU AML), Kenya (KDPA), South Africa (POPIA), Ghana, Rwanda, Egypt, and 5 more African jurisdictions. No API key required \u2014 evaluation runs fully offline via in-process Rego (regopy).",
+      "description": "Check whether an agent action complies with applicable African regulatory requirements before executing it. Returns a JSON decision: allow / deny / escalate / audit \u2014 with the triggered rule and exact regulatory citation. Covers Nigeria (CBN, NDPA 2023, NIIRA 2025, NFIU AML, BVN/NIN), Kenya (KDPA), South Africa (POPIA), Ghana, Rwanda, Egypt, Tanzania, Uganda, Ethiopia, Mauritius \u2014 21 policy packs across 10 countries. No API key required \u2014 evaluation runs fully offline via in-process Rego (regopy).",
       "env_vars": [],
       "humanized_name": "Comply54 Compliance Tool",
       "init_params_schema": {

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -2907,6 +2907,61 @@
       }
     },
     {
+      "description": "Check whether an agent action complies with applicable African regulatory requirements before executing it. Returns a JSON decision: allow / deny / escalate / audit \u2014 with the triggered rule and exact regulatory citation. Covers Nigeria (CBN, NDPA 2023, NIIRA 2025, NFIU AML), Kenya (KDPA), South Africa (POPIA), Ghana, Rwanda, Egypt, and 5 more African jurisdictions. No API key required \u2014 evaluation runs fully offline via in-process Rego (regopy).",
+      "env_vars": [],
+      "humanized_name": "Comply54 Compliance Tool",
+      "init_params_schema": {
+        "properties": {
+          "compliance": {
+            "description": "A SectorCompliance instance from comply54 (e.g. NigeriaFintechCompliance()).",
+            "title": "Compliance"
+          }
+        },
+        "required": [
+          "compliance"
+        ],
+        "title": "Comply54ComplianceTool",
+        "type": "object"
+      },
+      "name": "Comply54ComplianceTool",
+      "package_dependencies": [
+        "comply54"
+      ],
+      "run_params_schema": {
+        "description": "Input schema for Comply54ComplianceTool.",
+        "properties": {
+          "action": {
+            "description": "The action or tool name the agent intends to perform (e.g. 'transfer_funds', 'approve_loan').",
+            "title": "Action",
+            "type": "string"
+          },
+          "params": {
+            "default": {},
+            "description": "Parameters for the action (e.g. amount, recipient, account number).",
+            "title": "Params",
+            "type": "object"
+          },
+          "output": {
+            "default": "",
+            "description": "Proposed output text to check for PII leakage or policy violations.",
+            "title": "Output",
+            "type": "string"
+          },
+          "context": {
+            "default": {},
+            "description": "Session context used to evaluate dynamic rules (e.g. {'kyc_tier': 3}).",
+            "title": "Context",
+            "type": "object"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "title": "_ComplianceInput",
+        "type": "object"
+      }
+    },
+    {
       "description": "A tool that can be used to semantic search a query from a CSV's content.",
       "env_vars": [],
       "humanized_name": "Search a CSV's content",


### PR DESCRIPTION
## Description

Adds `Comply54ComplianceTool`, `Comply54GuardedTool`, and `comply54_guard_tools()` to `lib/crewai-tools/` — pre-execution African financial and data-protection compliance enforcement for CrewAI agents.

**Why now:** Nigeria's CBN issued an AI-in-AML mandate in March 2026 requiring banks and fintechs to enforce compliance controls on AI agent actions. There is currently no crewAI tool addressing African regulatory requirements, which represent a fast-growing developer market.

**What it does:**

Returns a structured JSON decision — `allow` / `deny` / `escalate` / `audit` — with the triggered rule, exact regulatory citation (document, section, authority, year), and a stable audit ID before the agent executes any regulated action.

**Jurisdiction coverage:** 21 policy packs across 12 African countries — Nigeria (CBN NIP Framework, NDPA 2023, NIIRA 2025, NFIU AML, BVN/NIN), Kenya (KDPA 2019), South Africa (POPIA), Ghana, Rwanda, Egypt, Tanzania, Uganda, Ethiopia, Mauritius.

**No API key required.** Evaluation runs fully offline via in-process Rego (regopy). No OPA binary, no subprocess, no network call.

## Three integration patterns

**Pattern 1 — Explicit self-check** (agent decides when to call):
```python
from crewai_tools import Comply54ComplianceTool
from comply54.sectors import NigeriaFintechCompliance

tool = Comply54ComplianceTool(compliance=NigeriaFintechCompliance())
agent = Agent(role="Fintech Agent", tools=[transfer_funds_tool, tool], ...)
```

**Pattern 2 — Automatic pre-execution guard** (transparent to agent):
```python
from crewai_tools import comply54_guard_tools
from comply54.sectors import NigeriaFintechCompliance

guarded = comply54_guard_tools(
    NigeriaFintechCompliance(),
    [transfer_funds_tool, approve_payment_tool],
    context={"kyc_tier": 3},
)
agent = Agent(role="Fintech Agent", tools=guarded, ...)
```

**Pattern 3 — Output-level task guardrail** (blocks PII leakage before delivery):
```python
from comply54.crewai import Comply54TaskGuardrail
task = Task(..., guardrail=Comply54TaskGuardrail(NigeriaFintechCompliance()), agent=agent)
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Files changed

| File | Change |
|---|---|
| `lib/crewai-tools/src/crewai_tools/tools/comply54_tool/comply54_tool.py` | New tool implementation |
| `lib/crewai-tools/src/crewai_tools/tools/comply54_tool/__init__.py` | Package init |
| `lib/crewai-tools/src/crewai_tools/tools/comply54_tool/README.md` | Usage docs |
| `lib/crewai-tools/src/crewai_tools/tools/__init__.py` | Export 3 new symbols |
| `lib/crewai-tools/pyproject.toml` | Add `comply54` optional extra |
| `lib/crewai-tools/tool.specs.json` | Add `Comply54ComplianceTool` spec entry |
| `lib/crewai-tools/tests/tools/test_comply54_tool.py` | Unit tests (all mocked, no real Rego) |

## Checklist

- [x] Tool lives under `lib/crewai-tools/src/crewai_tools/tools/comply54_tool/`
- [x] Class ends with `Tool` and subclasses `BaseTool`
- [x] Precise `args_schema` with Pydantic field descriptions and validation
- [x] No `env_vars` (comply54 requires no API key)
- [x] `package_dependencies = ["comply54"]` declared
- [x] Lazy import with clear `ImportError` message pointing to `pip install crewai-tools[comply54]`
- [x] Optional extra added in `pyproject.toml`
- [x] `tool.specs.json` entry added manually (auto-generator requires internal PR secrets)
- [x] Unit tests added — all mocked, deterministic, no network calls
- [x] Tool `README.md` with usage patterns and all three integration examples

## Links

- Feature request: crewAIInc/crewAI#6392 (opened 2026-06-30)
- comply54 on PyPI: https://pypi.org/project/comply54/
- comply54 docs: https://comply54.io
- comply54 on GitHub: https://github.com/kingztech2019/comply54 (Apache 2.0)

## Attribution

Implemented by [@kingztech2019](https://github.com/kingztech2019).

## AI Assistance

Claude (Anthropic) was used to assist with code generation and review.

## IP

The comply54 library is original work by the contributor (Apache 2.0). No third-party IP is included.

<!-- crewai-require-issue-check -->