### PR TITLE
fix(reasoning): use flexible regex to detect READY state to prevent agent deadlocks

### DIFF
--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -105,6 +105,13 @@ FUNCTION_SCHEMA: Final[dict[str, Any]] = {
 }
 
 
+def _is_ready(response: str) -> bool:
+    """Check if the response indicates the agent is ready."""
+    if re.search(r"(?i)\bnot\s+ready\b", response):
+        return False
+    return bool(re.search(r"(?i)\bready\b", response))
+
+
 class AgentReasoning:
     """
     Handles the agent planning/reasoning process, enabling an agent to reflect
@@ -410,7 +417,7 @@ class AgentReasoning:
             return (
                 response_str,
                 [],
-                bool(re.search(r"(?i)(?<!not )\bready\b", response_str)),
+                _is_ready(response_str),
             )
 
         except Exception as e:
@@ -434,7 +441,7 @@ class AgentReasoning:
                 return (
                     fallback_str,
                     [],
-                    bool(re.search(r"(?i)(?<!not )\bready\b", fallback_str)),
+                    _is_ready(fallback_str),
                 )
             except Exception as inner_e:
                 self.logger.error(f"Error during fallback text parsing: {inner_e!s}")
@@ -594,7 +601,7 @@ class AgentReasoning:
             return "No plan was generated.", False
 
         plan = response
-        ready = bool(re.search(r"(?i)(?<!not )\bready\b", response))
+        ready = _is_ready(response)
 
         return plan, ready
 

--- a/lib/crewai/src/crewai/utilities/reasoning_handler.py
+++ b/lib/crewai/src/crewai/utilities/reasoning_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from pydantic import BaseModel, Field
@@ -409,7 +410,7 @@ class AgentReasoning:
             return (
                 response_str,
                 [],
-                "READY: I am ready to execute the task." in response_str,
+                bool(re.search(r"(?i)(?<!not )\bready\b", response_str)),
             )
 
         except Exception as e:
@@ -433,7 +434,7 @@ class AgentReasoning:
                 return (
                     fallback_str,
                     [],
-                    "READY: I am ready to execute the task." in fallback_str,
+                    bool(re.search(r"(?i)(?<!not )\bready\b", fallback_str)),
                 )
             except Exception as inner_e:
                 self.logger.error(f"Error during fallback text parsing: {inner_e!s}")
@@ -593,7 +594,7 @@ class AgentReasoning:
             return "No plan was generated.", False
 
         plan = response
-        ready = "READY: I am ready to execute the task." in response
+        ready = bool(re.search(r"(?i)(?<!not )\bready\b", response))
 
         return plan, ready
 

--- a/lib/crewai/tests/utilities/test_reasoning_handler.py
+++ b/lib/crewai/tests/utilities/test_reasoning_handler.py
@@ -1,0 +1,28 @@
+import pytest
+
+from crewai.utilities.reasoning_handler import _is_ready
+
+class TestReasoningHandlerIsReady:
+    @pytest.mark.parametrize(
+        "response, expected",
+        [
+            ("READY", True),
+            ("ready", True),
+            ("READY: I am ready to execute the task.", True),
+            ("I am READY to go.", True),
+            ("Status: ready", True),
+            ("NOT READY", False),
+            ("not ready", False),
+            ("NOT  READY", False),
+            ("NOT\nREADY", False),
+            ("NOT\tREADY", False),
+            ("NOT READY: I need to refine.", False),
+            ("The agent is NOT READY to proceed.", False),
+            ("I am NOT    READY.", False),
+            ("NOT ready at all", False),
+            ("Something else completely", False),
+            ("", False),
+        ],
+    )
+    def test_is_ready_detects_ready_and_not_ready_correctly(self, response, expected):
+        assert _is_ready(response) == expected


### PR DESCRIPTION
This PR fixes a bug in the `AgentReasoning` loop where the readiness check was hardcoded to expect the exact string `"READY: I am ready to execute the task."`. 

Newer local/open-source models, or models under slightly altered prompts, frequently output just `"READY"` or some other variation, causing the planning executor to fail to detect readiness and trap the agent in an infinite planning loop. 

This replaces the hardcoded exact string matches with a flexible regular expression `(?i)(?<!not )\bready\b` that safely identifies when the model is ready, gracefully ignoring "not ready".

<!-- crewai-require-issue-check -->