### PR TITLE
docs: add MongoDB to Rag Tool documentation

### DIFF
--- a/docs/edge/en/tools/ai-ml/ragtool.mdx
+++ b/docs/edge/en/tools/ai-ml/ragtool.mdx
@@ -62,6 +62,7 @@ The `RagTool` can be used with a wide variety of data sources, including:
 - 📝 GitHub repositories
 - 🐘 PostgreSQL databases
 - 🐬 MySQL databases
+- 🍃 MongoDB Atlas Collections
 - 🤖 Slack conversations
 - 💬 Discord messages
 - 🗨️ Discourse forums


### PR DESCRIPTION
## Summary

Added MongoDB to list of supported data sources to help users discover other ways of storing their data. 

## Validation

- Previewed the changes locally with Mintlify
- Confirmed the updated page renders correctly
- Ran the Mintlify broken-link check

<!-- crewai-require-issue-check -->