### PR TITLE
feat: add turbopuffer vector store integration

### DIFF
--- a/docs/edge/en/concepts/knowledge.mdx
+++ b/docs/edge/en/concepts/knowledge.mdx
@@ -27,11 +27,12 @@ Also, use relative paths from the `knowledge` directory when creating the source
 
 ### Vector store (RAG) client configuration
 
-CrewAI exposes a provider-neutral RAG client abstraction for vector stores. The default provider is ChromaDB, and Qdrant is supported as well. You can switch providers using configuration utilities.
+CrewAI exposes a provider-neutral RAG client abstraction for vector stores. The default provider is ChromaDB, with Qdrant and turbopuffer also supported. You can switch providers using configuration utilities.
 
 Supported today:
 - ChromaDB (default)
 - Qdrant
+- turbopuffer
 
 ```python Code
 from crewai.rag.config.utils import set_rag_config, get_rag_client, clear_rag_config
@@ -45,6 +46,12 @@ chromadb_client = get_rag_client()
 from crewai.rag.qdrant.config import QdrantConfig
 set_rag_config(QdrantConfig())
 qdrant_client = get_rag_client()
+
+# turbopuffer
+from turbopuffer import Turbopuffer
+from crewai.rag.turbopuffer.config import TurbopufferConfig
+set_rag_config(TurbopufferConfig(client=Turbopuffer(region="gcp-us-central1")))
+turbopuffer_client = get_rag_client()
 
 # Example operations (same API for any provider)
 client = qdrant_client  # or chromadb_client

--- a/docs/edge/en/concepts/knowledge.mdx
+++ b/docs/edge/en/concepts/knowledge.mdx
@@ -47,7 +47,7 @@ from crewai.rag.qdrant.config import QdrantConfig
 set_rag_config(QdrantConfig())
 qdrant_client = get_rag_client()
 
-# turbopuffer
+# turbopuffer (see https://turbopuffer.com/docs/regions for available regions)
 from turbopuffer import Turbopuffer
 from crewai.rag.turbopuffer.config import TurbopufferConfig
 set_rag_config(TurbopufferConfig(client=Turbopuffer(region="gcp-us-central1")))

--- a/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/rag/rag_tool.py
@@ -197,12 +197,12 @@ class RagTool(BaseTool):
             return self._create_provider_config("chromadb", {}, None)
 
         vectordb_cfg = cast(VectorDbConfig, config.get("vectordb", {}))
-        provider: Literal["chromadb", "qdrant"] = vectordb_cfg.get(
+        provider: Literal["chromadb", "qdrant", "turbopuffer"] = vectordb_cfg.get(
             "provider", "chromadb"
         )
         provider_config: dict[str, Any] = vectordb_cfg.get("config", {})
 
-        supported = ("chromadb", "qdrant")
+        supported = ("chromadb", "qdrant", "turbopuffer")
         if provider not in supported:
             raise ValueError(
                 f"Unsupported vector database provider: '{provider}'. "
@@ -222,7 +222,7 @@ class RagTool(BaseTool):
 
     @staticmethod
     def _create_provider_config(
-        provider: Literal["chromadb", "qdrant"],
+        provider: Literal["chromadb", "qdrant", "turbopuffer"],
         provider_config: dict[str, Any],
         embedding_function: EmbeddingFunction[Any] | None,
     ) -> Any:
@@ -242,6 +242,14 @@ class RagTool(BaseTool):
             if embedding_function is not None:
                 kwargs["embedding_function"] = embedding_function
             return QdrantConfig(**kwargs)
+
+        if provider == "turbopuffer":
+            from crewai.rag.turbopuffer.config import TurbopufferConfig
+
+            kwargs = dict(provider_config)
+            if embedding_function is not None:
+                kwargs["embedding_function"] = embedding_function
+            return TurbopufferConfig(**kwargs)
 
         raise ValueError(f"Unhandled provider: {provider}")
 

--- a/lib/crewai-tools/src/crewai_tools/tools/rag/types.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/rag/types.py
@@ -54,7 +54,7 @@ class VectorDbConfig(TypedDict):
         config: RAG configuration options.
     """
 
-    provider: Literal["chromadb", "qdrant"]
+    provider: Literal["chromadb", "qdrant", "turbopuffer"]
     config: dict[str, Any]
 
 

--- a/lib/crewai-tools/tests/tools/rag/rag_tool_test.py
+++ b/lib/crewai-tools/tests/tools/rag/rag_tool_test.py
@@ -309,3 +309,47 @@ def test_rag_tool_config_with_qdrant_and_azure_embeddings(
 
         assert tool.adapter is not None
         assert isinstance(tool.adapter, CrewAIRagAdapter)
+
+
+@patch("crewai_tools.adapters.crewai_rag_adapter.create_client")
+def test_rag_tool_config_with_turbopuffer_and_azure_embeddings(
+    mock_create_client: Mock,
+) -> None:
+    """Test RagTool with Turbopuffer vector DB and Azure embeddings config."""
+    mock_embedding_func = MagicMock()
+    mock_embedding_func.return_value = [[0.1] * 1536]
+
+    mock_client = MagicMock()
+    mock_client.get_or_create_collection = MagicMock(return_value=None)
+    mock_create_client.return_value = mock_client
+
+    with patch(
+        "crewai_tools.tools.rag.rag_tool.build_embedder",
+        return_value=mock_embedding_func,
+    ):
+
+        class MyTool(RagTool):
+            pass
+
+        # Turbopuffer requires a pre-configured client in the provider config.
+        config = {
+            "vectordb": {
+                "provider": "turbopuffer",
+                "config": {"client": MagicMock()},
+            },
+            "embedding_model": {
+                "provider": "azure",
+                "config": {
+                    "model": "text-embedding-3-large",
+                    "api_key": "test-key",
+                    "api_base": "https://test.openai.azure.com/",
+                    "api_version": "2024-02-01",
+                    "deployment_id": "test-deployment",
+                },
+            },
+        }
+
+        tool = MyTool(config=config)
+
+        assert tool.adapter is not None
+        assert isinstance(tool.adapter, CrewAIRagAdapter)

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -77,6 +77,10 @@ docling = [
 qdrant = [
     "qdrant-client[fastembed]~=1.14.3",
 ]
+turbopuffer = [
+    "turbopuffer>=1.0.0,<2",
+    "fastembed>=0.3.0",
+]
 aws = [
     "boto3~=1.42.90",
     "aiobotocore~=3.5.0",

--- a/lib/crewai/src/crewai/rag/config/optional_imports/base.py
+++ b/lib/crewai/src/crewai/rag/config/optional_imports/base.py
@@ -14,7 +14,7 @@ class _MissingProvider:
     Raises RuntimeError when instantiated to indicate missing dependencies.
     """
 
-    provider: Literal["chromadb", "qdrant", "__missing__"] = field(
+    provider: Literal["chromadb", "qdrant", "turbopuffer", "__missing__"] = field(
         default="__missing__"
     )
 

--- a/lib/crewai/src/crewai/rag/config/optional_imports/protocols.py
+++ b/lib/crewai/src/crewai/rag/config/optional_imports/protocols.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from crewai.rag.chromadb.config import ChromaDBConfig
     from crewai.rag.qdrant.client import QdrantClient
     from crewai.rag.qdrant.config import QdrantConfig
+    from crewai.rag.turbopuffer.client import TurbopufferClient
+    from crewai.rag.turbopuffer.config import TurbopufferConfig
 
 
 class ChromaFactoryModule(Protocol):
@@ -25,4 +27,12 @@ class QdrantFactoryModule(Protocol):
 
     def create_client(self, config: QdrantConfig) -> QdrantClient:
         """Creates a Qdrant client from configuration."""
+        ...
+
+
+class TurbopufferFactoryModule(Protocol):
+    """Protocol for turbopuffer factory module."""
+
+    def create_client(self, config: TurbopufferConfig) -> TurbopufferClient:
+        """Creates a turbopuffer client from configuration."""
         ...

--- a/lib/crewai/src/crewai/rag/config/optional_imports/providers.py
+++ b/lib/crewai/src/crewai/rag/config/optional_imports/providers.py
@@ -21,3 +21,10 @@ class MissingQdrantConfig(_MissingProvider):
     """Placeholder for missing Qdrant configuration."""
 
     provider: Literal["qdrant"] = field(default="qdrant")
+
+
+@pyd_dataclass(config=ConfigDict(extra="forbid"))
+class MissingTurbopufferConfig(_MissingProvider):
+    """Placeholder for missing turbopuffer configuration."""
+
+    provider: Literal["turbopuffer"] = field(default="turbopuffer")

--- a/lib/crewai/src/crewai/rag/config/optional_imports/types.py
+++ b/lib/crewai/src/crewai/rag/config/optional_imports/types.py
@@ -4,6 +4,6 @@ from typing import Annotated, Literal
 
 
 SupportedProvider = Annotated[
-    Literal["chromadb", "qdrant"],
+    Literal["chromadb", "qdrant", "turbopuffer"],
     "Supported RAG provider types, add providers here as they become available",
 ]

--- a/lib/crewai/src/crewai/rag/config/types.py
+++ b/lib/crewai/src/crewai/rag/config/types.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from crewai.rag.qdrant.config import QdrantConfig as QdrantConfig_
 
     QdrantConfig = QdrantConfig_
+    from crewai.rag.turbopuffer.config import TurbopufferConfig as TurbopufferConfig_
+
+    TurbopufferConfig = TurbopufferConfig_
 else:
     try:
         from crewai.rag.chromadb.config import ChromaDBConfig
@@ -30,7 +33,14 @@ else:
             MissingQdrantConfig as QdrantConfig,
         )
 
-SupportedProviderConfig: TypeAlias = ChromaDBConfig | QdrantConfig
+    try:
+        from crewai.rag.turbopuffer.config import TurbopufferConfig
+    except ImportError:
+        from crewai.rag.config.optional_imports.providers import (
+            MissingTurbopufferConfig as TurbopufferConfig,
+        )
+
+SupportedProviderConfig: TypeAlias = ChromaDBConfig | QdrantConfig | TurbopufferConfig
 RagConfigType: TypeAlias = Annotated[
     SupportedProviderConfig, Field(discriminator=DISCRIMINATOR)
 ]

--- a/lib/crewai/src/crewai/rag/factory.py
+++ b/lib/crewai/src/crewai/rag/factory.py
@@ -6,6 +6,7 @@ from typing import cast
 from crewai.rag.config.optional_imports.protocols import (
     ChromaFactoryModule,
     QdrantFactoryModule,
+    TurbopufferFactoryModule,
 )
 from crewai.rag.config.types import RagConfigType
 from crewai.rag.core.base_client import BaseClient
@@ -74,5 +75,15 @@ def create_client(config: RagConfigType) -> BaseClient:
             ),
         )
         return qdrant_mod.create_client(config)
+
+    if config.provider == "turbopuffer":
+        tpuf_mod = cast(
+            TurbopufferFactoryModule,
+            require(
+                "crewai.rag.turbopuffer.factory",
+                purpose="The 'turbopuffer' provider",
+            ),
+        )
+        return tpuf_mod.create_client(config)
 
     raise ValueError(f"Unsupported provider: {config.provider}")

--- a/lib/crewai/src/crewai/rag/turbopuffer/__init__.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/__init__.py
@@ -1,0 +1,1 @@
+"""turbopuffer vector database client implementation."""

--- a/lib/crewai/src/crewai/rag/turbopuffer/client.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/client.py
@@ -1,0 +1,462 @@
+"""turbopuffer client implementation."""
+
+from typing import Any, cast
+
+from turbopuffer import omit
+from typing_extensions import Unpack
+
+from crewai.rag.core.base_client import (
+    BaseClient,
+    BaseCollectionAddParams,
+    BaseCollectionParams,
+    BaseCollectionSearchParams,
+)
+from crewai.rag.core.exceptions import ClientMethodMismatchError
+from crewai.rag.turbopuffer.constants import DistanceMetric
+from crewai.rag.turbopuffer.types import (
+    AsyncEmbeddingFunction,
+    EmbeddingFunction,
+    TurbopufferClientType,
+)
+from crewai.rag.turbopuffer.utils import (
+    _build_metadata_filter,
+    _build_upsert_row,
+    _is_async_client,
+    _is_async_embedding_function,
+    _is_sync_client,
+    _process_search_results,
+    _validate_namespace_name,
+)
+from crewai.rag.types import SearchResult
+
+
+class TurbopufferClient(BaseClient):
+    """turbopuffer implementation of the BaseClient protocol.
+
+    Provides vector database operations for turbopuffer, supporting both
+    synchronous and asynchronous clients.
+
+    Attributes:
+        client: turbopuffer client instance (Turbopuffer or AsyncTurbopuffer).
+        embedding_function: Function to generate embeddings for documents.
+        default_limit: Default number of results to return in searches.
+        default_score_threshold: Default minimum score for search results.
+        distance_metric: Distance metric for similarity search.
+    """
+
+    def __init__(
+        self,
+        client: TurbopufferClientType,
+        embedding_function: EmbeddingFunction | AsyncEmbeddingFunction,
+        default_limit: int = 5,
+        default_score_threshold: float = 0.6,
+        default_batch_size: int = 100,
+        distance_metric: DistanceMetric = "cosine_distance",
+    ) -> None:
+        """Initialize TurbopufferClient with client and embedding function.
+
+        Args:
+            client: Pre-configured turbopuffer client instance.
+            embedding_function: Embedding function for text to vector conversion.
+            default_limit: Default number of results to return in searches.
+            default_score_threshold: Default minimum score for search results.
+            default_batch_size: Default batch size for adding documents.
+            distance_metric: Distance metric for similarity search.
+        """
+        self.client = client
+        self.embedding_function = embedding_function
+        self.default_limit = default_limit
+        self.default_score_threshold = default_score_threshold
+        self.default_batch_size = default_batch_size
+        self.distance_metric = distance_metric
+
+    def create_collection(self, **kwargs: Unpack[BaseCollectionParams]) -> None:
+        """Create a new collection (namespace) in turbopuffer.
+
+        turbopuffer namespaces are created lazily on first write, so this
+        method only validates the namespace name format.
+
+        Keyword Args:
+            collection_name: Name of the namespace to create.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+            ValueError: If namespace name is invalid.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="create_collection",
+                expected_client="Turbopuffer",
+                alt_method="acreate_collection",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        _validate_namespace_name(collection_name)
+
+    async def acreate_collection(self, **kwargs: Unpack[BaseCollectionParams]) -> None:
+        """Create a new collection (namespace) in turbopuffer asynchronously.
+
+        Keyword Args:
+            collection_name: Name of the namespace to create.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+            ValueError: If namespace name is invalid.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="acreate_collection",
+                expected_client="AsyncTurbopuffer",
+                alt_method="create_collection",
+                alt_client="Turbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        _validate_namespace_name(collection_name)
+
+    def get_or_create_collection(
+        self, **kwargs: Unpack[BaseCollectionParams]
+    ) -> Any:
+        """Get an existing namespace or prepare it for creation.
+
+        turbopuffer namespaces are created lazily, so this validates
+        the name and returns the namespace name.
+
+        Keyword Args:
+            collection_name: Name of the namespace.
+
+        Returns:
+            The namespace name string.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+            ValueError: If namespace name is invalid.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="get_or_create_collection",
+                expected_client="Turbopuffer",
+                alt_method="aget_or_create_collection",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        _validate_namespace_name(collection_name)
+        return collection_name
+
+    async def aget_or_create_collection(
+        self, **kwargs: Unpack[BaseCollectionParams]
+    ) -> Any:
+        """Get an existing namespace or prepare it for creation asynchronously.
+
+        Keyword Args:
+            collection_name: Name of the namespace.
+
+        Returns:
+            The namespace name string.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+            ValueError: If namespace name is invalid.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="aget_or_create_collection",
+                expected_client="AsyncTurbopuffer",
+                alt_method="get_or_create_collection",
+                alt_client="Turbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        _validate_namespace_name(collection_name)
+        return collection_name
+
+    def add_documents(self, **kwargs: Unpack[BaseCollectionAddParams]) -> None:
+        """Add documents with their embeddings to a namespace.
+
+        Keyword Args:
+            collection_name: The namespace to add documents to.
+            documents: List of BaseRecord dicts containing document data.
+            batch_size: Optional batch size for processing documents.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+            ValueError: If documents list is empty.
+            TypeError: If async embedding function used with sync method.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="add_documents",
+                expected_client="Turbopuffer",
+                alt_method="aadd_documents",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        documents = kwargs["documents"]
+        batch_size = kwargs.get("batch_size", self.default_batch_size)
+
+        if not documents:
+            raise ValueError("Documents list cannot be empty")
+
+        if _is_async_embedding_function(self.embedding_function):
+            raise TypeError(
+                "Async embedding function cannot be used with sync add_documents. "
+                "Use aadd_documents instead."
+            )
+        sync_fn = cast(EmbeddingFunction, self.embedding_function)
+
+        ns = self.client.namespace(collection_name)
+
+        for i in range(0, len(documents), batch_size):
+            batch_docs = documents[i : min(i + batch_size, len(documents))]
+            upsert_rows = []
+            for doc in batch_docs:
+                embedding = sync_fn(doc["content"])
+                row = _build_upsert_row(doc, embedding)
+                upsert_rows.append(row)
+            ns.write(
+                upsert_rows=upsert_rows,
+                distance_metric=self.distance_metric,
+            )
+
+    async def aadd_documents(self, **kwargs: Unpack[BaseCollectionAddParams]) -> None:
+        """Add documents with their embeddings to a namespace asynchronously.
+
+        Keyword Args:
+            collection_name: The namespace to add documents to.
+            documents: List of BaseRecord dicts containing document data.
+            batch_size: Optional batch size for processing documents.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+            ValueError: If documents list is empty.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="aadd_documents",
+                expected_client="AsyncTurbopuffer",
+                alt_method="add_documents",
+                alt_client="Turbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        documents = kwargs["documents"]
+        batch_size = kwargs.get("batch_size", self.default_batch_size)
+
+        if not documents:
+            raise ValueError("Documents list cannot be empty")
+
+        ns = self.client.namespace(collection_name)
+
+        for i in range(0, len(documents), batch_size):
+            batch_docs = documents[i : min(i + batch_size, len(documents))]
+            upsert_rows = []
+            for doc in batch_docs:
+                if _is_async_embedding_function(self.embedding_function):
+                    async_fn = cast(AsyncEmbeddingFunction, self.embedding_function)
+                    embedding = await async_fn(doc["content"])
+                else:
+                    sync_fn = cast(EmbeddingFunction, self.embedding_function)
+                    embedding = sync_fn(doc["content"])
+                row = _build_upsert_row(doc, embedding)
+                upsert_rows.append(row)
+            await ns.write(
+                upsert_rows=upsert_rows,
+                distance_metric=self.distance_metric,
+            )
+
+    def search(
+        self, **kwargs: Unpack[BaseCollectionSearchParams]
+    ) -> list[SearchResult]:
+        """Search for similar documents using a query.
+
+        Keyword Args:
+            collection_name: Name of the namespace to search in.
+            query: The text query to search for.
+            limit: Maximum number of results to return.
+            metadata_filter: Optional filter for metadata fields.
+            score_threshold: Optional minimum similarity score (0-1).
+
+        Returns:
+            List of SearchResult dicts containing id, content, metadata, and score.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+            TypeError: If async embedding function used with sync method.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="search",
+                expected_client="Turbopuffer",
+                alt_method="asearch",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        query = kwargs["query"]
+        limit = kwargs.get("limit", self.default_limit)
+        metadata_filter = kwargs.get("metadata_filter")
+        score_threshold = kwargs.get("score_threshold", self.default_score_threshold)
+
+        if _is_async_embedding_function(self.embedding_function):
+            raise TypeError(
+                "Async embedding function cannot be used with sync search. "
+                "Use asearch instead."
+            )
+        sync_fn = cast(EmbeddingFunction, self.embedding_function)
+        query_embedding = sync_fn(query)
+
+        ns = self.client.namespace(collection_name)
+
+        query_kwargs: dict[str, Any] = {
+            "rank_by": ("vector", "ANN", query_embedding),
+            "top_k": limit,
+            "exclude_attributes": ["vector"],
+        }
+
+        if metadata_filter:
+            query_kwargs["filters"] = _build_metadata_filter(metadata_filter)
+        else:
+            query_kwargs["filters"] = omit
+
+        result = ns.query(**query_kwargs)
+        return _process_search_results(
+            result.rows or [],
+            score_threshold=score_threshold,
+        )
+
+    async def asearch(
+        self, **kwargs: Unpack[BaseCollectionSearchParams]
+    ) -> list[SearchResult]:
+        """Search for similar documents using a query asynchronously.
+
+        Keyword Args:
+            collection_name: Name of the namespace to search in.
+            query: The text query to search for.
+            limit: Maximum number of results to return.
+            metadata_filter: Optional filter for metadata fields.
+            score_threshold: Optional minimum similarity score (0-1).
+
+        Returns:
+            List of SearchResult dicts containing id, content, metadata, and score.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="asearch",
+                expected_client="AsyncTurbopuffer",
+                alt_method="search",
+                alt_client="Turbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        query = kwargs["query"]
+        limit = kwargs.get("limit", self.default_limit)
+        metadata_filter = kwargs.get("metadata_filter")
+        score_threshold = kwargs.get("score_threshold", self.default_score_threshold)
+
+        if _is_async_embedding_function(self.embedding_function):
+            async_fn = cast(AsyncEmbeddingFunction, self.embedding_function)
+            query_embedding = await async_fn(query)
+        else:
+            sync_fn = cast(EmbeddingFunction, self.embedding_function)
+            query_embedding = sync_fn(query)
+
+        ns = self.client.namespace(collection_name)
+
+        query_kwargs: dict[str, Any] = {
+            "rank_by": ("vector", "ANN", query_embedding),
+            "top_k": limit,
+            "exclude_attributes": ["vector"],
+        }
+
+        if metadata_filter:
+            query_kwargs["filters"] = _build_metadata_filter(metadata_filter)
+        else:
+            query_kwargs["filters"] = omit
+
+        result = await ns.query(**query_kwargs)
+        return _process_search_results(
+            result.rows or [],
+            score_threshold=score_threshold,
+        )
+
+    def delete_collection(self, **kwargs: Unpack[BaseCollectionParams]) -> None:
+        """Delete a namespace and all its data.
+
+        Keyword Args:
+            collection_name: Name of the namespace to delete.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="delete_collection",
+                expected_client="Turbopuffer",
+                alt_method="adelete_collection",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        ns = self.client.namespace(collection_name)
+        ns.delete_all()
+
+    async def adelete_collection(self, **kwargs: Unpack[BaseCollectionParams]) -> None:
+        """Delete a namespace and all its data asynchronously.
+
+        Keyword Args:
+            collection_name: Name of the namespace to delete.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="adelete_collection",
+                expected_client="AsyncTurbopuffer",
+                alt_method="delete_collection",
+                alt_client="Turbopuffer",
+            )
+
+        collection_name = kwargs["collection_name"]
+        ns = self.client.namespace(collection_name)
+        await ns.delete_all()
+
+    def reset(self) -> None:
+        """Reset by deleting all namespaces.
+
+        Raises:
+            ClientMethodMismatchError: If called with an async client.
+        """
+        if not _is_sync_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="reset",
+                expected_client="Turbopuffer",
+                alt_method="areset",
+                alt_client="AsyncTurbopuffer",
+            )
+
+        for ns in self.client.namespaces():
+            self.client.namespace(ns.id).delete_all()
+
+    async def areset(self) -> None:
+        """Reset by deleting all namespaces asynchronously.
+
+        Raises:
+            ClientMethodMismatchError: If called with a sync client.
+        """
+        if not _is_async_client(self.client):
+            raise ClientMethodMismatchError(
+                method_name="areset",
+                expected_client="AsyncTurbopuffer",
+                alt_method="reset",
+                alt_client="Turbopuffer",
+            )
+
+        async for ns in self.client.namespaces():
+            await self.client.namespace(ns.id).delete_all()

--- a/lib/crewai/src/crewai/rag/turbopuffer/config.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/config.py
@@ -1,0 +1,78 @@
+"""turbopuffer configuration model."""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import Any, Literal, cast
+
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+from crewai.rag.config.base import BaseRagConfig
+from crewai.rag.turbopuffer.constants import (
+    DEFAULT_DISTANCE_METRIC,
+    DEFAULT_EMBEDDING_MODEL,
+    DistanceMetric,
+)
+from crewai.rag.turbopuffer.types import (
+    TurbopufferClientWrapper,
+    TurbopufferEmbeddingFunctionWrapper,
+)
+
+
+def _default_embedding_function() -> TurbopufferEmbeddingFunctionWrapper:
+    """Build the default embedder: fastembed all-MiniLM-L6-v2, loaded lazily on
+    first use so config construction never triggers a model download.
+
+    Returns:
+        Embedding function that returns a vector for a single string.
+    """
+    model: Any = None
+
+    def embed_fn(text: str) -> list[float]:
+        """Embed a single text string, loading the model on first use.
+
+        Args:
+            text: Text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        nonlocal model
+        if model is None:
+            try:
+                from fastembed import TextEmbedding
+            except ImportError as e:
+                raise ImportError(
+                    "The default turbopuffer embedder requires 'fastembed'. "
+                    "Install it with `pip install 'crewai[turbopuffer]'`, or pass "
+                    "your own embedding_function to TurbopufferConfig."
+                ) from e
+            model = TextEmbedding(model_name=DEFAULT_EMBEDDING_MODEL)
+        embeddings = list(model.embed([text]))
+        return embeddings[0].tolist() if embeddings else []
+
+    return cast(TurbopufferEmbeddingFunctionWrapper, embed_fn)
+
+
+@pyd_dataclass(frozen=True)
+class TurbopufferConfig(BaseRagConfig):
+    """Configuration for turbopuffer client.
+
+    The user must provide a pre-configured turbopuffer client instance
+    with the desired region and API key already set.
+    """
+
+    provider: Literal["turbopuffer"] = field(default="turbopuffer", init=False)
+    client: TurbopufferClientWrapper | None = field(default=None)
+    embedding_function: TurbopufferEmbeddingFunctionWrapper = field(
+        default_factory=_default_embedding_function
+    )
+    distance_metric: DistanceMetric = field(default=DEFAULT_DISTANCE_METRIC)
+
+    def __post_init__(self) -> None:
+        """Validate that client was provided."""
+        if self.client is None:
+            raise ValueError(
+                "A pre-configured turbopuffer client instance is required. "
+                "Example: TurbopufferConfig(client=Turbopuffer(region='gcp-us-central1'))"
+            )

--- a/lib/crewai/src/crewai/rag/turbopuffer/constants.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/constants.py
@@ -1,0 +1,12 @@
+"""Constants for turbopuffer implementation."""
+
+import re
+from typing import Final, Literal
+
+
+DistanceMetric = Literal["cosine_distance"]
+
+DEFAULT_DISTANCE_METRIC: Final[DistanceMetric] = "cosine_distance"
+DEFAULT_EMBEDDING_MODEL: Final[str] = "sentence-transformers/all-MiniLM-L6-v2"
+NAMESPACE_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9\-_.]{1,128}$")
+CONTENT_KEY: Final[str] = "content"

--- a/lib/crewai/src/crewai/rag/turbopuffer/factory.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/factory.py
@@ -1,0 +1,24 @@
+"""Factory functions for creating turbopuffer clients from configuration."""
+
+from crewai.rag.turbopuffer.client import TurbopufferClient
+from crewai.rag.turbopuffer.config import TurbopufferConfig
+
+
+def create_client(config: TurbopufferConfig) -> TurbopufferClient:
+    """Create a turbopuffer client from configuration.
+
+    Args:
+        config: The turbopuffer configuration containing a pre-configured
+            turbopuffer client instance.
+
+    Returns:
+        A configured TurbopufferClient instance.
+    """
+    return TurbopufferClient(
+        client=config.client,
+        embedding_function=config.embedding_function,
+        default_limit=config.limit,
+        default_score_threshold=config.score_threshold,
+        default_batch_size=config.batch_size,
+        distance_metric=config.distance_metric,
+    )

--- a/lib/crewai/src/crewai/rag/turbopuffer/types.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/types.py
@@ -1,0 +1,62 @@
+"""Type definitions specific to turbopuffer implementation."""
+
+from typing import Any, Protocol, TypeAlias
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import CoreSchema, core_schema
+from turbopuffer import AsyncTurbopuffer, Turbopuffer
+
+
+TurbopufferClientType: TypeAlias = Turbopuffer | AsyncTurbopuffer
+
+
+class EmbeddingFunction(Protocol):
+    """Protocol for embedding functions that convert text to vectors."""
+
+    def __call__(self, text: str) -> list[float]:
+        """Convert text to embedding vector.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        ...
+
+
+class AsyncEmbeddingFunction(Protocol):
+    """Protocol for async embedding functions that convert text to vectors."""
+
+    async def __call__(self, text: str) -> list[float]:
+        """Convert text to embedding vector asynchronously.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        ...
+
+
+class TurbopufferEmbeddingFunctionWrapper:
+    """Pydantic-compatible wrapper for turbopuffer embedding functions."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        """Generate Pydantic core schema for turbopuffer EmbeddingFunction."""
+        return core_schema.any_schema()
+
+
+class TurbopufferClientWrapper:
+    """Pydantic-compatible wrapper for turbopuffer client instances."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        """Generate Pydantic core schema for turbopuffer client."""
+        return core_schema.any_schema()

--- a/lib/crewai/src/crewai/rag/turbopuffer/utils.py
+++ b/lib/crewai/src/crewai/rag/turbopuffer/utils.py
@@ -1,0 +1,179 @@
+"""Utility functions for turbopuffer operations."""
+
+import asyncio
+from typing import Any, TypeGuard
+from uuid import uuid4
+
+from turbopuffer import AsyncTurbopuffer, Turbopuffer
+
+from crewai.rag.turbopuffer.constants import (
+    CONTENT_KEY,
+    NAMESPACE_PATTERN,
+)
+from crewai.rag.turbopuffer.types import (
+    AsyncEmbeddingFunction,
+    EmbeddingFunction,
+    TurbopufferClientType,
+)
+from crewai.rag.types import BaseRecord, SearchResult
+
+
+def _is_sync_client(client: TurbopufferClientType) -> TypeGuard[Turbopuffer]:
+    """Type guard to check if the client is a synchronous Turbopuffer client.
+
+    Args:
+        client: The client to check.
+
+    Returns:
+        True if the client is a Turbopuffer (sync), False otherwise.
+    """
+    return isinstance(client, Turbopuffer)
+
+
+def _is_async_client(client: TurbopufferClientType) -> TypeGuard[AsyncTurbopuffer]:
+    """Type guard to check if the client is an asynchronous AsyncTurbopuffer client.
+
+    Args:
+        client: The client to check.
+
+    Returns:
+        True if the client is an AsyncTurbopuffer, False otherwise.
+    """
+    return isinstance(client, AsyncTurbopuffer)
+
+
+def _is_async_embedding_function(
+    func: EmbeddingFunction | AsyncEmbeddingFunction,
+) -> TypeGuard[AsyncEmbeddingFunction]:
+    """Type guard to check if the embedding function is async.
+
+    Args:
+        func: The embedding function to check.
+
+    Returns:
+        True if the function is async, False otherwise.
+    """
+    return asyncio.iscoroutinefunction(func)
+
+
+def _validate_namespace_name(name: str) -> None:
+    """Validate that a namespace name matches turbopuffer's constraints.
+
+    Args:
+        name: The namespace name to validate.
+
+    Raises:
+        ValueError: If the name doesn't match the pattern [A-Za-z0-9-_.]{1,128}.
+    """
+    if not NAMESPACE_PATTERN.match(name):
+        raise ValueError(
+            f"Invalid namespace name '{name}'. "
+            "Must match pattern [A-Za-z0-9-_.] and be 1-128 characters."
+        )
+
+
+def _build_upsert_row(doc: BaseRecord, embedding: list[float]) -> dict[str, Any]:
+    """Convert a BaseRecord and its embedding into a turbopuffer upsert row.
+
+    Args:
+        doc: Document dictionary containing content, metadata, and optional doc_id.
+        embedding: The embedding vector for the document content.
+
+    Returns:
+        Dictionary ready to be passed to turbopuffer's write() as an upsert row.
+    """
+    doc_id = doc.get("doc_id", str(uuid4()))
+
+    row: dict[str, Any] = {
+        "id": doc_id,
+        "vector": embedding,
+        CONTENT_KEY: doc["content"],
+    }
+
+    metadata = doc.get("metadata", {})
+    if isinstance(metadata, list):
+        metadata = metadata[0] if metadata else {}
+    elif not isinstance(metadata, dict):
+        metadata = dict(metadata) if metadata else {}
+
+    row.update(metadata)
+
+    return row
+
+
+def _normalize_turbopuffer_score(dist: float) -> float:
+    """Normalize a turbopuffer cosine distance to a [0, 1] similarity score.
+
+    Args:
+        dist: Raw cosine distance from turbopuffer (range [0, 2], lower is closer).
+
+    Returns:
+        Similarity score in [0, 1] where 1 is most similar.
+    """
+    # cosine_distance range is [0, 2]
+    return max(0.0, min(1.0, 1.0 - (dist / 2.0)))
+
+
+def _process_search_results(
+    rows: list[Any],
+    score_threshold: float | None = None,
+) -> list[SearchResult]:
+    """Process turbopuffer query result rows into SearchResult format.
+
+    Args:
+        rows: Result rows from turbopuffer query.
+        score_threshold: Optional minimum score to include in results.
+
+    Returns:
+        List of SearchResult dictionaries.
+    """
+    results: list[SearchResult] = []
+    for row in rows:
+        row_dict: dict[str, Any] = (
+            row.to_dict() if hasattr(row, "to_dict") else dict(row)
+        )
+
+        dist = row_dict.get("$dist", 0.0)
+        score = _normalize_turbopuffer_score(dist)
+
+        if score_threshold is not None and score < score_threshold:
+            continue
+
+        doc_id = str(row_dict.get("id", ""))
+        content = str(row_dict.get(CONTENT_KEY, ""))
+
+        skip_keys = {"id", "vector", CONTENT_KEY, "$dist"}
+        metadata: dict[str, Any] = {
+            key: value for key, value in row_dict.items() if key not in skip_keys
+        }
+
+        result: SearchResult = {
+            "id": doc_id,
+            "content": content,
+            "metadata": metadata,
+            "score": score,
+        }
+        results.append(result)
+
+    return results
+
+
+def _build_metadata_filter(
+    metadata_filter: dict[str, Any],
+) -> tuple[str, str, Any] | tuple[str, list[tuple[str, str, Any]]]:
+    """Convert a crewAI metadata filter dict to turbopuffer filter format.
+
+    Args:
+        metadata_filter: Dictionary of key-value pairs to filter on.
+
+    Returns:
+        Single condition tuple for one filter, or ("And", [...]) for multiple.
+    """
+    conditions = []
+    for key, value in metadata_filter.items():
+        conditions.append((key, "Eq", value))
+
+    if len(conditions) == 1:
+        return conditions[0]
+
+    return ("And", conditions)

--- a/lib/crewai/tests/rag/turbopuffer/test_client.py
+++ b/lib/crewai/tests/rag/turbopuffer/test_client.py
@@ -1,0 +1,605 @@
+"""Tests for TurbopufferClient implementation."""
+
+from unittest.mock import AsyncMock, Mock, MagicMock
+
+import pytest
+from crewai.rag.core.exceptions import ClientMethodMismatchError
+from crewai.rag.turbopuffer.client import TurbopufferClient
+from crewai.rag.types import BaseRecord
+from turbopuffer import AsyncTurbopuffer, Turbopuffer
+
+
+@pytest.fixture
+def mock_turbopuffer_client():
+    """Create a mock turbopuffer client."""
+    client = Mock(spec=Turbopuffer)
+    mock_ns = Mock()
+    client.namespace.return_value = mock_ns
+    return client
+
+
+@pytest.fixture
+def mock_async_turbopuffer_client():
+    """Create a mock async turbopuffer client."""
+    client = Mock(spec=AsyncTurbopuffer)
+    mock_ns = Mock()
+    client.namespace.return_value = mock_ns
+    return client
+
+
+@pytest.fixture
+def client(mock_turbopuffer_client) -> TurbopufferClient:
+    """Create a TurbopufferClient instance for testing."""
+    mock_embedding = Mock()
+    mock_embedding.return_value = [0.1, 0.2, 0.3]
+    return TurbopufferClient(
+        client=mock_turbopuffer_client, embedding_function=mock_embedding
+    )
+
+
+@pytest.fixture
+def async_client(mock_async_turbopuffer_client) -> TurbopufferClient:
+    """Create a TurbopufferClient instance with async client for testing."""
+    mock_embedding = Mock()
+    mock_embedding.return_value = [0.1, 0.2, 0.3]
+    return TurbopufferClient(
+        client=mock_async_turbopuffer_client, embedding_function=mock_embedding
+    )
+
+
+class TestTurbopufferClient:
+    """Test suite for TurbopufferClient."""
+
+    def test_create_collection(self, client, mock_turbopuffer_client):
+        """Test that create_collection validates name without SDK calls."""
+        client.create_collection(collection_name="test_collection")
+        # turbopuffer auto-creates namespaces, so no SDK call expected
+        mock_turbopuffer_client.namespace.assert_not_called()
+
+    def test_create_collection_invalid_name(self, client):
+        """Test that create_collection raises error for invalid names."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            client.create_collection(collection_name="invalid name with spaces!")
+
+    def test_create_collection_wrong_client_type(self, mock_async_turbopuffer_client):
+        """Test that create_collection raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method create_collection\(\) requires",
+        ):
+            client.create_collection(collection_name="test_collection")
+
+    @pytest.mark.asyncio
+    async def test_acreate_collection(self, async_client, mock_async_turbopuffer_client):
+        """Test that acreate_collection validates name asynchronously."""
+        await async_client.acreate_collection(collection_name="test_collection")
+        mock_async_turbopuffer_client.namespace.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_acreate_collection_invalid_name(self, async_client):
+        """Test that acreate_collection raises error for invalid names."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            await async_client.acreate_collection(
+                collection_name="invalid name with spaces!"
+            )
+
+    @pytest.mark.asyncio
+    async def test_acreate_collection_wrong_client_type(self, mock_turbopuffer_client):
+        """Test that acreate_collection raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method acreate_collection\(\) requires",
+        ):
+            await client.acreate_collection(collection_name="test_collection")
+
+    def test_get_or_create_collection(self, client, mock_turbopuffer_client):
+        """Test get_or_create_collection returns namespace name."""
+        result = client.get_or_create_collection(collection_name="test_collection")
+        assert result == "test_collection"
+        mock_turbopuffer_client.namespace.assert_not_called()
+
+    def test_get_or_create_collection_invalid_name(self, client):
+        """Test get_or_create_collection raises error for invalid names."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            client.get_or_create_collection(collection_name="bad name!!")
+
+    def test_get_or_create_collection_wrong_client_type(
+        self, mock_async_turbopuffer_client
+    ):
+        """Test get_or_create_collection raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method get_or_create_collection\(\) requires",
+        ):
+            client.get_or_create_collection(collection_name="test_collection")
+
+    @pytest.mark.asyncio
+    async def test_aget_or_create_collection(
+        self, async_client, mock_async_turbopuffer_client
+    ):
+        """Test aget_or_create_collection returns namespace name."""
+        result = await async_client.aget_or_create_collection(
+            collection_name="test_collection"
+        )
+        assert result == "test_collection"
+        mock_async_turbopuffer_client.namespace.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_aget_or_create_collection_wrong_client_type(
+        self, mock_turbopuffer_client
+    ):
+        """Test aget_or_create_collection raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method aget_or_create_collection\(\) requires",
+        ):
+            await client.aget_or_create_collection(collection_name="test_collection")
+
+    def test_add_documents(self, client, mock_turbopuffer_client):
+        """Test that add_documents writes documents to namespace."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        documents: list[BaseRecord] = [
+            {
+                "content": "Test document",
+                "metadata": {"source": "test"},
+            }
+        ]
+
+        client.add_documents(collection_name="test_collection", documents=documents)
+
+        mock_turbopuffer_client.namespace.assert_called_once_with("test_collection")
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.write.assert_called_once()
+
+        call_args = mock_ns.write.call_args
+        upsert_rows = call_args.kwargs["upsert_rows"]
+        assert len(upsert_rows) == 1
+        assert upsert_rows[0]["vector"] == [0.1, 0.2, 0.3]
+        assert upsert_rows[0]["content"] == "Test document"
+        assert upsert_rows[0]["source"] == "test"
+        assert call_args.kwargs["distance_metric"] == "cosine_distance"
+
+    def test_add_documents_with_doc_id(self, client, mock_turbopuffer_client):
+        """Test that add_documents uses provided doc_id."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        documents: list[BaseRecord] = [
+            {
+                "doc_id": "custom-id-123",
+                "content": "Test document",
+                "metadata": {"source": "test"},
+            }
+        ]
+
+        client.add_documents(collection_name="test_collection", documents=documents)
+
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        call_args = mock_ns.write.call_args
+        upsert_rows = call_args.kwargs["upsert_rows"]
+        assert upsert_rows[0]["id"] == "custom-id-123"
+
+    def test_add_documents_empty_list(self, client):
+        """Test that add_documents raises error for empty documents list."""
+        documents: list[BaseRecord] = []
+
+        with pytest.raises(ValueError, match="Documents list cannot be empty"):
+            client.add_documents(
+                collection_name="test_collection", documents=documents
+            )
+
+    def test_add_documents_batching(self, client, mock_turbopuffer_client):
+        """Test that add_documents batches documents correctly."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+        client.default_batch_size = 2
+
+        documents: list[BaseRecord] = [
+            {"content": f"Document {i}", "metadata": {"idx": i}} for i in range(5)
+        ]
+
+        client.add_documents(collection_name="test_collection", documents=documents)
+
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        assert mock_ns.write.call_count == 3  # 2 + 2 + 1
+
+    def test_add_documents_wrong_client_type(self, mock_async_turbopuffer_client):
+        """Test that add_documents raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        documents: list[BaseRecord] = [
+            {"content": "Test document", "metadata": {"source": "test"}}
+        ]
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method add_documents\(\) requires"
+        ):
+            client.add_documents(
+                collection_name="test_collection", documents=documents
+            )
+
+    @pytest.mark.asyncio
+    async def test_aadd_documents(self, async_client, mock_async_turbopuffer_client):
+        """Test that aadd_documents writes documents asynchronously."""
+        mock_ns = mock_async_turbopuffer_client.namespace.return_value
+        mock_ns.write = AsyncMock()
+        async_client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        documents: list[BaseRecord] = [
+            {
+                "content": "Test document",
+                "metadata": {"source": "test"},
+            }
+        ]
+
+        await async_client.aadd_documents(
+            collection_name="test_collection", documents=documents
+        )
+
+        mock_async_turbopuffer_client.namespace.assert_called_once_with(
+            "test_collection"
+        )
+        mock_ns.write.assert_called_once()
+
+        call_args = mock_ns.write.call_args
+        upsert_rows = call_args.kwargs["upsert_rows"]
+        assert len(upsert_rows) == 1
+        assert upsert_rows[0]["vector"] == [0.1, 0.2, 0.3]
+        assert upsert_rows[0]["content"] == "Test document"
+        assert upsert_rows[0]["source"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_aadd_documents_empty_list(self, async_client):
+        """Test that aadd_documents raises error for empty documents list."""
+        documents: list[BaseRecord] = []
+
+        with pytest.raises(ValueError, match="Documents list cannot be empty"):
+            await async_client.aadd_documents(
+                collection_name="test_collection", documents=documents
+            )
+
+    @pytest.mark.asyncio
+    async def test_aadd_documents_wrong_client_type(self, mock_turbopuffer_client):
+        """Test that aadd_documents raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        documents: list[BaseRecord] = [
+            {"content": "Test document", "metadata": {"source": "test"}}
+        ]
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method aadd_documents\(\) requires"
+        ):
+            await client.aadd_documents(
+                collection_name="test_collection", documents=documents
+            )
+
+    def test_search(self, client, mock_turbopuffer_client):
+        """Test that search returns matching documents."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        mock_row = MagicMock()
+        mock_row.to_dict.return_value = {
+            "id": "doc-123",
+            "content": "Test content",
+            "source": "test",
+            "$dist": 0.1,
+        }
+
+        mock_result = Mock()
+        mock_result.rows = [mock_row]
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.query.return_value = mock_result
+
+        results = client.search(
+            collection_name="test_collection", query="test query"
+        )
+
+        mock_turbopuffer_client.namespace.assert_called_once_with("test_collection")
+        client.embedding_function.assert_called_once_with("test query")
+        mock_ns.query.assert_called_once()
+
+        call_args = mock_ns.query.call_args
+        assert call_args.kwargs["rank_by"] == ("vector", "ANN", [0.1, 0.2, 0.3])
+        assert call_args.kwargs["top_k"] == 5
+        assert call_args.kwargs["exclude_attributes"] == ["vector"]
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc-123"
+        assert results[0]["content"] == "Test content"
+        assert results[0]["metadata"] == {"source": "test"}
+        assert results[0]["score"] == pytest.approx(0.95)
+
+    def test_search_with_metadata_filter(self, client, mock_turbopuffer_client):
+        """Test that search applies metadata filters correctly."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        mock_result = Mock()
+        mock_result.rows = []
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.query.return_value = mock_result
+
+        client.search(
+            collection_name="test_collection",
+            query="test query",
+            metadata_filter={"category": "tech"},
+        )
+
+        call_args = mock_ns.query.call_args
+        assert call_args.kwargs["filters"] == ("category", "Eq", "tech")
+
+    def test_search_with_multiple_metadata_filters(
+        self, client, mock_turbopuffer_client
+    ):
+        """Test that search converts multiple metadata filters to And clause."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        mock_result = Mock()
+        mock_result.rows = []
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.query.return_value = mock_result
+
+        client.search(
+            collection_name="test_collection",
+            query="test query",
+            metadata_filter={"category": "tech", "status": "published"},
+        )
+
+        call_args = mock_ns.query.call_args
+        filters = call_args.kwargs["filters"]
+        assert filters[0] == "And"
+        assert len(filters[1]) == 2
+
+    def test_search_with_score_threshold(self, client, mock_turbopuffer_client):
+        """Test that search filters results by score threshold."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        # One result above threshold, one below
+        mock_row_good = MagicMock()
+        mock_row_good.to_dict.return_value = {
+            "id": "doc-1",
+            "content": "Good match",
+            "$dist": 0.1,  # score = 0.95
+        }
+        mock_row_bad = MagicMock()
+        mock_row_bad.to_dict.return_value = {
+            "id": "doc-2",
+            "content": "Bad match",
+            "$dist": 1.8,  # score = 0.1
+        }
+
+        mock_result = Mock()
+        mock_result.rows = [mock_row_good, mock_row_bad]
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.query.return_value = mock_result
+
+        results = client.search(
+            collection_name="test_collection",
+            query="test query",
+            score_threshold=0.5,
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc-1"
+
+    def test_search_with_limit(self, client, mock_turbopuffer_client):
+        """Test that search passes limit to query."""
+        client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        mock_result = Mock()
+        mock_result.rows = []
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.query.return_value = mock_result
+
+        client.search(
+            collection_name="test_collection",
+            query="test query",
+            limit=10,
+        )
+
+        call_args = mock_ns.query.call_args
+        assert call_args.kwargs["top_k"] == 10
+
+    def test_search_wrong_client_type(self, mock_async_turbopuffer_client):
+        """Test that search raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method search\(\) requires"
+        ):
+            client.search(collection_name="test_collection", query="test query")
+
+    @pytest.mark.asyncio
+    async def test_asearch(self, async_client, mock_async_turbopuffer_client):
+        """Test that asearch returns matching documents asynchronously."""
+        async_client.embedding_function.return_value = [0.1, 0.2, 0.3]
+
+        mock_row = MagicMock()
+        mock_row.to_dict.return_value = {
+            "id": "doc-123",
+            "content": "Test content",
+            "source": "test",
+            "$dist": 0.1,
+        }
+
+        mock_result = Mock()
+        mock_result.rows = [mock_row]
+        mock_ns = mock_async_turbopuffer_client.namespace.return_value
+        mock_ns.query = AsyncMock(return_value=mock_result)
+
+        results = await async_client.asearch(
+            collection_name="test_collection", query="test query"
+        )
+
+        mock_async_turbopuffer_client.namespace.assert_called_once_with(
+            "test_collection"
+        )
+        async_client.embedding_function.assert_called_once_with("test query")
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc-123"
+        assert results[0]["content"] == "Test content"
+        assert results[0]["metadata"] == {"source": "test"}
+        assert results[0]["score"] == pytest.approx(0.95)
+
+    @pytest.mark.asyncio
+    async def test_asearch_wrong_client_type(self, mock_turbopuffer_client):
+        """Test that asearch raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method asearch\(\) requires"
+        ):
+            await client.asearch(
+                collection_name="test_collection", query="test query"
+            )
+
+    def test_delete_collection(self, client, mock_turbopuffer_client):
+        """Test that delete_collection calls delete_all on namespace."""
+        client.delete_collection(collection_name="test_collection")
+
+        mock_turbopuffer_client.namespace.assert_called_once_with("test_collection")
+        mock_ns = mock_turbopuffer_client.namespace.return_value
+        mock_ns.delete_all.assert_called_once()
+
+    def test_delete_collection_wrong_client_type(self, mock_async_turbopuffer_client):
+        """Test that delete_collection raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method delete_collection\(\) requires",
+        ):
+            client.delete_collection(collection_name="test_collection")
+
+    @pytest.mark.asyncio
+    async def test_adelete_collection(
+        self, async_client, mock_async_turbopuffer_client
+    ):
+        """Test that adelete_collection calls delete_all asynchronously."""
+        mock_ns = mock_async_turbopuffer_client.namespace.return_value
+        mock_ns.delete_all = AsyncMock()
+
+        await async_client.adelete_collection(collection_name="test_collection")
+
+        mock_async_turbopuffer_client.namespace.assert_called_once_with(
+            "test_collection"
+        )
+        mock_ns.delete_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_adelete_collection_wrong_client_type(self, mock_turbopuffer_client):
+        """Test that adelete_collection raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError,
+            match=r"Method adelete_collection\(\) requires",
+        ):
+            await client.adelete_collection(collection_name="test_collection")
+
+    def test_reset(self, client, mock_turbopuffer_client):
+        """Test that reset deletes all namespaces."""
+        # namespaces() yields NamespaceSummary objects that only expose .id;
+        # deletion must go through client.namespace(id).delete_all().
+        summary1 = Mock()
+        summary1.id = "ns1"
+        summary2 = Mock()
+        summary2.id = "ns2"
+        summary3 = Mock()
+        summary3.id = "ns3"
+        mock_turbopuffer_client.namespaces.return_value = [summary1, summary2, summary3]
+
+        client.reset()
+
+        mock_turbopuffer_client.namespaces.assert_called_once()
+        assert mock_turbopuffer_client.namespace.call_count == 3
+        mock_turbopuffer_client.namespace.assert_any_call("ns1")
+        mock_turbopuffer_client.namespace.assert_any_call("ns2")
+        mock_turbopuffer_client.namespace.assert_any_call("ns3")
+        assert mock_turbopuffer_client.namespace.return_value.delete_all.call_count == 3
+
+    def test_reset_no_namespaces(self, client, mock_turbopuffer_client):
+        """Test that reset handles no namespaces gracefully."""
+        mock_turbopuffer_client.namespaces.return_value = []
+
+        client.reset()
+
+        mock_turbopuffer_client.namespaces.assert_called_once()
+
+    def test_reset_wrong_client_type(self, mock_async_turbopuffer_client):
+        """Test that reset raises error for async client."""
+        client = TurbopufferClient(
+            client=mock_async_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method reset\(\) requires"
+        ):
+            client.reset()
+
+    @pytest.mark.asyncio
+    async def test_areset(self, async_client, mock_async_turbopuffer_client):
+        """Test that areset deletes all namespaces asynchronously."""
+        # namespaces() yields NamespaceSummary objects that only expose .id;
+        # deletion must go through client.namespace(id).delete_all().
+        summary1 = Mock()
+        summary1.id = "ns1"
+        summary2 = Mock()
+        summary2.id = "ns2"
+
+        async def async_ns_iter():
+            for ns in [summary1, summary2]:
+                yield ns
+
+        mock_async_turbopuffer_client.namespaces.return_value = async_ns_iter()
+        mock_async_turbopuffer_client.namespace.return_value.delete_all = AsyncMock()
+
+        await async_client.areset()
+
+        assert mock_async_turbopuffer_client.namespace.call_count == 2
+        mock_async_turbopuffer_client.namespace.assert_any_call("ns1")
+        mock_async_turbopuffer_client.namespace.assert_any_call("ns2")
+        assert (
+            mock_async_turbopuffer_client.namespace.return_value.delete_all.call_count
+            == 2
+        )
+
+    @pytest.mark.asyncio
+    async def test_areset_wrong_client_type(self, mock_turbopuffer_client):
+        """Test that areset raises error for sync client."""
+        client = TurbopufferClient(
+            client=mock_turbopuffer_client, embedding_function=Mock()
+        )
+
+        with pytest.raises(
+            ClientMethodMismatchError, match=r"Method areset\(\) requires"
+        ):
+            await client.areset()

--- a/lib/crewai/tests/rag/turbopuffer/test_config.py
+++ b/lib/crewai/tests/rag/turbopuffer/test_config.py
@@ -1,0 +1,28 @@
+"""Tests for turbopuffer configuration defaults."""
+
+import builtins
+
+import pytest
+from crewai.rag.turbopuffer.config import _default_embedding_function
+
+
+def test_default_embedding_function_defers_fastembed(monkeypatch):
+    """The default embedder must not import fastembed or load the model until the
+    first embedding call, so config construction never triggers a download."""
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "fastembed" or name.startswith("fastembed."):
+            raise ImportError("fastembed blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    # Building the default must not import fastembed / download anything.
+    embed_fn = _default_embedding_function()
+    assert callable(embed_fn)
+
+    # fastembed is only needed on the first call; a missing optional dependency
+    # surfaces as a clear, actionable error there.
+    with pytest.raises(ImportError, match="fastembed"):
+        embed_fn("hello world")

--- a/lib/crewai/tests/rag/turbopuffer/test_utils.py
+++ b/lib/crewai/tests/rag/turbopuffer/test_utils.py
@@ -1,0 +1,230 @@
+"""Tests for turbopuffer utility functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from crewai.rag.turbopuffer.utils import (
+    _build_metadata_filter,
+    _build_upsert_row,
+    _normalize_turbopuffer_score,
+    _process_search_results,
+    _validate_namespace_name,
+)
+from crewai.rag.types import BaseRecord
+
+
+class TestValidateNamespaceName:
+    """Test suite for _validate_namespace_name."""
+
+    def test_valid_simple_name(self):
+        """Test valid simple alphanumeric name."""
+        _validate_namespace_name("my-collection")
+
+    def test_valid_name_with_dots(self):
+        """Test valid name with dots."""
+        _validate_namespace_name("my.collection.v2")
+
+    def test_valid_name_with_underscores(self):
+        """Test valid name with underscores."""
+        _validate_namespace_name("my_collection_v2")
+
+    def test_valid_single_char(self):
+        """Test valid single character name."""
+        _validate_namespace_name("a")
+
+    def test_valid_max_length(self):
+        """Test valid name at max length (128 chars)."""
+        _validate_namespace_name("a" * 128)
+
+    def test_invalid_empty(self):
+        """Test that empty name raises error."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            _validate_namespace_name("")
+
+    def test_invalid_spaces(self):
+        """Test that name with spaces raises error."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            _validate_namespace_name("my collection")
+
+    def test_invalid_special_chars(self):
+        """Test that name with special chars raises error."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            _validate_namespace_name("my!collection")
+
+    def test_invalid_too_long(self):
+        """Test that name exceeding 128 chars raises error."""
+        with pytest.raises(ValueError, match="Invalid namespace name"):
+            _validate_namespace_name("a" * 129)
+
+
+class TestBuildUpsertRow:
+    """Test suite for _build_upsert_row."""
+
+    def test_basic_document(self):
+        """Test building row from basic document."""
+        doc: BaseRecord = {"content": "Hello world"}
+        row = _build_upsert_row(doc, [0.1, 0.2, 0.3])
+
+        assert row["content"] == "Hello world"
+        assert row["vector"] == [0.1, 0.2, 0.3]
+        assert "id" in row  # auto-generated UUID
+
+    def test_document_with_doc_id(self):
+        """Test building row preserves provided doc_id."""
+        doc: BaseRecord = {"doc_id": "my-id", "content": "Hello world"}
+        row = _build_upsert_row(doc, [0.1, 0.2, 0.3])
+
+        assert row["id"] == "my-id"
+
+    def test_document_with_metadata(self):
+        """Test building row flattens metadata into row."""
+        doc: BaseRecord = {
+            "content": "Hello world",
+            "metadata": {"source": "test", "category": "greeting"},
+        }
+        row = _build_upsert_row(doc, [0.1, 0.2, 0.3])
+
+        assert row["source"] == "test"
+        assert row["category"] == "greeting"
+
+    def test_document_without_metadata(self):
+        """Test building row without metadata."""
+        doc: BaseRecord = {"content": "Hello world"}
+        row = _build_upsert_row(doc, [0.1, 0.2, 0.3])
+
+        # Should only have id, vector, content
+        assert set(row.keys()) == {"id", "vector", "content"}
+
+    def test_document_with_list_metadata(self):
+        """Test building row with list metadata uses first element."""
+        doc: BaseRecord = {
+            "content": "Hello world",
+            "metadata": [{"source": "test"}],
+        }
+        row = _build_upsert_row(doc, [0.1, 0.2, 0.3])
+
+        assert row["source"] == "test"
+
+
+class TestNormalizeTurbopufferScore:
+    """Test suite for _normalize_turbopuffer_score."""
+
+    def test_zero_distance(self):
+        """Zero distance returns score 1.0 (perfect match)."""
+        assert _normalize_turbopuffer_score(0.0) == 1.0
+
+    def test_max_distance(self):
+        """Max cosine distance (2.0) returns score 0.0."""
+        assert _normalize_turbopuffer_score(2.0) == 0.0
+
+    def test_mid_distance(self):
+        """Mid distance (1.0) returns score 0.5."""
+        assert _normalize_turbopuffer_score(1.0) == 0.5
+
+    def test_small_distance(self):
+        """Small distance returns a high score."""
+        assert _normalize_turbopuffer_score(0.1) == pytest.approx(0.95)
+
+    def test_clamps_below_zero(self):
+        """Distances beyond the [0, 2] range clamp to 0."""
+        assert _normalize_turbopuffer_score(3.0) == 0.0
+
+    def test_clamps_above_one(self):
+        """Negative distances clamp to 1."""
+        assert _normalize_turbopuffer_score(-1.0) == 1.0
+
+
+class TestProcessSearchResults:
+    """Test suite for _process_search_results."""
+
+    def test_empty_rows(self):
+        """Test processing empty rows returns empty list."""
+        results = _process_search_results([])
+        assert results == []
+
+    def test_single_result(self):
+        """Test processing a single result row."""
+        mock_row = MagicMock()
+        mock_row.to_dict.return_value = {
+            "id": "doc-1",
+            "content": "Test content",
+            "source": "test",
+            "$dist": 0.2,
+        }
+
+        results = _process_search_results([mock_row])
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc-1"
+        assert results[0]["content"] == "Test content"
+        assert results[0]["metadata"] == {"source": "test"}
+        assert results[0]["score"] == pytest.approx(0.9)
+
+    def test_filters_by_score_threshold(self):
+        """Test that results below score threshold are filtered out."""
+        mock_row_good = MagicMock()
+        mock_row_good.to_dict.return_value = {
+            "id": "doc-1",
+            "content": "Good",
+            "$dist": 0.2,  # score = 0.9
+        }
+        mock_row_bad = MagicMock()
+        mock_row_bad.to_dict.return_value = {
+            "id": "doc-2",
+            "content": "Bad",
+            "$dist": 1.8,  # score = 0.1
+        }
+
+        results = _process_search_results(
+            [mock_row_good, mock_row_bad], score_threshold=0.5
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc-1"
+
+    def test_excludes_reserved_keys_from_metadata(self):
+        """Test that reserved keys are excluded from metadata."""
+        mock_row = MagicMock()
+        mock_row.to_dict.return_value = {
+            "id": "doc-1",
+            "vector": [0.1, 0.2],
+            "content": "Test",
+            "$dist": 0.0,
+            "custom_field": "value",
+        }
+
+        results = _process_search_results([mock_row])
+
+        assert "vector" not in results[0]["metadata"]
+        assert "$dist" not in results[0]["metadata"]
+        assert "id" not in results[0]["metadata"]
+        assert "content" not in results[0]["metadata"]
+        assert results[0]["metadata"] == {"custom_field": "value"}
+
+
+class TestBuildMetadataFilter:
+    """Test suite for _build_metadata_filter."""
+
+    def test_single_filter(self):
+        """Test single key-value filter returns simple tuple."""
+        result = _build_metadata_filter({"category": "tech"})
+        assert result == ("category", "Eq", "tech")
+
+    def test_multiple_filters(self):
+        """Test multiple filters return And clause."""
+        result = _build_metadata_filter({"category": "tech", "status": "published"})
+        assert result[0] == "And"
+        conditions = result[1]
+        assert len(conditions) == 2
+        assert ("category", "Eq", "tech") in conditions
+        assert ("status", "Eq", "published") in conditions
+
+    def test_numeric_value(self):
+        """Test filter with numeric value."""
+        result = _build_metadata_filter({"count": 5})
+        assert result == ("count", "Eq", 5)
+
+    def test_boolean_value(self):
+        """Test filter with boolean value."""
+        result = _build_metadata_filter({"active": True})
+        assert result == ("active", "Eq", True)

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T15:35:51.457693Z"
+exclude-newer = "2026-07-06T16:12:05.359448Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1408,6 +1408,10 @@ qdrant-edge = [
 tools = [
     { name = "crewai-tools" },
 ]
+turbopuffer = [
+    { name = "fastembed" },
+    { name = "turbopuffer" },
+]
 voyageai = [
     { name = "voyageai" },
 ]
@@ -1438,6 +1442,7 @@ requires-dist = [
     { name = "crewai-tools", marker = "extra == 'tools'", editable = "lib/crewai-tools" },
     { name = "docling", marker = "extra == 'docling'", specifier = "~=2.97.0" },
     { name = "docling-core", extras = ["chunking"], marker = "extra == 'docling'", specifier = ">=2.74.1" },
+    { name = "fastembed", marker = "extra == 'turbopuffer'", specifier = ">=0.3.0" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = "~=1.65.0" },
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "httpx-auth", marker = "extra == 'a2a'", specifier = "~=0.23.1" },
@@ -1472,9 +1477,10 @@ requires-dist = [
     { name = "tokenizers", specifier = ">=0.21,<1" },
     { name = "tomli", specifier = "~=2.0.2" },
     { name = "tomli-w", specifier = "~=1.1.0" },
+    { name = "turbopuffer", marker = "extra == 'turbopuffer'", specifier = ">=1.0.0,<2" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "turbopuffer", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"
@@ -9176,6 +9182,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
     { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
     { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
+]
+
+[[package]]
+name = "turbopuffer"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/e5/c7df3bde9efbbafdcf10ba5ae2a0159e4a894183393e2dc02d2cb1c19792/turbopuffer-1.21.0.tar.gz", hash = "sha256:988ddfceab082190673a097edb1e32636a8958cc6ad6c5260b2990513c12ded9", size = 337493, upload-time = "2026-04-07T15:47:34.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/30/995ae0edbb748d6a98bcbb0040ed354e2df31a06092a60e986763de52893/turbopuffer-1.21.0-py3-none-any.whl", hash = "sha256:adbea8fc118138e311047571f1438b4a2ce0d67aa759c1dd33fc3b90bdf2c424", size = 122566, upload-time = "2026-04-07T15:47:35.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary
Adds support for turbopuffer as a vector store integration

- `crewai.rag.turbopuffer` — client (sync + async), config, factory, types, utils
- Docs + tests (client, utils, config, `RagTool` routing)


<!-- crewai-require-issue-check -->