### PR TITLE
feat(tools): add newsflash corroborated news event search tool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -117,6 +117,9 @@ from crewai_tools.tools.mongodb_vector_search_tool.vector_search import (
 )
 from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
+from crewai_tools.tools.newsflash_news_tool.newsflash_news_tool import (
+    NewsflashNewsTool,
+)
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
@@ -281,6 +284,7 @@ __all__ = [
     "MultiOnTool",
     "MySQLSearchTool",
     "NL2SQLTool",
+    "NewsflashNewsTool",
     "OCRTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -107,6 +107,9 @@ from crewai_tools.tools.mongodb_vector_search_tool import (
 )
 from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
+from crewai_tools.tools.newsflash_news_tool.newsflash_news_tool import (
+    NewsflashNewsTool,
+)
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
@@ -265,6 +268,7 @@ __all__ = [
     "MultiOnTool",
     "MySQLSearchTool",
     "NL2SQLTool",
+    "NewsflashNewsTool",
     "OCRTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/README.md
@@ -1,0 +1,52 @@
+# NewsflashNewsTool Documentation
+
+## Description
+
+Search real-time news as **deduplicated, corroborated events** using
+[Newsflash](https://newsflash.sh). Instead of returning one raw article per hit,
+Newsflash clusters coverage from many outlets into a single event with a
+corroboration count and a confidence score (`min(1, sources / 3)`). The
+`min_confidence` argument lets an agent require that a story has been
+independently reported by multiple outlets before acting on it — a simple,
+effective gate against single-source and fabricated news.
+
+## Installation
+
+```shell
+pip install 'crewai[tools]'
+```
+
+No extra dependencies are needed (the tool uses the standard `requests` package).
+
+## Example
+
+```python
+from crewai_tools import NewsflashNewsTool
+
+# Works without an API key (50 requests/day)
+tool = NewsflashNewsTool()
+
+# Semantic search, only events corroborated by 2+ sources
+tool.run(query="AI chip export restrictions", min_confidence=0.6)
+
+# Keyword search restricted to a category
+tool.run(query="bitcoin", semantic=False, category="crypto", limit=5)
+```
+
+## Arguments
+
+- `query` (str, required): Search query.
+- `semantic` (bool, default `True`): Meaning-based search; set `False` for exact
+  keyword matching.
+- `category` (str, optional): One of `crypto`, `tradfi`, `business`, `tech`,
+  `politics`, `world`, `science`, `health`, `energy`, `sports`.
+- `limit` (int, default `10`): Maximum number of events to return (max 50).
+- `min_confidence` (float, default `0.0`): Only return events with confidence at
+  or above this value. `1.0` means at least 3 independent outlets reported the
+  same happening.
+
+## Environment Variables
+
+- `NEWSFLASH_API_KEY` (optional): API key for higher rate limits and deeper
+  history (free keys via email at https://newsflash.sh). Keyless access works
+  out of the box with 50 requests/day.

--- a/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/README.md
@@ -16,7 +16,7 @@ effective gate against single-source and fabricated news.
 pip install 'crewai[tools]'
 ```
 
-No extra dependencies are needed (the tool uses the standard `requests` package).
+No extra dependencies are needed (the tool uses the existing `requests` dependency).
 
 ## Example
 

--- a/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/newsflash_news_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/newsflash_news_tool.py
@@ -1,0 +1,202 @@
+import logging
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+_CATEGORIES = [
+    "crypto",
+    "tradfi",
+    "business",
+    "tech",
+    "politics",
+    "world",
+    "science",
+    "health",
+    "energy",
+    "sports",
+]
+
+_MAX_API_LIMIT = 50
+
+
+class NewsflashNewsToolSchema(BaseModel):
+    """Input for NewsflashNewsTool."""
+
+    query: str = Field(
+        ..., description="Search query for news events, e.g. 'bitcoin etf approval'"
+    )
+    semantic: bool = Field(
+        True,
+        description=(
+            "Use semantic (meaning-based) search. Set to False for exact keyword "
+            "matching."
+        ),
+    )
+    category: str | None = Field(
+        None,
+        description=(
+            "Optional category filter. One of: " + ", ".join(_CATEGORIES) + "."
+        ),
+    )
+    limit: int = Field(
+        10, ge=1, le=_MAX_API_LIMIT, description="Maximum number of events to return"
+    )
+    min_confidence: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Only return events with confidence >= this value. Confidence is "
+            "min(1, corroborating_sources / 3): 1.0 means at least 3 independent "
+            "outlets reported the same happening. Raise this to filter out "
+            "single-source, unverified stories."
+        ),
+    )
+
+
+class NewsflashNewsTool(BaseTool):
+    name: str = "Newsflash News Search"
+    description: str = (
+        "Search real-time news as deduplicated, corroborated events. Newsflash "
+        "clusters articles from many outlets into one event with a corroboration "
+        "count and a confidence score (min(1, sources/3)), so agents can filter "
+        "out single-source or fabricated stories via min_confidence. Works "
+        "without an API key (50 requests/day)."
+    )
+    args_schema: type[BaseModel] = NewsflashNewsToolSchema
+    base_url: str = "https://newsflash.sh/api"
+    request_timeout: int = 15
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="NEWSFLASH_API_KEY",
+                description=(
+                    "Optional Newsflash API key for higher rate limits and deeper "
+                    "history. Keyless access works out of the box (50 requests/day)."
+                ),
+                required=False,
+            ),
+        ]
+    )
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        api_key = os.environ.get("NEWSFLASH_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}{path}",
+            params=params,
+            headers=self._headers(),
+            timeout=self.request_timeout,
+        )
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        return data
+
+    def _first_article_url(self, event_id: Any) -> str | None:
+        """Fetch event details and return the URL of its first article."""
+        try:
+            details = self._get(f"/events/{event_id}")
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Could not fetch details for event {event_id}: {e}")
+            return None
+        articles = details.get("articles") or []
+        if articles:
+            url = articles[0].get("url")
+            return url if isinstance(url, str) else None
+        return None
+
+    def _format_event(self, index: int, event: dict[str, Any], link: str | None) -> str:
+        sources = event.get("sources") or []
+        corroboration = event.get("corroboration", len(sources))
+        confidence = event.get("confidence", 0.0)
+        lines = [
+            f"{index}. {event.get('canonical_title', 'Untitled event')}",
+            (
+                f"   Category: {event.get('category', 'unknown')} | "
+                f"Confidence: {confidence:.2f} | "
+                f"Corroboration: {corroboration} source(s)"
+                + (f" ({', '.join(sources)})" if sources else "")
+            ),
+            f"   First seen: {event.get('first_seen_at', 'unknown')}",
+        ]
+        summary = (event.get("summary") or "").strip()
+        if summary:
+            lines.append(f"   Summary: {summary}")
+        if link:
+            lines.append(f"   Link: {link}")
+        return "\n".join(lines)
+
+    def _run(self, **kwargs: Any) -> str:
+        query = kwargs.get("query") or kwargs.get("search_query")
+        if not query:
+            return "Error: a search query is required."
+        semantic = kwargs.get("semantic", True)
+        category = kwargs.get("category")
+        limit = kwargs.get("limit", 10)
+        min_confidence = kwargs.get("min_confidence", 0.0)
+
+        # Over-fetch when a confidence floor is set so filtering can still
+        # yield up to `limit` events; the API caps limit at 50.
+        request_limit = limit
+        if min_confidence > 0:
+            request_limit = min(_MAX_API_LIMIT, max(limit * 3, limit))
+
+        params = {
+            "q": query,
+            "semantic": "1" if semantic else "0",
+            "limit": request_limit,
+        }
+        if category:
+            params["category"] = category
+
+        try:
+            data = self._get("/events", params=params)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error querying the Newsflash API: {e}")
+            return f"Error querying the Newsflash API: {e}"
+
+        events = [
+            event
+            for event in data.get("events", [])
+            if event.get("confidence", 0.0) >= min_confidence
+        ][:limit]
+
+        if not events:
+            note = (data.get("window") or {}).get("note")
+            message = (
+                f"No corroborated news events found for '{query}'"
+                + (f" in category '{category}'" if category else "")
+                + (
+                    f" with confidence >= {min_confidence}"
+                    if min_confidence > 0
+                    else ""
+                )
+                + "."
+            )
+            return f"{message} ({note})" if note else message
+
+        # Fetch article links only for the events actually returned.
+        formatted = [
+            self._format_event(i, event, self._first_article_url(event.get("id")))
+            for i, event in enumerate(events, start=1)
+        ]
+
+        header = f"Newsflash events for '{query}' ({len(events)} shown"
+        if min_confidence > 0:
+            header += f", confidence >= {min_confidence}"
+        header += "):"
+        return "\n\n".join([header, *formatted])
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> str:
+        return self._run(*args, **kwargs)

--- a/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/newsflash_news_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/newsflash_news_tool/newsflash_news_tool.py
@@ -1,6 +1,7 @@
+import asyncio
 import logging
 import os
-from typing import Any
+from typing import Any, Literal
 
 from crewai.tools import BaseTool, EnvVar
 from pydantic import BaseModel, Field
@@ -9,7 +10,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-_CATEGORIES = [
+Category = Literal[
     "crypto",
     "tradfi",
     "business",
@@ -38,11 +39,9 @@ class NewsflashNewsToolSchema(BaseModel):
             "matching."
         ),
     )
-    category: str | None = Field(
+    category: Category | None = Field(
         None,
-        description=(
-            "Optional category filter. One of: " + ", ".join(_CATEGORIES) + "."
-        ),
+        description="Optional category filter.",
     )
     limit: int = Field(
         10, ge=1, le=_MAX_API_LIMIT, description="Maximum number of events to return"
@@ -72,6 +71,9 @@ class NewsflashNewsTool(BaseTool):
     args_schema: type[BaseModel] = NewsflashNewsToolSchema
     base_url: str = "https://newsflash.sh/api"
     request_timeout: int = 15
+    # Article links require one /events/{id} call each; cap them so a wide
+    # search doesn't turn into N+1 requests against the caller's rate budget.
+    max_link_fetches: int = 5
     env_vars: list[EnvVar] = Field(
         default_factory=lambda: [
             EnvVar(
@@ -105,6 +107,8 @@ class NewsflashNewsTool(BaseTool):
 
     def _first_article_url(self, event_id: Any) -> str | None:
         """Fetch event details and return the URL of its first article."""
+        if event_id is None:
+            return None
         try:
             details = self._get(f"/events/{event_id}")
         except requests.exceptions.RequestException as e:
@@ -186,9 +190,15 @@ class NewsflashNewsTool(BaseTool):
             )
             return f"{message} ({note})" if note else message
 
-        # Fetch article links only for the events actually returned.
+        # Fetch article links for the top events only (one detail call each).
         formatted = [
-            self._format_event(i, event, self._first_article_url(event.get("id")))
+            self._format_event(
+                i,
+                event,
+                self._first_article_url(event.get("id"))
+                if i <= self.max_link_fetches
+                else None,
+            )
             for i, event in enumerate(events, start=1)
         ]
 
@@ -199,4 +209,5 @@ class NewsflashNewsTool(BaseTool):
         return "\n\n".join([header, *formatted])
 
     async def _arun(self, *args: Any, **kwargs: Any) -> str:
-        return self._run(*args, **kwargs)
+        # requests is synchronous; keep it off the event loop.
+        return await asyncio.to_thread(self._run, *args, **kwargs)

--- a/lib/crewai-tools/tests/tools/newsflash_news_tool_test.py
+++ b/lib/crewai-tools/tests/tools/newsflash_news_tool_test.py
@@ -1,0 +1,190 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools.tools.newsflash_news_tool.newsflash_news_tool import NewsflashNewsTool
+
+
+def _mock_response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+SEARCH_PAYLOAD = {
+    "count": 2,
+    "events": [
+        {
+            "id": 1,
+            "canonical_title": "Fed cuts rates by 25bps",
+            "summary": "The Federal Reserve cut its benchmark rate.",
+            "category": "tradfi",
+            "first_seen_at": "2026-07-24T10:00:00.000Z",
+            "last_seen_at": "2026-07-24T12:00:00.000Z",
+            "sources": ["reuters", "apnews", "bloomberg"],
+            "corroboration": 3,
+            "confidence": 1.0,
+        },
+        {
+            "id": 2,
+            "canonical_title": "Obscure single-source rumor",
+            "summary": "Only one outlet reported this.",
+            "category": "tradfi",
+            "first_seen_at": "2026-07-24T11:00:00.000Z",
+            "last_seen_at": "2026-07-24T11:00:00.000Z",
+            "sources": ["someblog"],
+            "corroboration": 1,
+            "confidence": 0.3333333333333333,
+        },
+    ],
+}
+
+DETAIL_PAYLOADS = {
+    "1": {
+        "id": 1,
+        "articles": [
+            {
+                "source": "reuters",
+                "title": "Fed cuts rates by 25bps",
+                "url": "https://reuters.com/fed-cut",
+                "published_at": "2026-07-24T10:00:00.000Z",
+            }
+        ],
+    },
+    "2": {
+        "id": 2,
+        "articles": [
+            {
+                "source": "someblog",
+                "title": "Obscure single-source rumor",
+                "url": "https://someblog.example/rumor",
+                "published_at": "2026-07-24T11:00:00.000Z",
+            }
+        ],
+    },
+}
+
+
+def _routed_get(url, **kwargs):
+    if url.endswith("/events"):
+        return _mock_response(SEARCH_PAYLOAD)
+    event_id = url.rsplit("/", 1)[-1]
+    return _mock_response(DETAIL_PAYLOADS[event_id])
+
+
+@pytest.fixture
+def newsflash_tool():
+    return NewsflashNewsTool()
+
+
+def test_newsflash_tool_initialization():
+    tool = NewsflashNewsTool()
+    assert tool.base_url == "https://newsflash.sh/api"
+    assert tool.name == "Newsflash News Search"
+    assert any(var.name == "NEWSFLASH_API_KEY" for var in tool.env_vars)
+    # Keyless usage is supported, so the key must not be required
+    assert all(
+        not var.required for var in tool.env_vars if var.name == "NEWSFLASH_API_KEY"
+    )
+
+
+@patch("requests.get")
+def test_newsflash_tool_search(mock_get, newsflash_tool):
+    mock_get.side_effect = _routed_get
+
+    result = newsflash_tool.run(query="fed rates")
+
+    assert "Fed cuts rates by 25bps" in result
+    assert "3 source(s)" in result
+    assert "reuters, apnews, bloomberg" in result
+    assert "https://reuters.com/fed-cut" in result
+    # Low-confidence event is included by default (min_confidence=0.0)
+    assert "Obscure single-source rumor" in result
+
+
+@patch("requests.get")
+def test_newsflash_tool_min_confidence_filters_uncorroborated(mock_get, newsflash_tool):
+    mock_get.side_effect = _routed_get
+
+    result = newsflash_tool.run(query="fed rates", min_confidence=0.6)
+
+    assert "Fed cuts rates by 25bps" in result
+    assert "Obscure single-source rumor" not in result
+    # Details must only be fetched for events that pass the filter:
+    # 1 search call + 1 detail call
+    detail_calls = [
+        call for call in mock_get.call_args_list if "/events/" in call.args[0]
+    ]
+    assert len(detail_calls) == 1
+    assert detail_calls[0].args[0].endswith("/events/1")
+
+
+@patch("requests.get")
+def test_newsflash_tool_limit_caps_detail_fetches(mock_get, newsflash_tool):
+    mock_get.side_effect = _routed_get
+
+    result = newsflash_tool.run(query="fed rates", limit=1)
+
+    assert "Fed cuts rates by 25bps" in result
+    assert "Obscure single-source rumor" not in result
+    detail_calls = [
+        call for call in mock_get.call_args_list if "/events/" in call.args[0]
+    ]
+    assert len(detail_calls) == 1
+
+
+@patch("requests.get")
+def test_newsflash_tool_query_params(mock_get, newsflash_tool):
+    mock_get.side_effect = _routed_get
+
+    newsflash_tool.run(query="bitcoin", semantic=False, category="crypto", limit=5)
+
+    search_call = mock_get.call_args_list[0]
+    params = search_call.kwargs["params"]
+    assert params["q"] == "bitcoin"
+    assert params["semantic"] == "0"
+    assert params["category"] == "crypto"
+    assert params["limit"] == 5
+
+
+@patch("requests.get")
+def test_newsflash_tool_sends_bearer_key_when_set(
+    mock_get, newsflash_tool, monkeypatch
+):
+    monkeypatch.setenv("NEWSFLASH_API_KEY", "nf_test_key")
+    mock_get.side_effect = _routed_get
+
+    newsflash_tool.run(query="fed rates", limit=1)
+
+    headers = mock_get.call_args_list[0].kwargs["headers"]
+    assert headers["Authorization"] == "Bearer nf_test_key"
+
+
+@patch("requests.get")
+def test_newsflash_tool_keyless_sends_no_auth_header(
+    mock_get, newsflash_tool, monkeypatch
+):
+    monkeypatch.delenv("NEWSFLASH_API_KEY", raising=False)
+    mock_get.side_effect = _routed_get
+
+    newsflash_tool.run(query="fed rates", limit=1)
+
+    headers = mock_get.call_args_list[0].kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+@patch("requests.get")
+def test_newsflash_tool_no_results(mock_get, newsflash_tool):
+    mock_get.return_value = _mock_response(
+        {
+            "count": 0,
+            "events": [],
+            "window": {"note": "the test tier can query the last 24 hours"},
+        }
+    )
+
+    result = newsflash_tool.run(query="nonexistent topic", min_confidence=0.9)
+
+    assert "No corroborated news events found" in result
+    assert "nonexistent topic" in result

--- a/lib/crewai-tools/tests/tools/newsflash_news_tool_test.py
+++ b/lib/crewai-tools/tests/tools/newsflash_news_tool_test.py
@@ -2,7 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from crewai_tools.tools.newsflash_news_tool.newsflash_news_tool import NewsflashNewsTool
+from pydantic import ValidationError
+
+from crewai_tools.tools.newsflash_news_tool.newsflash_news_tool import (
+    NewsflashNewsTool,
+    NewsflashNewsToolSchema,
+)
 
 
 def _mock_response(payload):
@@ -188,3 +193,46 @@ def test_newsflash_tool_no_results(mock_get, newsflash_tool):
 
     assert "No corroborated news events found" in result
     assert "nonexistent topic" in result
+
+
+def test_newsflash_tool_rejects_unknown_category():
+    # Validation must fail before any API call is made.
+    with pytest.raises(ValidationError):
+        NewsflashNewsToolSchema(query="fed rates", category="astrology")
+
+
+@patch("requests.get")
+def test_newsflash_tool_bounds_detail_fetches(mock_get, newsflash_tool):
+    # A wide result set must not fan out into N+1 detail requests: article
+    # links are only fetched for the first `max_link_fetches` events.
+    events = [
+        {
+            "id": i,
+            "canonical_title": f"Event {i}",
+            "category": "business",
+            "confidence": 1.0,
+            "corroboration": 3,
+            "sources": ["a", "b", "c"],
+            "first_seen_at": "2026-08-01T00:00:00Z",
+            "summary": "s",
+        }
+        for i in range(1, 9)
+    ]
+
+    def routed(url, **kwargs):
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        if url.endswith("/events"):
+            response.json.return_value = {"count": len(events), "events": events}
+        else:
+            response.json.return_value = {"articles": [{"url": "https://x.test/a"}]}
+        return response
+
+    mock_get.side_effect = routed
+    result = newsflash_tool.run(query="anything", limit=8)
+
+    assert "Event 8" in result, "all events are still formatted"
+    detail_calls = [
+        call for call in mock_get.call_args_list if "/events/" in call.args[0]
+    ]
+    assert len(detail_calls) == newsflash_tool.max_link_fetches


### PR DESCRIPTION
## What

Adds `NewsflashNewsTool` (`lib/crewai-tools`), a search tool over [Newsflash](https://newsflash.sh) — real-time corroborated news events + 5-year archive, built for agents. Disclosure: I built Newsflash.

Instead of one raw article per hit, Newsflash dedupes coverage from many outlets into a single **event** with a corroboration count and a confidence score (`min(1, sources/3)`). The tool's `min_confidence` argument lets a crew require independent multi-outlet corroboration before acting on a story — agents that consume news as ground truth are only as reliable as their weakest single source, and a corroboration gate is a cheap, structural defense against fabricated or premature reporting.

## Tool

- Args: `query` (required), `semantic` (default `True`), `category`, `limit` (default 10), `min_confidence` (default 0.0)
- Output: formatted events with category, confidence, corroboration count + source list, and the first article link (details fetched only for returned events, capped at `limit`)
- **Keyless testability**: works with no API key (50 requests/day), so reviewers can run it as-is; optional `NEWSFLASH_API_KEY` (declared `required=False`) for higher limits
- No new dependencies (uses `requests` from core deps); follows the `BaseTool` + `args_schema` + `env_vars` `default_factory` pattern from `SerperDevTool`

## Local checks

- `uv run pytest tests/tools/newsflash_news_tool_test.py -vv` (in `lib/crewai-tools`) — **8 passed** (mocked `requests`, no network, matching existing tool test style)
- `tests/test_generate_tool_specs.py` + `tests/test_optional_dependencies.py` — 10 passed, 1 skipped
- `uv run ruff check` / `ruff format --check` on the changed files — clean
- `uv run mypy` on the new tool — no issues
- Live keyless smoke test against the real API verified formatting end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTSt4BDWJCsGjUyLCnbuj5


<!-- crewai-require-issue-check -->