### PR TITLE
fix: strip cache_breakpoint from LiteLLM provider path

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -767,6 +767,18 @@ class LLM(BaseLLM):
             messages = self._process_message_files(messages)
         formatted_messages = self._format_messages_for_provider(messages)
 
+        # Strip provider-internal cache_breakpoint flags before sending to
+        # LiteLLM. Native provider adapters (AnthropicCompletion, etc.) consume
+        # the flag in their own _format_messages path and never reach here.
+        # LiteLLM providers (Groq, OpenAI-compatible, etc.) have no concept of
+        # this flag and will raise an error if they receive it.
+        from crewai.llms.cache import CACHE_BREAKPOINT_KEY
+
+        formatted_messages = [
+            {k: v for k, v in msg.items() if k != CACHE_BREAKPOINT_KEY}
+            for msg in formatted_messages
+        ]
+
         params = {
             "model": self.model,
             "messages": formatted_messages,

--- a/lib/crewai/tests/llms/test_prompt_cache.py
+++ b/lib/crewai/tests/llms/test_prompt_cache.py
@@ -189,3 +189,58 @@ class TestNonAnthropicStripsMarker:
         formatted = llm._format_messages(messages)
         for m in formatted:
             assert CACHE_BREAKPOINT_KEY not in m
+
+
+class TestLiteLLMPathStripsMarker:
+    """Regression tests for issue #5886: cache_breakpoint must be stripped
+    on the LiteLLM code path (used by Groq, OpenAI-compatible, etc.)
+    which does NOT call BaseLLM._format_messages().
+    """
+
+    def test_prepare_completion_params_strips_cache_breakpoint(self) -> None:
+        """_prepare_completion_params must strip cache_breakpoint from the
+        messages payload so providers like Groq do not receive unsupported keys.
+        """
+        from crewai.llm import LLM
+
+        llm = LLM(model="groq/llama-3.3-70b-versatile", is_litellm=True)
+        messages = [
+            mark_cache_breakpoint({"role": "system", "content": "You are a researcher"}),
+            mark_cache_breakpoint({"role": "user", "content": "Write a summary of AI trends"}),
+        ]
+        params = llm._prepare_completion_params(messages)
+        for msg in params["messages"]:
+            assert CACHE_BREAKPOINT_KEY not in msg, (
+                f"cache_breakpoint leaked to LiteLLM params: {msg}"
+            )
+
+    def test_prepare_completion_params_preserves_original_markers(self) -> None:
+        """Stripping must not mutate the caller's messages, as executors
+        reuse their messages list across ReAct loop iterations.
+        """
+        from crewai.llm import LLM
+
+        llm = LLM(model="groq/llama-3.3-70b-versatile", is_litellm=True)
+        messages = [
+            mark_cache_breakpoint({"role": "system", "content": "stable system"}),
+            mark_cache_breakpoint({"role": "user", "content": "stable user"}),
+        ]
+        llm._prepare_completion_params(messages)
+        assert messages[0][CACHE_BREAKPOINT_KEY] is True
+        assert messages[1][CACHE_BREAKPOINT_KEY] is True
+
+    def test_prepare_completion_params_without_markers(self) -> None:
+        """Messages without cache_breakpoint must pass through unchanged."""
+        from crewai.llm import LLM
+
+        llm = LLM(model="groq/llama-3.3-70b-versatile", is_litellm=True)
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+        ]
+        params = llm._prepare_completion_params(messages)
+        assert len(params["messages"]) == 2
+        assert params["messages"][0]["content"] == "You are helpful"
+        assert params["messages"][1]["content"] == "Hello"
+        for msg in params["messages"]:
+            assert CACHE_BREAKPOINT_KEY not in msg


### PR DESCRIPTION
## Summary

- mark_cache_breakpoint() is called on messages in CrewAgentExecutor and AgentExecutor for all providers, but only the Anthropic native adapter consumes and removes the flag.
- The LiteLLM code path (LLM.call(), used by Groq, OpenAI-compatible, etc.) passes through _prepare_completion_params() which did not strip the cache_breakpoint key, causing providers like Groq to reject the message with 'messages.0': property 'cache_breakpoint' is unsupported.
- Fix: strip CACHE_BREAKPOINT_KEY from all messages in _prepare_completion_params() before building the wire payload. The strip is non-mutating (creates new dicts) so agent executor message buffers retain their markers across ReAct loop iterations.

## Test plan

- [x] TestLiteLLMPathStripsMarker::test_prepare_completion_params_strips_cache_breakpoint: confirms the key is absent from the params passed to LiteLLM
- [x] TestLiteLLMPathStripsMarker::test_prepare_completion_params_preserves_original_markers: confirms caller's message list is not mutated
- [x] TestLiteLLMPathStripsMarker::test_prepare_completion_params_without_markers: confirms plain messages pass through unchanged
- [x] All 12 existing tests in test_prompt_cache.py continue to pass

Fixes #5886