### PR TITLE
fix(cli): keep generated dependency range stable

### DIFF
--- a/lib/cli/src/crewai_cli/version.py
+++ b/lib/cli/src/crewai_cli/version.py
@@ -21,7 +21,8 @@ from crewai_cli import __version__ as _crewai_cli_version
 def get_crewai_dependency_range(current_version: str | None = None) -> str:
     """Return the supported CrewAI dependency range for generated projects."""
     parsed_version = Version(current_version or _crewai_cli_version)
-    return f">={parsed_version},<{parsed_version.major + 1}.0.0"
+    minimum_version = f"{parsed_version.major}.{parsed_version.minor}.0"
+    return f">={minimum_version},<{parsed_version.major + 1}.0.0"
 
 
 def get_crewai_tools_dependency(current_version: str | None = None) -> str:

--- a/lib/cli/tests/test_create_crew.py
+++ b/lib/cli/tests/test_create_crew.py
@@ -374,7 +374,7 @@ def test_env_vars_are_uppercased_in_env_file(
     create_crew("Test Crew")
 
     env_file_path = crew_path / ".env"
-    content = env_file_path.read_text()
+    content = env_file_path.read_text(encoding="utf-8")
     assert "MODEL=" in content
 
 
@@ -759,7 +759,7 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
     )
     assert not any(path.startswith("src/") for path in generated_paths)
 
-    pyproject = tomli.loads((tmp_path / "json_crew" / "pyproject.toml").read_text())
+    pyproject = tomli.loads((tmp_path / "json_crew" / "pyproject.toml").read_text(encoding="utf-8"))
     dependency = pyproject["project"]["dependencies"][0]
     assert dependency == get_crewai_tools_dependency()
     assert Version("1.15.0") in Requirement(dependency).specifier
@@ -772,7 +772,7 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
         "definition": "crew.jsonc",
     }
 
-    crew_template = (tmp_path / "json_crew" / "crew.jsonc").read_text()
+    crew_template = (tmp_path / "json_crew" / "crew.jsonc").read_text(encoding="utf-8")
     assert (
         '"guardrail": "Every factual claim needs context support."'
         in crew_template
@@ -816,7 +816,7 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
 
     agent_template = (
         tmp_path / "json_crew" / "agents" / "researcher.jsonc"
-    ).read_text()
+    ).read_text(encoding="utf-8")
     assert "You can use {placeholder} inputs in role, goal, or backstory" in (
         agent_template
     )
@@ -926,8 +926,8 @@ def test_json_create_dmn_mode_uses_non_interactive_defaults(tmp_path, monkeypatc
     assert (project_root / "agents" / "researcher.jsonc").exists()
     assert not (project_root / ".env").exists()
 
-    crew_template = (project_root / "crew.jsonc").read_text()
-    agent_template = (project_root / "agents" / "researcher.jsonc").read_text()
+    crew_template = (project_root / "crew.jsonc").read_text(encoding="utf-8")
+    agent_template = (project_root / "agents" / "researcher.jsonc").read_text(encoding="utf-8")
 
     assert '"memory": true' in crew_template
     assert '"description": "Research current AI trends and write a concise summary."' in (

--- a/lib/cli/tests/test_version.py
+++ b/lib/cli/tests/test_version.py
@@ -35,7 +35,9 @@ def test_dynamic_versioning_consistency() -> None:
 
 def test_generated_project_dependency_uses_next_major_upper_bound() -> None:
     assert get_crewai_dependency_range("1.15.0") == ">=1.15.0,<2.0.0"
+    assert get_crewai_dependency_range("1.15.6") == ">=1.15.0,<2.0.0"
     assert get_crewai_tools_dependency("1.15.0") == "crewai[tools]>=1.15.0,<2.0.0"
+    assert get_crewai_tools_dependency("1.15.6") == "crewai[tools]>=1.15.0,<2.0.0"
 
 
 class TestVersionChecking:


### PR DESCRIPTION
## Summary
- Keep generated CrewAI dependency ranges pinned to the current minor baseline instead of the CLI patch version.
- Preserve the next-major upper bound for generated projects and install hints.
- Make JSON crew scaffold tests read generated UTF-8 files explicitly on Windows.

Fixes #6643

## Testing
- `E:\hermes\bin\uv.exe run --python 3.10 pytest lib/cli/tests/test_create_crew.py::test_json_create_provider_preselects_default_model lib/cli/tests/test_run_crew.py::test_missing_crewai_package_shows_full_install_hint lib/cli/tests/test_version.py::test_generated_project_dependency_uses_next_major_upper_bound -q --basetemp K:/ai-projs/crewAI/.work-artifacts/pytest-tmp/issue-6643-green`
- `E:\hermes\bin\uv.exe run --python 3.10 ruff check lib/cli/src/crewai_cli/version.py lib/cli/tests/test_version.py lib/cli/tests/test_create_crew.py`
- `E:\hermes\bin\uv.exe run --python 3.10 ruff format --check lib/cli/src/crewai_cli/version.py lib/cli/tests/test_version.py lib/cli/tests/test_create_crew.py`