### PR TITLE
fix(cli): reject non-runnable project roots

### DIFF
--- a/lib/cli/src/crewai_cli/run_crew.py
+++ b/lib/cli/src/crewai_cli/run_crew.py
@@ -713,9 +713,24 @@ def _run_flow_project(
     _execute_uv_script("kickoff", entity_type="flow")
 
 
+def _has_project_script(pyproject_data: dict[str, Any], script_name: str) -> bool:
+    project_config = pyproject_data.get("project")
+    if not isinstance(project_config, dict):
+        return False
+    scripts = project_config.get("scripts")
+    return isinstance(scripts, dict) and script_name in scripts
+
+
 def _run_classic_crew_project(
     pyproject_data: dict[str, Any], trained_agents_file: str | None
 ) -> None:
+    if not _has_project_script(pyproject_data, "run_crew"):
+        raise click.UsageError(
+            "The current directory is not a runnable CrewAI crew or flow project. "
+            "Run `crewai run` from the generated project directory, or add a "
+            "[project.scripts].run_crew entry to pyproject.toml."
+        )
+
     _execute_uv_script(
         "run_crew",
         entity_type="crew",

--- a/lib/cli/tests/test_run_crew.py
+++ b/lib/cli/tests/test_run_crew.py
@@ -930,13 +930,48 @@ def test_run_crew_runs_explicit_declarative_definition(monkeypatch, capsys):
     assert calls == [("flow.yaml", '{"topic":"AI"}')]
 
 
+def test_run_crew_rejects_pyproject_without_run_crew_script(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        run_crew_module,
+        "read_toml",
+        lambda: {"project": {"name": "parent-project", "scripts": {}}},
+    )
+    monkeypatch.setattr(
+        run_crew_module,
+        "configured_project_json_crew",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        run_crew_module,
+        "_warn_if_old_poetry_project",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(run_crew_module, "get_crewai_project_type", lambda *a, **k: None)
+    monkeypatch.setattr(
+        run_crew_module,
+        "_execute_uv_script",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(click.UsageError) as exc_info:
+        run_crew_module.run_crew()
+
+    assert "not a runnable CrewAI crew or flow project" in exc_info.value.message
+    assert "Run `crewai run` from the generated project directory" in exc_info.value.message
+    assert calls == []
+
 def test_run_crew_runs_classic_crew_project(monkeypatch, capsys):
     calls = []
 
     monkeypatch.setattr(
         run_crew_module,
         "read_toml",
-        lambda: {"tool": {"crewai": {"type": "crew"}}},
+        lambda: {
+            "project": {"scripts": {"run_crew": "demo.main:run"}},
+            "tool": {"crewai": {"type": "crew"}},
+        },
     )
     monkeypatch.setattr(
         run_crew_module,


### PR DESCRIPTION
## Summary
- Fail early when `crewai run` is launched from a Python project that is not a runnable CrewAI crew or flow project.
- Preserve the classic crew fallback for projects that define `[project.scripts].run_crew`.
- Add regression coverage so a non-CrewAI parent project does not fall through to `uv run run_crew`.

Fixes #6305

## Testing
- `E:\hermes\bin\uv.exe run --python 3.10 pytest lib/cli/tests/test_run_crew.py::test_run_crew_rejects_pyproject_without_run_crew_script lib/cli/tests/test_run_crew.py::test_run_crew_runs_classic_crew_project -q --basetemp K:/ai-projs/crewAI/.work-artifacts/pytest-tmp/issue-6305-green`
- `E:\hermes\bin\uv.exe run --python 3.10 ruff check lib/cli/src/crewai_cli/run_crew.py lib/cli/tests/test_run_crew.py`
- `E:\hermes\bin\uv.exe run --python 3.10 ruff format --check lib/cli/src/crewai_cli/run_crew.py lib/cli/tests/test_run_crew.py`
- `git diff --check`

## Notes
- `E:\hermes\bin\uv.exe run --python 3.10 pytest lib/cli/tests/test_run_crew.py -q --basetemp K:/ai-projs/crewAI/.work-artifacts/pytest-tmp/issue-6305-file` currently reports 43 passed and one unrelated existing failure in `test_missing_crewai_package_shows_full_install_hint`, which is tracked by #6643.

<!-- crewai-require-issue-check -->