### PR TITLE
Use UTF-8 for user data JSON

### DIFF
--- a/lib/crewai-core/src/crewai_core/user_data.py
+++ b/lib/crewai-core/src/crewai_core/user_data.py
@@ -36,7 +36,7 @@ def _load_user_data() -> dict[str, Any]:
     p = _user_data_file()
     if p.exists():
         try:
-            return cast(dict[str, Any], json.loads(p.read_text()))
+            return cast(dict[str, Any], json.loads(p.read_text(encoding="utf-8")))
         except (json.JSONDecodeError, OSError, PermissionError) as e:
             logger.warning("Failed to load user data: %s", e)
     return {}
@@ -46,7 +46,7 @@ def _save_user_data(data: dict[str, Any]) -> None:
     """Write the full user-data dict, ignoring write errors with a warning."""
     try:
         p = _user_data_file()
-        p.write_text(json.dumps(data, indent=2))
+        p.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except (OSError, PermissionError) as e:
         logger.warning("Failed to save user data: %s", e)
 

--- a/lib/crewai-core/src/crewai_core/user_data.py
+++ b/lib/crewai-core/src/crewai_core/user_data.py
@@ -37,7 +37,7 @@ def _load_user_data() -> dict[str, Any]:
     if p.exists():
         try:
             return cast(dict[str, Any], json.loads(p.read_text(encoding="utf-8")))
-        except (json.JSONDecodeError, OSError, PermissionError) as e:
+        except (json.JSONDecodeError, OSError, PermissionError, UnicodeDecodeError) as e:
             logger.warning("Failed to load user data: %s", e)
     return {}
 
@@ -46,7 +46,7 @@ def _save_user_data(data: dict[str, Any]) -> None:
     """Write the full user-data dict, ignoring write errors with a warning."""
     try:
         p = _user_data_file()
-        p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        p.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
     except (OSError, PermissionError) as e:
         logger.warning("Failed to save user data: %s", e)
 

--- a/lib/crewai-core/tests/test_smoke.py
+++ b/lib/crewai-core/tests/test_smoke.py
@@ -79,6 +79,7 @@ def test_user_data_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         "first_execution_done": True,
         "display_name": "José",
     }
+    assert "José" in user_data._user_data_file().read_text(encoding="utf-8")
     assert user_data.has_user_declined_tracing() is False
     monkeypatch.setenv("CREWAI_TRACING_ENABLED", "true")
     assert user_data.is_tracing_enabled() is True

--- a/lib/crewai-core/tests/test_smoke.py
+++ b/lib/crewai-core/tests/test_smoke.py
@@ -66,9 +66,19 @@ def test_user_data_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         "crewai_core.paths.appdirs.user_data_dir",
         lambda app, author: str(tmp_path / app),
     )
-    user_data.update_user_data({"trace_consent": True, "first_execution_done": True})
+    user_data.update_user_data(
+        {
+            "trace_consent": True,
+            "first_execution_done": True,
+            "display_name": "José",
+        }
+    )
     data = user_data._load_user_data()
-    assert data == {"trace_consent": True, "first_execution_done": True}
+    assert data == {
+        "trace_consent": True,
+        "first_execution_done": True,
+        "display_name": "José",
+    }
     assert user_data.has_user_declined_tracing() is False
     monkeypatch.setenv("CREWAI_TRACING_ENABLED", "true")
     assert user_data.is_tracing_enabled() is True


### PR DESCRIPTION
## Summary
- read and write the crewai-core user data JSON file with explicit UTF-8 encoding
- extend the smoke test to cover a non-ASCII value round trip

## Problem
The `.crewai_user.json` helper currently relies on the platform default encoding. That can make trace-consent/user-data persistence locale-dependent on Windows or other non-UTF-8 environments.

## Before / After
Before: user-data JSON reads/writes used the process default encoding.

After: user-data JSON reads/writes use UTF-8 consistently.

## Verification
- `python -m py_compile lib/crewai-core/src/crewai_core/user_data.py lib/crewai-core/tests/test_smoke.py`
- `uv run --project lib/crewai-core pytest lib/crewai-core/tests/test_smoke.py -q`