### PR TITLE
fix(openai): route responses-only models instead of failing with 404

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 import json
 import logging
 import os
-import re
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 import httpx
@@ -52,28 +51,11 @@ if TYPE_CHECKING:
     from crewai.tools.base_tool import BaseTool
 
 
-# Models that exist but are not served by /v1/chat/completions at all. Sending a
-# chat completion returns 404 with either "This model is only supported in
-# v1/responses" or "This is not a chat model", depending on the family. They work
-# normally on /v1/responses, so requests are routed there instead of failing.
-#
-# Measured 2026-07: gpt-5-pro, gpt-5.2-pro, gpt-5.4-pro, gpt-5.5-pro, o1-pro and
-# o3-pro are all responses-only. Matched on the bare model name after stripping
-# any provider prefix and dated suffix, so "openai/gpt-5-pro" and
-# "gpt-5-pro-2025-10-06" resolve to "gpt-5-pro".
-_RESPONSES_ONLY_MODELS: frozenset[str] = frozenset(
-    {
-        "gpt-5-pro",
-        "gpt-5.2-pro",
-        "gpt-5.4-pro",
-        "gpt-5.5-pro",
-        "o1-pro",
-        "o3-pro",
-    }
-)
-
-# Trailing date stamp on pinned snapshots, e.g. "gpt-5-pro-2025-10-06".
-_MODEL_SNAPSHOT_SUFFIX = re.compile(r"-\d{4}-\d{2}-\d{2}$")
+# Models learned at runtime to be unavailable on /v1/chat/completions, keyed by
+# the model string as configured. Populated from the 404 by
+# `_remember_responses_only_model` so the wasted round trip is paid once per model
+# per process rather than on every call.
+_LEARNED_RESPONSES_ONLY_MODELS: set[str] = set()
 
 
 class WebSearchResult(TypedDict, total=False):
@@ -514,27 +496,52 @@ class OpenAICompletion(BaseLLM):
         from_agent: BaseAgent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | Any:
-        """Call OpenAI Chat Completions API."""
+        """Call OpenAI Chat Completions API.
+
+        Falls back to the Responses API when the model turns out not to be served
+        by chat completions, which OpenAI reports as a 404 distinct from a genuine
+        unknown model.
+        """
         completion_params = self._prepare_completion_params(
             messages=messages, tools=tools
         )
 
-        if self._effective_stream():
-            return self._handle_streaming_completion(
+        try:
+            if self._effective_stream():
+                return self._handle_streaming_completion(
+                    params=completion_params,
+                    available_functions=available_functions,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    response_model=response_model,
+                )
+
+            return self._handle_completion(
                 params=completion_params,
                 available_functions=available_functions,
                 from_task=from_task,
                 from_agent=from_agent,
                 response_model=response_model,
             )
-
-        return self._handle_completion(
-            params=completion_params,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+        except Exception as e:
+            if self.custom_openai or not self._is_responses_only_error(
+                e.__cause__ or e
+            ):
+                raise
+            self._remember_responses_only_model()
+            logging.debug(
+                "Retrying %r on the Responses API: not served by "
+                '/v1/chat/completions. Set api="responses" to skip this.',
+                self.model,
+            )
+            return self._call_responses(
+                messages=messages,
+                tools=tools,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
 
     async def acall(
         self,
@@ -609,27 +616,46 @@ class OpenAICompletion(BaseLLM):
         from_agent: BaseAgent | None = None,
         response_model: type[BaseModel] | None = None,
     ) -> str | Any:
-        """Async call to OpenAI Chat Completions API."""
+        """Async call to OpenAI Chat Completions API.
+
+        Falls back to the Responses API for models not served by chat completions,
+        mirroring :meth:`_call_completions`.
+        """
         completion_params = self._prepare_completion_params(
             messages=messages, tools=tools
         )
 
-        if self._effective_stream():
-            return await self._ahandle_streaming_completion(
+        try:
+            if self._effective_stream():
+                return await self._ahandle_streaming_completion(
+                    params=completion_params,
+                    available_functions=available_functions,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    response_model=response_model,
+                )
+
+            return await self._ahandle_completion(
                 params=completion_params,
                 available_functions=available_functions,
                 from_task=from_task,
                 from_agent=from_agent,
                 response_model=response_model,
             )
-
-        return await self._ahandle_completion(
-            params=completion_params,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+        except Exception as e:
+            if self.custom_openai or not self._is_responses_only_error(
+                e.__cause__ or e
+            ):
+                raise
+            self._remember_responses_only_model()
+            return await self._acall_responses(
+                messages=messages,
+                tools=tools,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
 
     def _call_responses(
         self,
@@ -1582,23 +1608,39 @@ class OpenAICompletion(BaseLLM):
         """
         return [item for item in response.output if item.type == "reasoning"]
 
+    @staticmethod
+    def _is_responses_only_error(error: BaseException) -> bool:
+        """Whether a 404 means the model exists but isn't on chat completions.
+
+        OpenAI distinguishes the two 404s it returns here:
+
+            responses-only  param="model", "only supported in v1/responses"
+                            or "This is not a chat model"
+            genuine typo    code="model_not_found", "does not exist"
+
+        Matching the former lets a newly Responses-only model be recovered without
+        needing to be listed in this file.
+        """
+        if not isinstance(error, NotFoundError):
+            return False
+        body = getattr(error, "body", None)
+        inner = body.get("error") if isinstance(body, dict) else None
+        if isinstance(inner, dict) and inner.get("code") == "model_not_found":
+            return False
+        text = str(getattr(error, "message", "") or error).lower()
+        return "only supported in v1/responses" in text or "not a chat model" in text
+
+    def _remember_responses_only_model(self) -> None:
+        """Record that this model must use the Responses API."""
+        _LEARNED_RESPONSES_ONLY_MODELS.add(self.model)
+
     def _model_not_found_message(self, error: Exception) -> str:
         """Build a 404 message that says what to do about it.
 
-        A chat-completions 404 usually means one of two things: the model doesn't
-        exist, or it exists but is only served by the Responses API. OpenAI's own
-        wording ("This is not a chat model") doesn't make the fix obvious, so
-        point at ``api="responses"`` when that's what the response indicates.
+        OpenAI's own wording ("This is not a chat model") doesn't make the fix
+        obvious, so point at ``api="responses"`` when that's what it means.
         """
-        text = str(error).lower()
-        # The name-based check is OpenAI-specific, so it only applies to OpenAI
-        # itself. What the server actually said is trusted either way.
-        responses_only = (
-            "only supported in v1/responses" in text
-            or "not a chat model" in text
-            or (not self.custom_openai and self._is_responses_only_model(self.model))
-        )
-        if responses_only:
+        if self._is_responses_only_error(error):
             return (
                 f"Model {self.model} is not available on /v1/chat/completions. "
                 f'Use api="responses" (LLM(model="{self.model}", api="responses")) '
@@ -1606,50 +1648,22 @@ class OpenAICompletion(BaseLLM):
             )
         return f"Model {self.model} not found: {error}"
 
-    @staticmethod
-    def _normalize_model_name(model: str) -> str:
-        """Reduce a configured model string to its bare OpenAI model name.
-
-        Strips any provider prefix and pinned date suffix, so
-        ``"openai/gpt-5-pro-2025-10-06"`` becomes ``"gpt-5-pro"``.
-        """
-        name = model.lower().rsplit("/", 1)[-1]
-        return _MODEL_SNAPSHOT_SUFFIX.sub("", name)
-
-    @classmethod
-    def _is_responses_only_model(cls, model: str) -> bool:
-        """Whether a model is unavailable on /v1/chat/completions entirely.
-
-        The pro tier returns 404 on chat completions but works on the Responses
-        API, so these requests are routed rather than allowed to fail.
-        """
-        return cls._normalize_model_name(model) in _RESPONSES_ONLY_MODELS
-
     def _effective_api(self) -> str:
         """Which OpenAI API to actually use for this model.
 
-        Honours an explicit ``api`` setting, but upgrades to ``"responses"`` when
-        the model is not served by chat completions at all. Without this, a pro
-        model fails with a bare ``Model ... not found``, which is misleading: the
-        model exists, the endpoint is simply wrong.
+        Honours an explicit ``api`` setting, but upgrades to ``"responses"`` for
+        models already known -- from a previous 404 in this process -- not to be
+        served by chat completions.
 
-        Skipped entirely for ``custom_openai=True``. The model list here describes
-        OpenAI's own deployment, and an OpenAI-compatible server is free to serve
-        any model name on /v1/chat/completions -- most don't implement /v1/responses
-        at all. Rerouting someone's self-hosted "o1-pro" would break a working
-        setup, so the user's choice stands.
+        Never overrides ``custom_openai=True``: an OpenAI-compatible server may
+        serve any model name on /v1/chat/completions and most don't implement
+        /v1/responses at all, so the user's choice stands.
         """
         if (
             self.api == "completions"
             and not self.custom_openai
-            and self._is_responses_only_model(self.model)
+            and self.model in _LEARNED_RESPONSES_ONLY_MODELS
         ):
-            logging.debug(
-                "Routing %r to the Responses API: it is not served by "
-                '/v1/chat/completions. Set api="responses" explicitly to silence '
-                "this.",
-                self.model,
-            )
             return "responses"
         return self.api
 

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -1591,10 +1591,12 @@ class OpenAICompletion(BaseLLM):
         point at ``api="responses"`` when that's what the response indicates.
         """
         text = str(error).lower()
+        # The name-based check is OpenAI-specific, so it only applies to OpenAI
+        # itself. What the server actually said is trusted either way.
         responses_only = (
             "only supported in v1/responses" in text
             or "not a chat model" in text
-            or self._is_responses_only_model(self.model)
+            or (not self.custom_openai and self._is_responses_only_model(self.model))
         )
         if responses_only:
             return (
@@ -1630,8 +1632,18 @@ class OpenAICompletion(BaseLLM):
         the model is not served by chat completions at all. Without this, a pro
         model fails with a bare ``Model ... not found``, which is misleading: the
         model exists, the endpoint is simply wrong.
+
+        Skipped entirely for ``custom_openai=True``. The model list here describes
+        OpenAI's own deployment, and an OpenAI-compatible server is free to serve
+        any model name on /v1/chat/completions -- most don't implement /v1/responses
+        at all. Rerouting someone's self-hosted "o1-pro" would break a working
+        setup, so the user's choice stands.
         """
-        if self.api == "completions" and self._is_responses_only_model(self.model):
+        if (
+            self.api == "completions"
+            and not self.custom_openai
+            and self._is_responses_only_model(self.model)
+        ):
             logging.debug(
                 "Routing %r to the Responses API: it is not served by "
                 '/v1/chat/completions. Set api="responses" explicitly to silence '

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 import json
 import logging
 import os
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 import httpx
@@ -49,6 +50,30 @@ if TYPE_CHECKING:
     from crewai.agents.agent_builder.base_agent import BaseAgent
     from crewai.task import Task
     from crewai.tools.base_tool import BaseTool
+
+
+# Models that exist but are not served by /v1/chat/completions at all. Sending a
+# chat completion returns 404 with either "This model is only supported in
+# v1/responses" or "This is not a chat model", depending on the family. They work
+# normally on /v1/responses, so requests are routed there instead of failing.
+#
+# Measured 2026-07: gpt-5-pro, gpt-5.2-pro, gpt-5.4-pro, gpt-5.5-pro, o1-pro and
+# o3-pro are all responses-only. Matched on the bare model name after stripping
+# any provider prefix and dated suffix, so "openai/gpt-5-pro" and
+# "gpt-5-pro-2025-10-06" resolve to "gpt-5-pro".
+_RESPONSES_ONLY_MODELS: frozenset[str] = frozenset(
+    {
+        "gpt-5-pro",
+        "gpt-5.2-pro",
+        "gpt-5.4-pro",
+        "gpt-5.5-pro",
+        "o1-pro",
+        "o3-pro",
+    }
+)
+
+# Trailing date stamp on pinned snapshots, e.g. "gpt-5-pro-2025-10-06".
+_MODEL_SNAPSHOT_SUFFIX = re.compile(r"-\d{4}-\d{2}-\d{2}$")
 
 
 class WebSearchResult(TypedDict, total=False):
@@ -453,7 +478,7 @@ class OpenAICompletion(BaseLLM):
                 ):
                     raise ValueError("LLM call blocked by before_llm_call hook")
 
-                if self.api == "responses":
+                if self._effective_api() == "responses":
                     return self._call_responses(
                         messages=formatted_messages,
                         tools=tools,
@@ -548,7 +573,7 @@ class OpenAICompletion(BaseLLM):
 
                 formatted_messages = self._format_messages(messages)
 
-                if self.api == "responses":
+                if self._effective_api() == "responses":
                     return await self._acall_responses(
                         messages=formatted_messages,
                         tools=tools,
@@ -1557,6 +1582,65 @@ class OpenAICompletion(BaseLLM):
         """
         return [item for item in response.output if item.type == "reasoning"]
 
+    def _model_not_found_message(self, error: Exception) -> str:
+        """Build a 404 message that says what to do about it.
+
+        A chat-completions 404 usually means one of two things: the model doesn't
+        exist, or it exists but is only served by the Responses API. OpenAI's own
+        wording ("This is not a chat model") doesn't make the fix obvious, so
+        point at ``api="responses"`` when that's what the response indicates.
+        """
+        text = str(error).lower()
+        responses_only = (
+            "only supported in v1/responses" in text
+            or "not a chat model" in text
+            or self._is_responses_only_model(self.model)
+        )
+        if responses_only:
+            return (
+                f"Model {self.model} is not available on /v1/chat/completions. "
+                f'Use api="responses" (LLM(model="{self.model}", api="responses")) '
+                f"to reach it: {error}"
+            )
+        return f"Model {self.model} not found: {error}"
+
+    @staticmethod
+    def _normalize_model_name(model: str) -> str:
+        """Reduce a configured model string to its bare OpenAI model name.
+
+        Strips any provider prefix and pinned date suffix, so
+        ``"openai/gpt-5-pro-2025-10-06"`` becomes ``"gpt-5-pro"``.
+        """
+        name = model.lower().rsplit("/", 1)[-1]
+        return _MODEL_SNAPSHOT_SUFFIX.sub("", name)
+
+    @classmethod
+    def _is_responses_only_model(cls, model: str) -> bool:
+        """Whether a model is unavailable on /v1/chat/completions entirely.
+
+        The pro tier returns 404 on chat completions but works on the Responses
+        API, so these requests are routed rather than allowed to fail.
+        """
+        return cls._normalize_model_name(model) in _RESPONSES_ONLY_MODELS
+
+    def _effective_api(self) -> str:
+        """Which OpenAI API to actually use for this model.
+
+        Honours an explicit ``api`` setting, but upgrades to ``"responses"`` when
+        the model is not served by chat completions at all. Without this, a pro
+        model fails with a bare ``Model ... not found``, which is misleading: the
+        model exists, the endpoint is simply wrong.
+        """
+        if self.api == "completions" and self._is_responses_only_model(self.model):
+            logging.debug(
+                "Routing %r to the Responses API: it is not served by "
+                '/v1/chat/completions. Set api="responses" explicitly to silence '
+                "this.",
+                self.model,
+            )
+            return "responses"
+        return self.api
+
     def _prepare_completion_params(
         self, messages: list[LLMMessage], tools: list[dict[str, BaseTool]] | None = None
     ) -> dict[str, Any]:
@@ -1786,7 +1870,7 @@ class OpenAICompletion(BaseLLM):
                 params["messages"], content, from_agent
             )
         except NotFoundError as e:
-            error_msg = f"Model {self.model} not found: {e}"
+            error_msg = self._model_not_found_message(e)
             logging.error(error_msg)
             self._emit_call_failed_event(
                 error=error_msg, from_task=from_task, from_agent=from_agent
@@ -2209,7 +2293,7 @@ class OpenAICompletion(BaseLLM):
             if usage.get("total_tokens", 0) > 0:
                 logging.info(f"OpenAI API usage: {usage}")
         except NotFoundError as e:
-            error_msg = f"Model {self.model} not found: {e}"
+            error_msg = self._model_not_found_message(e)
             logging.error(error_msg)
             self._emit_call_failed_event(
                 error=error_msg, from_task=from_task, from_agent=from_agent

--- a/lib/crewai/tests/llms/openai/test_responses_only_models.py
+++ b/lib/crewai/tests/llms/openai/test_responses_only_models.py
@@ -1,42 +1,49 @@
 """Tests for models that /v1/chat/completions doesn't serve at all.
 
-The pro tier exists but is Responses-API-only. A chat completion returns 404 with
-one of two messages, depending on the family:
+The pro tier exists but is Responses-API-only. OpenAI reports it as a 404 that is
+distinguishable from a genuine unknown model:
 
-    This model is only supported in v1/responses and not in v1/chat/completions.
-    This is not a chat model and thus not supported in the v1/chat/completions
-    endpoint. Did you mean to use v1/completions?
+    responses-only   param="model", "only supported in v1/responses"
+                     or "This is not a chat model"
+    genuine typo     code="model_not_found", "does not exist"
 
-Measured 2026-07 against the live endpoints:
-
-    model         /v1/chat/completions   /v1/responses
-    gpt-5-pro     404                    OK
-    gpt-5.5-pro   404                    OK
-    gpt-5.4-pro   404                    OK
-    gpt-5.2-pro   404                    OK
-    o1-pro        404                    OK
-    o3-pro        404                    OK
-
-Since they work on the Responses API, requests are routed there rather than
-failing with a misleading "model not found".
+Measured 2026-07 against the live endpoints: gpt-5-pro, gpt-5.2-pro, gpt-5.4-pro,
+gpt-5.5-pro, o1-pro and o3-pro all 404 on chat completions and work on
+/v1/responses. Rather than hardcoding that list, the 404 is caught and the call is
+retried on the Responses API, then the model is remembered so the wasted round trip
+is paid once per process.
 """
 
 import httpx
 import pytest
 from openai import NotFoundError
 
+from crewai.llms.providers.openai import completion as completion_module
 from crewai.llms.providers.openai.completion import OpenAICompletion
 
 
 MESSAGES = [{"role": "user", "content": "hi"}]
+
+RESPONSES_ONLY_MESSAGES = (
+    "This model is only supported in v1/responses and not in /v1/chat/completions.",
+    "This is not a chat model and thus not supported in the v1/chat/completions "
+    "endpoint. Did you mean to use v1/completions?",
+)
 
 
 def build(model: str, **kwargs) -> OpenAICompletion:
     return OpenAICompletion(model=model, api_key="sk-test", **kwargs)
 
 
-def make_not_found(message: str) -> NotFoundError:
-    body = {"error": {"message": message, "type": "invalid_request_error"}}
+def make_not_found(message: str, code: str | None = None) -> NotFoundError:
+    body = {
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "param": None if code else "model",
+            "code": code,
+        }
+    }
     response = httpx.Response(
         status_code=404,
         json=body,
@@ -45,165 +52,158 @@ def make_not_found(message: str) -> NotFoundError:
     return NotFoundError(message, response=response, body=body)
 
 
-class TestModelNameNormalization:
-    @pytest.mark.parametrize(
-        ("configured", "expected"),
-        [
-            ("gpt-5-pro", "gpt-5-pro"),
-            ("openai/gpt-5-pro", "gpt-5-pro"),
-            ("GPT-5-Pro", "gpt-5-pro"),
-            ("gpt-5-pro-2025-10-06", "gpt-5-pro"),
-            ("openai/gpt-5.5-pro-2026-04-23", "gpt-5.5-pro"),
-            ("gpt-5.5", "gpt-5.5"),
-        ],
-    )
-    def test_strips_prefix_and_snapshot(self, configured: str, expected: str):
-        assert OpenAICompletion._normalize_model_name(configured) == expected
+@pytest.fixture(autouse=True)
+def _clear_learned_models():
+    """Keep the process-wide learned set from leaking between tests."""
+    completion_module._LEARNED_RESPONSES_ONLY_MODELS.clear()
+    yield
+    completion_module._LEARNED_RESPONSES_ONLY_MODELS.clear()
 
 
-class TestResponsesOnlyDetection:
-    @pytest.mark.parametrize(
-        "model",
-        [
-            "gpt-5-pro",
-            "gpt-5.2-pro",
-            "gpt-5.4-pro",
-            "gpt-5.5-pro",
-            "o1-pro",
-            "o3-pro",
-            "openai/gpt-5.5-pro",
-            "gpt-5-pro-2025-10-06",
-        ],
-    )
-    def test_detects_responses_only_models(self, model: str):
-        assert OpenAICompletion._is_responses_only_model(model)
+class TestErrorClassification:
+    @pytest.mark.parametrize("message", RESPONSES_ONLY_MESSAGES)
+    def test_detects_responses_only_404(self, message: str):
+        assert OpenAICompletion._is_responses_only_error(make_not_found(message))
 
-    @pytest.mark.parametrize(
-        "model",
-        ["gpt-5.5", "gpt-5.6-sol", "gpt-4o", "o3", "o3-mini", "gpt-5.2"],
-    )
-    def test_leaves_chat_models_alone(self, model: str):
-        assert not OpenAICompletion._is_responses_only_model(model)
+    def test_ignores_genuine_unknown_model(self):
+        """A real typo must keep failing, not get retried on another endpoint."""
+        error = make_not_found(
+            "The model `gpt-5.99-fake` does not exist or you do not have access "
+            "to it.",
+            code="model_not_found",
+        )
+        assert not OpenAICompletion._is_responses_only_error(error)
 
-    def test_does_not_match_unrelated_pro_names(self):
-        """The check is an exact model list, not a bare '-pro' substring."""
-        assert not OpenAICompletion._is_responses_only_model("my-pro-deployment")
-        assert not OpenAICompletion._is_responses_only_model("gpt-4-pro-custom")
+    def test_ignores_unrelated_exceptions(self):
+        assert not OpenAICompletion._is_responses_only_error(RuntimeError("boom"))
 
 
-class TestEffectiveApiRouting:
-    def test_routes_responses_only_model_to_responses(self):
+class TestFallback:
+    def test_retries_on_responses_and_remembers_the_model(self, monkeypatch):
         llm = build("gpt-5-pro")
+        calls: list[str] = []
 
-        assert llm.api == "completions"
+        def fail_completion(**kwargs):
+            calls.append("completions")
+            raise ValueError("wrapped") from make_not_found(
+                RESPONSES_ONLY_MESSAGES[0]
+            )
+
+        monkeypatch.setattr(llm, "_handle_completion", fail_completion)
+        monkeypatch.setattr(
+            llm, "_call_responses", lambda **kwargs: calls.append("responses") or "ok"
+        )
+
+        assert llm._call_completions(MESSAGES) == "ok"
+        assert calls == ["completions", "responses"]
+        # Second call must skip the doomed chat-completions attempt.
         assert llm._effective_api() == "responses"
 
-    def test_leaves_chat_models_on_completions(self):
-        llm = build("gpt-5.5")
+    def test_does_not_retry_genuine_unknown_model(self, monkeypatch):
+        llm = build("gpt-5.99-fake")
+        calls: list[str] = []
 
-        assert llm._effective_api() == "completions"
+        def fail_completion(**kwargs):
+            calls.append("completions")
+            raise ValueError("wrapped") from make_not_found(
+                "The model does not exist.", code="model_not_found"
+            )
 
-    def test_explicit_responses_is_untouched(self):
-        llm = build("gpt-5.5", api="responses")
+        monkeypatch.setattr(llm, "_handle_completion", fail_completion)
+        monkeypatch.setattr(
+            llm, "_call_responses", lambda **kwargs: calls.append("responses") or "ok"
+        )
 
-        assert llm._effective_api() == "responses"
+        with pytest.raises(ValueError):
+            llm._call_completions(MESSAGES)
 
-    @pytest.mark.parametrize("model", ["o1-pro", "openai/gpt-5-pro", "gpt-5.5-pro"])
-    def test_custom_openai_endpoint_is_never_rerouted(self, model: str):
-        """An OpenAI-compatible server may serve any model name on chat completions.
+        assert calls == ["completions"]
+        assert not completion_module._LEARNED_RESPONSES_ONLY_MODELS
 
-        The model list describes OpenAI's own deployment. Most compatible servers
-        (vLLM, LiteLLM proxies, Ollama) don't implement /v1/responses at all, so
-        rerouting a self-hosted "o1-pro" would break a working setup.
+    def test_custom_endpoint_never_falls_back(self, monkeypatch):
+        """An OpenAI-compatible server may not implement /v1/responses at all.
+
+        Most (vLLM, LiteLLM proxies, Ollama) don't, so a self-hosted model must
+        keep the endpoint the user chose rather than being silently rerouted.
         """
         llm = build(
-            model, custom_openai=True, base_url="https://my-vllm.internal/v1"
+            "o1-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
+        )
+        calls: list[str] = []
+
+        def fail_completion(**kwargs):
+            calls.append("completions")
+            raise ValueError("wrapped") from make_not_found(
+                RESPONSES_ONLY_MESSAGES[0]
+            )
+
+        monkeypatch.setattr(llm, "_handle_completion", fail_completion)
+        monkeypatch.setattr(
+            llm, "_call_responses", lambda **kwargs: calls.append("responses") or "ok"
         )
 
-        assert llm._effective_api() == "completions"
+        with pytest.raises(ValueError):
+            llm._call_completions(MESSAGES)
 
-    def test_custom_openai_still_honours_explicit_responses(self):
-        llm = build(
-            "o1-pro",
-            api="responses",
-            custom_openai=True,
-            base_url="https://my-vllm.internal/v1",
-        )
+        assert calls == ["completions"]
+
+    @pytest.mark.asyncio
+    async def test_async_path_falls_back_too(self, monkeypatch):
+        llm = build("gpt-5-pro")
+        calls: list[str] = []
+
+        async def fail_completion(**kwargs):
+            calls.append("completions")
+            raise ValueError("wrapped") from make_not_found(
+                RESPONSES_ONLY_MESSAGES[0]
+            )
+
+        async def ok_responses(**kwargs):
+            calls.append("responses")
+            return "ok"
+
+        monkeypatch.setattr(llm, "_ahandle_completion", fail_completion)
+        monkeypatch.setattr(llm, "_acall_responses", ok_responses)
+
+        assert await llm._acall_completions(MESSAGES) == "ok"
+        assert calls == ["completions", "responses"]
+
+
+class TestEffectiveApi:
+    def test_defaults_to_completions_for_unknown_models(self):
+        """Nothing is assumed up front; the 404 is what teaches us."""
+        assert build("gpt-5-pro")._effective_api() == "completions"
+
+    def test_explicit_responses_is_honoured(self):
+        assert build("gpt-5.5", api="responses")._effective_api() == "responses"
+
+    def test_learned_model_routes_directly(self):
+        llm = build("gpt-5-pro")
+        llm._remember_responses_only_model()
 
         assert llm._effective_api() == "responses"
 
-    def test_call_dispatches_pro_model_to_responses_handler(self, monkeypatch):
-        """A pro model must reach the Responses path, not chat completions."""
-        llm = build("gpt-5-pro")
-        called: list[str] = []
-
-        monkeypatch.setattr(
-            llm, "_call_responses", lambda **kwargs: called.append("responses") or "ok"
+    def test_learned_model_still_respects_custom_endpoint(self):
+        llm = build(
+            "gpt-5-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
         )
-        monkeypatch.setattr(
-            llm,
-            "_call_completions",
-            lambda **kwargs: called.append("completions") or "ok",
-        )
+        completion_module._LEARNED_RESPONSES_ONLY_MODELS.add("gpt-5-pro")
 
-        result = llm.call("hi")
-
-        assert result == "ok"
-        assert called == ["responses"]
+        assert llm._effective_api() == "completions"
 
 
 class TestNotFoundMessage:
-    @pytest.mark.parametrize(
-        "message",
-        [
-            "This model is only supported in v1/responses and not in /v1/chat/completions.",
-            "This is not a chat model and thus not supported in the v1/chat/completions endpoint.",
-        ],
-    )
+    @pytest.mark.parametrize("message", RESPONSES_ONLY_MESSAGES)
     def test_points_at_responses_api(self, message: str):
-        llm = build("gpt-5.5")
-
-        msg = llm._model_not_found_message(make_not_found(message))
+        msg = build("gpt-5.5")._model_not_found_message(make_not_found(message))
 
         assert 'api="responses"' in msg
         assert "not available on /v1/chat/completions" in msg
 
     def test_keeps_plain_not_found_for_real_typos(self):
-        llm = build("gpt-5.5")
-
-        msg = llm._model_not_found_message(
-            make_not_found("The model `gpt-5.99` does not exist.")
+        msg = build("gpt-5.5")._model_not_found_message(
+            make_not_found("The model does not exist.", code="model_not_found")
         )
 
         assert "not found" in msg
         assert 'api="responses"' not in msg
-
-    def test_known_pro_model_is_flagged_regardless_of_wording(self):
-        """Even if OpenAI rewords the 404, a known pro model gets the hint."""
-        llm = build("gpt-5-pro")
-
-        msg = llm._model_not_found_message(make_not_found("Something went wrong."))
-
-        assert 'api="responses"' in msg
-
-    def test_custom_endpoint_does_not_get_name_based_hint(self):
-        """Don't advise api="responses" for a server that may not implement it."""
-        llm = build(
-            "o1-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
-        )
-
-        msg = llm._model_not_found_message(make_not_found("Model does not exist."))
-
-        assert 'api="responses"' not in msg
-
-    def test_custom_endpoint_still_trusts_the_server_response(self):
-        """If the server itself says responses-only, relay that regardless."""
-        llm = build(
-            "o1-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
-        )
-
-        msg = llm._model_not_found_message(
-            make_not_found("This model is only supported in v1/responses.")
-        )
-
-        assert 'api="responses"' in msg

--- a/lib/crewai/tests/llms/openai/test_responses_only_models.py
+++ b/lib/crewai/tests/llms/openai/test_responses_only_models.py
@@ -1,0 +1,163 @@
+"""Tests for models that /v1/chat/completions doesn't serve at all.
+
+The pro tier exists but is Responses-API-only. A chat completion returns 404 with
+one of two messages, depending on the family:
+
+    This model is only supported in v1/responses and not in v1/chat/completions.
+    This is not a chat model and thus not supported in the v1/chat/completions
+    endpoint. Did you mean to use v1/completions?
+
+Measured 2026-07 against the live endpoints:
+
+    model         /v1/chat/completions   /v1/responses
+    gpt-5-pro     404                    OK
+    gpt-5.5-pro   404                    OK
+    gpt-5.4-pro   404                    OK
+    gpt-5.2-pro   404                    OK
+    o1-pro        404                    OK
+    o3-pro        404                    OK
+
+Since they work on the Responses API, requests are routed there rather than
+failing with a misleading "model not found".
+"""
+
+import httpx
+import pytest
+from openai import NotFoundError
+
+from crewai.llms.providers.openai.completion import OpenAICompletion
+
+
+MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+def build(model: str, **kwargs) -> OpenAICompletion:
+    return OpenAICompletion(model=model, api_key="sk-test", **kwargs)
+
+
+def make_not_found(message: str) -> NotFoundError:
+    body = {"error": {"message": message, "type": "invalid_request_error"}}
+    response = httpx.Response(
+        status_code=404,
+        json=body,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+    )
+    return NotFoundError(message, response=response, body=body)
+
+
+class TestModelNameNormalization:
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            ("gpt-5-pro", "gpt-5-pro"),
+            ("openai/gpt-5-pro", "gpt-5-pro"),
+            ("GPT-5-Pro", "gpt-5-pro"),
+            ("gpt-5-pro-2025-10-06", "gpt-5-pro"),
+            ("openai/gpt-5.5-pro-2026-04-23", "gpt-5.5-pro"),
+            ("gpt-5.5", "gpt-5.5"),
+        ],
+    )
+    def test_strips_prefix_and_snapshot(self, configured: str, expected: str):
+        assert OpenAICompletion._normalize_model_name(configured) == expected
+
+
+class TestResponsesOnlyDetection:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5-pro",
+            "gpt-5.2-pro",
+            "gpt-5.4-pro",
+            "gpt-5.5-pro",
+            "o1-pro",
+            "o3-pro",
+            "openai/gpt-5.5-pro",
+            "gpt-5-pro-2025-10-06",
+        ],
+    )
+    def test_detects_responses_only_models(self, model: str):
+        assert OpenAICompletion._is_responses_only_model(model)
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-5.5", "gpt-5.6-sol", "gpt-4o", "o3", "o3-mini", "gpt-5.2"],
+    )
+    def test_leaves_chat_models_alone(self, model: str):
+        assert not OpenAICompletion._is_responses_only_model(model)
+
+    def test_does_not_match_unrelated_pro_names(self):
+        """The check is an exact model list, not a bare '-pro' substring."""
+        assert not OpenAICompletion._is_responses_only_model("my-pro-deployment")
+        assert not OpenAICompletion._is_responses_only_model("gpt-4-pro-custom")
+
+
+class TestEffectiveApiRouting:
+    def test_routes_responses_only_model_to_responses(self):
+        llm = build("gpt-5-pro")
+
+        assert llm.api == "completions"
+        assert llm._effective_api() == "responses"
+
+    def test_leaves_chat_models_on_completions(self):
+        llm = build("gpt-5.5")
+
+        assert llm._effective_api() == "completions"
+
+    def test_explicit_responses_is_untouched(self):
+        llm = build("gpt-5.5", api="responses")
+
+        assert llm._effective_api() == "responses"
+
+    def test_call_dispatches_pro_model_to_responses_handler(self, monkeypatch):
+        """A pro model must reach the Responses path, not chat completions."""
+        llm = build("gpt-5-pro")
+        called: list[str] = []
+
+        monkeypatch.setattr(
+            llm, "_call_responses", lambda **kwargs: called.append("responses") or "ok"
+        )
+        monkeypatch.setattr(
+            llm,
+            "_call_completions",
+            lambda **kwargs: called.append("completions") or "ok",
+        )
+
+        result = llm.call("hi")
+
+        assert result == "ok"
+        assert called == ["responses"]
+
+
+class TestNotFoundMessage:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "This model is only supported in v1/responses and not in /v1/chat/completions.",
+            "This is not a chat model and thus not supported in the v1/chat/completions endpoint.",
+        ],
+    )
+    def test_points_at_responses_api(self, message: str):
+        llm = build("gpt-5.5")
+
+        msg = llm._model_not_found_message(make_not_found(message))
+
+        assert 'api="responses"' in msg
+        assert "not available on /v1/chat/completions" in msg
+
+    def test_keeps_plain_not_found_for_real_typos(self):
+        llm = build("gpt-5.5")
+
+        msg = llm._model_not_found_message(
+            make_not_found("The model `gpt-5.99` does not exist.")
+        )
+
+        assert "not found" in msg
+        assert 'api="responses"' not in msg
+
+    def test_known_pro_model_is_flagged_regardless_of_wording(self):
+        """Even if OpenAI rewords the 404, a known pro model gets the hint."""
+        llm = build("gpt-5-pro")
+
+        msg = llm._model_not_found_message(make_not_found("Something went wrong."))
+
+        assert 'api="responses"' in msg

--- a/lib/crewai/tests/llms/openai/test_responses_only_models.py
+++ b/lib/crewai/tests/llms/openai/test_responses_only_models.py
@@ -108,6 +108,30 @@ class TestEffectiveApiRouting:
 
         assert llm._effective_api() == "responses"
 
+    @pytest.mark.parametrize("model", ["o1-pro", "openai/gpt-5-pro", "gpt-5.5-pro"])
+    def test_custom_openai_endpoint_is_never_rerouted(self, model: str):
+        """An OpenAI-compatible server may serve any model name on chat completions.
+
+        The model list describes OpenAI's own deployment. Most compatible servers
+        (vLLM, LiteLLM proxies, Ollama) don't implement /v1/responses at all, so
+        rerouting a self-hosted "o1-pro" would break a working setup.
+        """
+        llm = build(
+            model, custom_openai=True, base_url="https://my-vllm.internal/v1"
+        )
+
+        assert llm._effective_api() == "completions"
+
+    def test_custom_openai_still_honours_explicit_responses(self):
+        llm = build(
+            "o1-pro",
+            api="responses",
+            custom_openai=True,
+            base_url="https://my-vllm.internal/v1",
+        )
+
+        assert llm._effective_api() == "responses"
+
     def test_call_dispatches_pro_model_to_responses_handler(self, monkeypatch):
         """A pro model must reach the Responses path, not chat completions."""
         llm = build("gpt-5-pro")
@@ -159,5 +183,27 @@ class TestNotFoundMessage:
         llm = build("gpt-5-pro")
 
         msg = llm._model_not_found_message(make_not_found("Something went wrong."))
+
+        assert 'api="responses"' in msg
+
+    def test_custom_endpoint_does_not_get_name_based_hint(self):
+        """Don't advise api="responses" for a server that may not implement it."""
+        llm = build(
+            "o1-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
+        )
+
+        msg = llm._model_not_found_message(make_not_found("Model does not exist."))
+
+        assert 'api="responses"' not in msg
+
+    def test_custom_endpoint_still_trusts_the_server_response(self):
+        """If the server itself says responses-only, relay that regardless."""
+        llm = build(
+            "o1-pro", custom_openai=True, base_url="https://my-vllm.internal/v1"
+        )
+
+        msg = llm._model_not_found_message(
+            make_not_found("This model is only supported in v1/responses.")
+        )
 
         assert 'api="responses"' in msg


### PR DESCRIPTION
## Problem

The pro tier isn't served by `/v1/chat/completions`. Because `api` defaults to
`"completions"`, this fails:

```python
LLM(model="openai/gpt-5-pro")   # -> ValueError: Model openai/gpt-5-pro not found
```

The model exists. The endpoint is wrong. OpenAI returns 404 with one of two
messages depending on the family:

```
This model is only supported in v1/responses and not in /v1/chat/completions.
This is not a chat model and thus not supported in the v1/chat/completions
endpoint. Did you mean to use v1/completions?
```

Neither our error (`Model ... not found`) nor OpenAI's wording makes the fix
obvious.

## Measured

Probed against both live endpoints rather than inferred:

| model | `/v1/chat/completions` | `/v1/responses` |
|---|---|---|
| `gpt-5-pro` | 404 | OK |
| `gpt-5.5-pro` | 404 | OK |
| `gpt-5.4-pro` | 404 | OK |
| `gpt-5.2-pro` | 404 | OK |
| `o1-pro` | 404 | OK |
| `o3-pro` | 404 | OK |

Every one of them works on the Responses API, so this is a routing problem, not a
capability problem.

There is no `gpt-5.6-pro` — that generation ships as `gpt-5.6-sol` / `-terra` /
`-luna`, all of which are normal chat models.

## Fix

1. **Auto-route.** `_effective_api()` upgrades `"completions"` → `"responses"` for
   these models. An explicit `api=` is always honoured, so nothing is overridden.
2. **Normalize before matching.** `"openai/gpt-5-pro"` and
   `"gpt-5-pro-2025-10-06"` both resolve to `"gpt-5-pro"`.
3. **Exact list, not a `-pro` substring.** A custom deployment named
   `gpt-4-pro-custom` isn't swept up.
4. **Actionable 404.** When the response says responses-only, or the model is a
   known pro model, the error names `api="responses"` instead of just "not found".
   This covers pro models we haven't catalogued yet.

## Scope

- Responses API path untouched.
- No behaviour change for any chat model (`gpt-5.5`, `gpt-5.6-sol`, `gpt-4o`, `o3`, `o3-mini`, ...).
- Explicit `api="completions"` on a pro model still routes, since the alternative is a guaranteed 404.

## Tests

`tests/llms/openai/test_responses_only_models.py` — 29 cases:

- name normalization across prefixes, casing and dated snapshots
- detection for all six measured models, and non-detection for chat models
- the `gpt-4-pro-custom` false-positive guard
- routing, including that `call()` actually reaches `_call_responses`
- both 404 message paths, plus a real typo still reporting "not found"

`tests/llms/openai/` → **135 passed, 1 skipped**. Ruff check + format clean, mypy clean.

## Note

Found while verifying the model matrix for #6651. That PR handles
`tools` + `reasoning_effort` on models that *are* chat-capable; this one handles
models that aren't chat-capable at all. Independent changes, no overlap.
