### PR TITLE
fix(openai): make tool calling work on the Responses API path

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -668,6 +668,52 @@ class OpenAICompletion(BaseLLM):
             response_model=response_model,
         )
 
+    @staticmethod
+    def _to_responses_input(message: LLMMessage) -> list[Any]:
+        """Translate a chat-format message into Responses ``input`` items.
+
+        Tool calling is expressed differently by the two APIs. Chat Completions
+        uses an assistant message carrying ``tool_calls`` (with ``content: None``)
+        followed by ``role: "tool"`` results; the Responses API uses flat
+        ``function_call`` / ``function_call_output`` items keyed by ``call_id``.
+
+        Passing the chat shape straight through is rejected:
+
+            Invalid type for 'input[1].content': expected one of an array of
+            objects or string, but got null instead.
+
+        Anything without tool calls is already valid and passes through unchanged.
+        """
+        role = message.get("role")
+
+        if role == "assistant" and message.get("tool_calls"):
+            items: list[Any] = []
+            content = message.get("content")
+            if content:
+                items.append({"role": "assistant", "content": content})
+            for call in message["tool_calls"]:
+                function = call.get("function", {})
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call.get("id", ""),
+                        "name": function.get("name", ""),
+                        "arguments": function.get("arguments", "{}"),
+                    }
+                )
+            return items
+
+        if role == "tool":
+            return [
+                {
+                    "type": "function_call_output",
+                    "call_id": message.get("tool_call_id", ""),
+                    "output": str(message.get("content", "")),
+                }
+            ]
+
+        return [message]
+
     def _prepare_responses_params(
         self,
         messages: list[LLMMessage],
@@ -694,7 +740,7 @@ class OpenAICompletion(BaseLLM):
                 else:
                     instructions = content_str
             else:
-                input_messages.append(message)
+                input_messages.extend(self._to_responses_input(message))
 
         # Prepend reasoning items for ZDR (zero-data-retention) chaining when configured
         final_input: list[Any] = []

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1252,7 +1252,15 @@ def extract_tool_call_info(
         )
         func_info = tool_call.get("function", {})
         func_name = func_info.get("name", "") or tool_call.get("name", "")
-        func_args = func_info.get("arguments") or tool_call.get("input") or {}
+        # "arguments" is also read from the top level for the OpenAI Responses API,
+        # which emits {"id", "name", "arguments"} with no nested "function" object.
+        # Without it the args silently resolved to {} and the tool ran with no input.
+        func_args = (
+            func_info.get("arguments")
+            or tool_call.get("arguments")
+            or tool_call.get("input")
+            or {}
+        )
         return call_id, sanitize_tool_name(func_name), func_args
     return None
 
@@ -1283,6 +1291,16 @@ def is_tool_call_list(response: list[Any]) -> bool:
         return True
     # Bedrock-style
     if isinstance(first_item, dict) and "name" in first_item and "input" in first_item:
+        return True
+    # OpenAI Responses API style: {"id", "name", "arguments"}, with no nested
+    # "function" object and no "input". Without this the list isn't recognized as
+    # tool calls, so the executor hands it back verbatim and the agent returns raw
+    # tool-call JSON instead of running the tool and producing a final answer.
+    if (
+        isinstance(first_item, dict)
+        and "name" in first_item
+        and "arguments" in first_item
+    ):
         return True
     # Gemini-style
     if hasattr(first_item, "function_call") and first_item.function_call:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1246,9 +1246,16 @@ def extract_tool_call_info(
         call_id = getattr(tool_call, "id", f"call_{id(tool_call)}")
         return call_id, sanitize_tool_name(tool_call.name), tool_call.input
     if isinstance(tool_call, dict):
-        # Support OpenAI "id", Bedrock "toolUseId", or generate one
+        # Prefer the Responses API "call_id", then OpenAI "id", then Bedrock
+        # "toolUseId", else generate one. A raw Responses function_call item carries
+        # both "id" (fc_...) and "call_id" (call_...) with different values, and the
+        # matching function_call_output must reference "call_id" -- reading "id"
+        # would produce a tool result that can't be correlated to its invocation.
         call_id = (
-            tool_call.get("id") or tool_call.get("toolUseId") or f"call_{id(tool_call)}"
+            tool_call.get("call_id")
+            or tool_call.get("id")
+            or tool_call.get("toolUseId")
+            or f"call_{id(tool_call)}"
         )
         func_info = tool_call.get("function", {})
         func_name = func_info.get("name", "") or tool_call.get("name", "")

--- a/lib/crewai/tests/llms/openai/test_responses_tool_loop.py
+++ b/lib/crewai/tests/llms/openai/test_responses_tool_loop.py
@@ -1,0 +1,177 @@
+"""Tests for tool calling on the OpenAI Responses API path.
+
+The two APIs express tool calling differently:
+
+    Chat Completions   assistant message with `tool_calls` (content: None),
+                       then {"role": "tool", "tool_call_id": ...}
+    Responses          flat {"type": "function_call", "call_id", ...} and
+                       {"type": "function_call_output", "call_id", "output"} items
+
+Sending the chat shape to /v1/responses is rejected outright:
+
+    Invalid type for 'input[1].content': expected one of an array of objects or
+    string, but got null instead.
+
+Verified against the live endpoint: the chat shape 400s, the native items complete.
+"""
+
+import pytest
+
+from crewai.llms.providers.openai.completion import OpenAICompletion
+from crewai.utilities.agent_utils import extract_tool_call_info, is_tool_call_list
+
+
+# The shape OpenAICompletion._extract_function_calls_from_response builds from a
+# Responses payload: no nested "function" object, no "input".
+RESPONSES_TOOL_CALL = {
+    "id": "call_abc",
+    "name": "multiply",
+    "arguments": '{"a": 17, "b": 23}',
+}
+
+
+def build(model: str = "gpt-5.5", **kwargs) -> OpenAICompletion:
+    return OpenAICompletion(model=model, api_key="sk-test", api="responses", **kwargs)
+
+
+class TestToolCallRecognition:
+    """The executor must recognize Responses-shaped tool calls."""
+
+    def test_recognizes_responses_shape(self):
+        assert is_tool_call_list([RESPONSES_TOOL_CALL])
+
+    def test_extracts_arguments_from_top_level(self):
+        """Previously fell through to `input` and silently yielded {}."""
+        call_id, name, args = extract_tool_call_info(RESPONSES_TOOL_CALL)
+
+        assert call_id == "call_abc"
+        assert name == "multiply"
+        assert args == '{"a": 17, "b": 23}'
+
+    @pytest.mark.parametrize(
+        ("tool_call", "expected_args"),
+        [
+            (
+                {"id": "c", "function": {"name": "f", "arguments": '{"x":1}'}},
+                '{"x":1}',
+            ),
+            ({"toolUseId": "c", "name": "f", "input": {"x": 1}}, {"x": 1}),
+        ],
+    )
+    def test_other_provider_shapes_still_work(self, tool_call, expected_args):
+        """Chat Completions and Bedrock shapes must be unaffected."""
+        assert is_tool_call_list([tool_call])
+        assert extract_tool_call_info(tool_call)[2] == expected_args
+
+
+class TestResponsesInputTranslation:
+    """Chat-format tool messages must become native Responses items."""
+
+    def test_assistant_tool_calls_become_function_call_items(self):
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "multiply", "arguments": '{"a":17,"b":23}'},
+                }
+            ],
+        }
+
+        assert OpenAICompletion._to_responses_input(message) == [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "multiply",
+                "arguments": '{"a":17,"b":23}',
+            }
+        ]
+
+    def test_tool_result_becomes_function_call_output(self):
+        message = {"role": "tool", "tool_call_id": "call_1", "content": "391"}
+
+        assert OpenAICompletion._to_responses_input(message) == [
+            {"type": "function_call_output", "call_id": "call_1", "output": "391"}
+        ]
+
+    def test_assistant_text_alongside_tool_calls_is_preserved(self):
+        message = {
+            "role": "assistant",
+            "content": "Let me calculate.",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "multiply", "arguments": "{}"}}
+            ],
+        }
+
+        items = OpenAICompletion._to_responses_input(message)
+
+        assert items[0] == {"role": "assistant", "content": "Let me calculate."}
+        assert items[1]["type"] == "function_call"
+
+    def test_parallel_tool_calls_become_separate_items(self):
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "multiply", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "add", "arguments": "{}"}},
+            ],
+        }
+
+        items = OpenAICompletion._to_responses_input(message)
+
+        assert [i["call_id"] for i in items] == ["c1", "c2"]
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    )
+    def test_messages_without_tool_calls_pass_through(self, message):
+        assert OpenAICompletion._to_responses_input(message) == [message]
+
+    def test_non_string_tool_output_is_coerced(self):
+        """Tool results arrive as ints, dicts, etc. The API requires a string."""
+        message = {"role": "tool", "tool_call_id": "c1", "content": 391}
+
+        assert OpenAICompletion._to_responses_input(message)[0]["output"] == "391"
+
+
+class TestPreparedParams:
+    """End-to-end shape of the `input` list handed to the Responses API."""
+
+    def test_tool_conversation_produces_valid_input(self):
+        llm = build()
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "multiply 17 and 23"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "multiply", "arguments": '{"a":17,"b":23}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "391"},
+        ]
+
+        params = llm._prepare_responses_params(messages)
+
+        assert params["instructions"] == "You are helpful."
+        assert [item.get("type") or item["role"] for item in params["input"]] == [
+            "user",
+            "function_call",
+            "function_call_output",
+        ]
+        # The rejected shape was an item carrying an explicit content: None.
+        # function_call items have no content key at all, which is valid.
+        assert not any(
+            "content" in item and item["content"] is None for item in params["input"]
+        )

--- a/lib/crewai/tests/llms/openai/test_responses_tool_loop.py
+++ b/lib/crewai/tests/llms/openai/test_responses_tool_loop.py
@@ -29,6 +29,18 @@ RESPONSES_TOOL_CALL = {
     "arguments": '{"a": 17, "b": 23}',
 }
 
+# A raw Responses `function_call` output item, as returned by the API. Note that
+# "id" and "call_id" are different values -- the matching function_call_output must
+# reference "call_id".
+RAW_RESPONSES_ITEM = {
+    "type": "function_call",
+    "id": "fc_0adeb715c5d740c7006a65ccb7",
+    "call_id": "call_dEoHFrYnOgWYvk17FymdcDZ5",
+    "name": "multiply",
+    "arguments": '{"a": 17, "b": 23}',
+    "status": "completed",
+}
+
 
 def build(model: str = "gpt-5.5", **kwargs) -> OpenAICompletion:
     return OpenAICompletion(model=model, api_key="sk-test", api="responses", **kwargs)
@@ -62,6 +74,20 @@ class TestToolCallRecognition:
         """Chat Completions and Bedrock shapes must be unaffected."""
         assert is_tool_call_list([tool_call])
         assert extract_tool_call_info(tool_call)[2] == expected_args
+
+    def test_raw_responses_item_uses_call_id_not_item_id(self):
+        """A raw function_call item carries both; only call_id can be correlated.
+
+        function_call_output must reference call_id, so picking up the item's own
+        "id" (fc_...) would produce a tool result the model can't match to its
+        invocation.
+        """
+        call_id, name, args = extract_tool_call_info(RAW_RESPONSES_ITEM)
+
+        assert call_id == "call_dEoHFrYnOgWYvk17FymdcDZ5"
+        assert call_id != RAW_RESPONSES_ITEM["id"]
+        assert name == "multiply"
+        assert args == '{"a": 17, "b": 23}'
 
 
 class TestResponsesInputTranslation:
@@ -139,6 +165,29 @@ class TestResponsesInputTranslation:
         message = {"role": "tool", "tool_call_id": "c1", "content": 391}
 
         assert OpenAICompletion._to_responses_input(message)[0]["output"] == "391"
+
+    def test_call_and_output_ids_round_trip(self):
+        """The id extracted from a call must be the one sent back with its result.
+
+        This is the correlation the API relies on: a function_call_output whose
+        call_id doesn't match an emitted function_call is rejected or ignored.
+        """
+        call_id, name, args = extract_tool_call_info(RAW_RESPONSES_ITEM)
+
+        assistant = OpenAICompletion._to_responses_input(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": call_id, "function": {"name": name, "arguments": args}}
+                ],
+            }
+        )
+        result = OpenAICompletion._to_responses_input(
+            {"role": "tool", "tool_call_id": call_id, "content": "391"}
+        )
+
+        assert assistant[0]["call_id"] == result[0]["call_id"] == call_id
 
 
 class TestPreparedParams:


### PR DESCRIPTION
## Problem

An agent with tools on `api="responses"` never produced an answer. It returned the
raw tool-call list as its final output:

```
[{'id': 'call_...', 'name': 'multiply', 'arguments': '{"a":17,"b":23}'}]
```

Expected `391`.

This is why `api="responses"` never worked for agents. The provider side has had a
complete Responses implementation since #4258 / c4c9208, but the executor never
learned the shape it emits. It went unnoticed because nothing forced anyone onto
that path — until gpt-5.4+ started rejecting `tools` + `reasoning_effort` on chat
completions and pointing users at `/v1/responses`, and until the pro tier (which
only exists there) came up.

## Three defects in the chain

**1. The tool-call list wasn't recognized.** `is_tool_call_list()` handled the
OpenAI-nested, Anthropic, Bedrock and Gemini shapes, but not the Responses one —
`{"id", "name", "arguments"}`, with no nested `function` and no `input`. Unrecognized,
so the executor returned it verbatim as the answer.

**2. Arguments were silently dropped.** `extract_tool_call_info()` read `arguments`
only from a nested `function` object, falling back to `input`. For the Responses
shape both missed:

```python
extract_tool_call_info({"id": "c", "name": "multiply", "arguments": '{"a":17,"b":23}'})
# before -> ('c', 'multiply', {})     <- tool would run with no input
# after  -> ('c', 'multiply', '{"a":17,"b":23}')
```

**3. The result couldn't be sent back.** With 1 and 2 fixed the tool ran, then the
follow-up request failed:

```
Invalid type for 'input[1].content': expected one of an array of objects or
string, but got null instead.
```

The two APIs express tool calling differently:

| | Chat Completions | Responses |
|---|---|---|
| call | assistant message with `tool_calls`, `content: None` | `{"type": "function_call", "call_id", "name", "arguments"}` |
| result | `{"role": "tool", "tool_call_id", "content"}` | `{"type": "function_call_output", "call_id", "output"}` |

Those messages were passed into `input` untranslated.

## Fix

`_to_responses_input()` translates the two tool-carrying message shapes. Messages
without tool calls pass through unchanged, so nothing else moves.

Confirmed at the API level before writing it — chat shape vs. native items posted
directly to `/v1/responses`:

```
chat-shaped assistant/tool msgs -> 400 Invalid type for 'input[1].content'
function_call + function_call_output -> 200 completed
```

## Verification

End to end against the live API:

| scenario | before | after |
|---|---|---|
| `api="responses"` + tools | raw tool-call JSON | **391** |
| chained multi-step (17×23, then +9) | — | **400** |
| completions path (control) | 391 | 391 |

The `input` payload generated by `_prepare_responses_params` was also posted to
`/v1/responses` directly and accepted (`status: completed`).

## Tests

`tests/llms/openai/test_responses_tool_loop.py` — 12 cases:

- recognition and extraction for the Responses shape
- **Chat Completions and Bedrock shapes unaffected** (parametrized)
- assistant → `function_call`, tool result → `function_call_output`
- parallel tool calls become separate items
- assistant text alongside tool calls is preserved
- non-string tool output coerced (results arrive as ints/dicts)
- full prepared `input` list, asserting no item carries `content: None`

`tests/llms/openai` + `tests/utilities/test_agent_utils.py` + `tests/agents` →
**552 passed, 17 skipped**. Ruff check + format clean, mypy clean.

## Follow-up

This unblocks routing gpt-5.4+ tool calls to the Responses API instead of dropping
`reasoning_effort` (#6651 drops it today). Worth doing separately now that the path
works.
