### PR TITLE
fix: preserve replay data after kickoff_for_each

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1106,7 +1106,6 @@ class Crew(FlowTrackable, BaseModel):
 
         if not self.stream:
             self.usage_metrics = total_usage_metrics
-        self._task_output_handler.reset()
         return results
 
     async def kickoff_async(

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -1,5 +1,6 @@
 """Test Agent creation and execution basic functionality."""
 
+import gc
 from io import StringIO
 import json
 import threading
@@ -3060,6 +3061,58 @@ def test_replay_feature(researcher, writer):
         crew.replay(str(write.id))
         # Ensure context was passed correctly
         assert mock_execute_task.call_count == 3
+
+
+@pytest.mark.vcr()
+def test_kickoff_for_each_persists_latest_run_for_replay():
+    agent = Agent(
+        role="Researcher",
+        goal="Research a topic.",
+        backstory="You are a careful researcher.",
+    )
+    task = Task(
+        description="Research {topic}.",
+        expected_output="A concise research note.",
+        agent=agent,
+    )
+    crew = Crew(agents=[agent], tasks=[task], process=Process.sequential)
+
+    first_output = TaskOutput(
+        description="Research first.",
+        raw="first result",
+        agent="Researcher",
+    )
+    latest_output = TaskOutput(
+        description="Research latest.",
+        raw="latest result",
+        agent="Researcher",
+    )
+    try:
+        with (
+            patch("crewai.crew.get_env_context"),
+            patch("crewai.crew.clear_files"),
+            patch("crewai.crew.get_all_files", return_value=[]),
+            patch.object(crewai_event_bus, "emit"),
+            patch.object(
+                Task,
+                "execute_sync",
+                side_effect=[first_output, latest_output],
+            ) as mock_execute_task,
+        ):
+            results = crew.kickoff_for_each(
+                inputs=[{"topic": "first"}, {"topic": "latest"}]
+            )
+
+            stored_outputs = crew._task_output_handler.load()
+            assert len(results) == 2
+            assert len(stored_outputs) == 1
+            assert stored_outputs[0]["inputs"] == {"topic": "latest"}
+            assert stored_outputs[0]["output"]["raw"] == "latest result"
+
+        assert mock_execute_task.call_count == 2
+    finally:
+        crew._task_output_handler.reset()
+        gc.collect()
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Summary

Fixes #6650 by preserving the latest task-output records after `kickoff_for_each()` completes.

Each copied crew clears and writes its replay records as it runs. The parent crew then reset that shared storage after the final batch, leaving `replay()` with no records. Removing the final reset preserves the last batch, matching the behavior after a normal `kickoff()`.

## Testing

- `uv run pytest lib/crewai/tests/test_crew.py::test_kickoff_for_each_persists_latest_run_for_replay -o addopts='--tb=short -n 0 --timeout=60 --block-network --import-mode=importlib'`
- `uv run ruff check lib/crewai/src/crewai/crew.py lib/crewai/tests/test_crew.py`
- `uv run ruff format --check lib/crewai/src/crewai/crew.py lib/crewai/tests/test_crew.py`
- `uv run mypy lib/crewai/src/crewai/crew.py`
