### PR TITLE
docs: fix workspace package count and Python version in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to CrewAI. This guide covers everyth
 
 ## Prerequisites
 
-- Python 3.10–3.14 (development targets 3.12)
+- Python 3.10–3.13 (development targets 3.13)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [pre-commit](https://pre-commit.com/) for Git hooks
 
@@ -29,13 +29,15 @@ uv run pre-commit install
 
 ## Repository Structure
 
-This is a uv workspace with four packages under `lib/`:
+This is a uv workspace with six packages under `lib/`:
 
 | Package | Path | Description |
 |---------|------|-------------|
 | `crewai` | `lib/crewai/` | Core framework |
+| `crewai-core` | `lib/crewai-core/` | Core abstractions and types |
 | `crewai-tools` | `lib/crewai-tools/` | Tool integrations |
 | `crewai-files` | `lib/crewai-files/` | File handling |
+| `cli` | `lib/cli/` | Command-line interface |
 | `devtools` | `lib/devtools/` | Internal release tooling |
 
 Documentation lives in `docs/` with translations under `docs/{en,ar,ko,pt-BR}/`.


### PR DESCRIPTION
## Summary

Fixes two documentation discrepancies in `.github/CONTRIBUTING.md`:

### 1. Incorrect workspace package count (#6664)

The CONTRIBUTING.md stated "four packages under `lib/`" and listed only 4 packages in the table, but `pyproject.toml` defines 6 workspace members:

```toml
[tool.uv.workspace]
members = [
    "lib/crewai",
    "lib/crewai-tools",
    "lib/devtools",
    "lib/crewai-files",
    "lib/cli",
    "lib/crewai-core",
]
```

**Fix:** Updated count from "four" to "six" and added the missing `crewai-core` and `cli` packages to the table.

### 2. Python version discrepancy (#6662)

Three different Python versions were referenced:
- `.python-version`: **3.13**
- `.github/workflows/publish.yml`: **3.12**
- `.github/CONTRIBUTING.md`: "development targets **3.12**"
- `pyproject.toml`: `>=3.10,<3.14`

**Fix:** Updated CONTRIBUTING.md to say "3.10–3.13 (development targets 3.13)" to match the `.python-version` file and the upper bound in `pyproject.toml`.

## Testing

Documentation-only change, no code affected.

Fixes #6664
Fixes #6662