### PR TITLE
fix: mark E2B_API_KEY as required for E2B sandbox tools

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/e2b_sandbox_tool/e2b_base_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/e2b_sandbox_tool/e2b_base_tool.py
@@ -88,7 +88,7 @@ class E2BBaseTool(BaseTool):
             EnvVar(
                 name="E2B_API_KEY",
                 description="API key for E2B sandbox service",
-                required=False,
+                required=True,
             ),
             EnvVar(
                 name="E2B_DOMAIN",

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -8967,7 +8967,7 @@
           "default": null,
           "description": "API key for E2B sandbox service",
           "name": "E2B_API_KEY",
-          "required": false
+          "required": true
         },
         {
           "default": null,
@@ -9188,7 +9188,7 @@
           "default": null,
           "description": "API key for E2B sandbox service",
           "name": "E2B_API_KEY",
-          "required": false
+          "required": true
         },
         {
           "default": null,
@@ -9408,7 +9408,7 @@
           "default": null,
           "description": "API key for E2B sandbox service",
           "name": "E2B_API_KEY",
-          "required": false
+          "required": true
         },
         {
           "default": null,


### PR DESCRIPTION
## Summary

- `E2B_API_KEY` was declared with `required: false` on the shared E2B tool base (`E2BExecTool`, `E2BFileTool`, `E2BPythonTool`), even though none of the three tools can create or attach to a sandbox without it. This PR flips it to `required: true`.
- `E2B_DOMAIN` stays `required: false` — it's genuinely optional and defaults to `e2b.dev` when unset.
- Regenerated `lib/crewai-tools/tool.specs.json` by running `src/crewai_tools/generate_tool_specs.py` (not hand-edited) so the diff there is exactly the 3 `required` flags flipping from `false` to `true`, one per E2B tool.

## Why

`tool.specs.json` is the machine-readable source of truth for tool env var requirements, and downstream consumers rely on the `required` flag to validate configuration up front. With `E2B_API_KEY` flagged optional, a missing key only surfaces at runtime when sandbox creation fails, instead of at configuration time. Since no E2B tool works without the key, the spec should say so.

## Changes
- `lib/crewai-tools/src/crewai_tools/tools/e2b_sandbox_tool/e2b_base_tool.py`: `E2B_API_KEY` `EnvVar` entry now has `required=True` (single shared declaration used by all three E2B tools).
- `lib/crewai-tools/tool.specs.json`: regenerated via `generate_tool_specs.py`.

## Test plan
- [x] `ruff check` on the touched source file — all checks passed
- [x] `pytest lib/crewai-tools/tests/test_generate_tool_specs.py` — 10 passed
- [x] Confirmed no existing E2B-specific test file to update (none exists yet)
- [x] Regenerated `tool.specs.json` via the real generator script (`generate_tool_specs.py`), not hand-edited, and diffed to confirm only the 3 expected `required` flags changed
