### PR TITLE
feat(tools): add SlackSendMessageTool and SlackChannelHistoryTool

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -148,6 +148,10 @@ e2b = [
     "e2b-code-interpreter~=2.6.0",
 ]
 
+slack-sdk = [
+    "slack-sdk>=3.33.0",
+]
+
 
 [tool.uv]
 exclude-newer = "3 days"

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -188,6 +188,10 @@ from crewai_tools.tools.serply_api_tool.serply_webpage_to_markdown_tool import (
 from crewai_tools.tools.singlestore_search_tool.singlestore_search_tool import (
     SingleStoreSearchTool,
 )
+from crewai_tools.tools.slack_tool.slack_tool import (
+    SlackChannelHistoryTool,
+    SlackSendMessageTool,
+)
 from crewai_tools.tools.snowflake_search_tool.snowflake_search_tool import (
     SnowflakeConfig,
     SnowflakeSearchTool,
@@ -311,6 +315,8 @@ __all__ = [
     "SerplyWebSearchTool",
     "SerplyWebpageToMarkdownTool",
     "SingleStoreSearchTool",
+    "SlackChannelHistoryTool",
+    "SlackSendMessageTool",
     "SnowflakeConfig",
     "SnowflakeSearchTool",
     "SpiderTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -174,6 +174,10 @@ from crewai_tools.tools.serply_api_tool.serply_webpage_to_markdown_tool import (
     SerplyWebpageToMarkdownTool,
 )
 from crewai_tools.tools.singlestore_search_tool import SingleStoreSearchTool
+from crewai_tools.tools.slack_tool.slack_tool import (
+    SlackChannelHistoryTool,
+    SlackSendMessageTool,
+)
 from crewai_tools.tools.snowflake_search_tool import (
     SnowflakeConfig,
     SnowflakeSearchTool,
@@ -293,6 +297,8 @@ __all__ = [
     "SerplyWebSearchTool",
     "SerplyWebpageToMarkdownTool",
     "SingleStoreSearchTool",
+    "SlackChannelHistoryTool",
+    "SlackSendMessageTool",
     "SnowflakeConfig",
     "SnowflakeSearchTool",
     "SnowflakeSearchToolInput",

--- a/lib/crewai-tools/src/crewai_tools/tools/slack_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/slack_tool/README.md
@@ -10,6 +10,8 @@
 ## Installation
 ```shell
 pip install 'crewai[tools]'
+pip install 'crewai-tools[slack-sdk]'
+# or, with uv:
 uv add crewai-tools --extra slack-sdk
 ```
 

--- a/lib/crewai-tools/src/crewai_tools/tools/slack_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/slack_tool/README.md
@@ -1,0 +1,38 @@
+# Slack Tools Documentation
+
+## Description
+`SlackSendMessageTool` and `SlackChannelHistoryTool` let CrewAI agents interact with Slack: posting notifications or replies, and reading recent channel messages for context. Both use Slack's Web API via `slack_sdk`.
+
+## Features
+- **SlackSendMessageTool**: Post a message to a channel, optionally as a threaded reply (`thread_ts`)
+- **SlackChannelHistoryTool**: Fetch recent messages from a channel, most recent first
+
+## Installation
+```shell
+pip install 'crewai[tools]'
+uv add crewai-tools --extra slack-sdk
+```
+
+## Usage
+```python
+from crewai_tools import SlackSendMessageTool, SlackChannelHistoryTool
+
+send_tool = SlackSendMessageTool()
+send_tool._run(channel="#general", message="Deployment finished successfully.")
+
+history_tool = SlackChannelHistoryTool()
+history_tool._run(channel="C0123456789", limit=20)
+```
+
+## Configuration
+1. **Create a Slack app** at https://api.slack.com/apps and install it to your workspace.
+2. **Grant bot token scopes**:
+   - `chat:write` — required for `SlackSendMessageTool`
+   - `channels:history` (public channels) and/or `groups:history` (private channels) — required for `SlackChannelHistoryTool`
+3. **Invite the bot** to any channel it needs to post to or read from.
+4. Set the environment variable `SLACK_BOT_TOKEN` to the bot's `xoxb-...` token.
+
+## Notes
+- `SlackChannelHistoryTool` requires a channel ID (e.g. `C0123456789`), since Slack's `conversations.history` API does not accept channel names.
+- `SlackSendMessageTool` accepts either a channel ID or a name (e.g. `#general`).
+- Both tools return a descriptive string on Slack API errors rather than raising, so agents can react to failures (e.g. `channel_not_found`, `not_in_channel`) instead of crashing.

--- a/lib/crewai-tools/src/crewai_tools/tools/slack_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/slack_tool/__init__.py
@@ -1,0 +1,7 @@
+from crewai_tools.tools.slack_tool.slack_tool import (
+    SlackChannelHistoryTool,
+    SlackSendMessageTool,
+)
+
+
+__all__ = ["SlackChannelHistoryTool", "SlackSendMessageTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/slack_tool/slack_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/slack_tool/slack_tool.py
@@ -1,0 +1,176 @@
+import logging
+import os
+from typing import Any
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
+
+
+def _require_slack_sdk() -> Any:
+    try:
+        from slack_sdk import WebClient
+
+        return WebClient
+    except ImportError as exc:
+        raise ImportError(
+            "Missing optional dependency 'slack-sdk'. Install with: \n"
+            "  uv add crewai-tools --extra slack-sdk\n"
+            "or\n"
+            "  pip install slack-sdk\n"
+        ) from exc
+
+
+def _require_slack_bot_token() -> str:
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        raise ValueError(
+            "Environment variable SLACK_BOT_TOKEN is required for Slack tools. "
+            "Create a Slack app with a bot token (scopes: chat:write for sending "
+            "messages, channels:history/groups:history for reading history) and "
+            "set SLACK_BOT_TOKEN in your environment."
+        )
+    return token
+
+
+class SlackSendMessageToolSchema(BaseModel):
+    """Input for SlackSendMessageTool."""
+
+    channel: str = Field(
+        ...,
+        description="Slack channel to post to, as a channel ID (e.g. 'C0123456789') "
+        "or a name (e.g. '#general').",
+    )
+    message: str = Field(..., description="Message text to post to the channel.")
+    thread_ts: str | None = Field(
+        None,
+        description="Timestamp of a parent message to reply in a thread. "
+        "Omit to post a new top-level message.",
+    )
+
+
+class SlackSendMessageTool(BaseTool):
+    name: str = "Send Slack Message"
+    description: str = (
+        "Posts a message to a Slack channel. Use this to notify a channel or "
+        "reply in a thread. Requires a Slack bot token with the chat:write scope."
+    )
+    args_schema: type[BaseModel] = SlackSendMessageToolSchema
+
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="SLACK_BOT_TOKEN",
+                description="Slack bot token (xoxb-...) with chat:write scope",
+                required=True,
+            ),
+        ]
+    )
+    package_dependencies: list[str] = Field(default_factory=lambda: ["slack-sdk"])
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        _require_slack_sdk()
+        _require_slack_bot_token()
+
+    def _run(
+        self, channel: str, message: str, thread_ts: str | None = None, **_: Any
+    ) -> str:
+        web_client_cls = _require_slack_sdk()
+        client = web_client_cls(token=_require_slack_bot_token())
+
+        try:
+            from slack_sdk.errors import SlackApiError
+
+            response = client.chat_postMessage(
+                channel=channel, text=message, thread_ts=thread_ts
+            )
+            return (
+                f"Message posted to {channel} "
+                f"(ts={response.get('ts')}, thread_ts={thread_ts or response.get('ts')})."
+            )
+        except SlackApiError as e:
+            error_code = e.response.get("error", "unknown_error")
+            return f"Slack API error while posting to {channel}: {error_code}"
+        except Exception as e:
+            return f"Unexpected error posting Slack message to {channel}: {e}"
+
+    async def _arun(
+        self, channel: str, message: str, thread_ts: str | None = None, **kwargs: Any
+    ) -> str:
+        return self._run(
+            channel=channel, message=message, thread_ts=thread_ts, **kwargs
+        )
+
+
+class SlackChannelHistoryToolSchema(BaseModel):
+    """Input for SlackChannelHistoryTool."""
+
+    channel: str = Field(
+        ...,
+        description="Slack channel ID to read history from (e.g. 'C0123456789'). "
+        "Slack's conversations.history API requires a channel ID, not a name.",
+    )
+    limit: int = Field(
+        20,
+        ge=1,
+        le=200,
+        description="Maximum number of messages to fetch, most recent first.",
+    )
+
+
+class SlackChannelHistoryTool(BaseTool):
+    name: str = "Read Slack Channel History"
+    description: str = (
+        "Fetches recent messages from a Slack channel. Use this to give an agent "
+        "context on a conversation before it responds or takes action. Requires a "
+        "Slack bot token with the channels:history (or groups:history for private "
+        "channels) scope, and the bot must be a member of the channel."
+    )
+    args_schema: type[BaseModel] = SlackChannelHistoryToolSchema
+
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name="SLACK_BOT_TOKEN",
+                description="Slack bot token (xoxb-...) with channels:history scope",
+                required=True,
+            ),
+        ]
+    )
+    package_dependencies: list[str] = Field(default_factory=lambda: ["slack-sdk"])
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        _require_slack_sdk()
+        _require_slack_bot_token()
+
+    def _run(self, channel: str, limit: int = 20, **_: Any) -> str:
+        web_client_cls = _require_slack_sdk()
+        client = web_client_cls(token=_require_slack_bot_token())
+
+        try:
+            from slack_sdk.errors import SlackApiError
+
+            response = client.conversations_history(channel=channel, limit=limit)
+            messages = response.get("messages", [])
+            if not messages:
+                return f"No messages found in channel {channel}."
+
+            lines = []
+            for msg in messages:
+                user = msg.get("user", "unknown")
+                text = msg.get("text", "")
+                ts = msg.get("ts", "")
+                lines.append(f"[{ts}] {user}: {text}")
+            return "\n".join(lines)
+        except SlackApiError as e:
+            error_code = e.response.get("error", "unknown_error")
+            return f"Slack API error while reading history for {channel}: {error_code}"
+        except Exception as e:
+            return f"Unexpected error reading Slack channel history for {channel}: {e}"
+
+    async def _arun(self, channel: str, limit: int = 20, **kwargs: Any) -> str:
+        return self._run(channel=channel, limit=limit, **kwargs)

--- a/lib/crewai-tools/src/crewai_tools/tools/slack_tool/slack_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/slack_tool/slack_tool.py
@@ -1,6 +1,10 @@
+"""Slack tools for posting messages and reading channel history."""
+
+import asyncio
 import logging
 import os
 from typing import Any
+import uuid
 
 from crewai.tools import BaseTool, EnvVar
 from pydantic import BaseModel, Field
@@ -10,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def _require_slack_sdk() -> Any:
+    """Import and return `slack_sdk.WebClient`, raising a clear error if missing."""
     try:
         from slack_sdk import WebClient
 
@@ -24,6 +29,7 @@ def _require_slack_sdk() -> Any:
 
 
 def _require_slack_bot_token() -> str:
+    """Return the `SLACK_BOT_TOKEN` env var, raising a clear error if unset."""
     token = os.environ.get("SLACK_BOT_TOKEN")
     if not token:
         raise ValueError(
@@ -52,6 +58,8 @@ class SlackSendMessageToolSchema(BaseModel):
 
 
 class SlackSendMessageTool(BaseTool):
+    """Post a message to a Slack channel, optionally as a threaded reply."""
+
     name: str = "Send Slack Message"
     description: str = (
         "Posts a message to a Slack channel. Use this to notify a channel or "
@@ -71,6 +79,7 @@ class SlackSendMessageTool(BaseTool):
     package_dependencies: list[str] = Field(default_factory=lambda: ["slack-sdk"])
 
     def __init__(self, **kwargs: Any) -> None:
+        """Validate that `slack-sdk` is installed and `SLACK_BOT_TOKEN` is set."""
         super().__init__(**kwargs)
         _require_slack_sdk()
         _require_slack_bot_token()
@@ -78,14 +87,23 @@ class SlackSendMessageTool(BaseTool):
     def _run(
         self, channel: str, message: str, thread_ts: str | None = None, **_: Any
     ) -> str:
+        """Post `message` to `channel`, returning a status string.
+
+        Passes a per-call `client_msg_id` so that a retried request (e.g. after
+        a network error) is deduplicated by Slack instead of posting twice.
+        """
         web_client_cls = _require_slack_sdk()
         client = web_client_cls(token=_require_slack_bot_token())
+        client_msg_id = str(uuid.uuid4())
 
         try:
             from slack_sdk.errors import SlackApiError
 
             response = client.chat_postMessage(
-                channel=channel, text=message, thread_ts=thread_ts
+                channel=channel,
+                text=message,
+                thread_ts=thread_ts,
+                client_msg_id=client_msg_id,
             )
             return (
                 f"Message posted to {channel} "
@@ -100,8 +118,11 @@ class SlackSendMessageTool(BaseTool):
     async def _arun(
         self, channel: str, message: str, thread_ts: str | None = None, **kwargs: Any
     ) -> str:
-        return self._run(
-            channel=channel, message=message, thread_ts=thread_ts, **kwargs
+        """Async counterpart to `_run`, offloaded to a thread so the blocking
+        Slack HTTP call doesn't stall the event loop.
+        """
+        return await asyncio.to_thread(
+            self._run, channel=channel, message=message, thread_ts=thread_ts, **kwargs
         )
 
 
@@ -122,6 +143,8 @@ class SlackChannelHistoryToolSchema(BaseModel):
 
 
 class SlackChannelHistoryTool(BaseTool):
+    """Fetch recent messages from a Slack channel."""
+
     name: str = "Read Slack Channel History"
     description: str = (
         "Fetches recent messages from a Slack channel. Use this to give an agent "
@@ -143,11 +166,13 @@ class SlackChannelHistoryTool(BaseTool):
     package_dependencies: list[str] = Field(default_factory=lambda: ["slack-sdk"])
 
     def __init__(self, **kwargs: Any) -> None:
+        """Validate that `slack-sdk` is installed and `SLACK_BOT_TOKEN` is set."""
         super().__init__(**kwargs)
         _require_slack_sdk()
         _require_slack_bot_token()
 
     def _run(self, channel: str, limit: int = 20, **_: Any) -> str:
+        """Return up to `limit` recent messages from `channel` as readable lines."""
         web_client_cls = _require_slack_sdk()
         client = web_client_cls(token=_require_slack_bot_token())
 
@@ -173,4 +198,9 @@ class SlackChannelHistoryTool(BaseTool):
             return f"Unexpected error reading Slack channel history for {channel}: {e}"
 
     async def _arun(self, channel: str, limit: int = 20, **kwargs: Any) -> str:
-        return self._run(channel=channel, limit=limit, **kwargs)
+        """Async counterpart to `_run`, offloaded to a thread so the blocking
+        Slack HTTP call doesn't stall the event loop.
+        """
+        return await asyncio.to_thread(
+            self._run, channel=channel, limit=limit, **kwargs
+        )

--- a/lib/crewai-tools/tests/tools/slack_tool_test.py
+++ b/lib/crewai-tools/tests/tools/slack_tool_test.py
@@ -1,5 +1,7 @@
+import asyncio
 import os
-from unittest.mock import MagicMock, patch
+import uuid
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -46,7 +48,7 @@ def test_send_message_happy_path(mock_require_sdk):
     result = tool._run(channel="#general", message="hello world")
 
     mock_client_cls.return_value.chat_postMessage.assert_called_once_with(
-        channel="#general", text="hello world", thread_ts=None
+        channel="#general", text="hello world", thread_ts=None, client_msg_id=ANY
     )
     assert "Message posted to #general" in result
     assert "1234567890.000100" in result
@@ -64,8 +66,32 @@ def test_send_message_thread_reply(mock_require_sdk):
     tool._run(channel="C0123456789", message="reply", thread_ts="1234567890.000100")
 
     mock_client_cls.return_value.chat_postMessage.assert_called_once_with(
-        channel="C0123456789", text="reply", thread_ts="1234567890.000100"
+        channel="C0123456789",
+        text="reply",
+        thread_ts="1234567890.000100",
+        client_msg_id=ANY,
     )
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_send_message_client_msg_id_is_unique_uuid(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={"ok": True, "ts": "1234567890.000300"}
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackSendMessageTool()
+    tool._run(channel="#general", message="first")
+    tool._run(channel="#general", message="second")
+
+    calls = mock_client_cls.return_value.chat_postMessage.call_args_list
+    first_id = calls[0].kwargs["client_msg_id"]
+    second_id = calls[1].kwargs["client_msg_id"]
+
+    assert uuid.UUID(first_id)
+    assert uuid.UUID(second_id)
+    assert first_id != second_id
 
 
 @patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
@@ -146,3 +172,51 @@ def test_history_limit_validation():
     tool = SlackChannelHistoryTool()
     with pytest.raises(Exception):
         tool.run(channel="C0123456789", limit=500)
+
+
+@pytest.mark.asyncio
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+async def test_send_message_arun_does_not_block_event_loop(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={"ok": True, "ts": "1234567890.000400"}
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackSendMessageTool()
+    heartbeat_ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal heartbeat_ticks
+        for _ in range(5):
+            await asyncio.sleep(0)
+            heartbeat_ticks += 1
+
+    result, _ = await asyncio.gather(
+        tool._arun(channel="#general", message="hello async"),
+        heartbeat(),
+    )
+
+    assert "Message posted to #general" in result
+    assert heartbeat_ticks == 5
+
+
+@pytest.mark.asyncio
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+async def test_channel_history_arun_delegates_to_run(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={
+            "ok": True,
+            "messages": [{"user": "U123", "text": "hi", "ts": "1234567890.000500"}],
+        }
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackChannelHistoryTool()
+    result = await tool._arun(channel="C0123456789", limit=5)
+
+    mock_client_cls.return_value.conversations_history.assert_called_once_with(
+        channel="C0123456789", limit=5
+    )
+    assert "hi" in result

--- a/lib/crewai-tools/tests/tools/slack_tool_test.py
+++ b/lib/crewai-tools/tests/tools/slack_tool_test.py
@@ -1,0 +1,148 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools.tools.slack_tool.slack_tool import (
+    SlackChannelHistoryTool,
+    SlackSendMessageTool,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_slack_bot_token():
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+        yield
+
+
+def _mock_web_client(return_value=None, side_effect=None):
+    client = MagicMock()
+    if side_effect is not None:
+        client.chat_postMessage.side_effect = side_effect
+        client.conversations_history.side_effect = side_effect
+    else:
+        client.chat_postMessage.return_value = return_value
+        client.conversations_history.return_value = return_value
+    return client
+
+
+def test_missing_token_raises():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            SlackSendMessageTool()
+        with pytest.raises(ValueError):
+            SlackChannelHistoryTool()
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_send_message_happy_path(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={"ok": True, "ts": "1234567890.000100"}
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackSendMessageTool()
+    result = tool._run(channel="#general", message="hello world")
+
+    mock_client_cls.return_value.chat_postMessage.assert_called_once_with(
+        channel="#general", text="hello world", thread_ts=None
+    )
+    assert "Message posted to #general" in result
+    assert "1234567890.000100" in result
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_send_message_thread_reply(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={"ok": True, "ts": "1234567890.000200"}
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackSendMessageTool()
+    tool._run(channel="C0123456789", message="reply", thread_ts="1234567890.000100")
+
+    mock_client_cls.return_value.chat_postMessage.assert_called_once_with(
+        channel="C0123456789", text="reply", thread_ts="1234567890.000100"
+    )
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_send_message_api_error(mock_require_sdk):
+    from slack_sdk.errors import SlackApiError
+
+    error_response = MagicMock()
+    error_response.get.return_value = "channel_not_found"
+    api_error = SlackApiError("error", response=error_response)
+
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(side_effect=api_error)
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackSendMessageTool()
+    result = tool._run(channel="#nonexistent", message="hello")
+
+    assert "channel_not_found" in result
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_channel_history_happy_path(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={
+            "ok": True,
+            "messages": [
+                {"user": "U123", "text": "hi there", "ts": "1234567890.000100"},
+                {"user": "U456", "text": "hello!", "ts": "1234567890.000050"},
+            ],
+        }
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackChannelHistoryTool()
+    result = tool._run(channel="C0123456789", limit=20)
+
+    mock_client_cls.return_value.conversations_history.assert_called_once_with(
+        channel="C0123456789", limit=20
+    )
+    assert "hi there" in result
+    assert "hello!" in result
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_channel_history_empty(mock_require_sdk):
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(
+        return_value={"ok": True, "messages": []}
+    )
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackChannelHistoryTool()
+    result = tool._run(channel="C0123456789")
+
+    assert "No messages found" in result
+
+
+@patch("crewai_tools.tools.slack_tool.slack_tool._require_slack_sdk")
+def test_channel_history_api_error(mock_require_sdk):
+    from slack_sdk.errors import SlackApiError
+
+    error_response = MagicMock()
+    error_response.get.return_value = "not_in_channel"
+    api_error = SlackApiError("error", response=error_response)
+
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value = _mock_web_client(side_effect=api_error)
+    mock_require_sdk.return_value = mock_client_cls
+
+    tool = SlackChannelHistoryTool()
+    result = tool._run(channel="C0123456789")
+
+    assert "not_in_channel" in result
+
+
+def test_history_limit_validation():
+    tool = SlackChannelHistoryTool()
+    with pytest.raises(Exception):
+        tool.run(channel="C0123456789", limit=500)

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-23T07:28:34.098923224Z"
+exclude-newer = "2026-07-24T20:12:02.261846Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1713,6 +1713,9 @@ singlestore = [
     { name = "singlestoredb" },
     { name = "sqlalchemy" },
 ]
+slack-sdk = [
+    { name = "slack-sdk" },
+]
 snowflake = [
     { name = "cryptography" },
     { name = "snowflake-connector-python" },
@@ -1784,6 +1787,7 @@ requires-dist = [
     { name = "selenium", marker = "extra == 'selenium'", specifier = ">=4.27.1" },
     { name = "serpapi", marker = "extra == 'serpapi'", specifier = ">=0.1.5" },
     { name = "singlestoredb", marker = "extra == 'singlestore'", specifier = ">=1.12.4" },
+    { name = "slack-sdk", marker = "extra == 'slack-sdk'", specifier = ">=3.33.0" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.12.4" },
     { name = "snowflake-sqlalchemy", marker = "extra == 'snowflake'", specifier = ">=1.7.3" },
     { name = "spider-client", marker = "extra == 'spider-client'", specifier = ">=0.1.25" },
@@ -1796,7 +1800,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate-client'", specifier = ">=4.10.2" },
     { name = "youtube-transcript-api", specifier = "~=1.2.2" },
 ]
-provides-extras = ["apify", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
+provides-extras = ["apify", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "slack-sdk", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
 
 [[package]]
 name = "cryptography"
@@ -8462,6 +8466,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/75/a4964eb771a0c74d79ee7a3bee6fb5d9718909dd1b675e80d62a6a0ad90a/slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07", size = 252769, upload-time = "2026-06-30T18:04:41.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/55/42141b8338d46323d5b3c6095201b044c670c20f898643b322ea9b1543a1/slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585", size = 315866, upload-time = "2026-06-30T18:04:39.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `SlackSendMessageTool` (posts a message, optionally as a threaded reply via `thread_ts`) and `SlackChannelHistoryTool` (fetches recent channel messages for context), both under `lib/crewai-tools/src/crewai_tools/tools/slack_tool/`
- Uses `slack_sdk` (added as an optional dependency, extra name `slack-sdk`), lazily imported so it's not a hard dependency for users who don't need it
- Requires a `SLACK_BOT_TOKEN` env var; both tools validate its presence at init and return a descriptive string (rather than raising) on Slack API errors, following the pattern used by other tools in this repo

## Why
There's currently no Slack tool in `crewai-tools`, despite Slack being one of the most common integration targets for agentic workflows (notifying a channel, or giving an agent context from recent conversation). This fills that gap.

## Testing
- 8 new unit tests in `tests/tools/slack_tool_test.py`, all mocking `slack_sdk` (no real Slack workspace/token touched), covering: missing-token validation, happy path for both tools, thread replies, Slack API error handling, empty-history handling, and input validation (`limit` bounds)
- `ruff check`, `ruff format --check`, and `mypy` all pass on the new source
- Full existing `lib/crewai-tools/tests/` suite run for regressions: 270 passed, 2 skipped; remaining failures are pre-existing environment gaps unrelated to this change (missing optional `oxylabs` dependency, an interactive MongoDB test prompt)
- `uv.lock` regenerated with the exact uv version pinned in CI (0.11.3) to keep the diff minimal

## Disclosure
This PR was developed with AI assistance (Claude Code), with human review of the design, code, and test coverage before submission.

<!-- crewai-require-issue-check -->