### PR TITLE
fix(crew): preserve replay data after kickoff_for_each_async

### DIFF
--- a/lib/crewai/src/crewai/crews/utils.py
+++ b/lib/crewai/src/crewai/crews/utils.py
@@ -510,5 +510,4 @@ async def run_for_each_async(
             total_usage_metrics.add_usage_metrics(crew_copy.usage_metrics)
     crew.usage_metrics = total_usage_metrics
 
-    crew._task_output_handler.reset()
     return list(results)

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -1566,6 +1566,65 @@ async def test_async_kickoff_for_each_async_empty_input():
     assert results == [], "Result should be an empty list when input is empty"
 
 
+@pytest.mark.asyncio
+async def test_kickoff_for_each_async_persists_output_for_replay():
+    """kickoff_for_each_async must not wipe every copy's replay data.
+
+    run_for_each_async backs kickoff_for_each_async and akickoff_for_each, and
+    used to unconditionally reset the shared replay store right after
+    gathering results, so every call left the store empty regardless of what
+    the copies had just persisted.
+
+    The copies execute concurrently on separate threads and share one SQLite
+    store, so which one's output ends up persisted is not deterministic (this
+    differs from the sequential kickoff_for_each, which is guaranteed to keep
+    the final input's run). This test only pins the actual regression: the
+    store must retain at least one copy's output instead of always ending up
+    empty.
+    """
+    import gc
+
+    agent = Agent(
+        role="Researcher",
+        goal="Research a topic.",
+        backstory="You are a careful researcher.",
+    )
+    task = Task(
+        description="Research {topic}.",
+        expected_output="A concise research note.",
+        agent=agent,
+    )
+    crew = Crew(agents=[agent], tasks=[task], process=Process.sequential)
+
+    def fake_execute_sync(self: Task, *args: Any, **kwargs: Any) -> TaskOutput:
+        return TaskOutput(
+            description=self.description,
+            raw=f"{self.description} result",
+            agent="Researcher",
+        )
+
+    try:
+        with patch.object(
+            Task, "execute_sync", side_effect=fake_execute_sync, autospec=True
+        ) as mock_execute_task:
+            results = await crew.kickoff_for_each_async(
+                inputs=[{"topic": "first"}, {"topic": "latest"}]
+            )
+
+            stored_outputs = crew._task_output_handler.load()
+            assert len(results) == 2
+            assert len(stored_outputs) > 0
+            for stored in stored_outputs:
+                topic = stored["inputs"]["topic"]
+                assert topic in {"first", "latest"}
+                assert stored["output"]["raw"] == f"Research {topic}. result"
+
+        assert mock_execute_task.call_count == 2
+    finally:
+        crew._task_output_handler.reset()
+        gc.collect()
+
+
 def test_set_agents_step_callback():
     researcher_agent = Agent(
         role="Researcher",


### PR DESCRIPTION
## Summary

Contributes to #6704 by preserving replay data after `kickoff_for_each_async()` / `akickoff_for_each()` complete.

Both methods share `run_for_each_async()`. Each crew copy resets and repopulates the shared replay store as part of its own run, but `run_for_each_async()` then reset that same shared storage again right after gathering all the copies' results, discarding whatever they had just persisted — every call left the store empty. Removing that trailing reset is the async counterpart of the fix for #6650, which only covered the synchronous `kickoff_for_each()`.

Because the copies run concurrently on separate threads against one shared SQLite-backed store, which copy's output survives isn't deterministic the way it is for the sequential `kickoff_for_each()` (guaranteed last-input-wins). This PR only fixes the unconditional wipe-to-empty; it doesn't attempt to add ordering guarantees for the concurrent case, which is a separate, harder problem.

## Testing

- `uv run pytest lib/crewai/tests/test_crew.py::test_kickoff_for_each_async_persists_output_for_replay -q`
- `uv run pytest lib/crewai/tests/test_crew.py -q` (132 passed, 1 skipped)
- `uv run pytest lib/crewai/tests/crew/ lib/crewai/tests/skills/ -q` (161 passed)
- `uv run ruff check lib/crewai/src/crewai/crews/utils.py lib/crewai/tests/test_crew.py`
- `uv run ruff format --check lib/crewai/src/crewai/crews/utils.py lib/crewai/tests/test_crew.py`
- `uv run mypy lib/crewai/src/crewai/crews/utils.py`


<!-- crewai-require-issue-check -->