### PR TITLE
fix(flow): keep fields added after a checkpoint on dict state restore

### DIFF
--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -1796,7 +1796,10 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             raise ValueError("Stored state must have an 'id' field")
 
         if isinstance(self._state, dict):
-            self._state.clear()
+            # Merge rather than replace: a field added to `initial_state` after
+            # `stored_state` was saved should keep its fresh default instead of
+            # disappearing, matching the BaseModel branch below (model_validate
+            # fills unset fields from the model's own defaults).
             self._state.update(stored_state)
         elif isinstance(self._state, BaseModel):
             model = self._state

--- a/lib/crewai/tests/test_flow_persistence.py
+++ b/lib/crewai/tests/test_flow_persistence.py
@@ -39,6 +39,44 @@ def test_persist_decorator_saves_state(tmp_path, caplog):
     assert saved_state["message"] == "Hello, World!"
 
 
+def test_dict_state_restore_keeps_fields_added_after_the_checkpoint(tmp_path):
+    """Restoring an older checkpoint must not drop fields added since then.
+
+    _restore_state used to clear() the dict state before applying the stored
+    values, so any key present in the flow's current initial_state but absent
+    from an older checkpoint (e.g. a field added after that checkpoint was
+    saved) was wiped out entirely instead of keeping its fresh default.
+    """
+    db_path = os.path.join(tmp_path, "test_flows.db")
+    persistence = SQLiteFlowPersistence(db_path)
+
+    class FlowBeforeFieldAdded(Flow[Dict[str, object]]):
+        initial_state = {"counter": 0}
+
+        @start()
+        @persist(persistence)
+        def go(self):
+            self.state["counter"] = 5
+
+    old_flow = FlowBeforeFieldAdded(persistence=persistence)
+    old_flow.kickoff()
+    checkpoint_id = old_flow.state["id"]
+
+    class FlowAfterFieldAdded(Flow[Dict[str, object]]):
+        initial_state = {"counter": 0, "config_value": "fresh_default"}
+
+        @start()
+        @persist(persistence)
+        def go(self):
+            pass
+
+    new_flow = FlowAfterFieldAdded(persistence=persistence)
+    new_flow.kickoff(inputs={"id": checkpoint_id})
+
+    assert new_flow.state["counter"] == 5
+    assert new_flow.state["config_value"] == "fresh_default"
+
+
 def test_structured_state_persistence(tmp_path):
     """Test persistence with Pydantic model state."""
     db_path = os.path.join(tmp_path, "test_flows.db")


### PR DESCRIPTION
## Summary

Contributes to #6706 by keeping dict-typed flow state fields that were added to `initial_state` after an older checkpoint was saved.

`_restore_state` cleared the dict state before applying a stored checkpoint. `self._state` is populated from the flow's *current* `initial_state` at construction, so any key added since an older checkpoint was saved existed on the fresh instance with its default value — until `.clear()` wiped it out, leaving it missing entirely instead of falling back to that default. The `BaseModel` branch right below doesn't have this problem, since `model_validate` already fills unset fields from the model's own defaults; this brings the dict branch to the same behavior by merging the stored values on top of the constructed defaults instead of replacing the state outright.

## Testing

- `uv run pytest lib/crewai/tests/test_flow_persistence.py::test_dict_state_restore_keeps_fields_added_after_the_checkpoint -q`
- `uv run pytest lib/crewai/tests/test_flow_persistence.py lib/crewai/tests/test_flow_persistence_factory.py -q` (18 passed)
- `uv run pytest lib/crewai/tests/ -k flow -q` (600 passed, 22 skipped)
- `uv run ruff check lib/crewai/src/crewai/flow/runtime/__init__.py lib/crewai/tests/test_flow_persistence.py`
- `uv run ruff format --check lib/crewai/src/crewai/flow/runtime/__init__.py lib/crewai/tests/test_flow_persistence.py`
- `uv run mypy lib/crewai/src/crewai/flow/runtime/__init__.py`


<!-- crewai-require-issue-check -->