### PR TITLE
feat(hooks): add optional agent-hooks governance engine

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -383,6 +383,7 @@
                           "edge/en/learn/tool-hooks",
                           "edge/en/learn/execution-boundary-hooks",
                           "edge/en/learn/step-hooks",
+                          "edge/en/learn/agent-hooks",
                           "edge/en/learn/before-and-after-kickoff-hooks"
                         ]
                       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -401,6 +401,7 @@
                           "edge/en/learn/tool-hooks",
                           "edge/en/learn/execution-boundary-hooks",
                           "edge/en/learn/step-hooks",
+                          "edge/en/learn/agent-hooks",
                           "edge/en/learn/before-and-after-kickoff-hooks"
                         ]
                       }

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -25,7 +25,16 @@ model — `PRE_STEP` / `POST_STEP`, pure observation/telemetry, and
 ## Installation
 
 agent-hooks is an **optional** dependency with a compiled native core, so crewAI
-never requires it and `import crewai` never loads it. Install it from source:
+never requires it and `import crewai` never loads it. Install it with the
+`agent-hooks` extra:
+
+```bash
+pip install "crewai[agent-hooks]"
+```
+
+A prebuilt wheel is published for Linux x86_64 (Python 3.10+), so no build
+toolchain is needed there. On macOS, Windows, or Linux arm64 there is no wheel
+yet — install from source instead, which requires a Rust toolchain:
 
 ```bash
 pip install "agent-hooks-sdk @ git+https://github.com/responsibleai/agent-hooks.git#subdirectory=sdk/python"

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -106,8 +106,8 @@ The engine maps crewAI's points onto the eight agent-hooks points:
 | `INPUT` | `input` | resolved inputs | aborts the run | ✅ |
 | `PRE_TOOL_CALL` | `pre_tool_call` | tool args | blocks the call | ✅ |
 | `POST_TOOL_CALL` | `post_tool_call` | tool result | fails the result closed | ✅ |
-| `PRE_MODEL_CALL` | `pre_model_call` | messages | blocks the call | ⚠️ direct calls only |
-| `POST_MODEL_CALL` | `post_model_call` | response | fails the response closed | ⚠️ direct calls only |
+| `PRE_MODEL_CALL` | `pre_model_call` | messages | blocks the call | ✅ |
+| `POST_MODEL_CALL` | `post_model_call` | response | fails the response closed | ✅ |
 | `OUTPUT` | `output` | final output | blocks the output | ✅ |
 | `EXECUTION_END` | `agent_shutdown` | run summary | (records the end) | ✅ |
 
@@ -116,13 +116,13 @@ A `transform` at a **pre** point rewrites the args/messages in place; at a
 cannot raise, a **deny** there **fails closed** by replacing the result with a
 `[blocked by agent-hooks: <reason>]` marker rather than letting it through.
 
-<Warning>
-**Model-call coverage is partial.** `dispatch`-routed model calls (direct
-`llm.call(...)` and native providers) are governed. Model calls made through an
-**agent executor** currently run on a per-executor hook path that bypasses
-`dispatch`, so they are not yet governed by the engine — a tracked follow-up.
-Tool calls and execution boundaries are fully governed on every path.
-</Warning>
+<Note>
+**Model calls are governed on every path.** Both `dispatch`-routed calls
+(direct `llm.call(...)` and native providers) and calls made through an
+**agent executor** (sync or async) run the engine's adapter — the executor's
+model-call seam appends the same governor that `dispatch` does. Tool calls and
+execution boundaries are likewise governed on every path.
+</Note>
 
 crewAI's `PRE_STEP` / `POST_STEP` have no agent-hooks equivalent and remain
 crewAI-native.
@@ -166,7 +166,9 @@ Every emission produces a payload-free `InterceptionRecord`. Read
 
 - **agent-hooks is the engine.** `crewai.hooks.dispatch` appends the engine's
   per-point adapter as the authoritative final hook (installed via dependency
-  injection, so `dispatch` never imports the optional package). crewAI's `@on`
+  injection, so `dispatch` never imports the optional package). Seams that keep
+  their own hook list — the agent executor's model-call seam — append the same
+  adapter, so executor model calls are governed identically. crewAI's `@on`
   decorators and `before_tool_call` hooks are ergonomic sugar that run first.
 - **Optional & lazy.** The `agent_hooks` package loads only when the engine is
   first accessed; using it without the package installed raises an actionable

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -154,6 +154,7 @@ engine = use_agent_hooks(
     composition=CompositionConfig.run_all(),      # run every interceptor, aggregate strictest
     timeout=5.0,                                   # per-interceptor timeout (seconds)
     record_sink=lambda record: audit_log(record), # stream every decision to your audit sink
+    max_records=10_000,                            # bounded in-memory audit buffer
     points=[InterceptionPoint.PRE_TOOL_CALL],     # optionally restrict governed points
 )
 ```
@@ -170,9 +171,16 @@ engine = use_agent_hooks(
 
 ## Auditability
 
-Every emission produces a payload-free `InterceptionRecord`. Read
+Every completed agent-hooks emission produces a payload-free
+`InterceptionRecord`. Read
 `engine.records` (or `engine.take_records()` to drain), or attach a
-`record_sink` callback to stream them to your audit store as they happen.
+`record_sink` callback to stream them to your audit store as they happen. The
+in-memory buffer retains 10,000 records by default with oldest-first eviction;
+inspect `engine.records_dropped` to monitor evictions or set `max_records` when
+activating the engine. If crewAI cannot complete an emission, it fails the
+guarded action closed and logs the host error; no SDK record exists because the
+emitter did not return one. Host-error logs include only bounded correlation
+identifiers (session, request, and tool call), never intercepted payloads.
 
 ## How it works
 

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -34,10 +34,10 @@ pip install "crewai[agent-hooks]"
 
 A prebuilt wheel is published for Linux x86_64 (Python 3.10+), so no build
 toolchain is needed there. On macOS, Windows, or Linux arm64 there is no wheel
-yet — install from source instead, which requires a Rust toolchain:
+yet — the published source distribution requires a Rust toolchain:
 
 ```bash
-pip install "agent-hooks-sdk @ git+https://github.com/responsibleai/agent-hooks.git#subdirectory=sdk/python"
+pip install "agent-hooks-sdk==0.1.0a3"
 ```
 
 Check availability at runtime:
@@ -93,7 +93,7 @@ value is under `target`. A `Verdict` is one of three decisions:
 | Decision | Constructor | Meaning |
 |----------|-------------|---------|
 | **allow** | `Verdict(decision=Decision.ALLOW)` | proceed unchanged |
-| **deny** | `Verdict.deny(reason=...)` | block the action |
+| **deny** | `Verdict(decision=Decision.DENY, reason=...)` | block the action |
 | **transform** | `Verdict(decision=Decision.TRANSFORM, transform=Transform(path="$target", value=...))` | rewrite the interceptable value |
 
 `Verdict.warn(...)` (allow plus a recorded warning) and `Verdict.escalate(...)`
@@ -111,7 +111,7 @@ The engine maps crewAI's points onto the eight agent-hooks points:
 
 | crewAI point | agent-hooks point | `target` | Deny behavior | Governed |
 |--------------|-------------------|----------|---------------|----------|
-| `EXECUTION_START` | `agent_startup` | inputs | aborts the run | ✅ |
+| `EXECUTION_START` | `agent_startup` | registered tools | aborts the run | ✅ |
 | `INPUT` | `input` | resolved inputs | aborts the run | ✅ |
 | `PRE_TOOL_CALL` | `pre_tool_call` | tool args | blocks the call | ✅ |
 | `POST_TOOL_CALL` | `post_tool_call` | tool result | fails the result closed | ✅ |
@@ -126,11 +126,14 @@ cannot raise, a **deny** there **fails closed** by replacing the result with a
 `[blocked by agent-hooks: <reason>]` marker rather than letting it through.
 
 <Note>
-**Model calls are governed on every path.** Both `dispatch`-routed calls
-(direct `llm.call(...)` and native providers) and calls made through an
-**agent executor** (sync or async) run the engine's adapter — the executor's
-model-call seam appends the same governor that `dispatch` does. Tool calls and
-execution boundaries are likewise governed on every path.
+Model calls made through an **agent executor** (sync or async), direct generic
+`LLM.call(...)` / `LLM.acall(...)`, and textual direct synchronous
+native-provider calls run the engine's adapter. Direct calls to provider-specific
+`acall()` methods and direct native-provider Pydantic responses are not yet
+uniformly governed. Tool execution through crewAI's tool runners and
+native-provider execution helpers is governed. Executor post-model governance
+runs for textual, Pydantic, and structured tool-call responses; structured calls
+are normalized for policy inspection and retain their provider objects on allow.
 </Note>
 
 crewAI's `PRE_STEP` / `POST_STEP` have no agent-hooks equivalent and remain

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -1,0 +1,186 @@
+---
+title: Agent Hooks (control engine)
+description: Make the framework-neutral agent-hooks contract crewAI's control engine — one governance layer you can reuse across agent frameworks
+mode: "wide"
+---
+
+The **agent-hooks control engine** makes the framework-neutral
+[agent-hooks](https://github.com/responsibleai/agent-hooks) contract crewAI's
+control layer. agent-hooks defines a fixed set of lifecycle points, the context
+supplied at each, the `Verdict` an interceptor returns, and the obligations the
+host honours. You write a policy engine, content filter, rate limiter, or egress
+guard once as an agent-hooks `Interceptor`, activate it, and crewAI's `dispatch`
+delegates its lifecycle points to the agent-hooks emitter — running your
+interceptors as the **authoritative control layer** after any crewAI-native
+hooks.
+
+<Note>
+The agent-hooks engine governs the eight lifecycle **control** points. crewAI's
+native hooks remain the mechanism for things agent-hooks intentionally does not
+model — `PRE_STEP` / `POST_STEP`, pure observation/telemetry, and
+`request_human_input()` — and continue to run *before* the engine. See
+[Execution Hooks](/learn/execution-hooks).
+</Note>
+
+## Installation
+
+agent-hooks is an **optional** dependency with a compiled native core, so crewAI
+never requires it and `import crewai` never loads it. Install it from source:
+
+```bash
+pip install "agent-hooks-sdk @ git+https://github.com/responsibleai/agent-hooks.git#subdirectory=sdk/python"
+```
+
+Check availability at runtime:
+
+```python
+from crewai.hooks import HAS_AGENT_HOOKS  # loads the engine module on first access
+```
+
+## Quick start
+
+```python
+from crewai.hooks import use_agent_hooks
+from agent_hooks import AgentContext, Decision, Verdict
+
+
+class ToolAllowlist:
+    """Deny any tool that is not on an allowlist."""
+
+    def __init__(self, allowed: set[str]) -> None:
+        self._allowed = allowed
+
+    def intercept(self, ctx: AgentContext) -> Verdict:
+        if ctx["interception_point"] == "pre_tool_call":
+            name = ctx["tool_call"]["name"]
+            if name not in self._allowed:
+                return Verdict(decision=Decision.DENY, reason=f"tool '{name}' not allowed")
+        return Verdict(decision=Decision.ALLOW)
+
+
+engine = use_agent_hooks(ToolAllowlist(allowed={"web_search"}))
+try:
+    crew.kickoff(inputs={"topic": "quantum computing"})
+finally:
+    engine.close()  # deactivate and stop the background loop
+```
+
+`use_agent_hooks` accepts any number of interceptors, installs the engine as the
+process governor, and returns an `AgentHooksEngine`. It is also usable as a
+context manager:
+
+```python
+with use_agent_hooks(ToolAllowlist(allowed={"web_search"})) as engine:
+    crew.kickoff(inputs=...)
+    print(engine.records)  # auditable InterceptionRecord list
+```
+
+## Writing an interceptor
+
+An interceptor is any object with `intercept(context) -> Verdict`. The context is
+wire-shaped JSON (a `dict`) keyed by `interception_point`; the interceptable
+value is under `target`. A `Verdict` is one of three decisions:
+
+| Decision | Constructor | Meaning |
+|----------|-------------|---------|
+| **allow** | `Verdict(decision=Decision.ALLOW)` | proceed unchanged |
+| **deny** | `Verdict.deny(reason=...)` | block the action |
+| **transform** | `Verdict(decision=Decision.TRANSFORM, transform=Transform(path="$target", value=...))` | rewrite the interceptable value |
+
+`Verdict.warn(...)` (allow plus a recorded warning) and `Verdict.escalate(...)`
+(a liftable deny for the approval seam) are shortcuts for the other shapes.
+
+<Warning>
+Treat every context field as **untrusted**: it carries model output and tool
+results. Validate before you branch on it, and never feed it straight into a
+privileged tool, shell, or SQL statement.
+</Warning>
+
+## Lifecycle points and coverage
+
+The engine maps crewAI's points onto the eight agent-hooks points:
+
+| crewAI point | agent-hooks point | `target` | Deny behavior | Governed |
+|--------------|-------------------|----------|---------------|----------|
+| `EXECUTION_START` | `agent_startup` | inputs | aborts the run | ✅ |
+| `INPUT` | `input` | resolved inputs | aborts the run | ✅ |
+| `PRE_TOOL_CALL` | `pre_tool_call` | tool args | blocks the call | ✅ |
+| `POST_TOOL_CALL` | `post_tool_call` | tool result | fails the result closed | ✅ |
+| `PRE_MODEL_CALL` | `pre_model_call` | messages | blocks the call | ⚠️ direct calls only |
+| `POST_MODEL_CALL` | `post_model_call` | response | fails the response closed | ⚠️ direct calls only |
+| `OUTPUT` | `output` | final output | blocks the output | ✅ |
+| `EXECUTION_END` | `agent_shutdown` | run summary | (records the end) | ✅ |
+
+A `transform` at a **pre** point rewrites the args/messages in place; at a
+**post** point it replaces the result string. Because crewAI's *post* seams
+cannot raise, a **deny** there **fails closed** by replacing the result with a
+`[blocked by agent-hooks: <reason>]` marker rather than letting it through.
+
+<Warning>
+**Model-call coverage is partial.** `dispatch`-routed model calls (direct
+`llm.call(...)` and native providers) are governed. Model calls made through an
+**agent executor** currently run on a per-executor hook path that bypasses
+`dispatch`, so they are not yet governed by the engine — a tracked follow-up.
+Tool calls and execution boundaries are fully governed on every path.
+</Warning>
+
+crewAI's `PRE_STEP` / `POST_STEP` have no agent-hooks equivalent and remain
+crewAI-native.
+
+## Enforcement, composition, and approvals
+
+`use_agent_hooks` forwards the emitter's configuration:
+
+```python
+from agent_hooks import CompositionConfig, EnforcementMode
+from crewai.hooks import InterceptionPoint
+
+engine = use_agent_hooks(
+    PolicyA(),
+    PolicyB(),
+    mode=EnforcementMode.EVALUATE_ONLY,          # record decisions without blocking
+    composition=CompositionConfig.run_all(),      # run every interceptor, aggregate strictest
+    timeout=5.0,                                   # per-interceptor timeout (seconds)
+    record_sink=lambda record: audit_log(record), # stream every decision to your audit sink
+    points=[InterceptionPoint.PRE_TOOL_CALL],     # optionally restrict governed points
+)
+```
+
+- **Enforcement mode** — `ENFORCE` (default) acts on verdicts; `EVALUATE_ONLY`
+  records them without blocking or transforming (shadow mode — ideal for a safe
+  rollout).
+- **Composition** — how multiple interceptors combine (default
+  `sequential/first_deny`). See the agent-hooks spec for the full profile set.
+- **Approvals** — pass a `resolver` to lift `escalate` (liftable deny) verdicts
+  through an approval workflow.
+- **Timeouts** — each interceptor is bounded (default 5 s) and **fails closed**
+  on breach.
+
+## Auditability
+
+Every emission produces a payload-free `InterceptionRecord`. Read
+`engine.records` (or `engine.take_records()` to drain), or attach a
+`record_sink` callback to stream them to your audit store as they happen.
+
+## How it works
+
+- **agent-hooks is the engine.** `crewai.hooks.dispatch` appends the engine's
+  per-point adapter as the authoritative final hook (installed via dependency
+  injection, so `dispatch` never imports the optional package). crewAI's `@on`
+  decorators and `before_tool_call` hooks are ergonomic sugar that run first.
+- **Optional & lazy.** The `agent_hooks` package loads only when the engine is
+  first accessed; using it without the package installed raises an actionable
+  `ImportError`.
+- **Sync/async.** The agent-hooks emitter is asynchronous; crewAI's hook seams
+  are synchronous. The engine drives the emitter on a single dedicated
+  background event loop, which also serializes emissions so per-session
+  `sequence` numbers and records stay consistent.
+- **Fail closed.** Interceptor errors and timeouts become denies (per the
+  agent-hooks spec), and any unexpected engine error blocks rather than silently
+  allowing.
+
+<Note>
+agent-hooks is a **cooperative control contract, not a security boundary**: the
+host is trusted and interceptors run in-process. See the agent-hooks
+`SECURITY.md` for the normative statement.
+</Note>

--- a/docs/edge/en/learn/agent-hooks.mdx
+++ b/docs/edge/en/learn/agent-hooks.mdx
@@ -32,12 +32,13 @@ never requires it and `import crewai` never loads it. Install it with the
 pip install "crewai[agent-hooks]"
 ```
 
-A prebuilt wheel is published for Linux x86_64 (Python 3.10+), so no build
-toolchain is needed there. On macOS, Windows, or Linux arm64 there is no wheel
-yet — the published source distribution requires a Rust toolchain:
+Version `0.1.0a5` publishes Python 3.10+ abi3 wheels for glibc 2.28+ Linux
+x86_64/aarch64, macOS x86_64/arm64, and Windows x86_64. Other platforms, such
+as musl Linux and Windows ARM, fall back to the source distribution and require
+a Rust toolchain:
 
 ```bash
-pip install "agent-hooks-sdk==0.1.0a3"
+pip install "agent-hooks-sdk==0.1.0a5"
 ```
 
 Check availability at runtime:
@@ -153,6 +154,7 @@ engine = use_agent_hooks(
     mode=EnforcementMode.EVALUATE_ONLY,          # record decisions without blocking
     composition=CompositionConfig.run_all(),      # run every interceptor, aggregate strictest
     timeout=5.0,                                   # per-interceptor timeout (seconds)
+    emit_timeout=30.0,                              # complete emission wall-clock bound
     record_sink=lambda record: audit_log(record), # stream every decision to your audit sink
     max_records=10_000,                            # bounded in-memory audit buffer
     points=[InterceptionPoint.PRE_TOOL_CALL],     # optionally restrict governed points
@@ -167,7 +169,11 @@ engine = use_agent_hooks(
 - **Approvals** — pass a `resolver` to lift `escalate` (liftable deny) verdicts
   through an approval workflow.
 - **Timeouts** — each interceptor is bounded (default 5 s) and **fails closed**
-  on breach.
+  on breach. Synchronous interceptors, approval resolvers, identity providers,
+  and record sinks run behind bounded workers; timed-out work keeps its capacity
+  until it actually exits. A complete emission is bounded to 30 s by default.
+  Set `timeout=None` or `emit_timeout=None` only when every callback is
+  independently bounded.
 
 ## Auditability
 
@@ -175,6 +181,8 @@ Every completed agent-hooks emission produces a payload-free
 `InterceptionRecord`. Read
 `engine.records` (or `engine.take_records()` to drain), or attach a
 `record_sink` callback to stream them to your audit store as they happen. The
+sink must be synchronous; delivery failures are counted by
+`engine.record_sink_failures`. The
 in-memory buffer retains 10,000 records by default with oldest-first eviction;
 inspect `engine.records_dropped` to monitor evictions or set `max_records` when
 activating the engine. If crewAI cannot complete an emission, it fails the

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -123,7 +123,7 @@ agent-hooks = [
     # CI runs on ubuntu-latest, so `uv sync --all-extras` installs it there and the
     # governance tests run instead of skipping. The exact version is pinned in the
     # committed uv.lock.
-    "agent-hooks-sdk>=0.1.0a3; platform_system == 'Linux' and platform_machine == 'x86_64'",
+    "agent-hooks-sdk==0.1.0a3; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]
 
 

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -116,6 +116,15 @@ file-processing = [
 qdrant-edge = [
     "qdrant-edge-py>=0.6.0",
 ]
+agent-hooks = [
+    # Optional agent-hooks control engine. A prebuilt abi3 wheel is published for
+    # Linux x86_64 (Python 3.10+); other platforms would need a Rust toolchain to
+    # build from sdist, so the marker scopes the extra to where the wheel exists.
+    # CI runs on ubuntu-latest, so `uv sync --all-extras` installs it there and the
+    # governance tests run instead of skipping. The exact version is pinned in the
+    # committed uv.lock.
+    "agent-hooks-sdk>=0.1.0a3; platform_system == 'Linux' and platform_machine == 'x86_64'",
+]
 
 
 [tool.uv]

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -117,13 +117,9 @@ qdrant-edge = [
     "qdrant-edge-py>=0.6.0",
 ]
 agent-hooks = [
-    # Optional agent-hooks control engine. A prebuilt abi3 wheel is published for
-    # Linux x86_64 (Python 3.10+); other platforms would need a Rust toolchain to
-    # build from sdist, so the marker scopes the extra to where the wheel exists.
-    # CI runs on ubuntu-latest, so `uv sync --all-extras` installs it there and the
-    # governance tests run instead of skipping. The exact version is pinned in the
-    # committed uv.lock.
-    "agent-hooks-sdk==0.1.0a3; platform_system == 'Linux' and platform_machine == 'x86_64'",
+    # Optional agent-hooks control engine. The exact release is pinned in uv.lock;
+    # a5 publishes abi3 wheels for supported Linux, macOS, and Windows platforms.
+    "agent-hooks-sdk==0.1.0a5",
 ]
 
 

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -14,6 +14,7 @@ import contextvars
 import inspect
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+import uuid
 import warnings
 
 from crewai_core.printer import PRINTER
@@ -889,6 +890,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
         )
         if parse_error is not None:
             return parse_error
+        args_dict = args_dict or {}
+        governance_call_id = str(uuid.uuid4())
 
         if original_tool is None:
             for tool in self.original_tools or []:
@@ -925,15 +928,6 @@ class CrewAgentExecutor(BaseAgentExecutor):
         from_cache = False
         result: str = "Tool not found"
         raw_tool_result: Any = result
-        input_str = json.dumps(args_dict) if args_dict else ""
-        if self.tools_handler and self.tools_handler.cache and output_tool is not None:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                raw_tool_result = cached_result
-                result = format_native_tool_output_for_agent(output_tool, cached_result)
-                from_cache = True
 
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
         started_at = datetime.now()
@@ -953,13 +947,29 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         before_hook_context = ToolCallHookContext(
             tool_name=func_name,
-            tool_input=args_dict or {},
+            tool_input=args_dict,
             tool=structured_tool,
             agent=self.agent,
             task=self.task,
             crew=self.crew,
+            call_id=governance_call_id,
         )
         hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+        input_str = json.dumps(args_dict) if args_dict else ""
+        if (
+            not hook_blocked
+            and self.tools_handler
+            and self.tools_handler.cache
+            and output_tool is not None
+        ):
+            cached_result = self.tools_handler.cache.read(
+                tool=func_name, input=input_str
+            )
+            if cached_result is not None:
+                raw_tool_result = cached_result
+                result = format_native_tool_output_for_agent(output_tool, cached_result)
+                from_cache = True
 
         if hook_blocked:
             result = f"Tool execution blocked by hook. Tool: {func_name}"
@@ -973,7 +983,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
             and output_tool is not None
         ):
             try:
-                raw_result = available_functions[func_name](**(args_dict or {}))
+                raw_result = available_functions[func_name](**args_dict)
                 raw_tool_result = raw_result
 
                 if self.tools_handler and self.tools_handler.cache:
@@ -984,7 +994,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                         and callable(original_tool.cache_function)
                     ):
                         should_cache = original_tool.cache_function(
-                            args_dict or {}, raw_result
+                            args_dict, raw_result
                         )
                     if should_cache:
                         self.tools_handler.cache.add(
@@ -1012,13 +1022,16 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         after_hook_context = ToolCallHookContext(
             tool_name=func_name,
-            tool_input=args_dict or {},
+            tool_input=args_dict,
             tool=structured_tool,
             agent=self.agent,
             task=self.task,
             crew=self.crew,
             tool_result=result,
             raw_tool_result=raw_tool_result,
+            call_id=governance_call_id,
+            is_error=hook_blocked or max_usage_reached or error_event_emitted,
+            was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)
         if modified_result is not None:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1030,7 +1030,15 @@ class CrewAgentExecutor(BaseAgentExecutor):
             tool_result=result,
             raw_tool_result=raw_tool_result,
             call_id=governance_call_id,
-            is_error=hook_blocked or max_usage_reached or error_event_emitted,
+            is_error=(
+                hook_blocked
+                or max_usage_reached
+                or error_event_emitted
+                or (
+                    not from_cache
+                    and (output_tool is None or func_name not in available_functions)
+                )
+            ),
             was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -14,6 +14,7 @@ import contextvars
 import inspect
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+import uuid
 import warnings
 
 from crewai_core.printer import PRINTER
@@ -911,6 +912,8 @@ class CrewAgentExecutor(BaseAgentExecutor):
         )
         if parse_error is not None:
             return parse_error
+        args_dict = args_dict or {}
+        governance_call_id = str(uuid.uuid4())
 
         if original_tool is None:
             for tool in self.original_tools or []:
@@ -947,15 +950,6 @@ class CrewAgentExecutor(BaseAgentExecutor):
         from_cache = False
         result: str = "Tool not found"
         raw_tool_result: Any = result
-        input_str = json.dumps(args_dict) if args_dict else ""
-        if self.tools_handler and self.tools_handler.cache and output_tool is not None:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                raw_tool_result = cached_result
-                result = format_native_tool_output_for_agent(output_tool, cached_result)
-                from_cache = True
 
         agent_key = getattr(self.agent, "key", "unknown") if self.agent else "unknown"
         started_at = datetime.now()
@@ -975,13 +969,29 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         before_hook_context = ToolCallHookContext(
             tool_name=func_name,
-            tool_input=args_dict or {},
+            tool_input=args_dict,
             tool=structured_tool,
             agent=self.agent,
             task=self.task,
             crew=self.crew,
+            call_id=governance_call_id,
         )
         hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+        input_str = json.dumps(args_dict) if args_dict else ""
+        if (
+            not hook_blocked
+            and self.tools_handler
+            and self.tools_handler.cache
+            and output_tool is not None
+        ):
+            cached_result = self.tools_handler.cache.read(
+                tool=func_name, input=input_str
+            )
+            if cached_result is not None:
+                raw_tool_result = cached_result
+                result = format_native_tool_output_for_agent(output_tool, cached_result)
+                from_cache = True
 
         if hook_blocked:
             result = f"Tool execution blocked by hook. Tool: {func_name}"
@@ -995,7 +1005,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
             and output_tool is not None
         ):
             try:
-                raw_result = available_functions[func_name](**(args_dict or {}))
+                raw_result = available_functions[func_name](**args_dict)
                 raw_tool_result = raw_result
 
                 if self.tools_handler and self.tools_handler.cache:
@@ -1006,7 +1016,7 @@ class CrewAgentExecutor(BaseAgentExecutor):
                         and callable(original_tool.cache_function)
                     ):
                         should_cache = original_tool.cache_function(
-                            args_dict or {}, raw_result
+                            args_dict, raw_result
                         )
                     if should_cache:
                         self.tools_handler.cache.add(
@@ -1034,13 +1044,16 @@ class CrewAgentExecutor(BaseAgentExecutor):
 
         after_hook_context = ToolCallHookContext(
             tool_name=func_name,
-            tool_input=args_dict or {},
+            tool_input=args_dict,
             tool=structured_tool,
             agent=self.agent,
             task=self.task,
             crew=self.crew,
             tool_result=result,
             raw_tool_result=raw_tool_result,
+            call_id=governance_call_id,
+            is_error=hook_blocked or max_usage_reached or error_event_emitted,
+            was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)
         if modified_result is not None:

--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1052,7 +1052,15 @@ class CrewAgentExecutor(BaseAgentExecutor):
             tool_result=result,
             raw_tool_result=raw_tool_result,
             call_id=governance_call_id,
-            is_error=hook_blocked or max_usage_reached or error_event_emitted,
+            is_error=(
+                hook_blocked
+                or max_usage_reached
+                or error_event_emitted
+                or (
+                    not from_cache
+                    and (output_tool is None or func_name not in available_functions)
+                )
+            ),
             was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1927,6 +1927,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             }
 
         call_id, func_name, func_args = info
+        governance_call_id = str(uuid4())
 
         # Parse arguments
         parsed_args, parse_error = parse_tool_call_args(func_args, func_name, call_id)
@@ -1980,21 +1981,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         output_tool = original_tool or structured_tool
 
-        # Check cache before executing
         from_cache = False
         result = "Tool not found"
         raw_tool_result: Any = result
         tool_failure: ToolFailure | None = None
-        input_str = json.dumps(args_dict) if args_dict else ""
-        if self.tools_handler and self.tools_handler.cache and output_tool is not None:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                raw_tool_result = cached_result
-                result = format_native_tool_output_for_agent(output_tool, cached_result)
-                tool_failure = detect_tool_failure(cached_result)
-                from_cache = True
 
         # Emit tool usage started event
         started_at = datetime.now()
@@ -2019,8 +2009,25 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             agent=self.agent,
             task=self.task,
             crew=self.crew,
+            call_id=governance_call_id,
         )
         hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+        input_str = json.dumps(args_dict) if args_dict else ""
+        if (
+            not hook_blocked
+            and self.tools_handler
+            and self.tools_handler.cache
+            and output_tool is not None
+        ):
+            cached_result = self.tools_handler.cache.read(
+                tool=func_name, input=input_str
+            )
+            if cached_result is not None:
+                raw_tool_result = cached_result
+                result = format_native_tool_output_for_agent(output_tool, cached_result)
+                tool_failure = detect_tool_failure(cached_result)
+                from_cache = True
 
         if hook_blocked:
             result = f"Tool execution blocked by hook. Tool: {func_name}"
@@ -2095,6 +2102,14 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             crew=self.crew,
             tool_result=result,
             raw_tool_result=raw_tool_result,
+            call_id=governance_call_id,
+            is_error=(
+                hook_blocked
+                or max_usage_reached
+                or error_event_emitted
+                or tool_failure is not None
+            ),
+            was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)
         if modified_result is not None:

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -1950,6 +1950,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             }
 
         call_id, func_name, func_args = info
+        governance_call_id = str(uuid4())
 
         # Parse arguments
         parsed_args, parse_error = parse_tool_call_args(func_args, func_name, call_id)
@@ -2003,21 +2004,10 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
 
         output_tool = original_tool or structured_tool
 
-        # Check cache before executing
         from_cache = False
         result = "Tool not found"
         raw_tool_result: Any = result
         tool_failure: ToolFailure | None = None
-        input_str = json.dumps(args_dict) if args_dict else ""
-        if self.tools_handler and self.tools_handler.cache and output_tool is not None:
-            cached_result = self.tools_handler.cache.read(
-                tool=func_name, input=input_str
-            )
-            if cached_result is not None:
-                raw_tool_result = cached_result
-                result = format_native_tool_output_for_agent(output_tool, cached_result)
-                tool_failure = detect_tool_failure(cached_result)
-                from_cache = True
 
         # Emit tool usage started event
         started_at = datetime.now()
@@ -2042,8 +2032,25 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             agent=self.agent,
             task=self.task,
             crew=self.crew,
+            call_id=governance_call_id,
         )
         hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+        input_str = json.dumps(args_dict) if args_dict else ""
+        if (
+            not hook_blocked
+            and self.tools_handler
+            and self.tools_handler.cache
+            and output_tool is not None
+        ):
+            cached_result = self.tools_handler.cache.read(
+                tool=func_name, input=input_str
+            )
+            if cached_result is not None:
+                raw_tool_result = cached_result
+                result = format_native_tool_output_for_agent(output_tool, cached_result)
+                tool_failure = detect_tool_failure(cached_result)
+                from_cache = True
 
         if hook_blocked:
             result = f"Tool execution blocked by hook. Tool: {func_name}"
@@ -2118,6 +2125,14 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             crew=self.crew,
             tool_result=result,
             raw_tool_result=raw_tool_result,
+            call_id=governance_call_id,
+            is_error=(
+                hook_blocked
+                or max_usage_reached
+                or error_event_emitted
+                or tool_failure is not None
+            ),
+            was_blocked=hook_blocked,
         )
         modified_result = run_after_tool_call_hooks(after_hook_context)
         if modified_result is not None:

--- a/lib/crewai/src/crewai/hooks/__init__.py
+++ b/lib/crewai/src/crewai/hooks/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from crewai.hooks.decorators import (
     after_llm_call,
     after_tool_call,
@@ -84,11 +86,47 @@ def clear_all_global_hooks() -> dict[str, tuple[int, int]]:
     }
 
 
+if TYPE_CHECKING:
+    from crewai.hooks.agent_hooks_engine import (
+        AgentHooksEngine as AgentHooksEngine,
+        active_engine as active_engine,
+        disable_agent_hooks as disable_agent_hooks,
+        use_agent_hooks as use_agent_hooks,
+    )
+
+
+_LAZY_ENGINE_EXPORTS = frozenset(
+    {
+        "AgentHooksEngine",
+        "HAS_AGENT_HOOKS",
+        "active_engine",
+        "disable_agent_hooks",
+        "use_agent_hooks",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose the optional agent-hooks control engine front-end.
+
+    Keeps ``import crewai.hooks`` free of the optional agent-hooks dependency;
+    the engine module (and its probe import) loads only on first access.
+    """
+    if name in _LAZY_ENGINE_EXPORTS:
+        from crewai.hooks import agent_hooks_engine
+
+        return getattr(agent_hooks_engine, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
+    "HAS_AGENT_HOOKS",
+    "AgentHooksEngine",
     "HookAborted",
     "InterceptionPoint",
     "LLMCallHookContext",
     "ToolCallHookContext",
+    "active_engine",
     "after_llm_call",
     "after_tool_call",
     "before_llm_call",
@@ -102,6 +140,7 @@ __all__ = [
     "clear_before_llm_call_hooks",
     "clear_before_tool_call_hooks",
     "clear_hooks",
+    "disable_agent_hooks",
     "dispatch",
     "get_after_llm_call_hooks",
     "get_after_tool_call_hooks",
@@ -119,4 +158,5 @@ __all__ = [
     "unregister_before_llm_call_hook",
     "unregister_before_tool_call_hook",
     "unregister_hook",
+    "use_agent_hooks",
 ]

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -55,12 +55,13 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import functools
+import hashlib
 import json
 import logging
 import math
 import threading
 from typing import TYPE_CHECKING, Any, Final, TypeVar
-import uuid
 
 from crewai.hooks.dispatch import (
     HookAborted,
@@ -151,6 +152,12 @@ DEFAULT_POINTS: Final[tuple[InterceptionPoint, ...]] = (
     InterceptionPoint.EXECUTION_END,
 )
 
+#: Post points whose fail-closed action is a blocked *result* string rather than
+#: a raised :class:`HookAborted` (crewAI post seams cannot raise).
+_POST_POINTS: Final[frozenset[InterceptionPoint]] = frozenset(
+    {InterceptionPoint.POST_TOOL_CALL, InterceptionPoint.POST_MODEL_CALL}
+)
+
 _INSTALL_HINT: Final[str] = (
     "agent-hooks is not installed (or its native core failed to load). It is an "
     "optional dependency with a compiled core; install it from source:\n"
@@ -171,16 +178,20 @@ def _require() -> None:
         raise ImportError(_INSTALL_HINT) from _IMPORT_ERROR
 
 
-def _json_safe(value: object) -> Any:
+def _json_safe(value: object, _seen: frozenset[int] = frozenset()) -> Any:
     """Coerce ``value`` into a JSON-serializable form for an ``AgentContext``.
 
     Model output and tool results are untrusted and may contain objects the
     agent-hooks wire format cannot carry (which would fail the emission closed).
     This normalizes them at the boundary so an interceptor always sees a stable,
-    inspectable value.
+    inspectable value. Reference cycles are broken with a ``"<cycle>"``
+    placeholder so a self-referential container cannot raise ``RecursionError``
+    (which, raised before :meth:`AgentHooksEngine._decide`, would fail open).
 
     Args:
         value: Any Python value taken from a crewAI hook context.
+        _seen: Internal set of ``id()``s of containers currently being encoded,
+            used to detect cycles. Callers should not pass it.
 
     Returns:
         A value composed only of ``dict``/``list``/``str``/``int``/``float``/
@@ -191,15 +202,21 @@ def _json_safe(value: object) -> Any:
     if isinstance(value, float):
         return value if math.isfinite(value) else str(value)
     if isinstance(value, dict):
-        return {str(k): _json_safe(v) for k, v in value.items()}
+        if id(value) in _seen:
+            return "<cycle>"
+        seen = _seen | {id(value)}
+        return {str(k): _json_safe(v, seen) for k, v in value.items()}
     if isinstance(value, (list, tuple, set, frozenset)):
-        return [_json_safe(v) for v in value]
+        if id(value) in _seen:
+            return "<cycle>"
+        seen = _seen | {id(value)}
+        return [_json_safe(v, seen) for v in value]
     if isinstance(value, (bytes, bytearray)):
         return value.decode("utf-8", errors="replace")
     dump = getattr(value, "model_dump", None)
     if callable(dump):
         try:
-            return _json_safe(dump(mode="json"))
+            return _json_safe(dump(mode="json"), _seen)
         except Exception:
             logger.debug("model_dump() failed while normalizing %s", type(value))
     return str(value)
@@ -290,9 +307,60 @@ def _registered_tools(crew: Any, agent: Any = None) -> list[str]:
     return names
 
 
-def _new_call_id() -> str:
-    """Generate a correlation id for a tool-call emission."""
-    return uuid.uuid4().hex
+def _agent_envelope(agent: Any, framework: str) -> dict[str, Any]:
+    """Build the agent-hooks ``agent`` envelope for the agent that acted.
+
+    The per-session builder bakes in one agent id, but a crew/flow session
+    drives many agents; the engine stamps this envelope onto each built context
+    so an interceptor and the audit record attribute the emission to the agent
+    that actually acted, not the session's first agent.
+    """
+    agent_id, agent_name = _agent_ids(agent)
+    envelope: dict[str, Any] = {"id": agent_id, "framework": framework}
+    if agent_name:
+        envelope["name"] = agent_name
+    return envelope
+
+
+def _tool_call_id(session_id: str, name: str, args: Any) -> str:
+    """Derive a stable per-invocation tool-call id.
+
+    crewAI builds separate pre/post hook contexts for one tool invocation, so a
+    random id cannot correlate them. A digest over the session, tool name, and
+    (JSON-safe) arguments yields the same id at both seams, letting audit sinks
+    and post-call policies pair the pre and post records for one call.
+    """
+    payload = json.dumps(
+        {"session": session_id, "name": name, "args": args},
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def _model_response_parts(response: Any) -> tuple[Any, list[Any], str]:
+    """Split a model response into ``(content, tool_calls, finish_reason)``.
+
+    A model-boundary tool-use policy must see the tool calls the model
+    requested. When the response carries them (a structured mapping) they are
+    surfaced to the interceptor; a plain-string response yields no tool calls.
+    """
+    if isinstance(response, dict):
+        raw_calls = response.get("tool_calls")
+        tool_calls = (
+            [_json_safe(call) for call in raw_calls]
+            if isinstance(raw_calls, list)
+            else []
+        )
+        finish = response.get("finish_reason")
+        finish_reason = (
+            finish
+            if isinstance(finish, str)
+            else ("tool_calls" if tool_calls else "stop")
+        )
+        return _json_safe(response.get("content", "")), tool_calls, finish_reason
+    return _json_safe(response), [], "stop"
 
 
 class _EmitterLoop:
@@ -332,11 +400,34 @@ class _EmitterLoop:
         return future.result(timeout)
 
     def close(self) -> None:
-        """Stop the background loop and join its thread."""
+        """Stop the background loop, releasing any in-flight emission.
+
+        Pending emissions are cancelled first so a thread blocked in
+        :meth:`run` on ``future.result(None)`` is released (with a
+        ``CancelledError``) instead of deadlocking; only then is the loop
+        stopped and its thread joined.
+        """
+        if self._loop.is_running():
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    self._cancel_pending(), self._loop
+                ).result(timeout=5.0)
+            except Exception:
+                logger.debug("agent-hooks loop drain did not complete cleanly")
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=5.0)
         if not self._loop.is_running():
             self._loop.close()
+
+    @staticmethod
+    async def _cancel_pending() -> None:
+        """Cancel every other task on the loop and await their unwinding."""
+        current = asyncio.current_task()
+        pending = [task for task in asyncio.all_tasks() if task is not current]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -425,7 +516,7 @@ class AgentHooksEngine:
         )
         self._active = False
         self._closed = False
-        self._adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
+        raw_adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
             InterceptionPoint.PRE_TOOL_CALL: self._pre_tool_call,
             InterceptionPoint.POST_TOOL_CALL: self._post_tool_call,
             InterceptionPoint.PRE_MODEL_CALL: self._pre_model_call,
@@ -434,6 +525,13 @@ class AgentHooksEngine:
             InterceptionPoint.OUTPUT: self._output,
             InterceptionPoint.EXECUTION_START: self._execution_start,
             InterceptionPoint.EXECUTION_END: self._execution_end,
+        }
+        # Every adapter builds its context outside _decide()'s fail-closed
+        # guard, so wrap each so an unexpected build error fails closed instead
+        # of escaping to dispatch._invoke_hook (which would swallow it).
+        self._adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
+            point: self._wrap_fail_closed(point, adapter)
+            for point, adapter in raw_adapters.items()
         }
 
     # -- lifecycle ------------------------------------------------------------
@@ -550,14 +648,50 @@ class AgentHooksEngine:
 
     # -- per-point adapters ---------------------------------------------------
 
+    def _wrap_fail_closed(
+        self, point: InterceptionPoint, adapter: Callable[[Any], Any]
+    ) -> Callable[[Any], Any]:
+        """Wrap an adapter so any unexpected error fails closed.
+
+        Each adapter builds its context (``_json_safe`` / ``builder.*``) outside
+        :meth:`_decide`'s guard. Without this wrapper an error there (e.g. a
+        ``RecursionError`` from a cyclic tool input) would escape to
+        :func:`crewai.hooks.dispatch._invoke_hook`, which swallows non-abort
+        exceptions and lets the guarded action proceed **ungoverned**. A
+        legitimate :class:`HookAborted` still propagates unchanged; a *post*
+        point fails the result closed with a blocked marker (its seam cannot
+        raise), every other point raises a fail-closed abort.
+        """
+        is_post = point in _POST_POINTS
+
+        @functools.wraps(adapter)
+        def guarded(ctx: Any) -> Any:
+            try:
+                return adapter(ctx)
+            except HookAborted:
+                raise
+            except Exception:
+                logger.exception(
+                    "agent-hooks adapter for %s failed; failing closed", point.value
+                )
+                if is_post:
+                    return _blocked_result(_ENGINE_FAILED)
+                raise HookAborted(reason=_ENGINE_FAILED, source=_SOURCE) from None
+
+        return guarded
+
     def _pre_tool_call(self, ctx: ToolCallHookContext) -> None:
         """Adapt ``PRE_TOOL_CALL``: deny blocks the call; transform rewrites args."""
-        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        flow = getattr(ctx, "flow", None)
+        args = _json_safe(dict(ctx.tool_input))
+        session_id = _session_id(crew=ctx.crew, flow=flow, agent=ctx.agent)
+        builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.pre_tool_call(
-            call_id=_new_call_id(),
+            call_id=_tool_call_id(session_id, ctx.tool_name, args),
             name=ctx.tool_name,
-            args=_json_safe(dict(ctx.tool_input)),
+            args=args,
         )
+        agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
             raise HookAborted(reason=decision.reason, source=_SOURCE)
@@ -569,14 +703,18 @@ class AgentHooksEngine:
 
     def _post_tool_call(self, ctx: ToolCallHookContext) -> str | None:
         """Adapt ``POST_TOOL_CALL``: deny fails the result closed; transform rewrites it."""
-        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        flow = getattr(ctx, "flow", None)
+        args = _json_safe(dict(ctx.tool_input))
+        session_id = _session_id(crew=ctx.crew, flow=flow, agent=ctx.agent)
+        builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.post_tool_call(
-            call_id=_new_call_id(),
+            call_id=_tool_call_id(session_id, ctx.tool_name, args),
             name=ctx.tool_name,
-            args=_json_safe(dict(ctx.tool_input)),
+            args=args,
             value=_json_safe(ctx.tool_result),
             is_error=False,
         )
+        agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
             return _blocked_result(decision.reason)
@@ -586,11 +724,13 @@ class AgentHooksEngine:
 
     def _pre_model_call(self, ctx: LLMCallHookContext) -> None:
         """Adapt ``PRE_MODEL_CALL``: deny blocks the call; transform rewrites messages."""
-        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        flow = getattr(ctx, "flow", None)
+        builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.pre_model_call(
             model_id=_model_id(getattr(ctx, "llm", None)),
             messages=_json_safe(list(ctx.messages)),
         )
+        agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
             raise HookAborted(reason=decision.reason, source=_SOURCE)
@@ -602,13 +742,16 @@ class AgentHooksEngine:
 
     def _post_model_call(self, ctx: LLMCallHookContext) -> str | None:
         """Adapt ``POST_MODEL_CALL``: deny fails the response closed; transform rewrites it."""
-        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        flow = getattr(ctx, "flow", None)
+        content, tool_calls, finish_reason = _model_response_parts(ctx.response)
+        builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.post_model_call(
             model_id=_model_id(getattr(ctx, "llm", None)),
-            content=_json_safe(ctx.response),
-            tool_calls=[],
-            finish_reason="stop",
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
         )
+        agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
             return _blocked_result(decision.reason)
@@ -621,7 +764,7 @@ class AgentHooksEngine:
 
     def _input(self, ctx: InputContext) -> Any:
         """Adapt ``INPUT``: deny blocks execution; transform replaces the inputs."""
-        builder = self._builder(crew=ctx.crew)
+        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         agent_ctx = builder.input(content=_json_safe(ctx.payload))
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
@@ -637,7 +780,7 @@ class AgentHooksEngine:
         or ``dict``; rich ``CrewOutput`` objects cannot be safely reconstructed
         from the transformed value, so only ``deny`` acts on them.
         """
-        builder = self._builder(crew=ctx.crew)
+        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         payload = ctx.payload
         content = getattr(payload, "raw", None)
         agent_ctx = builder.output(
@@ -652,7 +795,7 @@ class AgentHooksEngine:
 
     def _execution_start(self, ctx: ExecutionStartContext) -> None:
         """Adapt ``EXECUTION_START`` -> ``agent_startup``: deny aborts the run."""
-        builder = self._builder(crew=ctx.crew)
+        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         agent_ctx = builder.agent_startup(
             tools_registered=_registered_tools(ctx.crew, ctx.agent),
             inputs=_json_safe(ctx.payload),
@@ -663,7 +806,7 @@ class AgentHooksEngine:
 
     def _execution_end(self, ctx: ExecutionEndContext) -> None:
         """Adapt ``EXECUTION_END`` -> ``agent_shutdown``: records the run's end."""
-        builder = self._builder(crew=ctx.crew)
+        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         agent_ctx = builder.agent_shutdown(reason=ctx.status)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -1,0 +1,765 @@
+"""crewAI's agent-hooks control engine.
+
+This module makes the framework-neutral
+`agent-hooks <https://github.com/responsibleai/agent-hooks>`_ contract crewAI's
+control engine. You register ``Interceptor`` objects (policy engines, content
+filters, rate limiters, egress guards) once; crewAI's ``dispatch`` then
+delegates its lifecycle points to the agent-hooks emitter, which runs them as
+the authoritative control layer after any crewAI-native hooks and records every
+decision as an auditable ``InterceptionRecord``.
+
+Design notes:
+    - ``agent-hooks`` is an **optional** dependency. It ships a compiled native
+      core and is not required by crewAI; this module imports it lazily and
+      raises an actionable :class:`ImportError` (see :data:`HAS_AGENT_HOOKS`)
+      only when the engine is actually activated.
+    - The ``agent-hooks`` emitter is asynchronous. crewAI's hook seams are
+      synchronous and may be called from either sync or async code, so the
+      engine drives the emitter on a single dedicated background event loop
+      (see :class:`_EmitterLoop`). Serializing every emission on one loop
+      preserves the emitter's per-session ``sequence``/record atomicity
+      guarantees (agent-hooks spec Section 12.2).
+    - Verdicts are mapped to crewAI's hook semantics and **fail closed**: a
+      ``deny`` blocks the guarded action, a ``transform`` rewrites the
+      interceptable value, and any engine-internal error blocks rather than
+      silently allowing.
+
+Failure modes:
+    - Interceptor errors/timeouts are turned into fail-closed denies by the
+      emitter itself (agent-hooks spec Section 6.3); the engine surfaces them as
+      a blocked call.
+    - An emission that raises unexpectedly is logged and treated as a deny.
+
+Interception-point mapping (crewAI -> agent-hooks):
+    ``PRE_TOOL_CALL`` -> ``pre_tool_call``,
+    ``POST_TOOL_CALL`` -> ``post_tool_call``,
+    ``PRE_MODEL_CALL`` -> ``pre_model_call``,
+    ``POST_MODEL_CALL`` -> ``post_model_call``,
+    ``INPUT`` -> ``input``,
+    ``OUTPUT`` -> ``output``,
+    ``EXECUTION_START`` -> ``agent_startup``,
+    ``EXECUTION_END`` -> ``agent_shutdown``.
+
+crewAI's ``PRE_STEP``/``POST_STEP`` points have no agent-hooks equivalent and
+remain crewAI-native (they are not governed by the engine).
+"""
+
+# The agent-hooks ``AgentContext`` is dynamic wire JSON (``dict[str, Any]``);
+# reading the post-transform ``target`` yields values a strict checker cannot
+# infer past ``Unknown``. Each is runtime-validated (``isinstance``) before use,
+# so relax only the unknown-type diagnostics for this boundary module. mypy
+# ``--strict`` (the repository's type gate) still applies in full.
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import json
+import logging
+import math
+import threading
+from typing import TYPE_CHECKING, Any, Final, TypeVar
+import uuid
+
+from crewai.hooks.dispatch import (
+    HookAborted,
+    InterceptionPoint,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine, Sequence
+
+    from crewai.hooks.contexts import (
+        ExecutionEndContext,
+        ExecutionStartContext,
+        InputContext,
+        OutputContext,
+    )
+    from crewai.hooks.llm_hooks import LLMCallHookContext
+    from crewai.hooks.tool_hooks import ToolCallHookContext
+
+
+# The optional agent-hooks package is imported lazily at runtime; its types are
+# surfaced as ``Any`` in this module's signatures so the module type-checks
+# under crewAI's strict mypy, which runs without the optional dependency
+# installed. The real objects are imported inside the methods that use them.
+AgentContext = Any
+AgentContextBuilder = Any
+ApprovalResolver = Any
+CompositionConfig = Any
+EnforcementMode = Any
+IdentityProvider = Any
+InterceptionEmitter = Any
+InterceptionRecord = Any
+Interceptor = Any
+
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+def _probe_agent_hooks() -> tuple[bool, Exception | None]:
+    """Detect agent-hooks availability, including native-core load failures.
+
+    Returns:
+        ``(available, error)`` where ``error`` is the captured import failure
+        when the package (or its compiled core) could not be loaded.
+    """
+    try:
+        import agent_hooks  # type: ignore[import-not-found]  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    except Exception as exc:  # ImportError, or a native-core load failure
+        return False, exc
+    return True, None
+
+
+# ``agent-hooks`` is an optional dependency: probe it once at import time so
+# callers can branch on availability without paying a repeated import cost, and
+# so importing this module never fails when it is absent.
+_availability = _probe_agent_hooks()
+#: Whether the optional ``agent_hooks`` dependency is importable.
+HAS_AGENT_HOOKS: Final[bool] = _availability[0]
+_IMPORT_ERROR: Final[Exception | None] = _availability[1]
+
+
+#: RECOMMENDED per-interceptor timeout in seconds (agent-hooks spec Section 7).
+DEFAULT_TIMEOUT: Final[float] = 5.0
+
+#: Framework identifier stamped on every emitted ``AgentContext``.
+_FRAMEWORK: Final[str] = "crewai"
+
+#: Default identity provider name understood by the emitter (agent-hooks Section 10.2).
+_DEFAULT_IDENTITY: Final[str] = "jcs-sha256"
+
+#: ``source`` attached to a :class:`HookAborted` raised by the engine.
+_SOURCE: Final[str] = "agent-hooks"
+
+#: Reserved reason used when the engine itself fails and must fail closed.
+_ENGINE_FAILED: Final[str] = "host_error:engine_failed"
+
+#: The eight agent-hooks lifecycle points the engine governs, in order.
+DEFAULT_POINTS: Final[tuple[InterceptionPoint, ...]] = (
+    InterceptionPoint.EXECUTION_START,
+    InterceptionPoint.INPUT,
+    InterceptionPoint.PRE_MODEL_CALL,
+    InterceptionPoint.POST_MODEL_CALL,
+    InterceptionPoint.PRE_TOOL_CALL,
+    InterceptionPoint.POST_TOOL_CALL,
+    InterceptionPoint.OUTPUT,
+    InterceptionPoint.EXECUTION_END,
+)
+
+_INSTALL_HINT: Final[str] = (
+    "agent-hooks is not installed (or its native core failed to load). It is an "
+    "optional dependency with a compiled core; install it from source:\n"
+    '    pip install "agent-hooks-sdk @ '
+    'git+https://github.com/responsibleai/agent-hooks.git#subdirectory=sdk/python"\n'
+    "See https://github.com/responsibleai/agent-hooks for details."
+)
+
+
+def _require() -> None:
+    """Raise an actionable :class:`ImportError` when agent-hooks is unavailable.
+
+    Raises:
+        ImportError: If the ``agent_hooks`` package (or its native core) could
+            not be imported at module load time.
+    """
+    if _IMPORT_ERROR is not None:
+        raise ImportError(_INSTALL_HINT) from _IMPORT_ERROR
+
+
+def _json_safe(value: object) -> Any:
+    """Coerce ``value`` into a JSON-serializable form for an ``AgentContext``.
+
+    Model output and tool results are untrusted and may contain objects the
+    agent-hooks wire format cannot carry (which would fail the emission closed).
+    This normalizes them at the boundary so an interceptor always sees a stable,
+    inspectable value.
+
+    Args:
+        value: Any Python value taken from a crewAI hook context.
+
+    Returns:
+        A value composed only of ``dict``/``list``/``str``/``int``/``float``/
+        ``bool``/``None`` (non-finite floats and unknown objects become ``str``).
+    """
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8", errors="replace")
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            return _json_safe(dump(mode="json"))
+        except Exception:
+            logger.debug("model_dump() failed while normalizing %s", type(value))
+    return str(value)
+
+
+def _to_text(value: Any) -> str:
+    """Render a (possibly transformed) interceptable value as a result string."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, default=str, ensure_ascii=False)
+
+
+def _transformed_payload(target: Any) -> Any:
+    """Extract the replacement payload from a transformed input/output target.
+
+    The ``input``/``output`` contexts wrap the value in a ``{"content": ...}``
+    envelope; a transform may rewrite the envelope or the content directly.
+    """
+    if isinstance(target, dict):
+        if "content" in target:
+            return target["content"]
+        return target
+    return target
+
+
+def _blocked_result(reason: str) -> str:
+    """Fail-closed replacement returned when a *post* point denies a result."""
+    return f"[blocked by agent-hooks: {reason}]"
+
+
+def _compose_reason(reason: str | None, message: str | None) -> str:
+    """Combine an interceptor verdict's ``reason`` and ``message``.
+
+    A verdict may carry a short machine ``reason`` (e.g. a policy reason code)
+    and a human ``message``. Both are surfaced so callers — and, ultimately,
+    crewAI customers who receive the blocked-call error — see the full policy
+    decision rather than just an opaque code. Falls back gracefully when only
+    one (or neither) is present.
+    """
+    reason_text = (reason or "").strip()
+    message_text = (message or "").strip()
+    if reason_text and message_text and message_text != reason_text:
+        return f"{reason_text}: {message_text}"
+    return reason_text or message_text or "blocked by agent-hooks interceptor"
+
+
+def _agent_ids(agent: Any) -> tuple[str, str | None]:
+    """Derive ``(agent_id, agent_name)`` from a crewAI agent (or ``None``)."""
+    if agent is None:
+        return "crewai-agent", None
+    ident = getattr(agent, "id", None)
+    role = getattr(agent, "role", None)
+    role_str = str(role) if role else None
+    agent_id = str(ident) if ident is not None else (role_str or "crewai-agent")
+    return agent_id, role_str
+
+
+def _session_id(*, crew: Any = None, flow: Any = None, agent: Any = None) -> str:
+    """Derive a stable session id, preferring crew/flow identity over agent."""
+    for obj in (crew, flow):
+        ident = getattr(obj, "id", None)
+        if ident is not None:
+            return str(ident)
+    ident = getattr(agent, "id", None)
+    if ident is not None:
+        return f"agent:{ident}"
+    return "crewai-session"
+
+
+def _model_id(llm: Any) -> str:
+    """Best-effort model identifier from a crewAI LLM reference."""
+    for attr in ("model", "model_name", "id"):
+        val = getattr(llm, attr, None)
+        if isinstance(val, str) and val:
+            return val
+    return "unknown"
+
+
+def _registered_tools(crew: Any, agent: Any = None) -> list[str]:
+    """Collect declared tool names for the ``agent_startup`` context."""
+    names: list[str] = []
+    for source in (agent, crew):
+        tools = getattr(source, "tools", None) or []
+        for tool in tools:
+            name = getattr(tool, "name", None)
+            if name:
+                names.append(str(name))
+    return names
+
+
+def _new_call_id() -> str:
+    """Generate a correlation id for a tool-call emission."""
+    return uuid.uuid4().hex
+
+
+class _EmitterLoop:
+    """Drive the async agent-hooks emitter from crewAI's sync hook seams.
+
+    Owns one daemon thread running a private event loop. All emissions are
+    submitted to that loop and awaited synchronously, which both bridges the
+    sync/async boundary and serializes emissions so the emitter's per-session
+    ``sequence`` and record buffer stay consistent.
+    """
+
+    __slots__ = ("_loop", "_thread")
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run, name="agent-hooks-emitter", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro: Coroutine[Any, Any, _T], timeout: float | None) -> _T:
+        """Submit ``coro`` to the background loop and block for its result.
+
+        Args:
+            coro: The coroutine to execute (an ``emit_unchecked`` call).
+            timeout: Optional wall-clock bound in seconds; ``None`` waits
+                indefinitely (the emitter enforces its own interceptor timeout).
+
+        Returns:
+            The coroutine's result.
+        """
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout)
+
+    def close(self) -> None:
+        """Stop the background loop and join its thread."""
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5.0)
+        if not self._loop.is_running():
+            self._loop.close()
+
+
+@dataclass(frozen=True, slots=True)
+class _Decision:
+    """The engine's normalized view of one emission outcome."""
+
+    proceeds: bool
+    is_transform: bool
+    reason: str
+
+
+class AgentHooksEngine:
+    """crewAI's agent-hooks control engine.
+
+    Wraps an agent-hooks ``InterceptionEmitter`` and exposes a per-point adapter
+    that :mod:`crewai.hooks.dispatch` runs as the authoritative final hook for
+    the eight lifecycle points. Construct with one or more ``Interceptor``
+    objects (or use :func:`use_agent_hooks`), then :meth:`activate` to install it
+    as the process governor. Every emission is recorded; inspect :attr:`records`
+    or supply a ``record_sink`` for audit.
+
+    Safe to use as a context manager; exiting calls :meth:`close`, which
+    deactivates the engine and stops the background loop.
+    """
+
+    def __init__(
+        self,
+        *interceptors: Interceptor,
+        mode: EnforcementMode | None = None,
+        composition: CompositionConfig | None = None,
+        resolver: ApprovalResolver | None = None,
+        timeout: float | None = DEFAULT_TIMEOUT,
+        identity_provider: str | IdentityProvider | None = _DEFAULT_IDENTITY,
+        record_sink: Callable[[InterceptionRecord], None] | None = None,
+        points: Sequence[InterceptionPoint] | None = None,
+        framework: str = _FRAMEWORK,
+        emit_timeout: float | None = None,
+    ) -> None:
+        """Build the underlying emitter and register the interceptors.
+
+        Args:
+            interceptors: agent-hooks interceptors to enforce, in order.
+            mode: ``ENFORCE`` (default) or ``EVALUATE_ONLY`` (record without
+                blocking).
+            composition: Composition profile/knobs; defaults to
+                ``sequential/first_deny``.
+            resolver: Optional approval resolver for liftable denies (Section 9).
+            timeout: Per-interceptor timeout in seconds (``None`` disables it).
+            identity_provider: Identity provider name, custom provider, or
+                ``None`` for identity-unbound records.
+            record_sink: Optional callback invoked with every record.
+            points: Lifecycle points to govern; defaults to :data:`DEFAULT_POINTS`.
+            framework: Framework id stamped on every context.
+            emit_timeout: Optional wall-clock bound per emission; ``None``
+                relies on the emitter's own interceptor timeout.
+
+        Raises:
+            ImportError: If agent-hooks is not installed.
+        """
+        _require()
+        from agent_hooks import (
+            EnforcementMode as _EnforcementMode,
+            InterceptionEmitter as _InterceptionEmitter,
+        )
+
+        emitter: Any = _InterceptionEmitter(
+            mode=mode if mode is not None else _EnforcementMode.ENFORCE,
+            resolver=resolver,
+            timeout=timeout,
+            composition=composition,
+            identity_provider=identity_provider,
+        )
+        for interceptor in interceptors:
+            emitter.register(interceptor)
+        if record_sink is not None:
+            emitter.set_record_sink(record_sink)
+
+        self._emitter: InterceptionEmitter = emitter
+        self._framework = framework
+        self._emit_timeout = emit_timeout
+        self._loop = _EmitterLoop()
+        self._builders: dict[str, AgentContextBuilder] = {}
+        self._builders_lock = threading.Lock()
+        self._points: frozenset[InterceptionPoint] = frozenset(
+            points if points is not None else DEFAULT_POINTS
+        )
+        self._active = False
+        self._closed = False
+        self._adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
+            InterceptionPoint.PRE_TOOL_CALL: self._pre_tool_call,
+            InterceptionPoint.POST_TOOL_CALL: self._post_tool_call,
+            InterceptionPoint.PRE_MODEL_CALL: self._pre_model_call,
+            InterceptionPoint.POST_MODEL_CALL: self._post_model_call,
+            InterceptionPoint.INPUT: self._input,
+            InterceptionPoint.OUTPUT: self._output,
+            InterceptionPoint.EXECUTION_START: self._execution_start,
+            InterceptionPoint.EXECUTION_END: self._execution_end,
+        }
+
+    # -- lifecycle ------------------------------------------------------------
+
+    @property
+    def emitter(self) -> InterceptionEmitter:
+        """The underlying agent-hooks emitter (for advanced configuration)."""
+        return self._emitter
+
+    @property
+    def records(self) -> list[InterceptionRecord]:
+        """All interception records emitted so far, in order."""
+        return list(self._emitter.results)
+
+    def take_records(self) -> list[InterceptionRecord]:
+        """Drain and return the buffered interception records."""
+        return list(self._emitter.take_records())
+
+    def adapter_for(self, point: InterceptionPoint) -> Callable[[Any], Any] | None:
+        """Return the governing adapter for ``point``, or ``None`` if not governed.
+
+        Called by :func:`crewai.hooks.dispatch.dispatch` (via the installed
+        governor) to append the engine as the authoritative final hook.
+        """
+        if point not in self._points:
+            return None
+        return self._adapters.get(point)
+
+    def activate(self) -> AgentHooksEngine:
+        """Install this engine as crewAI's control governor (idempotent)."""
+        if not self._active:
+            from crewai.hooks.dispatch import set_governor
+
+            set_governor(self.adapter_for)
+            self._active = True
+            logger.debug(
+                "agent-hooks engine activated on %d point(s)", len(self._points)
+            )
+        return self
+
+    def deactivate(self) -> None:
+        """Remove this engine as the governor if it is currently installed."""
+        if self._active:
+            from crewai.hooks.dispatch import clear_governor, get_governor
+
+            if get_governor() == self.adapter_for:
+                clear_governor()
+            self._active = False
+
+    def close(self) -> None:
+        """Deactivate the engine and stop the background emitter loop (idempotent)."""
+        if self._closed:
+            return
+        self._closed = True
+        self.deactivate()
+        self._loop.close()
+
+    def __enter__(self) -> AgentHooksEngine:
+        return self.activate()
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- emission core --------------------------------------------------------
+
+    def _builder(
+        self, *, crew: Any = None, flow: Any = None, agent: Any = None
+    ) -> AgentContextBuilder:
+        """Return the per-session context builder, creating it on first use."""
+        session_id = _session_id(crew=crew, flow=flow, agent=agent)
+        with self._builders_lock:
+            builder = self._builders.get(session_id)
+            if builder is None:
+                from agent_hooks import AgentContextBuilder
+
+                agent_id, agent_name = _agent_ids(agent)
+                builder = AgentContextBuilder(
+                    agent_id=agent_id,
+                    framework=self._framework,
+                    session_id=session_id,
+                    agent_name=agent_name,
+                )
+                self._builders[session_id] = builder
+            return builder
+
+    def _decide(self, ctx: AgentContext) -> _Decision:
+        """Run one emission and normalize the outcome, failing closed on error.
+
+        Args:
+            ctx: The fully built agent-hooks context. Mutated in place by the
+                emitter when a transform is applied (enforce mode).
+
+        Returns:
+            A :class:`_Decision` describing whether the action proceeds and
+            whether a transform was applied.
+        """
+        try:
+            record = self._loop.run(
+                self._emitter.emit_unchecked(ctx), self._emit_timeout
+            )
+        except Exception:
+            logger.exception(
+                "agent-hooks emission failed at %s; failing closed",
+                ctx.get("interception_point"),
+            )
+            return _Decision(proceeds=False, is_transform=False, reason=_ENGINE_FAILED)
+        verdict = record.verdict
+        reason = _compose_reason(verdict.reason, verdict.message)
+        return _Decision(
+            proceeds=record.proceeds,
+            is_transform=record.proceeds and verdict.decision.value == "transform",
+            reason=reason,
+        )
+
+    # -- per-point adapters ---------------------------------------------------
+
+    def _pre_tool_call(self, ctx: ToolCallHookContext) -> None:
+        """Adapt ``PRE_TOOL_CALL``: deny blocks the call; transform rewrites args."""
+        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        agent_ctx = builder.pre_tool_call(
+            call_id=_new_call_id(),
+            name=ctx.tool_name,
+            args=_json_safe(dict(ctx.tool_input)),
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+        if decision.is_transform:
+            new_args = agent_ctx.get("target")
+            if isinstance(new_args, dict):
+                ctx.tool_input.clear()
+                ctx.tool_input.update(new_args)
+
+    def _post_tool_call(self, ctx: ToolCallHookContext) -> str | None:
+        """Adapt ``POST_TOOL_CALL``: deny fails the result closed; transform rewrites it."""
+        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        agent_ctx = builder.post_tool_call(
+            call_id=_new_call_id(),
+            name=ctx.tool_name,
+            args=_json_safe(dict(ctx.tool_input)),
+            value=_json_safe(ctx.tool_result),
+            is_error=False,
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            return _blocked_result(decision.reason)
+        if decision.is_transform:
+            return _to_text(agent_ctx.get("target"))
+        return None
+
+    def _pre_model_call(self, ctx: LLMCallHookContext) -> None:
+        """Adapt ``PRE_MODEL_CALL``: deny blocks the call; transform rewrites messages."""
+        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        agent_ctx = builder.pre_model_call(
+            model_id=_model_id(getattr(ctx, "llm", None)),
+            messages=_json_safe(list(ctx.messages)),
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+        if decision.is_transform:
+            new_messages = agent_ctx.get("target")
+            if isinstance(new_messages, list):
+                ctx.messages.clear()
+                ctx.messages.extend(new_messages)
+
+    def _post_model_call(self, ctx: LLMCallHookContext) -> str | None:
+        """Adapt ``POST_MODEL_CALL``: deny fails the response closed; transform rewrites it."""
+        builder = self._builder(crew=ctx.crew, agent=ctx.agent)
+        agent_ctx = builder.post_model_call(
+            model_id=_model_id(getattr(ctx, "llm", None)),
+            content=_json_safe(ctx.response),
+            tool_calls=[],
+            finish_reason="stop",
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            return _blocked_result(decision.reason)
+        if decision.is_transform:
+            target = agent_ctx.get("target")
+            if isinstance(target, dict):
+                return _to_text(target.get("content"))
+            return _to_text(target)
+        return None
+
+    def _input(self, ctx: InputContext) -> Any:
+        """Adapt ``INPUT``: deny blocks execution; transform replaces the inputs."""
+        builder = self._builder(crew=ctx.crew)
+        agent_ctx = builder.input(content=_json_safe(ctx.payload))
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+        if decision.is_transform:
+            return _transformed_payload(agent_ctx.get("target"))
+        return None
+
+    def _output(self, ctx: OutputContext) -> Any:
+        """Adapt ``OUTPUT``: deny blocks the final output; transform replaces plain payloads.
+
+        A transform is only applied when the crewAI payload is a plain ``str``
+        or ``dict``; rich ``CrewOutput`` objects cannot be safely reconstructed
+        from the transformed value, so only ``deny`` acts on them.
+        """
+        builder = self._builder(crew=ctx.crew)
+        payload = ctx.payload
+        content = getattr(payload, "raw", None)
+        agent_ctx = builder.output(
+            content=_json_safe(content if content is not None else payload)
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+        if decision.is_transform and isinstance(payload, (str, dict)):
+            return _transformed_payload(agent_ctx.get("target"))
+        return None
+
+    def _execution_start(self, ctx: ExecutionStartContext) -> None:
+        """Adapt ``EXECUTION_START`` -> ``agent_startup``: deny aborts the run."""
+        builder = self._builder(crew=ctx.crew)
+        agent_ctx = builder.agent_startup(
+            tools_registered=_registered_tools(ctx.crew, ctx.agent),
+            inputs=_json_safe(ctx.payload),
+        )
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+
+    def _execution_end(self, ctx: ExecutionEndContext) -> None:
+        """Adapt ``EXECUTION_END`` -> ``agent_shutdown``: records the run's end."""
+        builder = self._builder(crew=ctx.crew)
+        agent_ctx = builder.agent_shutdown(reason=ctx.status)
+        decision = self._decide(agent_ctx)
+        if not decision.proceeds:
+            raise HookAborted(reason=decision.reason, source=_SOURCE)
+
+
+_active_engine: AgentHooksEngine | None = None
+
+
+def use_agent_hooks(
+    *interceptors: Interceptor,
+    mode: EnforcementMode | None = None,
+    composition: CompositionConfig | None = None,
+    resolver: ApprovalResolver | None = None,
+    timeout: float | None = DEFAULT_TIMEOUT,
+    identity_provider: str | IdentityProvider | None = _DEFAULT_IDENTITY,
+    record_sink: Callable[[InterceptionRecord], None] | None = None,
+    points: Sequence[InterceptionPoint] | None = None,
+    framework: str = _FRAMEWORK,
+    emit_timeout: float | None = None,
+) -> AgentHooksEngine:
+    """Make agent-hooks crewAI's active control engine and return it.
+
+    This is the one-call entry point: crewAI's ``dispatch`` delegates the eight
+    lifecycle points to the agent-hooks emitter, running the given interceptors
+    as the authoritative control layer after any crewAI-native hooks::
+
+        from crewai.hooks import use_agent_hooks
+
+        engine = use_agent_hooks(MyPolicy(), ContentFilter())
+        try:
+            crew.kickoff(inputs=...)
+        finally:
+            engine.close()
+
+    A previously active engine is closed first. Also usable as a context manager
+    (``with use_agent_hooks(...) as engine:``).
+
+    Args:
+        interceptors: agent-hooks interceptors to enforce, in order.
+        mode: ``ENFORCE`` (default) or ``EVALUATE_ONLY``.
+        composition: Composition profile/knobs (default ``sequential/first_deny``).
+        resolver: Optional approval resolver for liftable denies.
+        timeout: Per-interceptor timeout in seconds (``None`` disables it).
+        identity_provider: Identity provider name, custom provider, or ``None``.
+        record_sink: Optional callback invoked with every record.
+        points: Lifecycle points to govern (default :data:`DEFAULT_POINTS`).
+        framework: Framework id stamped on every context.
+        emit_timeout: Optional wall-clock bound per emission.
+
+    Returns:
+        The active :class:`AgentHooksEngine`. Call :meth:`AgentHooksEngine.close`
+        (or use it as a context manager) to deactivate and release resources.
+
+    Raises:
+        ImportError: If agent-hooks is not installed.
+    """
+    global _active_engine
+    if _active_engine is not None:
+        _active_engine.close()
+    engine = AgentHooksEngine(
+        *interceptors,
+        mode=mode,
+        composition=composition,
+        resolver=resolver,
+        timeout=timeout,
+        identity_provider=identity_provider,
+        record_sink=record_sink,
+        points=points,
+        framework=framework,
+        emit_timeout=emit_timeout,
+    )
+    engine.activate()
+    _active_engine = engine
+    return engine
+
+
+def disable_agent_hooks() -> None:
+    """Deactivate and close the active agent-hooks control engine, if any."""
+    global _active_engine
+    if _active_engine is not None:
+        _active_engine.close()
+        _active_engine = None
+
+
+def active_engine() -> AgentHooksEngine | None:
+    """Return the currently active :class:`AgentHooksEngine`, or ``None``."""
+    return _active_engine
+
+
+__all__ = [
+    "DEFAULT_POINTS",
+    "DEFAULT_TIMEOUT",
+    "HAS_AGENT_HOOKS",
+    "AgentHooksEngine",
+    "active_engine",
+    "disable_agent_hooks",
+    "use_agent_hooks",
+]

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -1020,7 +1020,7 @@ class AgentHooksEngine:
             )
         except Exception:
             session_id, request_id, call_id = _correlation_ids(ctx)
-            logger.exception(
+            logger.error(
                 "agent-hooks emission failed at %s; failing closed "
                 "failure_kind=emission_error session_id=%s request_id=%s call_id=%s",
                 ctx.get("interception_point"),
@@ -1069,7 +1069,7 @@ class AgentHooksEngine:
                 raise
             except Exception:
                 session_id, request_id, call_id = _correlation_ids(ctx)
-                logger.exception(
+                logger.error(
                     "agent-hooks adapter for %s failed; failing closed "
                     "failure_kind=adapter_error session_id=%s request_id=%s call_id=%s",
                     point.value,
@@ -1081,11 +1081,22 @@ class AgentHooksEngine:
                     if point is InterceptionPoint.POST_MODEL_CALL:
                         from crewai.hooks.llm_hooks import mark_post_model_blocked
 
-                        mark_post_model_blocked(
-                            ctx,
-                            reason=_ENGINE_FAILED,
-                            failure_kind="adapter_error",
-                        )
+                        try:
+                            mark_post_model_blocked(
+                                ctx,
+                                reason=_ENGINE_FAILED,
+                                failure_kind="adapter_error",
+                            )
+                        except Exception:
+                            logger.error(
+                                "agent-hooks post-model block provenance could not "
+                                "be retained; returning blocked result "
+                                "failure_kind=provenance_error session_id=%s "
+                                "request_id=%s call_id=%s",
+                                session_id,
+                                request_id,
+                                call_id,
+                            )
                     return _blocked_result(_ENGINE_FAILED)
                 raise HookAborted(reason=_ENGINE_FAILED, source=_SOURCE) from None
 

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -54,6 +54,8 @@ remain crewAI-native (they are not governed by the engine).
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
+import contextvars
 import copy
 from dataclasses import dataclass
 import functools
@@ -62,10 +64,13 @@ import json
 import logging
 import math
 import threading
-from typing import TYPE_CHECKING, Any, Final, TypeVar
+import time
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar
 import uuid
+import weakref
 
 from crewai.hooks.dispatch import (
+    AGENT_HOOKS_ABORT_SOURCE,
     HookAborted,
     InterceptionPoint,
 )
@@ -130,6 +135,9 @@ _IMPORT_ERROR: Final[Exception | None] = _availability[1]
 #: RECOMMENDED per-interceptor timeout in seconds (agent-hooks spec Section 7).
 DEFAULT_TIMEOUT: Final[float] = 5.0
 
+#: Default maximum records retained in memory before oldest-first eviction.
+DEFAULT_MAX_RECORDS: Final[int] = 10_000
+
 #: Framework identifier stamped on every emitted ``AgentContext``.
 _FRAMEWORK: Final[str] = "crewai"
 
@@ -137,12 +145,18 @@ _FRAMEWORK: Final[str] = "crewai"
 _DEFAULT_IDENTITY: Final[str] = "jcs-sha256"
 
 #: ``source`` attached to a :class:`HookAborted` raised by the engine.
-_SOURCE: Final[str] = "agent-hooks"
+_SOURCE: Final[object] = AGENT_HOOKS_ABORT_SOURCE
 
 #: Reserved reason used when the engine itself fails and must fail closed.
 _ENGINE_FAILED: Final[str] = "host_error:engine_failed"
 
 _TRANSFORM_INVALID: Final[str] = "host_error:transform_invalid"
+
+# Maximum callers allowed to wait behind the single active emission.
+_MAX_EMITTER_WAITERS: Final[int] = 64
+
+# Admission polling interval so close/failure wakes waiters promptly.
+_ADMISSION_POLL_SECONDS: Final[float] = 0.05
 
 #: The eight agent-hooks lifecycle points the engine governs, in order.
 DEFAULT_POINTS: Final[tuple[InterceptionPoint, ...]] = (
@@ -250,6 +264,39 @@ def _blocked_result(reason: str) -> str:
     return f"[blocked by agent-hooks: {reason}]"
 
 
+def _log_identifier(value: Any) -> str | None:
+    """Normalize a correlation identifier without allowing log injection."""
+    if value is None or isinstance(value, (dict, list, tuple, set, frozenset)):
+        return None
+    text = str(value).replace("\r", "\\r").replace("\n", "\\n")
+    return text[:128] or None
+
+
+def _correlation_ids(ctx: Any) -> tuple[str | None, str | None, str | None]:
+    """Extract payload-free session, request, and tool-call identifiers."""
+    session_id: Any = None
+    request_id: Any = None
+    call_id: Any = None
+    if isinstance(ctx, dict):
+        session = ctx.get("session")
+        if isinstance(session, dict):
+            session_id = session.get("id")
+        request_id = ctx.get("request_id")
+        tool_call = ctx.get("tool_call")
+        if isinstance(tool_call, dict):
+            call_id = tool_call.get("id")
+    else:
+        request_id = getattr(ctx, "request_id", None)
+        call_id = getattr(ctx, "call_id", None)
+        owner = getattr(ctx, "crew", None) or getattr(ctx, "flow", None)
+        session_id = getattr(owner, "id", None)
+    return (
+        _log_identifier(session_id),
+        _log_identifier(request_id),
+        _log_identifier(call_id),
+    )
+
+
 def _compose_reason(reason: str | None, message: str | None) -> str:
     """Combine an interceptor verdict's ``reason`` and ``message``.
 
@@ -347,6 +394,37 @@ def _model_response_parts(response: Any) -> tuple[Any, list[Any], str]:
             else ("tool_calls" if tool_calls else "stop")
         )
         return _json_safe(response.get("content", "")), tool_calls, finish_reason
+    if isinstance(response, list):
+        from crewai.utilities.agent_utils import (
+            extract_tool_call_info,
+            is_tool_call_list,
+        )
+
+        if is_tool_call_list(response):
+            tool_calls = []
+            for tool_call in response:
+                info = extract_tool_call_info(tool_call)
+                if info is None:
+                    continue
+                call_id, name, args = info
+                if isinstance(args, str):
+                    try:
+                        parsed_args = json.loads(args)
+                    except json.JSONDecodeError:
+                        parsed_args = {"raw": args}
+                    args = (
+                        parsed_args
+                        if isinstance(parsed_args, dict)
+                        else {"value": parsed_args}
+                    )
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "name": name,
+                        "args": _json_safe(args),
+                    }
+                )
+            return "", tool_calls, "tool_calls"
     return _json_safe(response), [], "stop"
 
 
@@ -359,10 +437,25 @@ class _EmitterLoop:
     ``sequence`` and record buffer stay consistent.
     """
 
-    __slots__ = ("_loop", "_thread")
+    __slots__ = (
+        "_active_future",
+        "_admission",
+        "_loop",
+        "_state",
+        "_state_lock",
+        "_thread",
+        "_waiter_slots",
+    )
 
-    def __init__(self) -> None:
+    def __init__(self, max_waiters: int = _MAX_EMITTER_WAITERS) -> None:
+        if max_waiters < 1:
+            raise ValueError("max_waiters must be at least 1")
         self._loop = asyncio.new_event_loop()
+        self._admission = threading.BoundedSemaphore(1)
+        self._waiter_slots = threading.BoundedSemaphore(max_waiters)
+        self._state_lock = threading.Lock()
+        self._state: Literal["open", "closing", "failed", "closed"] = "open"
+        self._active_future: Future[Any] | None = None
         self._thread = threading.Thread(
             target=self._run, name="agent-hooks-emitter", daemon=True
         )
@@ -382,11 +475,130 @@ class _EmitterLoop:
 
         Returns:
             The coroutine's result.
-        """
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout)
 
-    def close(self) -> None:
+        Raises:
+            TimeoutError: If admission or execution exceeds ``timeout``.
+            RuntimeError: If the loop has been closed.
+        """
+        if timeout is not None and timeout < 0:
+            coro.close()
+            raise ValueError("timeout must be non-negative or None")
+
+        with self._state_lock:
+            if self._state != "open":
+                coro.close()
+                raise RuntimeError("agent-hooks emitter loop is not open")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        if not self._waiter_slots.acquire(blocking=False):
+            coro.close()
+            raise RuntimeError("agent-hooks emitter admission queue is full")
+        try:
+            try:
+                admitted = self._acquire_admission(deadline)
+            except Exception:
+                coro.close()
+                raise
+        finally:
+            self._waiter_slots.release()
+        if not admitted:
+            coro.close()
+            raise FutureTimeoutError("agent-hooks emitter admission timed out")
+
+        started = threading.Event()
+        cancel_requested = threading.Event()
+        release_lock = threading.Lock()
+        released = False
+
+        def release_admission() -> None:
+            nonlocal released
+            with release_lock:
+                if not released:
+                    released = True
+                    self._admission.release()
+
+        async def execute() -> _T:
+            started.set()
+            try:
+                if cancel_requested.is_set():
+                    coro.close()
+                    raise asyncio.CancelledError
+                return await coro
+            finally:
+                release_admission()
+
+        execution = execute()
+        try:
+            with self._state_lock:
+                if self._state != "open":
+                    raise RuntimeError("agent-hooks emitter loop is not open")
+                future = asyncio.run_coroutine_threadsafe(execution, self._loop)
+                self._active_future = future
+        except Exception:
+            execution.close()
+            release_admission()
+            coro.close()
+            raise
+
+        def on_done(completed: Future[_T]) -> None:
+            with self._state_lock:
+                if self._active_future is completed:
+                    self._active_future = None
+            if not started.is_set():
+                cancel_requested.set()
+                coro.close()
+                release_admission()
+                started.set()
+
+        future.add_done_callback(on_done)
+        remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+        if not started.wait(timeout=remaining):
+            cancel_requested.set()
+            future.cancel()
+            raise FutureTimeoutError("agent-hooks emitter scheduling timed out")
+
+        remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+        try:
+            return future.result(timeout=remaining)
+        except FutureTimeoutError:
+            if not future.done():
+                future.cancel()
+            raise
+
+    def _acquire_admission(self, deadline: float | None) -> bool:
+        """Acquire the emission slot while observing lifecycle state."""
+        while True:
+            with self._state_lock:
+                if self._state != "open":
+                    raise RuntimeError("agent-hooks emitter loop is not open")
+
+            if deadline is None:
+                wait_seconds = _ADMISSION_POLL_SECONDS
+                blocking = True
+            else:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    wait_seconds = None
+                    blocking = False
+                else:
+                    wait_seconds = min(_ADMISSION_POLL_SECONDS, remaining)
+                    blocking = True
+
+            admitted = (
+                self._admission.acquire(timeout=wait_seconds)
+                if blocking
+                else self._admission.acquire(blocking=False)
+            )
+            if admitted:
+                with self._state_lock:
+                    if self._state == "open":
+                        return True
+                self._admission.release()
+                raise RuntimeError("agent-hooks emitter loop is not open")
+            if not blocking:
+                return False
+
+    def close(self, timeout: float = 5.0) -> None:
         """Stop the background loop, releasing any in-flight emission.
 
         Pending emissions are cancelled first so a thread blocked in
@@ -394,17 +606,39 @@ class _EmitterLoop:
         ``CancelledError``) instead of deadlocking; only then is the loop
         stopped and its thread joined.
         """
+        with self._state_lock:
+            if self._state == "closed":
+                return
+            if self._state == "closing":
+                raise RuntimeError("agent-hooks emitter loop is already closing")
+            self._state = "closing"
+            active_future = self._active_future
+
+        if active_future is not None and not active_future.done():
+            active_future.cancel()
+
         if self._loop.is_running():
             try:
                 asyncio.run_coroutine_threadsafe(
                     self._cancel_pending(), self._loop
-                ).result(timeout=5.0)
-            except Exception:
-                logger.debug("agent-hooks loop drain did not complete cleanly")
+                ).result(timeout=timeout)
+            except Exception as error:
+                with self._state_lock:
+                    self._state = "failed"
+                raise RuntimeError(
+                    "agent-hooks emitter loop did not drain cleanly"
+                ) from error
         self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join(timeout=5.0)
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            with self._state_lock:
+                self._state = "failed"
+            raise RuntimeError("agent-hooks emitter loop did not stop")
         if not self._loop.is_running():
             self._loop.close()
+        with self._state_lock:
+            self._active_future = None
+            self._state = "closed"
 
     @staticmethod
     async def _cancel_pending() -> None:
@@ -423,7 +657,16 @@ class _Decision:
 
     proceeds: bool
     is_transform: bool
+    is_policy_denial: bool
     reason: str
+
+
+@dataclass(slots=True)
+class _OwnerSessions:
+    """Active governance sessions retained for one live execution owner."""
+
+    owner_ref: Callable[[], Any | None]
+    session_ids: list[str]
 
 
 class AgentHooksEngine:
@@ -433,8 +676,9 @@ class AgentHooksEngine:
     that :mod:`crewai.hooks.dispatch` runs as the authoritative final hook for
     the eight lifecycle points. Construct with one or more ``Interceptor``
     objects (or use :func:`use_agent_hooks`), then :meth:`activate` to install it
-    as the process governor. Every emission is recorded; inspect :attr:`records`
-    or supply a ``record_sink`` for audit.
+    as the process governor. Completed emitter decisions are recorded; inspect
+    :attr:`records` or supply a ``record_sink`` for audit. Host-side emission
+    failures are logged and fail closed before an SDK record can be returned.
 
     Safe to use as a context manager; exiting calls :meth:`close`, which
     deactivates the engine and stops the background loop.
@@ -449,6 +693,7 @@ class AgentHooksEngine:
         timeout: float | None = DEFAULT_TIMEOUT,
         identity_provider: str | IdentityProvider | None = _DEFAULT_IDENTITY,
         record_sink: Callable[[InterceptionRecord], None] | None = None,
+        max_records: int = DEFAULT_MAX_RECORDS,
         points: Sequence[InterceptionPoint] | None = None,
         framework: str = _FRAMEWORK,
         emit_timeout: float | None = None,
@@ -466,6 +711,8 @@ class AgentHooksEngine:
             identity_provider: Identity provider name, custom provider, or
                 ``None`` for identity-unbound records.
             record_sink: Optional callback invoked with every record.
+            max_records: Maximum records retained in memory before oldest-first
+                eviction. Evictions are counted by :attr:`records_dropped`.
             points: Lifecycle points to govern; defaults to :data:`DEFAULT_POINTS`.
             framework: Framework id stamped on every context.
             emit_timeout: Optional wall-clock bound per emission; ``None``
@@ -488,19 +735,27 @@ class AgentHooksEngine:
             emitter.register(interceptor)
         if record_sink is not None:
             emitter.set_record_sink(record_sink)
+        emitter.set_max_records(max_records)
 
         self._emitter: InterceptionEmitter = emitter
         self._framework = framework
         self._emit_timeout = emit_timeout
         self._loop = _EmitterLoop()
         self._builders: dict[str, AgentContextBuilder] = {}
-        self._active_sessions: dict[int, list[str]] = {}
+        self._active_sessions: dict[int, _OwnerSessions] = {}
+        self._session_context: contextvars.ContextVar[
+            dict[int, tuple[str, ...]] | None
+        ] = contextvars.ContextVar(
+            f"agent_hooks_sessions_{id(self)}",
+            default=None,
+        )
         self._builders_lock = threading.Lock()
         self._points: frozenset[InterceptionPoint] = frozenset(
             points if points is not None else DEFAULT_POINTS
         )
         self._active = False
         self._closed = False
+        self._close_failed = False
         raw_adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
             InterceptionPoint.PRE_TOOL_CALL: self._pre_tool_call,
             InterceptionPoint.POST_TOOL_CALL: self._post_tool_call,
@@ -531,6 +786,11 @@ class AgentHooksEngine:
         """All interception records emitted so far, in order."""
         return list(self._emitter.results)
 
+    @property
+    def records_dropped(self) -> int:
+        """Records evicted from the bounded in-memory audit buffer."""
+        return int(self._emitter.records_dropped)
+
     def take_records(self) -> list[InterceptionRecord]:
         """Drain and return the buffered interception records."""
         return list(self._emitter.take_records())
@@ -547,6 +807,8 @@ class AgentHooksEngine:
 
     def activate(self) -> AgentHooksEngine:
         """Install this engine as crewAI's control governor (idempotent)."""
+        if self._closed or self._close_failed:
+            raise RuntimeError("a closed or failed agent-hooks engine cannot activate")
         if not self._active:
             from crewai.hooks.dispatch import set_governor
 
@@ -571,14 +833,19 @@ class AgentHooksEngine:
         global _active_engine
         if self._closed:
             return
-        self._closed = True
         self.deactivate()
-        self._loop.close()
+        try:
+            self._loop.close()
+        except Exception:
+            self._close_failed = True
+            raise
         with self._builders_lock:
             self._builders.clear()
             self._active_sessions.clear()
         if _active_engine is self:
             _active_engine = None
+        self._close_failed = False
+        self._closed = True
 
     def __enter__(self) -> AgentHooksEngine:
         return self.activate()
@@ -612,10 +879,29 @@ class AgentHooksEngine:
     ) -> str:
         owner = crew if crew is not None else flow
         if owner is not None:
+            owner_id = id(owner)
             with self._builders_lock:
-                sessions = self._active_sessions.get(id(owner))
-                if sessions:
-                    return sessions[-1]
+                owner_sessions = self._active_sessions.get(owner_id)
+                if (
+                    owner_sessions is not None
+                    and owner_sessions.owner_ref() is not owner
+                ):
+                    self._discard_owner_sessions_locked(owner_id, owner_sessions)
+                    owner_sessions = None
+                if owner_sessions is not None:
+                    context_sessions = (self._session_context.get() or {}).get(
+                        owner_id, ()
+                    )
+                    for session_id in reversed(context_sessions):
+                        if session_id in owner_sessions.session_ids:
+                            return session_id
+                    if len(owner_sessions.session_ids) == 1:
+                        return owner_sessions.session_ids[0]
+                    if owner_sessions.session_ids:
+                        raise RuntimeError(
+                            "multiple active agent-hooks sessions lack an "
+                            "execution-local session identifier"
+                        )
         return _session_id(crew=crew, flow=flow, agent=agent)
 
     def _begin_session(self, *, crew: Any = None, flow: Any = None) -> str:
@@ -623,22 +909,98 @@ class AgentHooksEngine:
         session_id = f"{base_id}:{uuid.uuid4()}"
         owner = crew if crew is not None else flow
         if owner is not None:
+            owner_id = id(owner)
             with self._builders_lock:
-                self._active_sessions.setdefault(id(owner), []).append(session_id)
+                owner_sessions = self._active_sessions.get(owner_id)
+                if (
+                    owner_sessions is not None
+                    and owner_sessions.owner_ref() is not owner
+                ):
+                    self._discard_owner_sessions_locked(owner_id, owner_sessions)
+                    owner_sessions = None
+                if owner_sessions is None:
+                    owner_sessions = _OwnerSessions(
+                        owner_ref=self._owner_reference(owner, owner_id),
+                        session_ids=[],
+                    )
+                    self._active_sessions[owner_id] = owner_sessions
+                owner_sessions.session_ids.append(session_id)
+            context_sessions = dict(self._session_context.get() or {})
+            context_sessions[owner_id] = (
+                *context_sessions.get(owner_id, ()),
+                session_id,
+            )
+            self._session_context.set(context_sessions)
         return session_id
 
     def _finish_session(self, *, crew: Any = None, flow: Any = None) -> None:
         owner = crew if crew is not None else flow
         if owner is None:
             return
+        owner_id = id(owner)
         with self._builders_lock:
-            sessions = self._active_sessions.get(id(owner))
-            if not sessions:
+            owner_sessions = self._active_sessions.get(owner_id)
+            if owner_sessions is None:
                 return
-            session_id = sessions.pop()
+            if owner_sessions.owner_ref() is not owner:
+                self._discard_owner_sessions_locked(owner_id, owner_sessions)
+                return
+            context_sessions = dict(self._session_context.get() or {})
+            context_stack = list(context_sessions.get(owner_id, ()))
+            if context_stack:
+                session_id = context_stack.pop()
+                if context_stack:
+                    context_sessions[owner_id] = tuple(context_stack)
+                else:
+                    context_sessions.pop(owner_id, None)
+                self._session_context.set(context_sessions)
+            elif len(owner_sessions.session_ids) == 1:
+                session_id = owner_sessions.session_ids[0]
+            elif owner_sessions.session_ids:
+                raise RuntimeError(
+                    "cannot finish an ambiguous agent-hooks execution session"
+                )
+            else:
+                return
+            if session_id not in owner_sessions.session_ids:
+                return
+            owner_sessions.session_ids.remove(session_id)
             self._builders.pop(session_id, None)
-            if not sessions:
-                self._active_sessions.pop(id(owner), None)
+            if not owner_sessions.session_ids:
+                self._active_sessions.pop(owner_id, None)
+
+    def _owner_reference(self, owner: Any, owner_id: int) -> Callable[[], Any | None]:
+        """Create an owner reference that removes abandoned session state."""
+        engine_ref = weakref.ref(self)
+
+        def discard(reference: weakref.ReferenceType[Any]) -> None:
+            engine = engine_ref()
+            if engine is not None:
+                engine._discard_owner_sessions(owner_id, reference)
+
+        try:
+            return weakref.ref(owner, discard)
+        except TypeError:
+            return lambda: owner
+
+    def _discard_owner_sessions(
+        self,
+        owner_id: int,
+        expected_ref: Callable[[], Any | None],
+    ) -> None:
+        """Remove abandoned state when the matching owner is collected."""
+        with self._builders_lock:
+            owner_sessions = self._active_sessions.get(owner_id)
+            if owner_sessions is not None and owner_sessions.owner_ref is expected_ref:
+                self._discard_owner_sessions_locked(owner_id, owner_sessions)
+
+    def _discard_owner_sessions_locked(
+        self, owner_id: int, owner_sessions: _OwnerSessions
+    ) -> None:
+        """Remove one owner's sessions while ``_builders_lock`` is held."""
+        self._active_sessions.pop(owner_id, None)
+        for session_id in owner_sessions.session_ids:
+            self._builders.pop(session_id, None)
 
     def _decide(self, ctx: AgentContext) -> _Decision:
         """Run one emission and normalize the outcome, failing closed on error.
@@ -657,16 +1019,27 @@ class AgentHooksEngine:
                 self._emitter.emit_unchecked(ctx), self._emit_timeout
             )
         except Exception:
+            session_id, request_id, call_id = _correlation_ids(ctx)
             logger.exception(
-                "agent-hooks emission failed at %s; failing closed",
+                "agent-hooks emission failed at %s; failing closed "
+                "failure_kind=emission_error session_id=%s request_id=%s call_id=%s",
                 ctx.get("interception_point"),
+                session_id,
+                request_id,
+                call_id,
             )
-            return _Decision(proceeds=False, is_transform=False, reason=_ENGINE_FAILED)
+            return _Decision(
+                proceeds=False,
+                is_transform=False,
+                is_policy_denial=False,
+                reason=_ENGINE_FAILED,
+            )
         verdict = record.verdict
         reason = _compose_reason(verdict.reason, verdict.message)
         return _Decision(
             proceeds=record.proceeds,
             is_transform=record.proceeds and ctx.get("target") != original_target,
+            is_policy_denial=not record.proceeds and record.decided_by is not None,
             reason=reason,
         )
 
@@ -695,10 +1068,24 @@ class AgentHooksEngine:
             except HookAborted:
                 raise
             except Exception:
+                session_id, request_id, call_id = _correlation_ids(ctx)
                 logger.exception(
-                    "agent-hooks adapter for %s failed; failing closed", point.value
+                    "agent-hooks adapter for %s failed; failing closed "
+                    "failure_kind=adapter_error session_id=%s request_id=%s call_id=%s",
+                    point.value,
+                    session_id,
+                    request_id,
+                    call_id,
                 )
                 if is_post:
+                    if point is InterceptionPoint.POST_MODEL_CALL:
+                        from crewai.hooks.llm_hooks import mark_post_model_blocked
+
+                        mark_post_model_blocked(
+                            ctx,
+                            reason=_ENGINE_FAILED,
+                            failure_kind="adapter_error",
+                        )
                     return _blocked_result(_ENGINE_FAILED)
                 raise HookAborted(reason=_ENGINE_FAILED, source=_SOURCE) from None
 
@@ -782,6 +1169,15 @@ class AgentHooksEngine:
         agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
+            from crewai.hooks.llm_hooks import mark_post_model_blocked
+
+            mark_post_model_blocked(
+                ctx,
+                reason=decision.reason,
+                failure_kind=(
+                    "policy_denial" if decision.is_policy_denial else "host_error"
+                ),
+            )
             return _blocked_result(decision.reason)
         if decision.is_transform:
             target = agent_ctx.get("target")
@@ -881,6 +1277,7 @@ def use_agent_hooks(
     timeout: float | None = DEFAULT_TIMEOUT,
     identity_provider: str | IdentityProvider | None = _DEFAULT_IDENTITY,
     record_sink: Callable[[InterceptionRecord], None] | None = None,
+    max_records: int = DEFAULT_MAX_RECORDS,
     points: Sequence[InterceptionPoint] | None = None,
     framework: str = _FRAMEWORK,
     emit_timeout: float | None = None,
@@ -910,6 +1307,8 @@ def use_agent_hooks(
         timeout: Per-interceptor timeout in seconds (``None`` disables it).
         identity_provider: Identity provider name, custom provider, or ``None``.
         record_sink: Optional callback invoked with every record.
+        max_records: Maximum records retained in memory before oldest-first
+            eviction.
         points: Lifecycle points to govern (default :data:`DEFAULT_POINTS`).
         framework: Framework id stamped on every context.
         emit_timeout: Optional wall-clock bound per emission.
@@ -932,6 +1331,7 @@ def use_agent_hooks(
         timeout=timeout,
         identity_provider=identity_provider,
         record_sink=record_sink,
+        max_records=max_records,
         points=points,
         framework=framework,
         emit_timeout=emit_timeout,
@@ -955,6 +1355,7 @@ def active_engine() -> AgentHooksEngine | None:
 
 
 __all__ = [
+    "DEFAULT_MAX_RECORDS",
     "DEFAULT_POINTS",
     "DEFAULT_TIMEOUT",
     "HAS_AGENT_HOOKS",

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -1269,9 +1269,9 @@ class AgentHooksEngine:
 
     def _execution_end(self, ctx: ExecutionEndContext) -> None:
         """Adapt ``EXECUTION_END`` -> ``agent_shutdown``: records the run's end."""
-        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         reason = "completed" if ctx.status == "completed" else "error"
         try:
+            builder = self._builder(crew=ctx.crew, flow=ctx.flow)
             self._decide(builder.agent_shutdown(reason=reason))
         finally:
             self._finish_session(crew=ctx.crew, flow=ctx.flow)

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -54,14 +54,16 @@ remain crewAI-native (they are not governed by the engine).
 from __future__ import annotations
 
 import asyncio
+import copy
 from dataclasses import dataclass
 import functools
-import hashlib
+import importlib
 import json
 import logging
 import math
 import threading
 from typing import TYPE_CHECKING, Any, Final, TypeVar
+import uuid
 
 from crewai.hooks.dispatch import (
     HookAborted,
@@ -110,7 +112,7 @@ def _probe_agent_hooks() -> tuple[bool, Exception | None]:
         when the package (or its compiled core) could not be loaded.
     """
     try:
-        import agent_hooks  # type: ignore[import-not-found]  # noqa: F401  # pyright: ignore[reportUnusedImport]
+        importlib.import_module("agent_hooks")
     except Exception as exc:  # ImportError, or a native-core load failure
         return False, exc
     return True, None
@@ -140,6 +142,8 @@ _SOURCE: Final[str] = "agent-hooks"
 #: Reserved reason used when the engine itself fails and must fail closed.
 _ENGINE_FAILED: Final[str] = "host_error:engine_failed"
 
+_TRANSFORM_INVALID: Final[str] = "host_error:transform_invalid"
+
 #: The eight agent-hooks lifecycle points the engine governs, in order.
 DEFAULT_POINTS: Final[tuple[InterceptionPoint, ...]] = (
     InterceptionPoint.EXECUTION_START,
@@ -160,9 +164,8 @@ _POST_POINTS: Final[frozenset[InterceptionPoint]] = frozenset(
 
 _INSTALL_HINT: Final[str] = (
     "agent-hooks is not installed (or its native core failed to load). It is an "
-    "optional dependency with a compiled core; install it from source:\n"
-    '    pip install "agent-hooks-sdk @ '
-    'git+https://github.com/responsibleai/agent-hooks.git#subdirectory=sdk/python"\n'
+    "optional dependency with a compiled core; install the pinned release:\n"
+    '    pip install "agent-hooks-sdk==0.1.0a3"\n'
     "See https://github.com/responsibleai/agent-hooks for details."
 )
 
@@ -298,11 +301,12 @@ def _model_id(llm: Any) -> str:
 def _registered_tools(crew: Any, agent: Any = None) -> list[str]:
     """Collect declared tool names for the ``agent_startup`` context."""
     names: list[str] = []
-    for source in (agent, crew):
+    crew_agents = getattr(crew, "agents", None) or []
+    for source in (agent, crew, *crew_agents):
         tools = getattr(source, "tools", None) or []
         for tool in tools:
             name = getattr(tool, "name", None)
-            if name:
+            if name and str(name) not in names:
                 names.append(str(name))
     return names
 
@@ -320,23 +324,6 @@ def _agent_envelope(agent: Any, framework: str) -> dict[str, Any]:
     if agent_name:
         envelope["name"] = agent_name
     return envelope
-
-
-def _tool_call_id(session_id: str, name: str, args: Any) -> str:
-    """Derive a stable per-invocation tool-call id.
-
-    crewAI builds separate pre/post hook contexts for one tool invocation, so a
-    random id cannot correlate them. A digest over the session, tool name, and
-    (JSON-safe) arguments yields the same id at both seams, letting audit sinks
-    and post-call policies pair the pre and post records for one call.
-    """
-    payload = json.dumps(
-        {"session": session_id, "name": name, "args": args},
-        sort_keys=True,
-        ensure_ascii=False,
-        default=str,
-    )
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
 
 
 def _model_response_parts(response: Any) -> tuple[Any, list[Any], str]:
@@ -488,13 +475,10 @@ class AgentHooksEngine:
             ImportError: If agent-hooks is not installed.
         """
         _require()
-        from agent_hooks import (
-            EnforcementMode as _EnforcementMode,
-            InterceptionEmitter as _InterceptionEmitter,
-        )
+        agent_hooks = importlib.import_module("agent_hooks")
 
-        emitter: Any = _InterceptionEmitter(
-            mode=mode if mode is not None else _EnforcementMode.ENFORCE,
+        emitter: Any = agent_hooks.InterceptionEmitter(
+            mode=mode if mode is not None else agent_hooks.EnforcementMode.ENFORCE,
             resolver=resolver,
             timeout=timeout,
             composition=composition,
@@ -510,6 +494,7 @@ class AgentHooksEngine:
         self._emit_timeout = emit_timeout
         self._loop = _EmitterLoop()
         self._builders: dict[str, AgentContextBuilder] = {}
+        self._active_sessions: dict[int, list[str]] = {}
         self._builders_lock = threading.Lock()
         self._points: frozenset[InterceptionPoint] = frozenset(
             points if points is not None else DEFAULT_POINTS
@@ -583,11 +568,17 @@ class AgentHooksEngine:
 
     def close(self) -> None:
         """Deactivate the engine and stop the background emitter loop (idempotent)."""
+        global _active_engine
         if self._closed:
             return
         self._closed = True
         self.deactivate()
         self._loop.close()
+        with self._builders_lock:
+            self._builders.clear()
+            self._active_sessions.clear()
+        if _active_engine is self:
+            _active_engine = None
 
     def __enter__(self) -> AgentHooksEngine:
         return self.activate()
@@ -601,14 +592,13 @@ class AgentHooksEngine:
         self, *, crew: Any = None, flow: Any = None, agent: Any = None
     ) -> AgentContextBuilder:
         """Return the per-session context builder, creating it on first use."""
-        session_id = _session_id(crew=crew, flow=flow, agent=agent)
+        session_id = self._current_session_id(crew=crew, flow=flow, agent=agent)
         with self._builders_lock:
             builder = self._builders.get(session_id)
             if builder is None:
-                from agent_hooks import AgentContextBuilder
-
                 agent_id, agent_name = _agent_ids(agent)
-                builder = AgentContextBuilder(
+                agent_hooks = importlib.import_module("agent_hooks")
+                builder = agent_hooks.AgentContextBuilder(
                     agent_id=agent_id,
                     framework=self._framework,
                     session_id=session_id,
@@ -616,6 +606,39 @@ class AgentHooksEngine:
                 )
                 self._builders[session_id] = builder
             return builder
+
+    def _current_session_id(
+        self, *, crew: Any = None, flow: Any = None, agent: Any = None
+    ) -> str:
+        owner = crew if crew is not None else flow
+        if owner is not None:
+            with self._builders_lock:
+                sessions = self._active_sessions.get(id(owner))
+                if sessions:
+                    return sessions[-1]
+        return _session_id(crew=crew, flow=flow, agent=agent)
+
+    def _begin_session(self, *, crew: Any = None, flow: Any = None) -> str:
+        base_id = _session_id(crew=crew, flow=flow)
+        session_id = f"{base_id}:{uuid.uuid4()}"
+        owner = crew if crew is not None else flow
+        if owner is not None:
+            with self._builders_lock:
+                self._active_sessions.setdefault(id(owner), []).append(session_id)
+        return session_id
+
+    def _finish_session(self, *, crew: Any = None, flow: Any = None) -> None:
+        owner = crew if crew is not None else flow
+        if owner is None:
+            return
+        with self._builders_lock:
+            sessions = self._active_sessions.get(id(owner))
+            if not sessions:
+                return
+            session_id = sessions.pop()
+            self._builders.pop(session_id, None)
+            if not sessions:
+                self._active_sessions.pop(id(owner), None)
 
     def _decide(self, ctx: AgentContext) -> _Decision:
         """Run one emission and normalize the outcome, failing closed on error.
@@ -628,6 +651,7 @@ class AgentHooksEngine:
             A :class:`_Decision` describing whether the action proceeds and
             whether a transform was applied.
         """
+        original_target = copy.deepcopy(ctx.get("target"))
         try:
             record = self._loop.run(
                 self._emitter.emit_unchecked(ctx), self._emit_timeout
@@ -642,7 +666,7 @@ class AgentHooksEngine:
         reason = _compose_reason(verdict.reason, verdict.message)
         return _Decision(
             proceeds=record.proceeds,
-            is_transform=record.proceeds and verdict.decision.value == "transform",
+            is_transform=record.proceeds and ctx.get("target") != original_target,
             reason=reason,
         )
 
@@ -684,10 +708,9 @@ class AgentHooksEngine:
         """Adapt ``PRE_TOOL_CALL``: deny blocks the call; transform rewrites args."""
         flow = getattr(ctx, "flow", None)
         args = _json_safe(dict(ctx.tool_input))
-        session_id = _session_id(crew=ctx.crew, flow=flow, agent=ctx.agent)
         builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.pre_tool_call(
-            call_id=_tool_call_id(session_id, ctx.tool_name, args),
+            call_id=ctx.call_id,
             name=ctx.tool_name,
             args=args,
         )
@@ -697,22 +720,24 @@ class AgentHooksEngine:
             raise HookAborted(reason=decision.reason, source=_SOURCE)
         if decision.is_transform:
             new_args = agent_ctx.get("target")
-            if isinstance(new_args, dict):
-                ctx.tool_input.clear()
-                ctx.tool_input.update(new_args)
+            if not isinstance(new_args, dict):
+                raise HookAborted(reason=_TRANSFORM_INVALID, source=_SOURCE)
+            ctx.tool_input.clear()
+            ctx.tool_input.update(new_args)
 
     def _post_tool_call(self, ctx: ToolCallHookContext) -> str | None:
         """Adapt ``POST_TOOL_CALL``: deny fails the result closed; transform rewrites it."""
+        if getattr(ctx, "was_blocked", False):
+            return None
         flow = getattr(ctx, "flow", None)
         args = _json_safe(dict(ctx.tool_input))
-        session_id = _session_id(crew=ctx.crew, flow=flow, agent=ctx.agent)
         builder = self._builder(crew=ctx.crew, flow=flow, agent=ctx.agent)
         agent_ctx = builder.post_tool_call(
-            call_id=_tool_call_id(session_id, ctx.tool_name, args),
+            call_id=ctx.call_id,
             name=ctx.tool_name,
             args=args,
             value=_json_safe(ctx.tool_result),
-            is_error=False,
+            is_error=getattr(ctx, "is_error", False),
         )
         agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
@@ -729,6 +754,7 @@ class AgentHooksEngine:
         agent_ctx = builder.pre_model_call(
             model_id=_model_id(getattr(ctx, "llm", None)),
             messages=_json_safe(list(ctx.messages)),
+            request_id=getattr(ctx, "request_id", None),
         )
         agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
@@ -736,9 +762,10 @@ class AgentHooksEngine:
             raise HookAborted(reason=decision.reason, source=_SOURCE)
         if decision.is_transform:
             new_messages = agent_ctx.get("target")
-            if isinstance(new_messages, list):
-                ctx.messages.clear()
-                ctx.messages.extend(new_messages)
+            if not isinstance(new_messages, list):
+                raise HookAborted(reason=_TRANSFORM_INVALID, source=_SOURCE)
+            ctx.messages.clear()
+            ctx.messages.extend(new_messages)
 
     def _post_model_call(self, ctx: LLMCallHookContext) -> str | None:
         """Adapt ``POST_MODEL_CALL``: deny fails the response closed; transform rewrites it."""
@@ -750,6 +777,7 @@ class AgentHooksEngine:
             content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
+            request_id=getattr(ctx, "request_id", None),
         )
         agent_ctx["agent"] = _agent_envelope(ctx.agent, self._framework)
         decision = self._decide(agent_ctx)
@@ -774,12 +802,7 @@ class AgentHooksEngine:
         return None
 
     def _output(self, ctx: OutputContext) -> Any:
-        """Adapt ``OUTPUT``: deny blocks the final output; transform replaces plain payloads.
-
-        A transform is only applied when the crewAI payload is a plain ``str``
-        or ``dict``; rich ``CrewOutput`` objects cannot be safely reconstructed
-        from the transformed value, so only ``deny`` acts on them.
-        """
+        """Adapt ``OUTPUT``: deny blocks the final output; transform replaces it."""
         builder = self._builder(crew=ctx.crew, flow=ctx.flow)
         payload = ctx.payload
         content = getattr(payload, "raw", None)
@@ -789,28 +812,62 @@ class AgentHooksEngine:
         decision = self._decide(agent_ctx)
         if not decision.proceeds:
             raise HookAborted(reason=decision.reason, source=_SOURCE)
-        if decision.is_transform and isinstance(payload, (str, dict)):
-            return _transformed_payload(agent_ctx.get("target"))
+        if decision.is_transform:
+            transformed = _transformed_payload(agent_ctx.get("target"))
+            from crewai.crews.crew_output import CrewOutput
+
+            if isinstance(payload, CrewOutput):
+                tasks_output = [
+                    task.model_copy(deep=True) for task in payload.tasks_output
+                ]
+                if tasks_output:
+                    tasks_output[-1] = tasks_output[-1].model_copy(
+                        update={
+                            "raw": _to_text(transformed),
+                            "pydantic": None,
+                            "json_dict": None,
+                        }
+                    )
+                return payload.model_copy(
+                    update={
+                        "raw": _to_text(transformed),
+                        "pydantic": None,
+                        "json_dict": None,
+                        "tasks_output": tasks_output,
+                    }
+                )
+            if isinstance(payload, (str, dict)):
+                return transformed
+            raise HookAborted(reason=_ENGINE_FAILED, source=_SOURCE)
         return None
 
     def _execution_start(self, ctx: ExecutionStartContext) -> None:
         """Adapt ``EXECUTION_START`` -> ``agent_startup``: deny aborts the run."""
-        builder = self._builder(crew=ctx.crew, flow=ctx.flow)
-        agent_ctx = builder.agent_startup(
-            tools_registered=_registered_tools(ctx.crew, ctx.agent),
-            inputs=_json_safe(ctx.payload),
-        )
-        decision = self._decide(agent_ctx)
+        self._begin_session(crew=ctx.crew, flow=ctx.flow)
+        try:
+            builder = self._builder(crew=ctx.crew, flow=ctx.flow)
+            agent_ctx = builder.agent_startup(
+                tools_registered=_registered_tools(ctx.crew, ctx.agent),
+            )
+            decision = self._decide(agent_ctx)
+        except Exception:
+            self._finish_session(crew=ctx.crew, flow=ctx.flow)
+            raise
         if not decision.proceeds:
+            try:
+                self._decide(builder.agent_shutdown(reason="error"))
+            finally:
+                self._finish_session(crew=ctx.crew, flow=ctx.flow)
             raise HookAborted(reason=decision.reason, source=_SOURCE)
 
     def _execution_end(self, ctx: ExecutionEndContext) -> None:
         """Adapt ``EXECUTION_END`` -> ``agent_shutdown``: records the run's end."""
         builder = self._builder(crew=ctx.crew, flow=ctx.flow)
-        agent_ctx = builder.agent_shutdown(reason=ctx.status)
-        decision = self._decide(agent_ctx)
-        if not decision.proceeds:
-            raise HookAborted(reason=decision.reason, source=_SOURCE)
+        reason = "completed" if ctx.status == "completed" else "error"
+        try:
+            self._decide(builder.agent_shutdown(reason=reason))
+        finally:
+            self._finish_session(crew=ctx.crew, flow=ctx.flow)
 
 
 _active_engine: AgentHooksEngine | None = None

--- a/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
+++ b/lib/crewai/src/crewai/hooks/agent_hooks_engine.py
@@ -60,9 +60,11 @@ import copy
 from dataclasses import dataclass
 import functools
 import importlib
+import inspect
 import json
 import logging
 import math
+import queue
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar
@@ -107,6 +109,7 @@ Interceptor = Any
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+_ENGINE_STATE_LOCK = threading.RLock()
 
 
 def _probe_agent_hooks() -> tuple[bool, Exception | None]:
@@ -137,6 +140,14 @@ DEFAULT_TIMEOUT: Final[float] = 5.0
 
 #: Default maximum records retained in memory before oldest-first eviction.
 DEFAULT_MAX_RECORDS: Final[int] = 10_000
+
+#: Default wall-clock bound for one complete governance emission.
+DEFAULT_EMIT_TIMEOUT: Final[float] = 30.0
+
+# Synchronous user callbacks are non-preemptible once running. Bound both the
+# workers and pending work so repeated timeouts cannot create unbounded threads.
+_MAX_CALLBACK_WORKERS: Final[int] = 4
+_MAX_CALLBACK_WAITERS: Final[int] = 64
 
 #: Framework identifier stamped on every emitted ``AgentContext``.
 _FRAMEWORK: Final[str] = "crewai"
@@ -179,7 +190,7 @@ _POST_POINTS: Final[frozenset[InterceptionPoint]] = frozenset(
 _INSTALL_HINT: Final[str] = (
     "agent-hooks is not installed (or its native core failed to load). It is an "
     "optional dependency with a compiled core; install the pinned release:\n"
-    '    pip install "agent-hooks-sdk==0.1.0a3"\n'
+    '    pip install "agent-hooks-sdk==0.1.0a5"\n'
     "See https://github.com/responsibleai/agent-hooks for details."
 )
 
@@ -426,6 +437,201 @@ def _model_response_parts(response: Any) -> tuple[Any, list[Any], str]:
                 )
             return "", tool_calls, "tool_calls"
     return _json_safe(response), [], "stop"
+
+
+@dataclass(slots=True)
+class _CallbackWork:
+    """One callback retained by the bounded pool until it actually exits."""
+
+    callback: Callable[[], Any]
+    future: Future[Any]
+
+
+class _BoundedCallbackPool:
+    """Run non-preemptible callbacks with bounded workers and queue capacity."""
+
+    def __init__(
+        self,
+        max_workers: int = _MAX_CALLBACK_WORKERS,
+        max_waiters: int = _MAX_CALLBACK_WAITERS,
+    ) -> None:
+        if max_workers < 1:
+            raise ValueError("max_workers must be at least 1")
+        if max_waiters < 0:
+            raise ValueError("max_waiters must be non-negative")
+        self._queue: queue.Queue[_CallbackWork | None] = queue.Queue(
+            maxsize=max_workers + max_waiters
+        )
+        self._slots = threading.BoundedSemaphore(max_workers + max_waiters)
+        self._state_lock = threading.Lock()
+        self._state: Literal["open", "closing", "failed", "closed"] = "open"
+        self._threads = [
+            threading.Thread(
+                target=self._worker,
+                name=f"agent-hooks-callback-{index}",
+                daemon=True,
+            )
+            for index in range(max_workers)
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    def submit(self, callback: Callable[[], Any]) -> Future[Any]:
+        """Submit one callback or fail closed when bounded admission is full."""
+        with self._state_lock:
+            if self._state != "open":
+                raise RuntimeError("agent-hooks callback pool is not open")
+            if not self._slots.acquire(blocking=False):
+                raise RuntimeError("agent-hooks callback admission queue is full")
+            future: Future[Any] = Future()
+            try:
+                self._queue.put_nowait(_CallbackWork(callback, future))
+            except Exception:
+                self._slots.release()
+                raise
+            return future
+
+    async def run_async(self, callback: Callable[[], Any]) -> Any:
+        """Await one bounded callback without blocking the emitter loop."""
+        return await asyncio.wrap_future(self.submit(callback))
+
+    def run_sync(self, callback: Callable[[], Any], timeout: float) -> Any:
+        """Wait at most ``timeout`` seconds while retaining capacity until exit."""
+        future = self.submit(callback)
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeoutError:
+            future.cancel()
+            raise
+
+    def close(self, timeout: float = 5.0) -> None:
+        """Cancel queued callbacks, stop workers, and expose blocked shutdown."""
+        with self._state_lock:
+            if self._state == "closed":
+                return
+            if self._state == "closing":
+                raise RuntimeError("agent-hooks callback pool is already closing")
+            if self._state == "open":
+                self._state = "closing"
+                while True:
+                    try:
+                        work = self._queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if work is not None:
+                        work.future.cancel()
+                        self._slots.release()
+                    self._queue.task_done()
+                for _ in self._threads:
+                    self._queue.put_nowait(None)
+
+        deadline = time.monotonic() + timeout
+        for thread in self._threads:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        if any(thread.is_alive() for thread in self._threads):
+            with self._state_lock:
+                self._state = "failed"
+            raise RuntimeError("agent-hooks callback pool did not stop")
+        with self._state_lock:
+            self._state = "closed"
+
+    def _worker(self) -> None:
+        while True:
+            work = self._queue.get()
+            try:
+                if work is None:
+                    return
+                if not work.future.set_running_or_notify_cancel():
+                    continue
+                try:
+                    result = work.callback()
+                except BaseException as error:
+                    work.future.set_exception(error)
+                else:
+                    work.future.set_result(result)
+            finally:
+                if work is not None:
+                    self._slots.release()
+                self._queue.task_done()
+
+
+class _IsolatedInterceptor:
+    """Adapt an interceptor so its initial call cannot block the emitter loop."""
+
+    def __init__(self, interceptor: Interceptor, pool: _BoundedCallbackPool) -> None:
+        self._interceptor = interceptor
+        self._pool = pool
+
+    async def intercept(self, context: AgentContext) -> Any:
+        try:
+            result = await self._pool.run_async(
+                lambda: self._interceptor.intercept(context)
+            )
+            if inspect.isawaitable(result):
+                return await result
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:
+            raise RuntimeError(type(error).__name__) from error
+        return result
+
+
+class _IsolatedResolver:
+    """Adapt an approval resolver to the same bounded callback contract."""
+
+    def __init__(self, resolver: ApprovalResolver, pool: _BoundedCallbackPool) -> None:
+        self._resolver = resolver
+        self._pool = pool
+
+    async def resolve(self, request: Any) -> Any:
+        try:
+            result = await self._pool.run_async(lambda: self._resolver.resolve(request))
+            if inspect.isawaitable(result):
+                return await result
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:
+            raise RuntimeError(type(error).__name__) from error
+        return result
+
+
+class _IsolatedRecordSink:
+    """Deliver audit records through bounded work with observable failures."""
+
+    def __init__(
+        self,
+        sink: Callable[[InterceptionRecord], None],
+        pool: _BoundedCallbackPool,
+        timeout: float,
+    ) -> None:
+        self._sink = sink
+        self._pool = pool
+        self._timeout = timeout
+        self._failure_lock = threading.Lock()
+        self._failures = 0
+
+    @property
+    def failures(self) -> int:
+        with self._failure_lock:
+            return self._failures
+
+    def __call__(self, record: InterceptionRecord) -> None:
+        try:
+            result = self._pool.run_sync(lambda: self._sink(record), self._timeout)
+            if inspect.isawaitable(result):
+                close = getattr(result, "close", None)
+                if callable(close):
+                    close()
+                raise TypeError("record_sink must be synchronous")
+        except BaseException as error:
+            with self._failure_lock:
+                self._failures += 1
+            logger.error(
+                "agent-hooks record sink failed; failure_kind=record_sink_error "
+                "error_type=%s",
+                type(error).__name__,
+            )
+            raise RuntimeError("agent-hooks record sink failed") from error
 
 
 class _EmitterLoop:
@@ -696,7 +902,7 @@ class AgentHooksEngine:
         max_records: int = DEFAULT_MAX_RECORDS,
         points: Sequence[InterceptionPoint] | None = None,
         framework: str = _FRAMEWORK,
-        emit_timeout: float | None = None,
+        emit_timeout: float | None = DEFAULT_EMIT_TIMEOUT,
     ) -> None:
         """Build the underlying emitter and register the interceptors.
 
@@ -715,64 +921,108 @@ class AgentHooksEngine:
                 eviction. Evictions are counted by :attr:`records_dropped`.
             points: Lifecycle points to govern; defaults to :data:`DEFAULT_POINTS`.
             framework: Framework id stamped on every context.
-            emit_timeout: Optional wall-clock bound per emission; ``None``
-                relies on the emitter's own interceptor timeout.
+            emit_timeout: Wall-clock bound for one complete emission. ``None``
+                disables the outer bound, but callback admission remains bounded.
 
         Raises:
             ImportError: If agent-hooks is not installed.
         """
         _require()
         agent_hooks = importlib.import_module("agent_hooks")
+        callback_pool = _BoundedCallbackPool()
+        callback_timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
+        record_sink_adapter = (
+            _IsolatedRecordSink(record_sink, callback_pool, callback_timeout)
+            if record_sink is not None
+            else None
+        )
 
-        emitter: Any = agent_hooks.InterceptionEmitter(
-            mode=mode if mode is not None else agent_hooks.EnforcementMode.ENFORCE,
-            resolver=resolver,
-            timeout=timeout,
-            composition=composition,
-            identity_provider=identity_provider,
-        )
-        for interceptor in interceptors:
-            emitter.register(interceptor)
-        if record_sink is not None:
-            emitter.set_record_sink(record_sink)
-        emitter.set_max_records(max_records)
+        isolated_identity = identity_provider
+        if identity_provider is not None and not isinstance(identity_provider, str):
+            provider = identity_provider
 
-        self._emitter: InterceptionEmitter = emitter
-        self._framework = framework
-        self._emit_timeout = emit_timeout
-        self._loop = _EmitterLoop()
-        self._builders: dict[str, AgentContextBuilder] = {}
-        self._active_sessions: dict[int, _OwnerSessions] = {}
-        self._session_context: contextvars.ContextVar[
-            dict[int, tuple[str, ...]] | None
-        ] = contextvars.ContextVar(
-            f"agent_hooks_sessions_{id(self)}",
-            default=None,
-        )
-        self._builders_lock = threading.Lock()
-        self._points: frozenset[InterceptionPoint] = frozenset(
-            points if points is not None else DEFAULT_POINTS
-        )
-        self._active = False
-        self._closed = False
-        self._close_failed = False
-        raw_adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
-            InterceptionPoint.PRE_TOOL_CALL: self._pre_tool_call,
-            InterceptionPoint.POST_TOOL_CALL: self._post_tool_call,
-            InterceptionPoint.PRE_MODEL_CALL: self._pre_model_call,
-            InterceptionPoint.POST_MODEL_CALL: self._post_model_call,
-            InterceptionPoint.INPUT: self._input,
-            InterceptionPoint.OUTPUT: self._output,
-            InterceptionPoint.EXECUTION_START: self._execution_start,
-            InterceptionPoint.EXECUTION_END: self._execution_end,
-        }
-        # Every adapter builds its context outside _decide()'s fail-closed
-        # guard, so wrap each so an unexpected build error fails closed instead
-        # of escaping to dispatch._invoke_hook (which would swallow it).
-        self._adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
-            point: self._wrap_fail_closed(point, adapter)
-            for point, adapter in raw_adapters.items()
-        }
+            def identity(context: AgentContext) -> Any:
+                try:
+                    return callback_pool.run_sync(
+                        lambda: provider.fn(context), callback_timeout
+                    )
+                except BaseException as error:
+                    raise RuntimeError(type(error).__name__) from error
+
+            isolated_identity = agent_hooks.IdentityProvider(
+                name=provider.name,
+                fn=identity,
+            )
+
+        try:
+            emitter: Any = agent_hooks.InterceptionEmitter(
+                mode=(
+                    mode if mode is not None else agent_hooks.EnforcementMode.ENFORCE
+                ),
+                resolver=(
+                    _IsolatedResolver(resolver, callback_pool)
+                    if resolver is not None
+                    else None
+                ),
+                timeout=timeout,
+                composition=composition,
+                identity_provider=isolated_identity,
+            )
+            for interceptor in interceptors:
+                emitter.register(_IsolatedInterceptor(interceptor, callback_pool))
+            if record_sink_adapter is not None:
+                emitter.set_record_sink(record_sink_adapter)
+            emitter.set_max_records(max_records)
+        except BaseException:
+            callback_pool.close()
+            raise
+
+        emitter_loop: _EmitterLoop | None = None
+        try:
+            emitter_loop = _EmitterLoop()
+            self._emitter: InterceptionEmitter = emitter
+            self._framework = framework
+            self._emit_timeout = emit_timeout
+            self._loop = emitter_loop
+            self._callback_pool = callback_pool
+            self._record_sink_adapter = record_sink_adapter
+            self._builders: dict[str, AgentContextBuilder] = {}
+            self._active_sessions: dict[int, _OwnerSessions] = {}
+            self._session_context: contextvars.ContextVar[
+                dict[int, tuple[str, ...]] | None
+            ] = contextvars.ContextVar(
+                f"agent_hooks_sessions_{id(self)}",
+                default=None,
+            )
+            self._builders_lock = threading.Lock()
+            self._points: frozenset[InterceptionPoint] = frozenset(
+                points if points is not None else DEFAULT_POINTS
+            )
+            self._active = False
+            self._closed = False
+            self._close_failed = False
+            raw_adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
+                InterceptionPoint.PRE_TOOL_CALL: self._pre_tool_call,
+                InterceptionPoint.POST_TOOL_CALL: self._post_tool_call,
+                InterceptionPoint.PRE_MODEL_CALL: self._pre_model_call,
+                InterceptionPoint.POST_MODEL_CALL: self._post_model_call,
+                InterceptionPoint.INPUT: self._input,
+                InterceptionPoint.OUTPUT: self._output,
+                InterceptionPoint.EXECUTION_START: self._execution_start,
+                InterceptionPoint.EXECUTION_END: self._execution_end,
+            }
+            # Every adapter builds its context outside _decide()'s fail-closed
+            # guard, so wrap each so an unexpected build error fails closed instead
+            # of escaping to dispatch._invoke_hook (which would swallow it).
+            self._adapters: dict[InterceptionPoint, Callable[[Any], Any]] = {
+                point: self._wrap_fail_closed(point, adapter)
+                for point, adapter in raw_adapters.items()
+            }
+        except BaseException:
+            if emitter_loop is not None:
+                emitter_loop.close()
+            callback_pool.close()
+            raise
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -795,6 +1045,13 @@ class AgentHooksEngine:
         """Drain and return the buffered interception records."""
         return list(self._emitter.take_records())
 
+    @property
+    def record_sink_failures(self) -> int:
+        """Number of audit records the configured sink failed to accept."""
+        if self._record_sink_adapter is None:
+            return 0
+        return self._record_sink_adapter.failures
+
     def adapter_for(self, point: InterceptionPoint) -> Callable[[Any], Any] | None:
         """Return the governing adapter for ``point``, or ``None`` if not governed.
 
@@ -806,46 +1063,72 @@ class AgentHooksEngine:
         return self._adapters.get(point)
 
     def activate(self) -> AgentHooksEngine:
-        """Install this engine as crewAI's control governor (idempotent)."""
-        if self._closed or self._close_failed:
-            raise RuntimeError("a closed or failed agent-hooks engine cannot activate")
-        if not self._active:
+        """Atomically install this engine as crewAI's process governor."""
+        global _active_engine
+        with _ENGINE_STATE_LOCK:
+            if self._closed or self._close_failed:
+                raise RuntimeError(
+                    "a closed or failed agent-hooks engine cannot activate"
+                )
+            if _active_engine is self and self._active:
+                return self
+
             from crewai.hooks.dispatch import set_governor
 
+            previous = _active_engine
             set_governor(self.adapter_for)
+            _active_engine = self
             self._active = True
             logger.debug(
                 "agent-hooks engine activated on %d point(s)", len(self._points)
             )
+        if previous is not None and previous is not self:
+            previous.close()
         return self
 
     def deactivate(self) -> None:
         """Remove this engine as the governor if it is currently installed."""
-        if self._active:
+        global _active_engine
+        with _ENGINE_STATE_LOCK:
+            if not self._active:
+                return
             from crewai.hooks.dispatch import clear_governor, get_governor
 
             if get_governor() == self.adapter_for:
                 clear_governor()
+            if _active_engine is self:
+                _active_engine = None
             self._active = False
 
     def close(self) -> None:
         """Deactivate the engine and stop the background emitter loop (idempotent)."""
-        global _active_engine
-        if self._closed:
-            return
-        self.deactivate()
-        try:
-            self._loop.close()
-        except Exception:
-            self._close_failed = True
-            raise
-        with self._builders_lock:
-            self._builders.clear()
-            self._active_sessions.clear()
-        if _active_engine is self:
-            _active_engine = None
-        self._close_failed = False
-        self._closed = True
+        with _ENGINE_STATE_LOCK:
+            if self._closed:
+                return
+            self.deactivate()
+            loop_error: Exception | None = None
+            try:
+                self._loop.close()
+            except Exception as error:
+                loop_error = error
+            try:
+                self._callback_pool.close()
+            except Exception:
+                self._close_failed = True
+                if loop_error is not None:
+                    logger.exception(
+                        "agent-hooks callback shutdown also failed after loop error"
+                    )
+                    raise loop_error from None
+                raise
+            if loop_error is not None:
+                self._close_failed = True
+                raise loop_error
+            with self._builders_lock:
+                self._builders.clear()
+                self._active_sessions.clear()
+            self._close_failed = False
+            self._closed = True
 
     def __enter__(self) -> AgentHooksEngine:
         return self.activate()
@@ -1291,7 +1574,7 @@ def use_agent_hooks(
     max_records: int = DEFAULT_MAX_RECORDS,
     points: Sequence[InterceptionPoint] | None = None,
     framework: str = _FRAMEWORK,
-    emit_timeout: float | None = None,
+    emit_timeout: float | None = DEFAULT_EMIT_TIMEOUT,
 ) -> AgentHooksEngine:
     """Make agent-hooks crewAI's active control engine and return it.
 
@@ -1322,7 +1605,7 @@ def use_agent_hooks(
             eviction.
         points: Lifecycle points to govern (default :data:`DEFAULT_POINTS`).
         framework: Framework id stamped on every context.
-        emit_timeout: Optional wall-clock bound per emission.
+        emit_timeout: Wall-clock bound per emission; defaults to 30 seconds.
 
     Returns:
         The active :class:`AgentHooksEngine`. Call :meth:`AgentHooksEngine.close`
@@ -1331,9 +1614,6 @@ def use_agent_hooks(
     Raises:
         ImportError: If agent-hooks is not installed.
     """
-    global _active_engine
-    if _active_engine is not None:
-        _active_engine.close()
     engine = AgentHooksEngine(
         *interceptors,
         mode=mode,
@@ -1348,24 +1628,24 @@ def use_agent_hooks(
         emit_timeout=emit_timeout,
     )
     engine.activate()
-    _active_engine = engine
     return engine
 
 
 def disable_agent_hooks() -> None:
     """Deactivate and close the active agent-hooks control engine, if any."""
-    global _active_engine
-    if _active_engine is not None:
-        _active_engine.close()
-        _active_engine = None
+    with _ENGINE_STATE_LOCK:
+        if _active_engine is not None:
+            _active_engine.close()
 
 
 def active_engine() -> AgentHooksEngine | None:
     """Return the currently active :class:`AgentHooksEngine`, or ``None``."""
-    return _active_engine
+    with _ENGINE_STATE_LOCK:
+        return _active_engine
 
 
 __all__ = [
+    "DEFAULT_EMIT_TIMEOUT",
     "DEFAULT_MAX_RECORDS",
     "DEFAULT_POINTS",
     "DEFAULT_TIMEOUT",

--- a/lib/crewai/src/crewai/hooks/dispatch.py
+++ b/lib/crewai/src/crewai/hooks/dispatch.py
@@ -343,6 +343,53 @@ def run_hooks(
         )
 
 
+# --- agent-hooks control engine (dependency-injected; optional) -------------
+# The engine is installed via set_governor() so this module never imports the
+# optional agent-hooks package. When active, dispatch() appends the engine's
+# per-point adapter as the authoritative final hook for the eight agent-hooks
+# lifecycle points; PRE_STEP / POST_STEP stay purely crewAI-native.
+GovernorFn = Callable[[InterceptionPoint], HookFn | None]
+_governor: GovernorFn | None = None
+
+
+def set_governor(governor: GovernorFn) -> None:
+    """Install the agent-hooks control engine as crewAI's governor.
+
+    Dependency-injected so this module never imports the optional agent-hooks
+    package. Idempotent replace: a second call supersedes the first.
+    """
+    global _governor
+    _governor = governor
+
+
+def clear_governor() -> None:
+    """Remove the active agent-hooks control engine, if any."""
+    global _governor
+    _governor = None
+
+
+def get_governor() -> GovernorFn | None:
+    """Return the active governor callable, or ``None``."""
+    return _governor
+
+
+def governed_hook(point: InterceptionPoint) -> HookFn | None:
+    """Return the governor's authoritative adapter for ``point``, or ``None``.
+
+    Seams that maintain their own ordered hook list outside :func:`dispatch`
+    (e.g. the agent executor's LLM-call seam, which runs an executor-local
+    snapshot of ``before_llm_call`` / ``after_llm_call`` hooks) use this to
+    append the agent-hooks control engine's per-point adapter exactly the way
+    :func:`dispatch` does, so an injected control engine governs those seams
+    too. Returns ``None`` when no engine is installed or the engine does not
+    govern ``point``.
+    """
+    governor = _governor
+    if governor is None:
+        return None
+    return governor(point)
+
+
 def dispatch(
     point: InterceptionPoint,
     ctx: Any,
@@ -353,9 +400,16 @@ def dispatch(
     """Dispatch a context to all hooks registered for a point.
 
     Resolves global then scoped hooks and runs them through :func:`run_hooks`.
-    No-op fast path when nothing is registered.
+    When an agent-hooks control engine is installed (see :func:`set_governor`),
+    its per-point adapter is appended as the authoritative final hook. No-op
+    fast path when nothing is registered and no engine governs the point.
     """
     hooks = _resolve_hooks(point)
+    governor = _governor
+    if governor is not None:
+        governed = governor(point)
+        if governed is not None:
+            hooks = [*hooks, governed]
     if not hooks:
         return ctx
     return run_hooks(point, ctx, hooks, reducer=reducer, verbose=verbose)

--- a/lib/crewai/src/crewai/hooks/dispatch.py
+++ b/lib/crewai/src/crewai/hooks/dispatch.py
@@ -313,6 +313,10 @@ def run_hooks(
             :func:`_default_reducer` (payload replacement). May raise
             :class:`HookAborted`.
         verbose: Whether to print swallowed-hook-error warnings.
+        final_hook: Optional hook run after ``hooks``, even when ``hooks`` is
+            empty or an earlier hook aborts. A regular hook's ``HookAborted`` is
+            deferred until ``final_hook`` runs and then re-raised, unless
+            ``final_hook`` itself aborts first.
 
     Returns:
         The (possibly mutated) context.

--- a/lib/crewai/src/crewai/hooks/dispatch.py
+++ b/lib/crewai/src/crewai/hooks/dispatch.py
@@ -297,6 +297,7 @@ def run_hooks(
     *,
     reducer: Reducer | None = None,
     verbose: bool = True,
+    final_hook: HookFn | None = None,
 ) -> Any:
     """Execute an explicit list of hooks against a context.
 
@@ -320,7 +321,7 @@ def run_hooks(
         HookAborted: If a hook or the reducer aborts the operation. Telemetry is
             still emitted before propagating.
     """
-    if not hooks:
+    if not hooks and final_hook is None:
         return ctx
 
     active_reducer = reducer if reducer is not None else _default_reducer
@@ -329,11 +330,25 @@ def run_hooks(
     abort_reason: str | None = None
     abort_source: str | None = None
     modified = False
+    pending_abort: HookAborted | None = None
 
     try:
         for hook in list(hooks):
-            if _invoke_hook(point, hook, ctx, active_reducer, verbose):
-                modified = True
+            try:
+                if _invoke_hook(point, hook, ctx, active_reducer, verbose):
+                    modified = True
+            except HookAborted as aborted:  # noqa: PERF203 - abort stops this queue
+                pending_abort = aborted
+                break
+        if final_hook is not None:
+            try:
+                if _invoke_hook(point, final_hook, ctx, active_reducer, verbose):
+                    modified = True
+            except HookAborted as aborted:
+                if pending_abort is None:
+                    pending_abort = aborted
+        if pending_abort is not None:
+            raise pending_abort
         outcome = "modified" if modified else "proceeded"
         return ctx
     except HookAborted as aborted:
@@ -345,7 +360,7 @@ def run_hooks(
         _emit_telemetry(
             point,
             outcome,
-            len(hooks),
+            len(hooks) + (1 if final_hook is not None else 0),
             (time.perf_counter() - start) * 1000.0,
             abort_reason,
             abort_source,
@@ -415,13 +430,21 @@ def dispatch(
     """
     hooks = _resolve_hooks(point)
     governor = _governor
+    governed: HookFn | None = None
     if governor is not None:
         governed = governor(point)
-        if governed is not None:
+        if governed is not None and point is not InterceptionPoint.EXECUTION_END:
             hooks = [*hooks, governed]
-    if not hooks:
+    if not hooks and governed is None:
         return ctx
-    return run_hooks(point, ctx, hooks, reducer=reducer, verbose=verbose)
+    return run_hooks(
+        point,
+        ctx,
+        hooks,
+        reducer=reducer,
+        verbose=verbose,
+        final_hook=(governed if point is InterceptionPoint.EXECUTION_END else None),
+    )
 
 
 def _wrap_with_filters(

--- a/lib/crewai/src/crewai/hooks/dispatch.py
+++ b/lib/crewai/src/crewai/hooks/dispatch.py
@@ -32,7 +32,7 @@ from enum import Enum
 from functools import wraps
 import inspect
 import time
-from typing import Any
+from typing import Any, Final
 
 from crewai.utilities.string_utils import sanitize_tool_name
 
@@ -74,6 +74,15 @@ class HookAborted(Exception):  # noqa: N818 - public contract name from OSS-86
         super().__init__(reason)
         self.reason = reason
         self.source = source
+
+
+class _AgentHooksAbortSource:
+    """Identity marker for aborts raised by the optional control engine."""
+
+    __name__ = "agent-hooks"
+
+
+AGENT_HOOKS_ABORT_SOURCE: Final = _AgentHooksAbortSource()
 
 
 HookFn = Callable[[Any], Any]

--- a/lib/crewai/src/crewai/hooks/llm_hooks.py
+++ b/lib/crewai/src/crewai/hooks/llm_hooks.py
@@ -49,8 +49,9 @@ class LLMCallHookContext:
         crew: Reference to the crew instance (None for direct LLM calls or LiteAgent)
         llm: Reference to the LLM instance
         iterations: Current iteration count (0 for direct LLM calls)
-        response: LLM response string (only set for after_llm_call hooks).
-            Can be modified by returning a new string from after_llm_call hook.
+        request_id: Stable identifier shared by one model call's pre/post hooks.
+        response: LLM response value (only set for after_llm_call hooks).
+            Text responses can be modified by returning a new string.
     """
 
     executor: CrewAgentExecutor | AgentExecutor | LiteAgent | None
@@ -60,28 +61,31 @@ class LLMCallHookContext:
     crew: Any
     llm: BaseLLM | None | str | Any
     iterations: int
-    response: str | None
+    request_id: str | None
+    response: Any
 
     def __init__(
         self,
         executor: CrewAgentExecutor | AgentExecutor | LiteAgent | None = None,
-        response: str | None = None,
+        response: Any = None,
         messages: list[LLMMessage] | None = None,
         llm: BaseLLM | str | Any | None = None,  # TODO: look into
         agent: Any | None = None,
         task: Any | None = None,
         crew: Any | None = None,
+        request_id: str | None = None,
     ) -> None:
         """Initialize hook context with executor reference or direct parameters.
 
         Args:
             executor: The CrewAgentExecutor or LiteAgent instance (None for direct LLM calls)
-            response: Optional response string (for after_llm_call hooks)
+            response: Optional response value (for after_llm_call hooks)
             messages: Optional messages list (for direct LLM calls when executor is None)
             llm: Optional LLM instance (for direct LLM calls when executor is None)
             agent: Optional agent reference (for direct LLM calls when executor is None)
             task: Optional task reference (for direct LLM calls when executor is None)
             crew: Optional crew reference (for direct LLM calls when executor is None)
+            request_id: Optional model-call correlation identifier
         """
         if executor is not None:
             self.executor = executor
@@ -109,6 +113,7 @@ class LLMCallHookContext:
             self.crew = crew
             self.iterations = 0
 
+        self.request_id = request_id
         self.response = response
 
     def request_human_input(

--- a/lib/crewai/src/crewai/hooks/llm_hooks.py
+++ b/lib/crewai/src/crewai/hooks/llm_hooks.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
+from weakref import WeakKeyDictionary
 
 from crewai_core.printer import PRINTER
 
@@ -158,6 +160,65 @@ class LLMCallHookContext:
             return response
         finally:
             event_listener.formatter.resume_live_updates()
+
+
+class PostModelCallBlockedError(RuntimeError):
+    """Terminal executor result for a governed post-model block."""
+
+    def __init__(
+        self,
+        blocked_response: str,
+        *,
+        reason: str,
+        request_id: str | None,
+        failure_kind: str,
+    ) -> None:
+        super().__init__(blocked_response)
+        self.blocked_response = blocked_response
+        self.reason = reason
+        self.request_id = request_id
+        self.failure_kind = failure_kind
+
+
+@dataclass(frozen=True, slots=True)
+class _PostModelBlock:
+    """Host-owned provenance for one governed post-model block."""
+
+    reason: str
+    failure_kind: str
+
+
+_post_model_blocks: WeakKeyDictionary[LLMCallHookContext, _PostModelBlock] = (
+    WeakKeyDictionary()
+)
+
+
+def mark_post_model_blocked(
+    context: LLMCallHookContext, *, reason: str, failure_kind: str
+) -> None:
+    """Record host-owned block provenance for the agent-hooks adapter."""
+    _post_model_blocks[context] = _PostModelBlock(
+        reason=reason,
+        failure_kind=failure_kind,
+    )
+
+
+def _consume_post_model_block(context: LLMCallHookContext) -> _PostModelBlock | None:
+    """Return and clear trusted governance block provenance for this response."""
+    return _post_model_blocks.pop(context, None)
+
+
+def raise_if_post_model_blocked(context: LLMCallHookContext) -> None:
+    """Raise the terminal result for a host-recorded post-model block."""
+    blocked = _consume_post_model_block(context)
+    if blocked is None:
+        return
+    raise PostModelCallBlockedError(
+        str(context.response),
+        reason=blocked.reason,
+        request_id=context.request_id,
+        failure_kind=blocked.failure_kind,
+    )
 
 
 # The legacy registries are aliased to the generic dispatcher's global hook

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+import uuid
 
 from crewai_core.printer import PRINTER
 
@@ -41,38 +42,47 @@ class ToolCallHookContext:
             IMPORTANT: Modify in-place (e.g., context.tool_input['key'] = value).
             Do NOT replace the dict (e.g., context.tool_input = {}), as this
             will not affect the actual tool execution.
-        tool: Reference to the CrewStructuredTool instance
+        tool: Reference to the CrewStructuredTool instance, when available
         agent: Agent executing the tool (may be None)
         task: Current task being executed (may be None)
         crew: Crew instance (may be None)
+        call_id: Stable identifier shared by the before/after contexts for one call.
         tool_result: Tool execution result (only set for after_tool_call hooks).
             Can be modified by returning a new string from after_tool_call hook.
         raw_tool_result: Raw Python tool execution result (only set for
             after_tool_call hooks). This is not modified by after hooks.
+        is_error: Whether the tool result represents a blocked or failed call.
+        was_blocked: Whether pre-tool policy prevented the invocation.
     """
 
     def __init__(
         self,
         tool_name: str,
         tool_input: dict[str, Any],
-        tool: CrewStructuredTool,
+        tool: CrewStructuredTool | None,
         agent: Agent | BaseAgent | LiteAgent | None = None,
         task: Task | None = None,
         crew: Crew | None = None,
         tool_result: str | None = None,
         raw_tool_result: Any | None = None,
+        call_id: str | None = None,
+        is_error: bool = False,
+        was_blocked: bool = False,
     ) -> None:
         """Initialize tool call hook context.
 
         Args:
             tool_name: Name of the tool being called
             tool_input: Tool input parameters (mutable)
-            tool: Tool instance reference
+            tool: Tool instance reference, when available
             agent: Optional agent executing the tool
             task: Optional current task
             crew: Optional crew instance
             tool_result: Optional tool result (for after hooks)
             raw_tool_result: Optional raw tool result (for after hooks)
+            call_id: Stable identifier for this invocation; generated when omitted
+            is_error: Whether the tool invocation was blocked or failed
+            was_blocked: Whether pre-tool policy prevented the invocation
         """
         self.tool_name = tool_name
         self.tool_input = tool_input
@@ -82,6 +92,9 @@ class ToolCallHookContext:
         self.crew = crew
         self.tool_result = tool_result
         self.raw_tool_result = raw_tool_result
+        self.call_id = call_id or str(uuid.uuid4())
+        self.is_error = is_error
+        self.was_blocked = was_blocked
 
     def request_human_input(
         self,

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -14,6 +14,7 @@ from typing import (
     TypedDict,
     cast,
 )
+import uuid
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, model_validator
@@ -1757,9 +1758,17 @@ class LLM(BaseLLM):
         function_args = {}
 
         if function_name in available_functions:
+            from crewai.hooks.tool_hooks import (
+                ToolCallHookContext,
+                run_after_tool_call_hooks,
+                run_before_tool_call_hooks,
+            )
+
+            call_id = str(uuid.uuid4())
             try:
                 function_args = json.loads(tool_call.function.arguments)
-                fn = available_functions[function_name]
+                if not isinstance(function_args, dict):
+                    raise ValueError("Tool arguments must be a JSON object")
 
                 started_at = datetime.now()
                 crewai_event_bus.emit(
@@ -1772,7 +1781,40 @@ class LLM(BaseLLM):
                     ),
                 )
 
-                result = fn(**function_args)
+                before_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    call_id=call_id,
+                )
+                blocked = run_before_tool_call_hooks(before_context)
+                if blocked:
+                    result: Any = (
+                        f"Tool execution blocked by hook. Tool: {function_name}"
+                    )
+                else:
+                    fn = available_functions[function_name]
+                    result = fn(**function_args)
+
+                result_text = result if isinstance(result, str) else str(result)
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=result_text,
+                    raw_tool_result=result,
+                    call_id=call_id,
+                    is_error=blocked,
+                    was_blocked=blocked,
+                )
+                modified_result = run_after_tool_call_hooks(after_context)
+                if modified_result is not None and modified_result != result_text:
+                    result = modified_result
+
                 crewai_event_bus.emit(
                     self,
                     event=ToolUsageFinishedEvent(
@@ -1794,12 +1836,24 @@ class LLM(BaseLLM):
                 )
                 return result
             except Exception as e:
-                fn = available_functions.get(function_name, lambda: None)
+                error_msg = f"Tool execution error: {e!s}"
                 logging.error(f"Error executing function '{function_name}': {e}")
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=error_msg,
+                    raw_tool_result=e,
+                    call_id=call_id,
+                    is_error=True,
+                )
+                governed_result = run_after_tool_call_hooks(after_context)
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
-                        error=f"Tool execution error: {e!s}",
+                        error=error_msg,
                         from_task=from_task,
                         from_agent=from_agent,
                         call_id=get_current_call_id(),
@@ -1810,11 +1864,12 @@ class LLM(BaseLLM):
                     event=ToolUsageErrorEvent(
                         tool_name=function_name,
                         tool_args=function_args,
-                        error=f"Tool execution error: {e!s}",
+                        error=error_msg,
                         from_task=from_task,
                         from_agent=from_agent,
                     ),
                 )
+                return governed_result if governed_result != error_msg else None
         return None
 
     def call(
@@ -2007,13 +2062,16 @@ class LLM(BaseLLM):
             if isinstance(messages, str):
                 messages = [{"role": "user", "content": messages}]
 
-            messages = await self._aprocess_message_files(messages)
-
             if "o1" in self.model.lower():
                 for message in messages:
                     if message.get("role") == "system":
                         msg_role: Literal["assistant"] = "assistant"
                         message["role"] = msg_role
+
+            if not self._invoke_before_llm_call_hooks(messages, from_agent):
+                raise ValueError("LLM call blocked by before_llm_call hook")
+
+            messages = await self._aprocess_message_files(messages)
 
             with suppress_warnings():
                 if callbacks and len(callbacks) > 0:
@@ -2024,7 +2082,16 @@ class LLM(BaseLLM):
                     )
 
                     if self._effective_stream():
-                        return await self._ahandle_streaming_response(
+                        result = await self._ahandle_streaming_response(
+                            params=params,
+                            callbacks=callbacks,
+                            available_functions=available_functions,
+                            from_task=from_task,
+                            from_agent=from_agent,
+                            response_model=response_model,
+                        )
+                    else:
+                        result = await self._ahandle_non_streaming_response(
                             params=params,
                             callbacks=callbacks,
                             available_functions=available_functions,
@@ -2033,14 +2100,12 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    return await self._ahandle_non_streaming_response(
-                        params=params,
-                        callbacks=callbacks,
-                        available_functions=available_functions,
-                        from_task=from_task,
-                        from_agent=from_agent,
-                        response_model=response_model,
-                    )
+                    if isinstance(result, str):
+                        result = self._invoke_after_llm_call_hooks(
+                            messages, result, from_agent
+                        )
+
+                    return result
                 except LLMContextLengthExceededError:
                     raise
                 except Exception as e:

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1758,6 +1758,7 @@ class LLM(BaseLLM):
         function_args = {}
 
         if function_name in available_functions:
+            from crewai.hooks.dispatch import HookAborted
             from crewai.hooks.tool_hooks import (
                 ToolCallHookContext,
                 run_after_tool_call_hooks,
@@ -1765,6 +1766,8 @@ class LLM(BaseLLM):
             )
 
             call_id = str(uuid.uuid4())
+            before_hook_started = False
+            post_hook_attempted = False
             try:
                 function_args = json.loads(tool_call.function.arguments)
                 if not isinstance(function_args, dict):
@@ -1789,6 +1792,7 @@ class LLM(BaseLLM):
                     task=from_task,
                     call_id=call_id,
                 )
+                before_hook_started = True
                 blocked = run_before_tool_call_hooks(before_context)
                 if blocked:
                     result: Any = (
@@ -1811,6 +1815,7 @@ class LLM(BaseLLM):
                     is_error=blocked,
                     was_blocked=blocked,
                 )
+                post_hook_attempted = True
                 modified_result = run_after_tool_call_hooks(after_context)
                 if modified_result is not None and modified_result != result_text:
                     result = modified_result
@@ -1835,21 +1840,25 @@ class LLM(BaseLLM):
                     from_agent=from_agent,
                 )
                 return result
+            except HookAborted:
+                raise
             except Exception as e:
                 error_msg = f"Tool execution error: {e!s}"
                 logging.error(f"Error executing function '{function_name}': {e}")
-                after_context = ToolCallHookContext(
-                    tool_name=function_name,
-                    tool_input=function_args,
-                    tool=None,
-                    agent=from_agent,
-                    task=from_task,
-                    tool_result=error_msg,
-                    raw_tool_result=e,
-                    call_id=call_id,
-                    is_error=True,
-                )
-                governed_result = run_after_tool_call_hooks(after_context)
+                governed_result: str | None = None
+                if before_hook_started and not post_hook_attempted:
+                    after_context = ToolCallHookContext(
+                        tool_name=function_name,
+                        tool_input=function_args,
+                        tool=None,
+                        agent=from_agent,
+                        task=from_task,
+                        tool_result=error_msg,
+                        raw_tool_result=e,
+                        call_id=call_id,
+                        is_error=True,
+                    )
+                    governed_result = run_after_tool_call_hooks(after_context)
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
@@ -1869,7 +1878,11 @@ class LLM(BaseLLM):
                         from_agent=from_agent,
                     ),
                 )
-                return governed_result if governed_result != error_msg else None
+                return (
+                    governed_result
+                    if governed_result is not None and governed_result != error_msg
+                    else None
+                )
         return None
 
     def call(
@@ -1955,18 +1968,19 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    if isinstance(result, str):
-                        result = self._invoke_after_llm_call_hooks(
-                            messages, result, from_agent
-                        )
-
-                    return result
+                    return self._invoke_after_llm_call_hooks(
+                        messages, result, from_agent
+                    )
                 except LLMContextLengthExceededError:
                     # Re-raise LLMContextLengthExceededError as it should be handled
                     # by the CrewAgentExecutor._invoke_loop method, which can then decide
                     # whether to summarize the content or abort based on the respect_context_window flag
                     raise
                 except Exception as e:
+                    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+                    if isinstance(e, PostModelCallBlockedError):
+                        raise
                     error_str = str(e)
                     unsupported_stop = "'stop'" in error_str and (
                         "Unsupported parameter" in error_str
@@ -2100,15 +2114,16 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    if isinstance(result, str):
-                        result = self._invoke_after_llm_call_hooks(
-                            messages, result, from_agent
-                        )
-
-                    return result
+                    return self._invoke_after_llm_call_hooks(
+                        messages, result, from_agent
+                    )
                 except LLMContextLengthExceededError:
                     raise
                 except Exception as e:
+                    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+                    if isinstance(e, PostModelCallBlockedError):
+                        raise
                     error_str = str(e)
                     unsupported_stop = "'stop'" in error_str and (
                         "Unsupported parameter" in error_str

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -14,6 +14,7 @@ from typing import (
     TypedDict,
     cast,
 )
+import uuid
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, model_validator
@@ -1758,9 +1759,17 @@ class LLM(BaseLLM):
         function_args = {}
 
         if function_name in available_functions:
+            from crewai.hooks.tool_hooks import (
+                ToolCallHookContext,
+                run_after_tool_call_hooks,
+                run_before_tool_call_hooks,
+            )
+
+            call_id = str(uuid.uuid4())
             try:
                 function_args = json.loads(tool_call.function.arguments)
-                fn = available_functions[function_name]
+                if not isinstance(function_args, dict):
+                    raise ValueError("Tool arguments must be a JSON object")
 
                 started_at = datetime.now()
                 crewai_event_bus.emit(
@@ -1773,7 +1782,40 @@ class LLM(BaseLLM):
                     ),
                 )
 
-                result = fn(**function_args)
+                before_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    call_id=call_id,
+                )
+                blocked = run_before_tool_call_hooks(before_context)
+                if blocked:
+                    result: Any = (
+                        f"Tool execution blocked by hook. Tool: {function_name}"
+                    )
+                else:
+                    fn = available_functions[function_name]
+                    result = fn(**function_args)
+
+                result_text = result if isinstance(result, str) else str(result)
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=result_text,
+                    raw_tool_result=result,
+                    call_id=call_id,
+                    is_error=blocked,
+                    was_blocked=blocked,
+                )
+                modified_result = run_after_tool_call_hooks(after_context)
+                if modified_result is not None and modified_result != result_text:
+                    result = modified_result
+
                 crewai_event_bus.emit(
                     self,
                     event=ToolUsageFinishedEvent(
@@ -1795,12 +1837,24 @@ class LLM(BaseLLM):
                 )
                 return result
             except Exception as e:
-                fn = available_functions.get(function_name, lambda: None)
+                error_msg = f"Tool execution error: {e!s}"
                 logging.error(f"Error executing function '{function_name}': {e}")
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=error_msg,
+                    raw_tool_result=e,
+                    call_id=call_id,
+                    is_error=True,
+                )
+                governed_result = run_after_tool_call_hooks(after_context)
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
-                        error=f"Tool execution error: {e!s}",
+                        error=error_msg,
                         from_task=from_task,
                         from_agent=from_agent,
                         call_id=get_current_call_id(),
@@ -1811,11 +1865,12 @@ class LLM(BaseLLM):
                     event=ToolUsageErrorEvent(
                         tool_name=function_name,
                         tool_args=function_args,
-                        error=f"Tool execution error: {e!s}",
+                        error=error_msg,
                         from_task=from_task,
                         from_agent=from_agent,
                     ),
                 )
+                return governed_result if governed_result != error_msg else None
         return None
 
     def call(
@@ -2008,13 +2063,16 @@ class LLM(BaseLLM):
             if isinstance(messages, str):
                 messages = [{"role": "user", "content": messages}]
 
-            messages = await self._aprocess_message_files(messages)
-
             if "o1" in self.model.lower():
                 for message in messages:
                     if message.get("role") == "system":
                         msg_role: Literal["assistant"] = "assistant"
                         message["role"] = msg_role
+
+            if not self._invoke_before_llm_call_hooks(messages, from_agent):
+                raise ValueError("LLM call blocked by before_llm_call hook")
+
+            messages = await self._aprocess_message_files(messages)
 
             with suppress_warnings():
                 if callbacks and len(callbacks) > 0:
@@ -2025,7 +2083,16 @@ class LLM(BaseLLM):
                     )
 
                     if self._effective_stream():
-                        return await self._ahandle_streaming_response(
+                        result = await self._ahandle_streaming_response(
+                            params=params,
+                            callbacks=callbacks,
+                            available_functions=available_functions,
+                            from_task=from_task,
+                            from_agent=from_agent,
+                            response_model=response_model,
+                        )
+                    else:
+                        result = await self._ahandle_non_streaming_response(
                             params=params,
                             callbacks=callbacks,
                             available_functions=available_functions,
@@ -2034,14 +2101,12 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    return await self._ahandle_non_streaming_response(
-                        params=params,
-                        callbacks=callbacks,
-                        available_functions=available_functions,
-                        from_task=from_task,
-                        from_agent=from_agent,
-                        response_model=response_model,
-                    )
+                    if isinstance(result, str):
+                        result = self._invoke_after_llm_call_hooks(
+                            messages, result, from_agent
+                        )
+
+                    return result
                 except LLMContextLengthExceededError:
                     raise
                 except Exception as e:

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1759,6 +1759,7 @@ class LLM(BaseLLM):
         function_args = {}
 
         if function_name in available_functions:
+            from crewai.hooks.dispatch import HookAborted
             from crewai.hooks.tool_hooks import (
                 ToolCallHookContext,
                 run_after_tool_call_hooks,
@@ -1766,6 +1767,8 @@ class LLM(BaseLLM):
             )
 
             call_id = str(uuid.uuid4())
+            before_hook_started = False
+            post_hook_attempted = False
             try:
                 function_args = json.loads(tool_call.function.arguments)
                 if not isinstance(function_args, dict):
@@ -1790,6 +1793,7 @@ class LLM(BaseLLM):
                     task=from_task,
                     call_id=call_id,
                 )
+                before_hook_started = True
                 blocked = run_before_tool_call_hooks(before_context)
                 if blocked:
                     result: Any = (
@@ -1812,6 +1816,7 @@ class LLM(BaseLLM):
                     is_error=blocked,
                     was_blocked=blocked,
                 )
+                post_hook_attempted = True
                 modified_result = run_after_tool_call_hooks(after_context)
                 if modified_result is not None and modified_result != result_text:
                     result = modified_result
@@ -1836,21 +1841,25 @@ class LLM(BaseLLM):
                     from_agent=from_agent,
                 )
                 return result
+            except HookAborted:
+                raise
             except Exception as e:
                 error_msg = f"Tool execution error: {e!s}"
                 logging.error(f"Error executing function '{function_name}': {e}")
-                after_context = ToolCallHookContext(
-                    tool_name=function_name,
-                    tool_input=function_args,
-                    tool=None,
-                    agent=from_agent,
-                    task=from_task,
-                    tool_result=error_msg,
-                    raw_tool_result=e,
-                    call_id=call_id,
-                    is_error=True,
-                )
-                governed_result = run_after_tool_call_hooks(after_context)
+                governed_result: str | None = None
+                if before_hook_started and not post_hook_attempted:
+                    after_context = ToolCallHookContext(
+                        tool_name=function_name,
+                        tool_input=function_args,
+                        tool=None,
+                        agent=from_agent,
+                        task=from_task,
+                        tool_result=error_msg,
+                        raw_tool_result=e,
+                        call_id=call_id,
+                        is_error=True,
+                    )
+                    governed_result = run_after_tool_call_hooks(after_context)
                 crewai_event_bus.emit(
                     self,
                     event=LLMCallFailedEvent(
@@ -1870,7 +1879,11 @@ class LLM(BaseLLM):
                         from_agent=from_agent,
                     ),
                 )
-                return governed_result if governed_result != error_msg else None
+                return (
+                    governed_result
+                    if governed_result is not None and governed_result != error_msg
+                    else None
+                )
         return None
 
     def call(
@@ -1956,18 +1969,19 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    if isinstance(result, str):
-                        result = self._invoke_after_llm_call_hooks(
-                            messages, result, from_agent
-                        )
-
-                    return result
+                    return self._invoke_after_llm_call_hooks(
+                        messages, result, from_agent
+                    )
                 except LLMContextLengthExceededError:
                     # Re-raise LLMContextLengthExceededError as it should be handled
                     # by the CrewAgentExecutor._invoke_loop method, which can then decide
                     # whether to summarize the content or abort based on the respect_context_window flag
                     raise
                 except Exception as e:
+                    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+                    if isinstance(e, PostModelCallBlockedError):
+                        raise
                     error_str = str(e)
                     unsupported_stop = "'stop'" in error_str and (
                         "Unsupported parameter" in error_str
@@ -2101,15 +2115,16 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    if isinstance(result, str):
-                        result = self._invoke_after_llm_call_hooks(
-                            messages, result, from_agent
-                        )
-
-                    return result
+                    return self._invoke_after_llm_call_hooks(
+                        messages, result, from_agent
+                    )
                 except LLMContextLengthExceededError:
                     raise
                 except Exception as e:
+                    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+                    if isinstance(e, PostModelCallBlockedError):
+                        raise
                     error_str = str(e)
                     unsupported_stop = "'stop'" in error_str and (
                         "Unsupported parameter" in error_str

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -737,6 +737,13 @@ class BaseLLM(BaseModel, ABC):
             )
             return None
 
+        from crewai.hooks.tool_hooks import (
+            ToolCallHookContext,
+            run_after_tool_call_hooks,
+            run_before_tool_call_hooks,
+        )
+
+        call_id = str(uuid.uuid4())
         try:
             started_at = datetime.now()
 
@@ -750,8 +757,39 @@ class BaseLLM(BaseModel, ABC):
                 ),
             )
 
-            fn = available_functions[function_name]
-            result = fn(**function_args)
+            before_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                call_id=call_id,
+            )
+            blocked = run_before_tool_call_hooks(before_context)
+            if blocked:
+                raw_result: Any = (
+                    f"Tool execution blocked by hook. Tool: {function_name}"
+                )
+            else:
+                fn = available_functions[function_name]
+                raw_result = fn(**function_args)
+
+            result = raw_result if isinstance(raw_result, str) else str(raw_result)
+            after_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                tool_result=result,
+                raw_tool_result=raw_result,
+                call_id=call_id,
+                is_error=blocked,
+                was_blocked=blocked,
+            )
+            modified_result = run_after_tool_call_hooks(after_context)
+            if modified_result is not None:
+                result = modified_result
 
             crewai_event_bus.emit(
                 self,
@@ -773,11 +811,24 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return str(result) if not isinstance(result, str) else result
+            return result
 
         except Exception as e:
             error_msg = f"Error executing function '{function_name}': {e!s}"
             logging.error(error_msg)
+
+            after_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                tool_result=error_msg,
+                raw_tool_result=e,
+                call_id=call_id,
+                is_error=True,
+            )
+            governed_result = run_after_tool_call_hooks(after_context)
 
             if not hasattr(crewai_event_bus, "emit"):
                 raise ValueError(
@@ -801,7 +852,7 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return None
+            return governed_result if governed_result != error_msg else None
 
     def _format_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         """Convert messages to standard format.
@@ -1022,6 +1073,7 @@ class BaseLLM(BaseModel, ABC):
             agent=None,
             task=None,
             crew=None,
+            request_id=get_current_call_id(),
         )
 
         try:
@@ -1084,6 +1136,7 @@ class BaseLLM(BaseModel, ABC):
             task=None,
             crew=None,
             response=response,
+            request_id=get_current_call_id(),
         )
 
         dispatch(

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -737,6 +737,7 @@ class BaseLLM(BaseModel, ABC):
             )
             return None
 
+        from crewai.hooks.dispatch import HookAborted
         from crewai.hooks.tool_hooks import (
             ToolCallHookContext,
             run_after_tool_call_hooks,
@@ -744,6 +745,8 @@ class BaseLLM(BaseModel, ABC):
         )
 
         call_id = str(uuid.uuid4())
+        before_hook_started = False
+        post_hook_attempted = False
         try:
             started_at = datetime.now()
 
@@ -765,6 +768,7 @@ class BaseLLM(BaseModel, ABC):
                 task=from_task,
                 call_id=call_id,
             )
+            before_hook_started = True
             blocked = run_before_tool_call_hooks(before_context)
             if blocked:
                 raw_result: Any = (
@@ -787,6 +791,7 @@ class BaseLLM(BaseModel, ABC):
                 is_error=blocked,
                 was_blocked=blocked,
             )
+            post_hook_attempted = True
             modified_result = run_after_tool_call_hooks(after_context)
             if modified_result is not None:
                 result = modified_result
@@ -813,22 +818,26 @@ class BaseLLM(BaseModel, ABC):
 
             return result
 
+        except HookAborted:
+            raise
         except Exception as e:
             error_msg = f"Error executing function '{function_name}': {e!s}"
             logging.error(error_msg)
 
-            after_context = ToolCallHookContext(
-                tool_name=function_name,
-                tool_input=function_args,
-                tool=None,
-                agent=from_agent,
-                task=from_task,
-                tool_result=error_msg,
-                raw_tool_result=e,
-                call_id=call_id,
-                is_error=True,
-            )
-            governed_result = run_after_tool_call_hooks(after_context)
+            governed_result: str | None = None
+            if before_hook_started and not post_hook_attempted:
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=error_msg,
+                    raw_tool_result=e,
+                    call_id=call_id,
+                    is_error=True,
+                )
+                governed_result = run_after_tool_call_hooks(after_context)
 
             if not hasattr(crewai_event_bus, "emit"):
                 raise ValueError(
@@ -852,7 +861,11 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return governed_result if governed_result != error_msg else None
+            return (
+                governed_result
+                if governed_result is not None and governed_result != error_msg
+                else None
+            )
 
     def _format_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         """Convert messages to standard format.
@@ -1094,9 +1107,9 @@ class BaseLLM(BaseModel, ABC):
     def _invoke_after_llm_call_hooks(
         self,
         messages: list[LLMMessage],
-        response: str,
+        response: Any,
         from_agent: BaseAgent | None = None,
-    ) -> str:
+    ) -> Any:
         """Invoke after_llm_call hooks for direct LLM calls (no agent context).
 
         This method should be called by native provider implementations after
@@ -1108,7 +1121,7 @@ class BaseLLM(BaseModel, ABC):
             from_agent: The agent that made the call (None for direct calls)
 
         Returns:
-            The potentially modified response string
+            The potentially modified response
 
         Example:
             >>> # In a native provider's call() method:
@@ -1117,13 +1130,14 @@ class BaseLLM(BaseModel, ABC):
             ...         messages, result, from_agent
             ...     )
         """
-        if from_agent is not None or not isinstance(response, str):
+        if from_agent is not None:
             return response
 
         from crewai.hooks.dispatch import InterceptionPoint, dispatch
         from crewai.hooks.llm_hooks import (
             LLMCallHookContext,
             after_llm_call_reducer,
+            raise_if_post_model_blocked,
         )
 
         # No early global-list guard: dispatch resolves global + execution-scoped
@@ -1144,5 +1158,6 @@ class BaseLLM(BaseModel, ABC):
             hook_context,
             reducer=after_llm_call_reducer,
         )
+        raise_if_post_model_blocked(hook_context)
 
         return hook_context.response if hook_context.response is not None else response

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -744,6 +744,7 @@ class BaseLLM(BaseModel, ABC):
             )
             return None
 
+        from crewai.hooks.dispatch import HookAborted
         from crewai.hooks.tool_hooks import (
             ToolCallHookContext,
             run_after_tool_call_hooks,
@@ -751,6 +752,8 @@ class BaseLLM(BaseModel, ABC):
         )
 
         call_id = str(uuid.uuid4())
+        before_hook_started = False
+        post_hook_attempted = False
         try:
             started_at = datetime.now()
 
@@ -772,6 +775,7 @@ class BaseLLM(BaseModel, ABC):
                 task=from_task,
                 call_id=call_id,
             )
+            before_hook_started = True
             blocked = run_before_tool_call_hooks(before_context)
             if blocked:
                 raw_result: Any = (
@@ -794,6 +798,7 @@ class BaseLLM(BaseModel, ABC):
                 is_error=blocked,
                 was_blocked=blocked,
             )
+            post_hook_attempted = True
             modified_result = run_after_tool_call_hooks(after_context)
             if modified_result is not None:
                 result = modified_result
@@ -820,22 +825,26 @@ class BaseLLM(BaseModel, ABC):
 
             return result
 
+        except HookAborted:
+            raise
         except Exception as e:
             error_msg = f"Error executing function '{function_name}': {e!s}"
             logging.error(error_msg)
 
-            after_context = ToolCallHookContext(
-                tool_name=function_name,
-                tool_input=function_args,
-                tool=None,
-                agent=from_agent,
-                task=from_task,
-                tool_result=error_msg,
-                raw_tool_result=e,
-                call_id=call_id,
-                is_error=True,
-            )
-            governed_result = run_after_tool_call_hooks(after_context)
+            governed_result: str | None = None
+            if before_hook_started and not post_hook_attempted:
+                after_context = ToolCallHookContext(
+                    tool_name=function_name,
+                    tool_input=function_args,
+                    tool=None,
+                    agent=from_agent,
+                    task=from_task,
+                    tool_result=error_msg,
+                    raw_tool_result=e,
+                    call_id=call_id,
+                    is_error=True,
+                )
+                governed_result = run_after_tool_call_hooks(after_context)
 
             if not hasattr(crewai_event_bus, "emit"):
                 raise ValueError(
@@ -859,7 +868,11 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return governed_result if governed_result != error_msg else None
+            return (
+                governed_result
+                if governed_result is not None and governed_result != error_msg
+                else None
+            )
 
     def _format_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         """Convert messages to standard format.
@@ -1101,9 +1114,9 @@ class BaseLLM(BaseModel, ABC):
     def _invoke_after_llm_call_hooks(
         self,
         messages: list[LLMMessage],
-        response: str,
+        response: Any,
         from_agent: BaseAgent | None = None,
-    ) -> str:
+    ) -> Any:
         """Invoke after_llm_call hooks for direct LLM calls (no agent context).
 
         This method should be called by native provider implementations after
@@ -1115,7 +1128,7 @@ class BaseLLM(BaseModel, ABC):
             from_agent: The agent that made the call (None for direct calls)
 
         Returns:
-            The potentially modified response string
+            The potentially modified response
 
         Example:
             >>> # In a native provider's call() method:
@@ -1124,13 +1137,14 @@ class BaseLLM(BaseModel, ABC):
             ...         messages, result, from_agent
             ...     )
         """
-        if from_agent is not None or not isinstance(response, str):
+        if from_agent is not None:
             return response
 
         from crewai.hooks.dispatch import InterceptionPoint, dispatch
         from crewai.hooks.llm_hooks import (
             LLMCallHookContext,
             after_llm_call_reducer,
+            raise_if_post_model_blocked,
         )
 
         # No early global-list guard: dispatch resolves global + execution-scoped
@@ -1151,5 +1165,6 @@ class BaseLLM(BaseModel, ABC):
             hook_context,
             reducer=after_llm_call_reducer,
         )
+        raise_if_post_model_blocked(hook_context)
 
         return hook_context.response if hook_context.response is not None else response

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -744,6 +744,13 @@ class BaseLLM(BaseModel, ABC):
             )
             return None
 
+        from crewai.hooks.tool_hooks import (
+            ToolCallHookContext,
+            run_after_tool_call_hooks,
+            run_before_tool_call_hooks,
+        )
+
+        call_id = str(uuid.uuid4())
         try:
             started_at = datetime.now()
 
@@ -757,8 +764,39 @@ class BaseLLM(BaseModel, ABC):
                 ),
             )
 
-            fn = available_functions[function_name]
-            result = fn(**function_args)
+            before_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                call_id=call_id,
+            )
+            blocked = run_before_tool_call_hooks(before_context)
+            if blocked:
+                raw_result: Any = (
+                    f"Tool execution blocked by hook. Tool: {function_name}"
+                )
+            else:
+                fn = available_functions[function_name]
+                raw_result = fn(**function_args)
+
+            result = raw_result if isinstance(raw_result, str) else str(raw_result)
+            after_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                tool_result=result,
+                raw_tool_result=raw_result,
+                call_id=call_id,
+                is_error=blocked,
+                was_blocked=blocked,
+            )
+            modified_result = run_after_tool_call_hooks(after_context)
+            if modified_result is not None:
+                result = modified_result
 
             crewai_event_bus.emit(
                 self,
@@ -780,11 +818,24 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return str(result) if not isinstance(result, str) else result
+            return result
 
         except Exception as e:
             error_msg = f"Error executing function '{function_name}': {e!s}"
             logging.error(error_msg)
+
+            after_context = ToolCallHookContext(
+                tool_name=function_name,
+                tool_input=function_args,
+                tool=None,
+                agent=from_agent,
+                task=from_task,
+                tool_result=error_msg,
+                raw_tool_result=e,
+                call_id=call_id,
+                is_error=True,
+            )
+            governed_result = run_after_tool_call_hooks(after_context)
 
             if not hasattr(crewai_event_bus, "emit"):
                 raise ValueError(
@@ -808,7 +859,7 @@ class BaseLLM(BaseModel, ABC):
                 from_agent=from_agent,
             )
 
-            return None
+            return governed_result if governed_result != error_msg else None
 
     def _format_messages(self, messages: str | list[LLMMessage]) -> list[LLMMessage]:
         """Convert messages to standard format.
@@ -1029,6 +1080,7 @@ class BaseLLM(BaseModel, ABC):
             agent=None,
             task=None,
             crew=None,
+            request_id=get_current_call_id(),
         )
 
         try:
@@ -1091,6 +1143,7 @@ class BaseLLM(BaseModel, ABC):
             task=None,
             crew=None,
             response=response,
+            request_id=get_current_call_id(),
         )
 
         dispatch(

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -126,6 +126,7 @@ class ToolUsage:
         Covers both tool-returned failures and framework-generated ones (a
         stringified exception, a spent usage limit).
         """
+        self.last_call_failed: bool = False
 
         if (
             self.function_calling_llm
@@ -148,7 +149,10 @@ class ToolUsage:
     def use(
         self, calling: ToolCalling | InstructorToolCalling, tool_string: str
     ) -> str:
+        self.last_failure = None
+        self.last_call_failed = False
         if isinstance(calling, ToolUsageError):
+            self.last_call_failed = True
             error = calling.message
             if self.agent and self.agent.verbose:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
@@ -159,6 +163,7 @@ class ToolUsage:
         try:
             tool = self._select_tool(calling.tool_name)
         except Exception as e:
+            self.last_call_failed = True
             error = getattr(e, "message", str(e))
             if self.task:
                 self.task.increment_tools_errors()
@@ -175,6 +180,7 @@ class ToolUsage:
                 return self._use(tool_string=tool_string, tool=tool, calling=calling)
 
             except Exception as e:
+                self.last_call_failed = True
                 error = getattr(e, "message", str(e))
                 if self.task:
                     self.task.increment_tools_errors()
@@ -196,7 +202,10 @@ class ToolUsage:
         Returns:
             The result of the tool execution as a string.
         """
+        self.last_failure = None
+        self.last_call_failed = False
         if isinstance(calling, ToolUsageError):
+            self.last_call_failed = True
             error = calling.message
             if self.agent and self.agent.verbose:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
@@ -207,6 +216,7 @@ class ToolUsage:
         try:
             tool = self._select_tool(calling.tool_name)
         except Exception as e:
+            self.last_call_failed = True
             error = getattr(e, "message", str(e))
             if self.task:
                 self.task.increment_tools_errors()
@@ -224,6 +234,7 @@ class ToolUsage:
                     tool_string=tool_string, tool=tool, calling=calling
                 )
             except Exception as e:
+                self.last_call_failed = True
                 error = getattr(e, "message", str(e))
                 if self.task:
                     self.task.increment_tools_errors()
@@ -253,6 +264,7 @@ class ToolUsage:
         """
         if self._check_tool_repeated_usage(calling=calling):
             try:
+                self.last_call_failed = True
                 result = I18N_DEFAULT.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
                 )
@@ -325,6 +337,7 @@ class ToolUsage:
                 available_tool, sanitize_tool_name(tool.name)
             )
             if usage_limit_error:
+                self.last_call_failed = True
                 result = usage_limit_error
                 self.last_raw_result = result
                 self.last_failure = ToolFailure(
@@ -450,6 +463,7 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
+                        self.last_call_failed = True
                         self._telemetry.tool_usage_error(llm=self.function_calling_llm)
                         error_message = I18N_DEFAULT.errors(
                             "tool_usage_exception"
@@ -503,6 +517,7 @@ class ToolUsage:
         # Repeated usage check happens before event emission - safe to return early
         if self._check_tool_repeated_usage(calling=calling):
             try:
+                self.last_call_failed = True
                 result = I18N_DEFAULT.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
                 )
@@ -576,6 +591,7 @@ class ToolUsage:
                 available_tool, sanitize_tool_name(tool.name)
             )
             if usage_limit_error:
+                self.last_call_failed = True
                 result = usage_limit_error
                 self.last_raw_result = result
                 self.last_failure = ToolFailure(
@@ -701,6 +717,7 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
+                        self.last_call_failed = True
                         self._telemetry.tool_usage_error(llm=self.function_calling_llm)
                         error_message = I18N_DEFAULT.errors(
                             "tool_usage_exception"

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -126,6 +126,7 @@ class ToolUsage:
         Covers both tool-returned failures and framework-generated ones (a
         stringified exception, a spent usage limit).
         """
+        self.last_call_failed: bool = False
 
         if (
             self.function_calling_llm
@@ -148,7 +149,10 @@ class ToolUsage:
     def use(
         self, calling: ToolCalling | InstructorToolCalling, tool_string: str
     ) -> str:
+        self.last_failure = None
+        self.last_call_failed = False
         if isinstance(calling, ToolUsageError):
+            self.last_call_failed = True
             error = calling.message
             if self.agent and self.agent.verbose:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
@@ -159,6 +163,7 @@ class ToolUsage:
         try:
             tool = self._select_tool(calling.tool_name)
         except Exception as e:
+            self.last_call_failed = True
             error = getattr(e, "message", str(e))
             if self.task:
                 self.task.increment_tools_errors()
@@ -175,6 +180,7 @@ class ToolUsage:
                 return self._use(tool_string=tool_string, tool=tool, calling=calling)
 
             except Exception as e:
+                self.last_call_failed = True
                 error = getattr(e, "message", str(e))
                 if self.task:
                     self.task.increment_tools_errors()
@@ -196,7 +202,10 @@ class ToolUsage:
         Returns:
             The result of the tool execution as a string.
         """
+        self.last_failure = None
+        self.last_call_failed = False
         if isinstance(calling, ToolUsageError):
+            self.last_call_failed = True
             error = calling.message
             if self.agent and self.agent.verbose:
                 PRINTER.print(content=f"\n\n{error}\n", color="red")
@@ -207,6 +216,7 @@ class ToolUsage:
         try:
             tool = self._select_tool(calling.tool_name)
         except Exception as e:
+            self.last_call_failed = True
             error = getattr(e, "message", str(e))
             if self.task:
                 self.task.increment_tools_errors()
@@ -224,6 +234,7 @@ class ToolUsage:
                     tool_string=tool_string, tool=tool, calling=calling
                 )
             except Exception as e:
+                self.last_call_failed = True
                 error = getattr(e, "message", str(e))
                 if self.task:
                     self.task.increment_tools_errors()
@@ -253,6 +264,7 @@ class ToolUsage:
         """
         if self._check_tool_repeated_usage(calling=calling):
             try:
+                self.last_call_failed = True
                 result = I18N_DEFAULT.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
                 )
@@ -325,6 +337,7 @@ class ToolUsage:
                 available_tool, sanitize_tool_name(tool.name)
             )
             if usage_limit_error:
+                self.last_call_failed = True
                 result = usage_limit_error
                 self.last_raw_result = result
                 self.last_failure = ToolFailure(
@@ -453,6 +466,7 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
+                        self.last_call_failed = True
                         self._telemetry.tool_usage_error(
                             llm=self.function_calling_llm,
                             tool_name=sanitize_tool_name(tool.name),
@@ -509,6 +523,7 @@ class ToolUsage:
         # Repeated usage check happens before event emission - safe to return early
         if self._check_tool_repeated_usage(calling=calling):
             try:
+                self.last_call_failed = True
                 result = I18N_DEFAULT.errors("task_repeated_usage").format(
                     tool_names=self.tools_names
                 )
@@ -582,6 +597,7 @@ class ToolUsage:
                 available_tool, sanitize_tool_name(tool.name)
             )
             if usage_limit_error:
+                self.last_call_failed = True
                 result = usage_limit_error
                 self.last_raw_result = result
                 self.last_failure = ToolFailure(
@@ -710,6 +726,7 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
+                        self.last_call_failed = True
                         self._telemetry.tool_usage_error(
                             llm=self.function_calling_llm,
                             tool_name=sanitize_tool_name(tool.name),

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -2008,6 +2008,9 @@ def _setup_after_llm_call_hooks(
         executor_context: The executor context to setup the hooks for.
         answer: The LLM response (string or Pydantic model).
         printer: Printer instance for error logging.
+        request_id: Optional host-owned correlation identifier for the model
+            call, threaded onto the hook context so the pre/post model hooks
+            share one id.
         verbose: Whether to print output.
 
     Returns:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -802,6 +802,10 @@ def is_context_length_exceeded(exception: Exception) -> bool:
     Returns:
         bool: True if the exception is due to context length exceeding
     """
+    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+    if isinstance(exception, PostModelCallBlockedError):
+        return False
     return LLMContextLengthExceededError(str(exception))._is_context_limit_error(
         str(exception)
     )
@@ -1454,6 +1458,10 @@ def check_native_tool_support(llm: Any, original_tools: list[BaseTool] | None) -
 
 def is_native_tool_calling_unsupported_error(error: BaseException) -> bool:
     """Return whether an error means native tool calling is unavailable."""
+    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+    if isinstance(error, PostModelCallBlockedError):
+        return False
     message = str(error).lower()
     return any(pattern in message for pattern in _NATIVE_TOOL_UNSUPPORTED_PATTERNS)
 
@@ -1914,6 +1922,7 @@ def _setup_before_llm_call_hooks(
     """
     if executor_context:
         from crewai.hooks.dispatch import (
+            AGENT_HOOKS_ABORT_SOURCE,
             HookAborted,
             InterceptionPoint,
             get_scoped_hooks,
@@ -1956,7 +1965,7 @@ def _setup_before_llm_call_hooks(
             # a string ``source`` identifier — surface its full reason so
             # customers see the policy decision. The sole caller
             # (_prepare_llm_call) already documents raising ValueError on block.
-            if not isinstance(aborted.source, str):
+            if aborted.source is not AGENT_HOOKS_ABORT_SOURCE:
                 if verbose:
                     printer.print(
                         content="LLM call blocked by before_llm_call hook",
@@ -2011,36 +2020,45 @@ def _setup_after_llm_call_hooks(
             governed_hook,
             run_hooks,
         )
-        from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
+        from crewai.hooks.llm_hooks import (
+            LLMCallHookContext,
+            after_llm_call_reducer,
+            raise_if_post_model_blocked,
+        )
 
-        if isinstance(answer, list) and is_tool_call_list(answer):
+        if isinstance(answer, dict) or (
+            isinstance(answer, list) and is_tool_call_list(answer)
+        ):
             governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
             if governed is None:
                 return answer
 
-            tool_calls: list[dict[str, Any]] = []
-            for tool_call in answer:
-                info = extract_tool_call_info(tool_call)
-                if info is None:
-                    continue
-                call_id, name, args = info
-                if isinstance(args, str):
-                    try:
-                        parsed_args = json.loads(args)
-                    except json.JSONDecodeError:
-                        parsed_args = {"raw": args}
-                    args = (
-                        parsed_args
-                        if isinstance(parsed_args, dict)
-                        else {"value": parsed_args}
-                    )
-                tool_calls.append({"id": call_id, "name": name, "args": args})
+            if isinstance(answer, dict):
+                structured_response = answer
+            else:
+                tool_calls: list[dict[str, Any]] = []
+                for tool_call in answer:
+                    info = extract_tool_call_info(tool_call)
+                    if info is None:
+                        continue
+                    call_id, name, args = info
+                    if isinstance(args, str):
+                        try:
+                            parsed_args = json.loads(args)
+                        except json.JSONDecodeError:
+                            parsed_args = {"raw": args}
+                        args = (
+                            parsed_args
+                            if isinstance(parsed_args, dict)
+                            else {"value": parsed_args}
+                        )
+                    tool_calls.append({"id": call_id, "name": name, "args": args})
 
-            structured_response: dict[str, Any] = {
-                "content": "",
-                "tool_calls": tool_calls,
-                "finish_reason": "tool_calls",
-            }
+                structured_response = {
+                    "content": "",
+                    "tool_calls": tool_calls,
+                    "finish_reason": "tool_calls",
+                }
             hook_context = LLMCallHookContext(
                 executor_context,
                 response=structured_response,
@@ -2053,9 +2071,10 @@ def _setup_after_llm_call_hooks(
                 reducer=after_llm_call_reducer,
                 verbose=verbose,
             )
+            raise_if_post_model_blocked(hook_context)
             return (
                 answer
-                if hook_context.response == structured_response
+                if hook_context.response is structured_response
                 else hook_context.response
             )
 
@@ -2079,6 +2098,7 @@ def _setup_after_llm_call_hooks(
 
         original_messages = executor_context.messages
 
+        pydantic_answer: BaseModel | None
         if isinstance(answer, BaseModel):
             pydantic_answer = answer
             hook_response: str = pydantic_answer.model_dump_json()
@@ -2114,6 +2134,8 @@ def _setup_after_llm_call_hooks(
                 executor_context.messages = original_messages
             else:
                 executor_context.messages = []
+
+        raise_if_post_model_blocked(hook_context)
 
         if pydantic_answer is not None:
             if hook_response != original_json:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -11,6 +11,7 @@ import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict
+import uuid
 
 from crewai_core.printer import PRINTER, ColoredText, Printer
 from crewai_core.settings import Settings
@@ -485,6 +486,7 @@ def _prepare_llm_call(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     messages: list[LLMMessage],
     printer: Printer,
+    request_id: str,
     verbose: bool = True,
 ) -> list[LLMMessage]:
     """Shared pre-call logic: run before hooks and resolve messages.
@@ -502,7 +504,9 @@ def _prepare_llm_call(
         ValueError: If a before hook blocks the call.
     """
     if executor_context is not None:
-        if not _setup_before_llm_call_hooks(executor_context, printer, verbose=verbose):
+        if not _setup_before_llm_call_hooks(
+            executor_context, printer, request_id=request_id, verbose=verbose
+        ):
             raise ValueError("LLM call blocked by before_llm_call hook")
         messages = executor_context.messages
     return messages
@@ -512,6 +516,7 @@ def _validate_and_finalize_llm_response(
     answer: Any,
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     printer: Printer,
+    request_id: str,
     verbose: bool = True,
 ) -> str | BaseModel | Any:
     """Shared post-call logic: validate response and run after hooks.
@@ -537,7 +542,11 @@ def _validate_and_finalize_llm_response(
         raise ValueError("Invalid response from LLM call - None or empty.")
 
     return _setup_after_llm_call_hooks(
-        executor_context, answer, printer, verbose=verbose
+        executor_context,
+        answer,
+        printer,
+        request_id=request_id,
+        verbose=verbose,
     )
 
 
@@ -577,7 +586,10 @@ def get_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
-    messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
+    request_id = str(uuid.uuid4())
+    messages = _prepare_llm_call(
+        executor_context, messages, printer, request_id, verbose=verbose
+    )
 
     answer = llm.call(
         messages,
@@ -590,7 +602,7 @@ def get_llm_response(
     )
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, request_id, verbose=verbose
     )
 
 
@@ -630,7 +642,10 @@ async def aget_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
-    messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
+    request_id = str(uuid.uuid4())
+    messages = _prepare_llm_call(
+        executor_context, messages, printer, request_id, verbose=verbose
+    )
 
     answer = await llm.acall(
         messages,
@@ -643,7 +658,7 @@ async def aget_llm_response(
     )
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, request_id, verbose=verbose
     )
 
 
@@ -1610,6 +1625,7 @@ def execute_single_native_tool_call(
         )
 
     call_id, func_name, func_args = info
+    governance_call_id = str(uuid.uuid4())
 
     parsed_args, parse_error = parse_tool_call_args(func_args, func_name, call_id)
     if parse_error is not None:
@@ -1653,18 +1669,9 @@ def execute_single_native_tool_call(
     output_tool = original_tool or structured_tool
 
     from_cache = False
-    input_str = json.dumps(args_dict) if args_dict else ""
     result = "Tool not found"
     raw_tool_result: Any = result
     tool_failure: ToolFailure | None = None
-
-    if tools_handler and tools_handler.cache and output_tool is not None:
-        cached_result = tools_handler.cache.read(tool=func_name, input=input_str)
-        if cached_result is not None:
-            raw_tool_result = cached_result
-            result = format_native_tool_output_for_agent(output_tool, cached_result)
-            tool_failure = detect_tool_failure(cached_result)
-            from_cache = True
 
     started_at = datetime.now()
     crewai_event_bus.emit(
@@ -1685,12 +1692,27 @@ def execute_single_native_tool_call(
     before_hook_context = ToolCallHookContext(
         tool_name=func_name,
         tool_input=args_dict,
-        tool=structured_tool,  # type: ignore[arg-type]
+        tool=structured_tool,
         agent=agent,
         task=task,
         crew=crew,
+        call_id=governance_call_id,
     )
     hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+    input_str = json.dumps(args_dict) if args_dict else ""
+    if (
+        not hook_blocked
+        and tools_handler
+        and tools_handler.cache
+        and output_tool is not None
+    ):
+        cached_result = tools_handler.cache.read(tool=func_name, input=input_str)
+        if cached_result is not None:
+            raw_tool_result = cached_result
+            result = format_native_tool_output_for_agent(output_tool, cached_result)
+            tool_failure = detect_tool_failure(cached_result)
+            from_cache = True
 
     error_event_emitted = False
     if hook_blocked:
@@ -1751,12 +1773,15 @@ def execute_single_native_tool_call(
     after_hook_context = ToolCallHookContext(
         tool_name=func_name,
         tool_input=args_dict,
-        tool=structured_tool,  # type: ignore[arg-type]
+        tool=structured_tool,
         agent=agent,
         task=task,
         crew=crew,
         tool_result=result,
         raw_tool_result=raw_tool_result,
+        call_id=governance_call_id,
+        is_error=hook_blocked or error_event_emitted or tool_failure is not None,
+        was_blocked=hook_blocked,
     )
     modified_result = run_after_tool_call_hooks(after_hook_context)
     if modified_result is not None:
@@ -1874,6 +1899,7 @@ def parse_tool_call_args(
 def _setup_before_llm_call_hooks(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     printer: Printer,
+    request_id: str | None = None,
     verbose: bool = True,
 ) -> bool:
     """Setup and invoke before_llm_call hooks for the executor context.
@@ -1912,7 +1938,7 @@ def _setup_before_llm_call_hooks(
 
         original_messages = executor_context.messages
 
-        hook_context = LLMCallHookContext(executor_context)
+        hook_context = LLMCallHookContext(executor_context, request_id=request_id)
         try:
             run_hooks(
                 InterceptionPoint.PRE_MODEL_CALL,
@@ -1962,10 +1988,11 @@ def _setup_before_llm_call_hooks(
 
 def _setup_after_llm_call_hooks(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
-    answer: str | BaseModel,
+    answer: Any,
     printer: Printer,
+    request_id: str | None = None,
     verbose: bool = True,
-) -> str | BaseModel:
+) -> Any:
     """Setup and invoke after_llm_call hooks for the executor context.
 
     Args:
@@ -1986,9 +2013,54 @@ def _setup_after_llm_call_hooks(
         )
         from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
 
-        # Don't stringify structured tool-call payloads: the executor would
-        # treat the result as a final answer and skip tool execution (#6529).
-        # Hooks still run on the follow-up textual response.
+        if isinstance(answer, list) and is_tool_call_list(answer):
+            governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
+            if governed is None:
+                return answer
+
+            tool_calls: list[dict[str, Any]] = []
+            for tool_call in answer:
+                info = extract_tool_call_info(tool_call)
+                if info is None:
+                    continue
+                call_id, name, args = info
+                if isinstance(args, str):
+                    try:
+                        parsed_args = json.loads(args)
+                    except json.JSONDecodeError:
+                        parsed_args = {"raw": args}
+                    args = (
+                        parsed_args
+                        if isinstance(parsed_args, dict)
+                        else {"value": parsed_args}
+                    )
+                tool_calls.append({"id": call_id, "name": name, "args": args})
+
+            structured_response: dict[str, Any] = {
+                "content": "",
+                "tool_calls": tool_calls,
+                "finish_reason": "tool_calls",
+            }
+            hook_context = LLMCallHookContext(
+                executor_context,
+                response=structured_response,
+                request_id=request_id,
+            )
+            run_hooks(
+                InterceptionPoint.POST_MODEL_CALL,
+                hook_context,
+                [governed],
+                reducer=after_llm_call_reducer,
+                verbose=verbose,
+            )
+            return (
+                answer
+                if hook_context.response == structured_response
+                else hook_context.response
+            )
+
+        # Other structured payloads stay untouched so executors can process
+        # provider-native responses without accidental stringification (#6529).
         if not isinstance(answer, (str, BaseModel)):
             return answer
 
@@ -2015,7 +2087,9 @@ def _setup_after_llm_call_hooks(
             pydantic_answer = None
             hook_response = str(answer)
 
-        hook_context = LLMCallHookContext(executor_context, response=hook_response)
+        hook_context = LLMCallHookContext(
+            executor_context, response=hook_response, request_id=request_id
+        )
         run_hooks(
             InterceptionPoint.POST_MODEL_CALL,
             hook_context,
@@ -2047,11 +2121,10 @@ def _setup_after_llm_call_hooks(
                     model_class: type[BaseModel] = type(pydantic_answer)
                     answer = model_class.model_validate_json(hook_response)
                 except Exception as e:
-                    if verbose:
-                        printer.print(
-                            content=f"Warning: Hook modified response but failed to reparse as {type(pydantic_answer).__name__}: {e}. Using original model.",
-                            color="yellow",
-                        )
+                    raise ValueError(
+                        f"Hook-modified response failed to reparse as "
+                        f"{type(pydantic_answer).__name__}: {e}"
+                    ) from e
         else:
             answer = hook_response
 

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1891,15 +1891,21 @@ def _setup_before_llm_call_hooks(
             HookAborted,
             InterceptionPoint,
             get_scoped_hooks,
+            governed_hook,
             run_hooks,
         )
         from crewai.hooks.llm_hooks import LLMCallHookContext, before_llm_call_reducer
 
-        # Executor snapshot first, then execution-scoped hooks — the same
-        # ordering dispatch() applies to global vs scoped hooks.
+        # Executor snapshot first, then execution-scoped hooks, then the
+        # agent-hooks control engine's authoritative adapter when installed —
+        # the same ordering dispatch() applies. Without appending the governor
+        # here an injected control engine would only run on the tool seams,
+        # leaving the pre-model-call point ungoverned on the agent executor path.
+        governed = governed_hook(InterceptionPoint.PRE_MODEL_CALL)
         hooks: list[Any] = [
             *executor_context.before_llm_call_hooks,
             *get_scoped_hooks(InterceptionPoint.PRE_MODEL_CALL),
+            *([governed] if governed is not None else []),
         ]
         if not hooks:
             return True
@@ -1915,13 +1921,26 @@ def _setup_before_llm_call_hooks(
                 reducer=before_llm_call_reducer,
                 verbose=verbose,
             )
-        except HookAborted:
+        except HookAborted as aborted:
+            # Preserve the historical contract for anonymous hook blocks (a
+            # hook returning False, or a bare HookAborted): the dispatcher tags
+            # these with the hook callable as ``source``, so return False and
+            # let the caller emit its generic block message. A governance
+            # engine (e.g. an injected agent-hooks control engine) raises with
+            # a string ``source`` identifier — surface its full reason so
+            # customers see the policy decision. The sole caller
+            # (_prepare_llm_call) already documents raising ValueError on block.
+            if not isinstance(aborted.source, str):
+                if verbose:
+                    printer.print(
+                        content="LLM call blocked by before_llm_call hook",
+                        color="yellow",
+                    )
+                return False
+            reason = aborted.reason or "LLM call blocked by before_llm_call hook"
             if verbose:
-                printer.print(
-                    content="LLM call blocked by before_llm_call hook",
-                    color="yellow",
-                )
-            return False
+                printer.print(content=reason, color="yellow")
+            raise ValueError(reason) from aborted
 
         if not isinstance(executor_context.messages, list):
             if verbose:
@@ -1959,7 +1978,12 @@ def _setup_after_llm_call_hooks(
         The potentially modified response (string or Pydantic model).
     """
     if executor_context:
-        from crewai.hooks.dispatch import InterceptionPoint, get_scoped_hooks, run_hooks
+        from crewai.hooks.dispatch import (
+            InterceptionPoint,
+            get_scoped_hooks,
+            governed_hook,
+            run_hooks,
+        )
         from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
 
         # Don't stringify structured tool-call payloads: the executor would
@@ -1968,11 +1992,15 @@ def _setup_after_llm_call_hooks(
         if not isinstance(answer, (str, BaseModel)):
             return answer
 
-        # Executor snapshot first, then execution-scoped hooks — the same
-        # ordering dispatch() applies to global vs scoped hooks.
+        # Executor snapshot first, then execution-scoped hooks, then the
+        # agent-hooks control engine's authoritative adapter when installed —
+        # the same ordering dispatch() applies. A post-model-call deny returns a
+        # fail-closed replacement response (the engine does not raise here).
+        governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
         hooks: list[Any] = [
             *executor_context.after_llm_call_hooks,
             *get_scoped_hooks(InterceptionPoint.POST_MODEL_CALL),
+            *([governed] if governed is not None else []),
         ]
         if not hooks:
             return answer

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -2143,6 +2143,17 @@ def _setup_after_llm_call_hooks(
                     model_class: type[BaseModel] = type(pydantic_answer)
                     answer = model_class.model_validate_json(hook_response)
                 except Exception as e:
+                    if governed is None:
+                        if verbose:
+                            printer.print(
+                                content=(
+                                    "Warning: Hook modified response but failed to "
+                                    f"reparse as {type(pydantic_answer).__name__}: "
+                                    f"{e}. Using original model."
+                                ),
+                                color="yellow",
+                            )
+                        return pydantic_answer
                     raise ValueError(
                         f"Hook-modified response failed to reparse as "
                         f"{type(pydantic_answer).__name__}: {e}"

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -2188,6 +2188,17 @@ def _setup_after_llm_call_hooks(
                     model_class: type[BaseModel] = type(pydantic_answer)
                     answer = model_class.model_validate_json(hook_response)
                 except Exception as e:
+                    if governed is None:
+                        if verbose:
+                            printer.print(
+                                content=(
+                                    "Warning: Hook modified response but failed to "
+                                    f"reparse as {type(pydantic_answer).__name__}: "
+                                    f"{e}. Using original model."
+                                ),
+                                color="yellow",
+                            )
+                        return pydantic_answer
                     raise ValueError(
                         f"Hook-modified response failed to reparse as "
                         f"{type(pydantic_answer).__name__}: {e}"

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -11,6 +11,7 @@ import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict
+import uuid
 
 from crewai_core.printer import PRINTER, ColoredText, Printer
 from crewai_core.settings import Settings
@@ -485,6 +486,7 @@ def _prepare_llm_call(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     messages: list[LLMMessage],
     printer: Printer,
+    request_id: str,
     verbose: bool = True,
 ) -> list[LLMMessage]:
     """Shared pre-call logic: run before hooks and resolve messages.
@@ -502,7 +504,9 @@ def _prepare_llm_call(
         ValueError: If a before hook blocks the call.
     """
     if executor_context is not None:
-        if not _setup_before_llm_call_hooks(executor_context, printer, verbose=verbose):
+        if not _setup_before_llm_call_hooks(
+            executor_context, printer, request_id=request_id, verbose=verbose
+        ):
             raise ValueError("LLM call blocked by before_llm_call hook")
         messages = executor_context.messages
     return messages
@@ -512,6 +516,7 @@ def _validate_and_finalize_llm_response(
     answer: Any,
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     printer: Printer,
+    request_id: str,
     verbose: bool = True,
 ) -> str | BaseModel | Any:
     """Shared post-call logic: validate response and run after hooks.
@@ -537,7 +542,11 @@ def _validate_and_finalize_llm_response(
         raise ValueError("Invalid response from LLM call - None or empty.")
 
     return _setup_after_llm_call_hooks(
-        executor_context, answer, printer, verbose=verbose
+        executor_context,
+        answer,
+        printer,
+        request_id=request_id,
+        verbose=verbose,
     )
 
 
@@ -577,7 +586,10 @@ def get_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
-    messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
+    request_id = str(uuid.uuid4())
+    messages = _prepare_llm_call(
+        executor_context, messages, printer, request_id, verbose=verbose
+    )
 
     answer = llm.call(
         messages,
@@ -590,7 +602,7 @@ def get_llm_response(
     )
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, request_id, verbose=verbose
     )
 
 
@@ -630,7 +642,10 @@ async def aget_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
-    messages = _prepare_llm_call(executor_context, messages, printer, verbose=verbose)
+    request_id = str(uuid.uuid4())
+    messages = _prepare_llm_call(
+        executor_context, messages, printer, request_id, verbose=verbose
+    )
 
     answer = await llm.acall(
         messages,
@@ -643,7 +658,7 @@ async def aget_llm_response(
     )
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, request_id, verbose=verbose
     )
 
 
@@ -1655,6 +1670,7 @@ def execute_single_native_tool_call(
         )
 
     call_id, func_name, func_args = info
+    governance_call_id = str(uuid.uuid4())
 
     parsed_args, parse_error = parse_tool_call_args(func_args, func_name, call_id)
     if parse_error is not None:
@@ -1698,18 +1714,9 @@ def execute_single_native_tool_call(
     output_tool = original_tool or structured_tool
 
     from_cache = False
-    input_str = json.dumps(args_dict) if args_dict else ""
     result = "Tool not found"
     raw_tool_result: Any = result
     tool_failure: ToolFailure | None = None
-
-    if tools_handler and tools_handler.cache and output_tool is not None:
-        cached_result = tools_handler.cache.read(tool=func_name, input=input_str)
-        if cached_result is not None:
-            raw_tool_result = cached_result
-            result = format_native_tool_output_for_agent(output_tool, cached_result)
-            tool_failure = detect_tool_failure(cached_result)
-            from_cache = True
 
     started_at = datetime.now()
     crewai_event_bus.emit(
@@ -1730,12 +1737,27 @@ def execute_single_native_tool_call(
     before_hook_context = ToolCallHookContext(
         tool_name=func_name,
         tool_input=args_dict,
-        tool=structured_tool,  # type: ignore[arg-type]
+        tool=structured_tool,
         agent=agent,
         task=task,
         crew=crew,
+        call_id=governance_call_id,
     )
     hook_blocked = run_before_tool_call_hooks(before_hook_context)
+
+    input_str = json.dumps(args_dict) if args_dict else ""
+    if (
+        not hook_blocked
+        and tools_handler
+        and tools_handler.cache
+        and output_tool is not None
+    ):
+        cached_result = tools_handler.cache.read(tool=func_name, input=input_str)
+        if cached_result is not None:
+            raw_tool_result = cached_result
+            result = format_native_tool_output_for_agent(output_tool, cached_result)
+            tool_failure = detect_tool_failure(cached_result)
+            from_cache = True
 
     error_event_emitted = False
     if hook_blocked:
@@ -1796,12 +1818,15 @@ def execute_single_native_tool_call(
     after_hook_context = ToolCallHookContext(
         tool_name=func_name,
         tool_input=args_dict,
-        tool=structured_tool,  # type: ignore[arg-type]
+        tool=structured_tool,
         agent=agent,
         task=task,
         crew=crew,
         tool_result=result,
         raw_tool_result=raw_tool_result,
+        call_id=governance_call_id,
+        is_error=hook_blocked or error_event_emitted or tool_failure is not None,
+        was_blocked=hook_blocked,
     )
     modified_result = run_after_tool_call_hooks(after_hook_context)
     if modified_result is not None:
@@ -1919,6 +1944,7 @@ def parse_tool_call_args(
 def _setup_before_llm_call_hooks(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     printer: Printer,
+    request_id: str | None = None,
     verbose: bool = True,
 ) -> bool:
     """Setup and invoke before_llm_call hooks for the executor context.
@@ -1957,7 +1983,7 @@ def _setup_before_llm_call_hooks(
 
         original_messages = executor_context.messages
 
-        hook_context = LLMCallHookContext(executor_context)
+        hook_context = LLMCallHookContext(executor_context, request_id=request_id)
         try:
             run_hooks(
                 InterceptionPoint.PRE_MODEL_CALL,
@@ -2007,10 +2033,11 @@ def _setup_before_llm_call_hooks(
 
 def _setup_after_llm_call_hooks(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
-    answer: str | BaseModel,
+    answer: Any,
     printer: Printer,
+    request_id: str | None = None,
     verbose: bool = True,
-) -> str | BaseModel:
+) -> Any:
     """Setup and invoke after_llm_call hooks for the executor context.
 
     Args:
@@ -2031,9 +2058,54 @@ def _setup_after_llm_call_hooks(
         )
         from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
 
-        # Don't stringify structured tool-call payloads: the executor would
-        # treat the result as a final answer and skip tool execution (#6529).
-        # Hooks still run on the follow-up textual response.
+        if isinstance(answer, list) and is_tool_call_list(answer):
+            governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
+            if governed is None:
+                return answer
+
+            tool_calls: list[dict[str, Any]] = []
+            for tool_call in answer:
+                info = extract_tool_call_info(tool_call)
+                if info is None:
+                    continue
+                call_id, name, args = info
+                if isinstance(args, str):
+                    try:
+                        parsed_args = json.loads(args)
+                    except json.JSONDecodeError:
+                        parsed_args = {"raw": args}
+                    args = (
+                        parsed_args
+                        if isinstance(parsed_args, dict)
+                        else {"value": parsed_args}
+                    )
+                tool_calls.append({"id": call_id, "name": name, "args": args})
+
+            structured_response: dict[str, Any] = {
+                "content": "",
+                "tool_calls": tool_calls,
+                "finish_reason": "tool_calls",
+            }
+            hook_context = LLMCallHookContext(
+                executor_context,
+                response=structured_response,
+                request_id=request_id,
+            )
+            run_hooks(
+                InterceptionPoint.POST_MODEL_CALL,
+                hook_context,
+                [governed],
+                reducer=after_llm_call_reducer,
+                verbose=verbose,
+            )
+            return (
+                answer
+                if hook_context.response == structured_response
+                else hook_context.response
+            )
+
+        # Other structured payloads stay untouched so executors can process
+        # provider-native responses without accidental stringification (#6529).
         if not isinstance(answer, (str, BaseModel)):
             return answer
 
@@ -2060,7 +2132,9 @@ def _setup_after_llm_call_hooks(
             pydantic_answer = None
             hook_response = str(answer)
 
-        hook_context = LLMCallHookContext(executor_context, response=hook_response)
+        hook_context = LLMCallHookContext(
+            executor_context, response=hook_response, request_id=request_id
+        )
         run_hooks(
             InterceptionPoint.POST_MODEL_CALL,
             hook_context,
@@ -2092,11 +2166,10 @@ def _setup_after_llm_call_hooks(
                     model_class: type[BaseModel] = type(pydantic_answer)
                     answer = model_class.model_validate_json(hook_response)
                 except Exception as e:
-                    if verbose:
-                        printer.print(
-                            content=f"Warning: Hook modified response but failed to reparse as {type(pydantic_answer).__name__}: {e}. Using original model.",
-                            color="yellow",
-                        )
+                    raise ValueError(
+                        f"Hook-modified response failed to reparse as "
+                        f"{type(pydantic_answer).__name__}: {e}"
+                    ) from e
         else:
             answer = hook_response
 

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -1936,15 +1936,21 @@ def _setup_before_llm_call_hooks(
             HookAborted,
             InterceptionPoint,
             get_scoped_hooks,
+            governed_hook,
             run_hooks,
         )
         from crewai.hooks.llm_hooks import LLMCallHookContext, before_llm_call_reducer
 
-        # Executor snapshot first, then execution-scoped hooks — the same
-        # ordering dispatch() applies to global vs scoped hooks.
+        # Executor snapshot first, then execution-scoped hooks, then the
+        # agent-hooks control engine's authoritative adapter when installed —
+        # the same ordering dispatch() applies. Without appending the governor
+        # here an injected control engine would only run on the tool seams,
+        # leaving the pre-model-call point ungoverned on the agent executor path.
+        governed = governed_hook(InterceptionPoint.PRE_MODEL_CALL)
         hooks: list[Any] = [
             *executor_context.before_llm_call_hooks,
             *get_scoped_hooks(InterceptionPoint.PRE_MODEL_CALL),
+            *([governed] if governed is not None else []),
         ]
         if not hooks:
             return True
@@ -1960,13 +1966,26 @@ def _setup_before_llm_call_hooks(
                 reducer=before_llm_call_reducer,
                 verbose=verbose,
             )
-        except HookAborted:
+        except HookAborted as aborted:
+            # Preserve the historical contract for anonymous hook blocks (a
+            # hook returning False, or a bare HookAborted): the dispatcher tags
+            # these with the hook callable as ``source``, so return False and
+            # let the caller emit its generic block message. A governance
+            # engine (e.g. an injected agent-hooks control engine) raises with
+            # a string ``source`` identifier — surface its full reason so
+            # customers see the policy decision. The sole caller
+            # (_prepare_llm_call) already documents raising ValueError on block.
+            if not isinstance(aborted.source, str):
+                if verbose:
+                    printer.print(
+                        content="LLM call blocked by before_llm_call hook",
+                        color="yellow",
+                    )
+                return False
+            reason = aborted.reason or "LLM call blocked by before_llm_call hook"
             if verbose:
-                printer.print(
-                    content="LLM call blocked by before_llm_call hook",
-                    color="yellow",
-                )
-            return False
+                printer.print(content=reason, color="yellow")
+            raise ValueError(reason) from aborted
 
         if not isinstance(executor_context.messages, list):
             if verbose:
@@ -2004,7 +2023,12 @@ def _setup_after_llm_call_hooks(
         The potentially modified response (string or Pydantic model).
     """
     if executor_context:
-        from crewai.hooks.dispatch import InterceptionPoint, get_scoped_hooks, run_hooks
+        from crewai.hooks.dispatch import (
+            InterceptionPoint,
+            get_scoped_hooks,
+            governed_hook,
+            run_hooks,
+        )
         from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
 
         # Don't stringify structured tool-call payloads: the executor would
@@ -2013,11 +2037,15 @@ def _setup_after_llm_call_hooks(
         if not isinstance(answer, (str, BaseModel)):
             return answer
 
-        # Executor snapshot first, then execution-scoped hooks — the same
-        # ordering dispatch() applies to global vs scoped hooks.
+        # Executor snapshot first, then execution-scoped hooks, then the
+        # agent-hooks control engine's authoritative adapter when installed —
+        # the same ordering dispatch() applies. A post-model-call deny returns a
+        # fail-closed replacement response (the engine does not raise here).
+        governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
         hooks: list[Any] = [
             *executor_context.after_llm_call_hooks,
             *get_scoped_hooks(InterceptionPoint.POST_MODEL_CALL),
+            *([governed] if governed is not None else []),
         ]
         if not hooks:
             return answer

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -802,6 +802,10 @@ def is_context_length_exceeded(exception: Exception) -> bool:
     Returns:
         bool: True if the exception is due to context length exceeding
     """
+    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+    if isinstance(exception, PostModelCallBlockedError):
+        return False
     return LLMContextLengthExceededError(str(exception))._is_context_limit_error(
         str(exception)
     )
@@ -1499,6 +1503,10 @@ def check_native_tool_support(llm: Any, original_tools: list[BaseTool] | None) -
 
 def is_native_tool_calling_unsupported_error(error: BaseException) -> bool:
     """Return whether an error means native tool calling is unavailable."""
+    from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+    if isinstance(error, PostModelCallBlockedError):
+        return False
     message = str(error).lower()
     return any(pattern in message for pattern in _NATIVE_TOOL_UNSUPPORTED_PATTERNS)
 
@@ -1959,6 +1967,7 @@ def _setup_before_llm_call_hooks(
     """
     if executor_context:
         from crewai.hooks.dispatch import (
+            AGENT_HOOKS_ABORT_SOURCE,
             HookAborted,
             InterceptionPoint,
             get_scoped_hooks,
@@ -2001,7 +2010,7 @@ def _setup_before_llm_call_hooks(
             # a string ``source`` identifier — surface its full reason so
             # customers see the policy decision. The sole caller
             # (_prepare_llm_call) already documents raising ValueError on block.
-            if not isinstance(aborted.source, str):
+            if aborted.source is not AGENT_HOOKS_ABORT_SOURCE:
                 if verbose:
                     printer.print(
                         content="LLM call blocked by before_llm_call hook",
@@ -2056,36 +2065,45 @@ def _setup_after_llm_call_hooks(
             governed_hook,
             run_hooks,
         )
-        from crewai.hooks.llm_hooks import LLMCallHookContext, after_llm_call_reducer
+        from crewai.hooks.llm_hooks import (
+            LLMCallHookContext,
+            after_llm_call_reducer,
+            raise_if_post_model_blocked,
+        )
 
-        if isinstance(answer, list) and is_tool_call_list(answer):
+        if isinstance(answer, dict) or (
+            isinstance(answer, list) and is_tool_call_list(answer)
+        ):
             governed = governed_hook(InterceptionPoint.POST_MODEL_CALL)
             if governed is None:
                 return answer
 
-            tool_calls: list[dict[str, Any]] = []
-            for tool_call in answer:
-                info = extract_tool_call_info(tool_call)
-                if info is None:
-                    continue
-                call_id, name, args = info
-                if isinstance(args, str):
-                    try:
-                        parsed_args = json.loads(args)
-                    except json.JSONDecodeError:
-                        parsed_args = {"raw": args}
-                    args = (
-                        parsed_args
-                        if isinstance(parsed_args, dict)
-                        else {"value": parsed_args}
-                    )
-                tool_calls.append({"id": call_id, "name": name, "args": args})
+            if isinstance(answer, dict):
+                structured_response = answer
+            else:
+                tool_calls: list[dict[str, Any]] = []
+                for tool_call in answer:
+                    info = extract_tool_call_info(tool_call)
+                    if info is None:
+                        continue
+                    call_id, name, args = info
+                    if isinstance(args, str):
+                        try:
+                            parsed_args = json.loads(args)
+                        except json.JSONDecodeError:
+                            parsed_args = {"raw": args}
+                        args = (
+                            parsed_args
+                            if isinstance(parsed_args, dict)
+                            else {"value": parsed_args}
+                        )
+                    tool_calls.append({"id": call_id, "name": name, "args": args})
 
-            structured_response: dict[str, Any] = {
-                "content": "",
-                "tool_calls": tool_calls,
-                "finish_reason": "tool_calls",
-            }
+                structured_response = {
+                    "content": "",
+                    "tool_calls": tool_calls,
+                    "finish_reason": "tool_calls",
+                }
             hook_context = LLMCallHookContext(
                 executor_context,
                 response=structured_response,
@@ -2098,9 +2116,10 @@ def _setup_after_llm_call_hooks(
                 reducer=after_llm_call_reducer,
                 verbose=verbose,
             )
+            raise_if_post_model_blocked(hook_context)
             return (
                 answer
-                if hook_context.response == structured_response
+                if hook_context.response is structured_response
                 else hook_context.response
             )
 
@@ -2124,6 +2143,7 @@ def _setup_after_llm_call_hooks(
 
         original_messages = executor_context.messages
 
+        pydantic_answer: BaseModel | None
         if isinstance(answer, BaseModel):
             pydantic_answer = answer
             hook_response: str = pydantic_answer.model_dump_json()
@@ -2159,6 +2179,8 @@ def _setup_after_llm_call_hooks(
                 executor_context.messages = original_messages
             else:
                 executor_context.messages = []
+
+        raise_if_post_model_blocked(hook_context)
 
         if pydantic_answer is not None:
             if hook_response != original_json:

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -2053,6 +2053,9 @@ def _setup_after_llm_call_hooks(
         executor_context: The executor context to setup the hooks for.
         answer: The LLM response (string or Pydantic model).
         printer: Printer instance for error logging.
+        request_id: Optional host-owned correlation identifier for the model
+            call, threaded onto the hook context so the pre/post model hooks
+            share one id.
         verbose: Whether to print output.
 
     Returns:

--- a/lib/crewai/src/crewai/utilities/tool_utils.py
+++ b/lib/crewai/src/crewai/utilities/tool_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from crewai.agents.parser import AgentAction
 from crewai.agents.tools_handler import ToolsHandler
@@ -110,7 +111,11 @@ async def aexecute_tool_and_check_finality(
     sanitized_tool_name = sanitize_tool_name(tool_calling.tool_name)
     tool = tool_name_to_tool_map.get(sanitized_tool_name)
     if tool:
-        tool_input = tool_calling.arguments if tool_calling.arguments else {}
+        call_id = str(uuid4())
+        tool_input = (
+            tool_calling.arguments if tool_calling.arguments is not None else {}
+        )
+        tool_calling.arguments = tool_input
         hook_context = ToolCallHookContext(
             tool_name=sanitized_tool_name,
             tool_input=tool_input,
@@ -118,6 +123,7 @@ async def aexecute_tool_and_check_finality(
             agent=agent,
             task=task,
             crew=crew,
+            call_id=call_id,
         )
 
         if run_before_tool_call_hooks(hook_context):
@@ -135,6 +141,9 @@ async def aexecute_tool_and_check_finality(
                 crew=crew,
                 tool_result=blocked_message,
                 raw_tool_result=blocked_message,
+                call_id=call_id,
+                is_error=True,
+                was_blocked=True,
             )
             modified_result = run_after_tool_call_hooks(blocked_hook_context)
             return ToolResult(
@@ -154,6 +163,10 @@ async def aexecute_tool_and_check_finality(
             crew=crew,
             tool_result=tool_result,
             raw_tool_result=raw_tool_result,
+            call_id=call_id,
+            is_error=(
+                tool_usage.last_call_failed or tool_usage.last_failure is not None
+            ),
         )
 
         modified_result = run_after_tool_call_hooks(after_hook_context)
@@ -175,7 +188,9 @@ async def aexecute_tool_and_check_finality(
             modified_result if modified_result is not None else tool_result,
             # A failed tool must not become the final answer -- the same
             # exclusion the native paths already apply to raised errors.
-            tool.result_as_answer and tool_usage.last_failure is None,
+            tool.result_as_answer
+            and tool_usage.last_failure is None
+            and not tool_usage.last_call_failed,
         )
 
     tool_result = I18N_DEFAULT.errors("wrong_tool_name").format(
@@ -273,7 +288,11 @@ def execute_tool_and_check_finality(
     sanitized_tool_name = sanitize_tool_name(tool_calling.tool_name)
     tool = tool_name_to_tool_map.get(sanitized_tool_name)
     if tool:
-        tool_input = tool_calling.arguments if tool_calling.arguments else {}
+        call_id = str(uuid4())
+        tool_input = (
+            tool_calling.arguments if tool_calling.arguments is not None else {}
+        )
+        tool_calling.arguments = tool_input
         hook_context = ToolCallHookContext(
             tool_name=sanitized_tool_name,
             tool_input=tool_input,
@@ -281,6 +300,7 @@ def execute_tool_and_check_finality(
             agent=agent,
             task=task,
             crew=crew,
+            call_id=call_id,
         )
 
         if run_before_tool_call_hooks(hook_context):
@@ -298,6 +318,9 @@ def execute_tool_and_check_finality(
                 crew=crew,
                 tool_result=blocked_message,
                 raw_tool_result=blocked_message,
+                call_id=call_id,
+                is_error=True,
+                was_blocked=True,
             )
             modified_result = run_after_tool_call_hooks(blocked_hook_context)
             return ToolResult(
@@ -317,6 +340,10 @@ def execute_tool_and_check_finality(
             crew=crew,
             tool_result=tool_result,
             raw_tool_result=raw_tool_result,
+            call_id=call_id,
+            is_error=(
+                tool_usage.last_call_failed or tool_usage.last_failure is not None
+            ),
         )
 
         modified_result = run_after_tool_call_hooks(after_hook_context)
@@ -338,7 +365,9 @@ def execute_tool_and_check_finality(
             modified_result if modified_result is not None else tool_result,
             # A failed tool must not become the final answer -- the same
             # exclusion the native paths already apply to raised errors.
-            tool.result_as_answer and tool_usage.last_failure is None,
+            tool.result_as_answer
+            and tool_usage.last_failure is None
+            and not tool_usage.last_call_failed,
         )
 
     tool_result = I18N_DEFAULT.errors("wrong_tool_name").format(

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -21,7 +21,11 @@ from crewai import Agent, Crew, Task
 from crewai.agents.parser import AgentFinish
 from crewai.events import crewai_event_bus
 from crewai.hooks import register_after_tool_call_hook, register_before_tool_call_hook
-from crewai.hooks.tool_hooks import ToolCallHookContext, clear_after_tool_call_hooks
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    clear_after_tool_call_hooks,
+    clear_before_tool_call_hooks,
+)
 from crewai.llm import LLM
 from crewai.tools.base_tool import BaseTool
 
@@ -1197,6 +1201,36 @@ class TestNativeToolCallingJsonParseError:
         )
 
         assert result["result"] == "ran: print(1)"
+
+    def test_empty_args_transform_reaches_execution(self) -> None:
+        class CodeTool(BaseTool):
+            name: str = "execute_code"
+            description: str = "Run code"
+
+            def _run(self, code: str) -> str:
+                return f"ran: {code}"
+
+        def supply_code(context: ToolCallHookContext) -> None:
+            context.tool_input["code"] = "safe"
+
+        tool = CodeTool()
+        executor = self._make_executor([tool])
+        from crewai.utilities.agent_utils import convert_tools_to_openai_schema
+
+        _, available_functions, _ = convert_tools_to_openai_schema([tool])
+        clear_before_tool_call_hooks()
+        register_before_tool_call_hook(supply_code)
+        try:
+            result = executor._execute_single_native_tool_call(
+                call_id="provider-call-1",
+                func_name="execute_code",
+                func_args={},
+                available_functions=available_functions,
+            )
+        finally:
+            clear_before_tool_call_hooks()
+
+        assert result["result"] == "ran: safe"
 
     def test_typed_output_is_json_agent_text(self) -> None:
         class SearchOutput(BaseModel):

--- a/lib/crewai/tests/agents/test_native_tool_calling.py
+++ b/lib/crewai/tests/agents/test_native_tool_calling.py
@@ -12,7 +12,7 @@ import os
 import threading
 import time
 from collections import Counter
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pydantic import BaseModel, Field
@@ -1147,6 +1147,41 @@ class TestNativeToolCallingJsonParseError:
         executor.task = mock_task
         return executor
 
+    @pytest.mark.parametrize("tool_is_registered", [False, True])
+    def test_unresolved_tool_sets_post_hook_error_status(
+        self, tool_is_registered: bool
+    ) -> None:
+        """Missing metadata or callable is an error in the post-hook record."""
+
+        class SearchTool(BaseTool):
+            name: str = "search"
+            description: str = "Search"
+
+            def _run(self) -> str:
+                return "result"
+
+        tools = [SearchTool()] if tool_is_registered else []
+        executor = self._make_executor(tools)
+        seen_errors: list[bool] = []
+
+        def capture(context: ToolCallHookContext) -> None:
+            seen_errors.append(context.is_error)
+
+        clear_after_tool_call_hooks()
+        register_after_tool_call_hook(capture)
+        try:
+            result = executor._execute_single_native_tool_call(
+                call_id="call-missing",
+                func_name="search" if tool_is_registered else "missing",
+                func_args={},
+                available_functions={},
+            )
+        finally:
+            clear_after_tool_call_hooks()
+
+        assert result["result"] == "Tool not found"
+        assert seen_errors == [True]
+
     def test_malformed_json_returns_parse_error(self) -> None:
         """Malformed JSON args must return a descriptive error, not silently become {}."""
 
@@ -1345,6 +1380,61 @@ class TestNativeToolCallingJsonParseError:
         react_loop.assert_called_once()
         assert "Native tool calling is unavailable" in executor.messages[-1]["content"]
         assert "Action Input" in executor.messages[-1]["content"]
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_governance_block_does_not_trigger_native_fallback(
+        self, use_async: bool
+    ) -> None:
+        """A terminal policy block cannot downgrade into text tool calling."""
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+
+        class SearchTool(BaseTool):
+            name: str = "search"
+            description: str = "Search for information"
+
+            def _run(self, query: str) -> str:
+                return f"result for {query}"
+
+        executor = self._make_executor([SearchTool()])
+        executor.llm = Mock()
+        executor.messages = [{"role": "user", "content": "Search for CrewAI"}]
+        executor.callbacks = []
+        executor.iterations = 0
+        executor.max_iter = 3
+        executor.request_within_rpm_limit = None
+        executor.respect_context_window = False
+        blocked = PostModelCallBlockedError(
+            "[blocked by agent-hooks: tool calling is not supported]",
+            reason="tool calling is not supported",
+            request_id="request-1",
+            failure_kind="policy_denial",
+        )
+
+        with (
+            patch(
+                "crewai.agents.crew_agent_executor.get_llm_response",
+                side_effect=blocked,
+            ),
+            patch(
+                "crewai.agents.crew_agent_executor.aget_llm_response",
+                new=AsyncMock(side_effect=blocked),
+            ),
+            patch.object(executor, "_invoke_loop_react") as react_loop,
+            patch.object(
+                executor,
+                "_ainvoke_loop_react",
+                new=AsyncMock(),
+            ) as async_react_loop,
+        ):
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await executor._ainvoke_loop_native_tools()
+                else:
+                    executor._invoke_loop_native_tools()
+
+        react_loop.assert_not_called()
+        async_react_loop.assert_not_awaited()
 
     def test_dict_args_bypass_json_parsing(self) -> None:
         """When func_args is already a dict, no JSON parsing occurs."""

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -9,6 +9,7 @@ unavailable.
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import TimeoutError as FutureTimeoutError
 import gc
 from importlib.resources import files
 import json
@@ -45,6 +46,7 @@ from crewai.hooks.dispatch import (
     clear_governor,
     dispatch,
     get_governor,
+    register,
 )
 from crewai.hooks.llm_hooks import (
     LLMCallHookContext,
@@ -418,7 +420,7 @@ class TestEmitterLoop:
             return "done"
 
         try:
-            with pytest.raises(TimeoutError):
+            with pytest.raises(FutureTimeoutError):
                 loop.run(hang(), 0.1)
             assert started.is_set()
             assert exited.wait(timeout=2.0), "timed-out emission did not unwind"
@@ -450,12 +452,12 @@ class TestEmitterLoop:
             return "done"
 
         try:
-            with pytest.raises(TimeoutError):
+            with pytest.raises(FutureTimeoutError):
                 loop.run(resist_cancellation(), 0.1)
             assert started.is_set()
             assert cancellation_seen.wait(timeout=2.0)
 
-            with pytest.raises(TimeoutError, match="admission"):
+            with pytest.raises(FutureTimeoutError, match="admission"):
                 loop.run(complete(), 0.1)
 
             loop._loop.call_soon_threadsafe(release_future[0].set_result, None)
@@ -1614,6 +1616,36 @@ class TestModelGovernance:
 
 @requires_ah
 class TestBoundaryGovernance:
+    def test_execution_end_abort_still_finalizes_governor(self) -> None:
+        """Native end-hook aborts cannot skip shutdown or retain sessions."""
+        from crewai.hooks.contexts import ExecutionEndContext
+
+        def abort_end(context: Any) -> None:
+            raise HookAborted(reason="native end denied")
+
+        register(InterceptionPoint.EXECUTION_END, abort_end)
+        engine = use_agent_hooks(_Allow())
+        crew = _crew()
+        try:
+            for _ in range(3):
+                dispatch(
+                    InterceptionPoint.EXECUTION_START,
+                    ExecutionStartContext(crew=crew, inputs={}, payload={}),
+                )
+                with pytest.raises(HookAborted, match="native end denied"):
+                    dispatch(
+                        InterceptionPoint.EXECUTION_END,
+                        ExecutionEndContext(crew=crew),
+                    )
+
+            points = [record.interception_point.value for record in engine.records]
+            assert points.count("agent_startup") == 3
+            assert points.count("agent_shutdown") == 3
+            assert engine._active_sessions == {}
+            assert engine._builders == {}
+        finally:
+            engine.close()
+
     def test_input_deny_raises(self):
         engine = use_agent_hooks(_DenyAt("input"))
         try:
@@ -1880,6 +1912,91 @@ class TestSessionScoping:
 
 @requires_ah
 class TestEngineLifecycle:
+    def test_host_failure_logs_exclude_exception_payloads(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Host failures log safe correlation only, never exception payloads."""
+        import logging
+
+        engine = use_agent_hooks(_Allow())
+        ctx = _tool_ctx(
+            crew=_crew("crew\nforged"),
+            call_id="call\nforged",
+        )
+        try:
+            def fail_run(
+                _loop: Any,
+                coro: Any,
+                *_args: Any,
+                **_kwargs: Any,
+            ) -> Any:
+                coro.close()
+                raise RuntimeError("SECRET_MODEL_OUTPUT\nforged")
+
+            monkeypatch.setattr(_EmitterLoop, "run", fail_run)
+            with caplog.at_level(
+                logging.ERROR,
+                logger="crewai.hooks.agent_hooks_engine",
+            ):
+                assert run_before_tool_call_hooks(ctx) is True
+
+            assert "SECRET_MODEL_OUTPUT" not in caplog.text
+            assert "crew\\nforged" in caplog.text
+            assert "call\\nforged" in caplog.text
+        finally:
+            engine.close()
+
+    def test_adapter_failure_logs_exclude_exception_payloads(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Adapter failures also avoid exception text and traceback payloads."""
+        import logging
+
+        engine = use_agent_hooks(_Allow())
+
+        def fail(context: Any) -> None:
+            raise RuntimeError("SECRET_TOOL_INPUT\nforged")
+
+        guarded = engine._wrap_fail_closed(InterceptionPoint.PRE_TOOL_CALL, fail)
+        try:
+            with caplog.at_level(
+                logging.ERROR,
+                logger="crewai.hooks.agent_hooks_engine",
+            ):
+                with pytest.raises(HookAborted):
+                    guarded(_tool_ctx(call_id="call\nforged"))
+
+            assert "SECRET_TOOL_INPUT" not in caplog.text
+            assert "call\\nforged" in caplog.text
+        finally:
+            engine.close()
+
+    def test_post_model_adapter_failure_survives_unmarkable_context(self) -> None:
+        """A provenance storage failure cannot escape the blocked-result path."""
+
+        class UnmarkableContext:
+            __slots__ = ("response",)
+            __hash__ = None
+
+            def __init__(self) -> None:
+                self.response = "model output"
+
+        engine = use_agent_hooks(_Allow())
+
+        def fail(context: Any) -> None:
+            raise RuntimeError("adapter failed")
+
+        guarded = engine._wrap_fail_closed(InterceptionPoint.POST_MODEL_CALL, fail)
+        try:
+            assert guarded(UnmarkableContext()) == (
+                "[blocked by agent-hooks: host_error:engine_failed]"
+            )
+        finally:
+            engine.close()
+
     def test_use_agent_hooks_installs_governor(self):
         engine = use_agent_hooks(_Allow())
         try:

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -9,6 +9,7 @@ unavailable.
 from __future__ import annotations
 
 import asyncio
+import gc
 from importlib.resources import files
 import json
 import threading
@@ -16,11 +17,14 @@ import types
 from typing import Any
 
 from crewai.hooks.agent_hooks_engine import (
+    DEFAULT_MAX_RECORDS,
     HAS_AGENT_HOOKS,
     _EmitterLoop,
     _agent_ids,
     _blocked_result,
+    _correlation_ids,
     _json_safe,
+    _log_identifier,
     _model_id,
     _registered_tools,
     _session_id,
@@ -167,6 +171,20 @@ class _TransformAt:
         return Verdict(decision=Decision.ALLOW)
 
 
+class _DenyToolNameAtPostModel:
+    def __init__(self, tool_name: str) -> None:
+        self.tool_name = tool_name
+
+    def intercept(self, ctx: Any) -> Any:
+        from agent_hooks import Decision, Verdict
+
+        if ctx["interception_point"] == "post_model_call":
+            tool_calls = ctx["response"]["tool_calls"]
+            if any(call.get("name") == self.tool_name for call in tool_calls):
+                return Verdict(decision=Decision.DENY, reason="tool denied")
+        return Verdict(decision=Decision.ALLOW)
+
+
 def _plain(ctx: Any) -> dict[str, Any]:
     """Render an agent-hooks ``AgentContext`` as a plain nested ``dict``."""
     return json.loads(json.dumps(dict(ctx), default=str))
@@ -263,6 +281,21 @@ class TestHelpers:
         assert _transformed_payload({"x": 1}) == {"x": 1}
         assert _transformed_payload("z") == "z"
 
+    def test_correlation_ids_are_payload_free_and_log_safe(self) -> None:
+        ctx = {
+            "session": {"id": "session\nforged"},
+            "request_id": "request-1",
+            "tool_call": {"id": "call-1", "args": {"secret": "ignored"}},
+        }
+
+        assert _correlation_ids(ctx) == (
+            "session\\nforged",
+            "request-1",
+            "call-1",
+        )
+        assert _log_identifier("x" * 200) == "x" * 128
+        assert _log_identifier({"secret": "ignored"}) is None
+
     def test_registered_tools(self):
         crew = _crew(tools=[_tool("a"), _tool("b")])
         assert _registered_tools(crew) == ["a", "b"]
@@ -281,6 +314,70 @@ class TestHelpers:
 
 
 class TestEmitterLoop:
+    def test_admission_waiter_budget_is_bounded(self) -> None:
+        """Excess submissions fail closed instead of joining an unbounded queue."""
+        loop = _EmitterLoop(max_waiters=1)
+
+        async def complete() -> str:
+            return "done"
+
+        assert loop._waiter_slots.acquire(blocking=False)
+        try:
+            with pytest.raises(RuntimeError, match="admission queue is full"):
+                loop.run(complete(), None)
+        finally:
+            loop._waiter_slots.release()
+            loop.close()
+
+    def test_close_wakes_submission_waiting_for_admission(self) -> None:
+        """A caller cannot remain blocked on admission after shutdown."""
+
+        class BlockingAdmission:
+            def __init__(self) -> None:
+                self.waiting = threading.Event()
+                self.allowed = threading.Event()
+
+            def acquire(
+                self,
+                blocking: bool = True,
+                timeout: float | None = None,
+            ) -> bool:
+                self.waiting.set()
+                if not blocking:
+                    return self.allowed.is_set()
+                return self.allowed.wait(timeout)
+
+            def release(self) -> None:
+                self.allowed.set()
+
+        loop = _EmitterLoop()
+        admission = BlockingAdmission()
+        loop._admission = admission
+        runner_done = threading.Event()
+
+        async def complete() -> str:
+            return "done"
+
+        def run() -> None:
+            try:
+                loop.run(complete(), None)
+            except BaseException:
+                pass
+            finally:
+                runner_done.set()
+
+        runner = threading.Thread(target=run)
+        try:
+            runner.start()
+            assert admission.waiting.wait(timeout=2.0)
+            loop.close()
+            assert runner_done.wait(timeout=2.0)
+        finally:
+            admission.allowed.set()
+            runner.join(timeout=2.0)
+            if loop._thread.is_alive():
+                loop.close()
+
     def test_close_releases_pending_emission(self):
         """``close()`` unblocks a thread waiting on a never-resolving emission."""
         loop = _EmitterLoop()
@@ -304,12 +401,224 @@ class TestEmitterLoop:
         t.join(timeout=2.0)
         assert not t.is_alive()
 
+    def test_timeout_cancels_and_releases_admission(self) -> None:
+        """A timed-out cancellable emission exits before another is admitted."""
+        loop = _EmitterLoop()
+        started = threading.Event()
+        exited = threading.Event()
+
+        async def hang() -> None:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                exited.set()
+
+        async def complete() -> str:
+            return "done"
+
+        try:
+            with pytest.raises(TimeoutError):
+                loop.run(hang(), 0.1)
+            assert started.is_set()
+            assert exited.wait(timeout=2.0), "timed-out emission did not unwind"
+            assert loop.run(complete(), 1.0) == "done"
+        finally:
+            loop.close()
+
+    def test_cancellation_resistant_timeout_keeps_admission_bounded(self) -> None:
+        """Timed-out work retains the sole slot until it actually exits."""
+        loop = _EmitterLoop()
+        started = threading.Event()
+        cancellation_seen = threading.Event()
+        exited = threading.Event()
+        release_future: list[asyncio.Future[None]] = []
+
+        async def resist_cancellation() -> None:
+            release = asyncio.get_running_loop().create_future()
+            release_future.append(release)
+            started.set()
+            try:
+                await asyncio.shield(release)
+            except asyncio.CancelledError:
+                cancellation_seen.set()
+                await release
+            finally:
+                exited.set()
+
+        async def complete() -> str:
+            return "done"
+
+        try:
+            with pytest.raises(TimeoutError):
+                loop.run(resist_cancellation(), 0.1)
+            assert started.is_set()
+            assert cancellation_seen.wait(timeout=2.0)
+
+            with pytest.raises(TimeoutError, match="admission"):
+                loop.run(complete(), 0.1)
+
+            loop._loop.call_soon_threadsafe(release_future[0].set_result, None)
+            assert exited.wait(timeout=2.0), "resistant emission never exited"
+            assert loop.run(complete(), 1.0) == "done"
+        finally:
+            loop.close()
+
+    def test_close_cannot_race_past_submission(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Close waits for atomic submission and leaves no blocked caller."""
+        original_submit = asyncio.run_coroutine_threadsafe
+        submitting = threading.Event()
+        release_submission = threading.Event()
+        first_submission = True
+
+        def submit(coro: Any, loop: asyncio.AbstractEventLoop) -> Any:
+            nonlocal first_submission
+            if first_submission:
+                first_submission = False
+                submitting.set()
+                assert release_submission.wait(timeout=2.0)
+            return original_submit(coro, loop)
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", submit)
+        loop = _EmitterLoop()
+        runner_done = threading.Event()
+        close_done = threading.Event()
+        close_errors: list[BaseException] = []
+
+        async def complete() -> str:
+            return "done"
+
+        def run() -> None:
+            try:
+                loop.run(complete(), None)
+            except BaseException:
+                pass
+            finally:
+                runner_done.set()
+
+        def close() -> None:
+            try:
+                loop.close(timeout=2.0)
+            except BaseException as error:
+                close_errors.append(error)
+            finally:
+                close_done.set()
+
+        runner = threading.Thread(target=run)
+        closer = threading.Thread(target=close)
+        runner.start()
+        assert submitting.wait(timeout=2.0)
+        closer.start()
+        release_submission.set()
+
+        assert runner_done.wait(timeout=2.0)
+        assert close_done.wait(timeout=2.0)
+        runner.join()
+        closer.join()
+        assert close_errors == []
+
+    def test_failed_close_is_observable_and_retryable(self) -> None:
+        """Cancellation-resistant work prevents false successful shutdown."""
+        loop = _EmitterLoop()
+        started = threading.Event()
+        cancelled = threading.Event()
+        exited = threading.Event()
+        release_event: list[asyncio.Event] = []
+
+        async def resist_cancellation() -> None:
+            release = asyncio.Event()
+            release_event.append(release)
+            started.set()
+            try:
+                while not release.is_set():
+                    try:
+                        await release.wait()
+                    except asyncio.CancelledError:
+                        cancelled.set()
+            finally:
+                exited.set()
+
+        def run() -> None:
+            try:
+                loop.run(resist_cancellation(), None)
+            except BaseException:
+                pass
+
+        runner = threading.Thread(target=run)
+        runner.start()
+        assert started.wait(timeout=2.0)
+
+        with pytest.raises(RuntimeError, match="did not drain"):
+            loop.close(timeout=0.1)
+        assert cancelled.is_set()
+
+        loop._loop.call_soon_threadsafe(release_event[0].set)
+        assert exited.wait(timeout=2.0)
+        loop.close(timeout=2.0)
+        runner.join(timeout=2.0)
+        assert not runner.is_alive()
+
 
 # --- tool-call governance (through the real seam) ---------------------------
 
 
 @requires_ah
 class TestToolGovernance:
+    def test_direct_tool_post_hook_is_attempted_once_on_abort(self) -> None:
+        """A post-hook abort cannot trigger a duplicate post dispatch."""
+        from crewai.hooks import register_after_tool_call_hook
+        from crewai.llm import LLM
+
+        calls = 0
+
+        def abort_post(context: ToolCallHookContext) -> None:
+            nonlocal calls
+            calls += 1
+            raise HookAborted(reason="stop")
+
+        tool_call = types.SimpleNamespace(
+            id="call-1",
+            function=types.SimpleNamespace(name="tool", arguments="{}"),
+        )
+        register_after_tool_call_hook(abort_post)
+
+        with pytest.raises(HookAborted):
+            LLM._handle_tool_call(
+                types.SimpleNamespace(),
+                [tool_call],
+                {"tool": lambda: "result"},
+            )
+
+        assert calls == 1
+
+    def test_invalid_direct_llm_tool_args_do_not_emit_orphan_post(self) -> None:
+        """A parse failure before the pre hook cannot produce a post record."""
+        from crewai.llm import LLM
+
+        tool_call = types.SimpleNamespace(
+            id="call-1",
+            function=types.SimpleNamespace(
+                name="dangerous_tool",
+                arguments="{invalid-json",
+            ),
+        )
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            result = LLM._handle_tool_call(
+                types.SimpleNamespace(),
+                [tool_call],
+                {"dangerous_tool": lambda: "executed"},
+            )
+
+            assert result is None
+            assert cap.at("pre_tool_call") == []
+            assert cap.at("post_tool_call") == []
+        finally:
+            engine.close()
+
     def test_litellm_tool_execution_is_governed(self):
         """A LiteLLM tool request cannot bypass a pre-tool deny."""
         from crewai.llm import LLM
@@ -382,6 +691,39 @@ class TestToolGovernance:
             assert invoked is False
         finally:
             engine.close()
+
+    def test_base_llm_post_hook_is_attempted_once_on_abort(self) -> None:
+        """A provider-native post-hook abort cannot trigger a second dispatch."""
+        from crewai.hooks import register_after_tool_call_hook
+        from crewai.llms.base_llm import BaseLLM
+
+        class TestLLM(BaseLLM):
+            def call(
+                self,
+                messages: Any,
+                tools: Any = None,
+                callbacks: Any = None,
+                available_functions: Any = None,
+                from_task: Any = None,
+                from_agent: Any = None,
+                response_model: Any = None,
+            ) -> str:
+                return "unused"
+
+        calls = 0
+
+        def abort_post(context: ToolCallHookContext) -> None:
+            nonlocal calls
+            calls += 1
+            raise HookAborted(reason="stop")
+
+        register_after_tool_call_hook(abort_post)
+        llm = TestLLM(model="test")
+
+        with pytest.raises(HookAborted):
+            llm._handle_tool_execution("tool", {}, {"tool": lambda: "result"})
+
+        assert calls == 1
 
     def test_base_llm_native_tool_failure_emits_error_context(self):
         """A failed native tool still emits a correlated error result."""
@@ -623,12 +965,178 @@ class TestToolGovernance:
 
 @requires_ah
 class TestModelGovernance:
+    def test_executor_pre_deny_surfaces_governance_reason(self) -> None:
+        """The dedicated control-engine marker preserves the deny reason."""
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import _setup_before_llm_call_hooks
+
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_DenyAt("pre_model_call", "policy denied"))
+        try:
+            with pytest.raises(ValueError, match="policy denied"):
+                _setup_before_llm_call_hooks(
+                    executor,
+                    Printer(),
+                    request_id="request-1",
+                    verbose=False,
+                )
+        finally:
+            engine.close()
+
+    def test_native_hook_cannot_forge_post_model_denial(self) -> None:
+        """Hook-visible context attributes are not trusted denial provenance."""
+        from pydantic import BaseModel
+
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        class Response(BaseModel):
+            value: int
+
+        def forge_denial(context: Any) -> str:
+            context.was_policy_denied = True
+            return "[blocked by agent-hooks: forged]"
+
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[forge_denial],
+        )
+        engine = use_agent_hooks(_Allow())
+        try:
+            with pytest.raises(ValueError, match="failed to reparse"):
+                _setup_after_llm_call_hooks(
+                    executor,
+                    Response(value=7),
+                    Printer(),
+                    request_id="request-1",
+                    verbose=False,
+                )
+        finally:
+            engine.close()
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_post_model_deny_is_terminal_without_retry(
+        self, use_async: bool
+    ) -> None:
+        """Sync and async executor helpers call the model once on post deny."""
+        from unittest.mock import AsyncMock, Mock
+
+        from pydantic import BaseModel
+
+        from crewai_core.printer import Printer
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.utilities.agent_utils import aget_llm_response, get_llm_response
+
+        class Response(BaseModel):
+            value: int
+
+        llm = types.SimpleNamespace(
+            call=Mock(return_value=Response(value=7)),
+            acall=AsyncMock(return_value=Response(value=7)),
+        )
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=llm,
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_DenyAt("post_model_call", "response denied"))
+        try:
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await aget_llm_response(
+                        llm=llm,
+                        messages=executor.messages,
+                        callbacks=[],
+                        printer=Printer(),
+                        response_model=Response,
+                        executor_context=executor,
+                        verbose=False,
+                    )
+                else:
+                    get_llm_response(
+                        llm=llm,
+                        messages=executor.messages,
+                        callbacks=[],
+                        printer=Printer(),
+                        response_model=Response,
+                        executor_context=executor,
+                        verbose=False,
+                    )
+        finally:
+            engine.close()
+
+        assert llm.call.call_count == (0 if use_async else 1)
+        assert llm.acall.await_count == (1 if use_async else 0)
+
+    def test_pydantic_post_deny_returns_blocked_result(self) -> None:
+        """A post-model deny is terminal and never enters model parsing."""
+        from pydantic import BaseModel
+
+        from crewai_core.printer import Printer
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        class Response(BaseModel):
+            value: int
+
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_DenyAt("post_model_call", "response denied"))
+        try:
+            with pytest.raises(PostModelCallBlockedError) as exc:
+                _setup_after_llm_call_hooks(
+                    executor,
+                    Response(value=7),
+                    Printer(),
+                    request_id="request-1",
+                    verbose=False,
+                )
+            assert exc.value.blocked_response == (
+                "[blocked by agent-hooks: response denied]"
+            )
+        finally:
+            engine.close()
+
     def test_invalid_pydantic_transform_fails_closed(self):
         """An invalid transformed model response never restores the original."""
         from pydantic import BaseModel
 
         from crewai_core.printer import Printer
 
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
         from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
 
         class Response(BaseModel):
@@ -646,7 +1154,7 @@ class TestModelGovernance:
         )
         engine = use_agent_hooks(_TransformAt("post_model_call", "not-json"))
         try:
-            with pytest.raises(ValueError, match="failed to reparse"):
+            with pytest.raises(PostModelCallBlockedError) as exc:
                 _setup_after_llm_call_hooks(
                     executor,
                     Response(value=7),
@@ -654,6 +1162,9 @@ class TestModelGovernance:
                     request_id="request-1",
                     verbose=False,
                 )
+            assert exc.value.failure_kind == "host_error"
+            assert exc.value.request_id == "request-1"
+            assert exc.value.reason.startswith("host_error:")
         finally:
             engine.close()
 
@@ -748,6 +1259,203 @@ class TestModelGovernance:
             assert pre["request_id"]
         finally:
             engine.close()
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "model response",
+            {"content": "model response", "tool_calls": [], "finish_reason": "stop"},
+            [
+                types.SimpleNamespace(
+                    id="call-1",
+                    function=types.SimpleNamespace(name="shell", arguments="{}"),
+                )
+            ],
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_direct_post_model_deny_is_terminal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        use_async: bool,
+        response: Any,
+    ) -> None:
+        """Direct responses cannot turn a governed block into ordinary output."""
+        from unittest.mock import AsyncMock, Mock
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.llm import LLM
+
+        sync_response = Mock(return_value=response)
+        async_response = AsyncMock(return_value=response)
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        monkeypatch.setattr(llm, "_handle_non_streaming_response", sync_response)
+        monkeypatch.setattr(llm, "_ahandle_non_streaming_response", async_response)
+        engine = use_agent_hooks(
+            _DenyAt("post_model_call", "input is too long for policy")
+        )
+        try:
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await llm.acall("hello")
+                else:
+                    llm.call("hello")
+        finally:
+            engine.close()
+
+        assert sync_response.call_count == (0 if use_async else 1)
+        assert async_response.await_count == (1 if use_async else 0)
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_executor_dictionary_post_model_deny_is_terminal(
+        self, use_async: bool
+    ) -> None:
+        """Executor dictionary responses cannot bypass post-model governance."""
+        from unittest.mock import AsyncMock, Mock
+
+        from crewai_core.printer import Printer
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.utilities.agent_utils import aget_llm_response, get_llm_response
+
+        response = {
+            "content": "model response",
+            "tool_calls": [],
+            "finish_reason": "stop",
+        }
+        llm = types.SimpleNamespace(
+            call=Mock(return_value=response),
+            acall=AsyncMock(return_value=response),
+        )
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=llm,
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_DenyAt("post_model_call", "response denied"))
+        try:
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await aget_llm_response(
+                        llm=llm,
+                        messages=executor.messages,
+                        callbacks=[],
+                        printer=Printer(),
+                        executor_context=executor,
+                        verbose=False,
+                    )
+                else:
+                    get_llm_response(
+                        llm=llm,
+                        messages=executor.messages,
+                        callbacks=[],
+                        printer=Printer(),
+                        executor_context=executor,
+                        verbose=False,
+                    )
+        finally:
+            engine.close()
+
+        assert llm.call.call_count == (0 if use_async else 1)
+        assert llm.acall.await_count == (1 if use_async else 0)
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_direct_tool_call_metadata_can_drive_post_model_deny(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        use_async: bool,
+    ) -> None:
+        """Direct tool-call lists expose canonical names to model policy."""
+        from unittest.mock import AsyncMock, Mock
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.llm import LLM
+
+        response = [
+            types.SimpleNamespace(
+                id="call-1",
+                function=types.SimpleNamespace(
+                    name="shell",
+                    arguments='{"cmd": "echo safe"}',
+                ),
+            )
+        ]
+        sync_response = Mock(return_value=response)
+        async_response = AsyncMock(return_value=response)
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        monkeypatch.setattr(llm, "_handle_non_streaming_response", sync_response)
+        monkeypatch.setattr(llm, "_ahandle_non_streaming_response", async_response)
+        engine = use_agent_hooks(_DenyToolNameAtPostModel("shell"))
+        try:
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await llm.acall("hello")
+                else:
+                    llm.call("hello")
+        finally:
+            engine.close()
+
+        assert sync_response.call_count == (0 if use_async else 1)
+        assert async_response.await_count == (1 if use_async else 0)
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_direct_post_model_deny_does_not_retry_unsupported_stop(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        use_async: bool,
+    ) -> None:
+        """A policy reason cannot enter LiteLLM's unsupported-stop retry."""
+        from unittest.mock import AsyncMock, Mock
+
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.llm import LLM
+
+        sync_response = Mock(
+            side_effect=["model response", AssertionError("model retried")]
+        )
+        async_response = AsyncMock(
+            side_effect=["model response", AssertionError("model retried")]
+        )
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        monkeypatch.setattr(llm, "_handle_non_streaming_response", sync_response)
+        monkeypatch.setattr(llm, "_ahandle_non_streaming_response", async_response)
+        engine = use_agent_hooks(
+            _DenyAt("post_model_call", "Unsupported parameter 'stop'")
+        )
+        try:
+            with pytest.raises(PostModelCallBlockedError):
+                if use_async:
+                    await llm.acall("hello")
+                else:
+                    llm.call("hello")
+        finally:
+            engine.close()
+
+        assert sync_response.call_count == (0 if use_async else 1)
+        assert async_response.await_count == (1 if use_async else 0)
+
+    def test_post_model_block_is_not_a_context_length_error(self) -> None:
+        """Policy text cannot route a terminal block into summarization/retry."""
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
+        from crewai.utilities.agent_utils import is_context_length_exceeded
+
+        error = PostModelCallBlockedError(
+            "[blocked by agent-hooks: input is too long]",
+            reason="input is too long",
+            request_id="request-1",
+            failure_kind="policy_denial",
+        )
+
+        assert is_context_length_exceeded(error) is False
 
     def test_pre_deny_raises(self):
         engine = use_agent_hooks(_DenyAt("pre_model_call"))
@@ -867,6 +1575,7 @@ class TestModelGovernance:
     def test_executor_structured_tool_call_deny_prevents_execution(self):
         from crewai_core.printer import Printer
 
+        from crewai.hooks.llm_hooks import PostModelCallBlockedError
         from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
 
         requested = types.SimpleNamespace(
@@ -885,14 +1594,17 @@ class TestModelGovernance:
         )
         engine = use_agent_hooks(_DenyAt("post_model_call", "tool denied"))
         try:
-            result = _setup_after_llm_call_hooks(
-                executor,
-                [requested],
-                Printer(),
-                request_id="request-1",
-                verbose=False,
+            with pytest.raises(PostModelCallBlockedError) as exc:
+                _setup_after_llm_call_hooks(
+                    executor,
+                    [requested],
+                    Printer(),
+                    request_id="request-1",
+                    verbose=False,
+                )
+            assert exc.value.blocked_response == (
+                "[blocked by agent-hooks: tool denied]"
             )
-            assert result == "[blocked by agent-hooks: tool denied]"
         finally:
             engine.close()
 
@@ -1034,6 +1746,90 @@ class TestBoundaryGovernance:
 
 @requires_ah
 class TestSessionScoping:
+    def test_concurrent_runs_of_one_owner_keep_distinct_sessions(self) -> None:
+        """Each execution context resolves the session it started."""
+
+        class Owner:
+            id = "shared-owner"
+
+        owner = Owner()
+        engine = use_agent_hooks(_Allow())
+        sessions_started = threading.Barrier(2)
+        sessions_observed = threading.Barrier(2)
+        observed: dict[str, tuple[str, str]] = {}
+
+        def run(label: str) -> None:
+            session_id = engine._begin_session(crew=owner)
+            sessions_started.wait()
+            observed[label] = (
+                session_id,
+                engine._current_session_id(crew=owner),
+            )
+            sessions_observed.wait()
+            engine._finish_session(crew=owner)
+
+        first = threading.Thread(target=run, args=("first",))
+        second = threading.Thread(target=run, args=("second",))
+        try:
+            first.start()
+            second.start()
+            first.join(timeout=2.0)
+            second.join(timeout=2.0)
+
+            assert not first.is_alive()
+            assert not second.is_alive()
+            assert observed["first"][0] == observed["first"][1]
+            assert observed["second"][0] == observed["second"][1]
+            assert observed["first"][0] != observed["second"][0]
+        finally:
+            engine.close()
+
+    def test_recycled_owner_address_does_not_reuse_stale_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A new owner cannot inherit a missing-end session at a reused address."""
+        from crewai.hooks import agent_hooks_engine
+
+        engine = use_agent_hooks(_Allow())
+        stale_owner = _crew("stale-owner")
+        current_owner = _crew("current-owner")
+        recycled_address = 42
+        monkeypatch.setattr(
+            agent_hooks_engine,
+            "id",
+            lambda _owner: recycled_address,
+            raising=False,
+        )
+        try:
+            stale_session_id = engine._begin_session(crew=stale_owner)
+            engine._builders[stale_session_id] = object()
+
+            assert engine._current_session_id(crew=current_owner) == "current-owner"
+            assert stale_session_id not in engine._builders
+        finally:
+            engine.close()
+
+    def test_collected_owner_discards_missing_end_session(self) -> None:
+        """Owner collection cleans session state when execution end is missing."""
+
+        class Owner:
+            id = "abandoned-owner"
+
+        engine = use_agent_hooks(_Allow())
+        owner = Owner()
+        owner_id = id(owner)
+        try:
+            session_id = engine._begin_session(crew=owner)
+            engine._builders[session_id] = object()
+
+            del owner
+            gc.collect()
+
+            assert owner_id not in engine._active_sessions
+            assert session_id not in engine._builders
+        finally:
+            engine.close()
+
     def test_builder_preserves_per_agent_identity(self):
         """Different agents in one crew keep their own id in the record.
 
@@ -1098,6 +1894,18 @@ class TestEngineLifecycle:
             assert len(engine.records) == 1
             assert len(engine.take_records()) == 1
             assert engine.records == []
+        finally:
+            engine.close()
+
+    def test_record_buffer_evicts_oldest_and_counts_drops(self) -> None:
+        engine = use_agent_hooks(_Allow(), max_records=2)
+        try:
+            for call_id in ("call-1", "call-2", "call-3"):
+                run_before_tool_call_hooks(_tool_ctx(call_id=call_id))
+
+            assert len(engine.records) == 2
+            assert engine.records_dropped == 1
+            assert DEFAULT_MAX_RECORDS > 2
         finally:
             engine.close()
 

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -1646,6 +1646,36 @@ class TestBoundaryGovernance:
         finally:
             engine.close()
 
+    def test_execution_end_finalizes_session_when_builder_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A builder failure in the end hook must still finish the session."""
+        from crewai.hooks.contexts import ExecutionEndContext
+
+        engine = use_agent_hooks(_Allow())
+        crew = _crew()
+        try:
+            dispatch(
+                InterceptionPoint.EXECUTION_START,
+                ExecutionStartContext(crew=crew, inputs={}, payload={}),
+            )
+            assert engine._active_sessions and engine._builders
+
+            def boom(**_kwargs: Any) -> Any:
+                raise RuntimeError("builder construction failed")
+
+            monkeypatch.setattr(engine, "_builder", boom)
+            with pytest.raises(HookAborted):
+                dispatch(
+                    InterceptionPoint.EXECUTION_END,
+                    ExecutionEndContext(crew=crew),
+                )
+
+            assert engine._active_sessions == {}
+            assert engine._builders == {}
+        finally:
+            engine.close()
+
     def test_input_deny_raises(self):
         engine = use_agent_hooks(_DenyAt("input"))
         try:
@@ -2022,6 +2052,9 @@ class TestEngineLifecycle:
 
             assert len(engine.records) == 2
             assert engine.records_dropped == 1
+            # Oldest-first eviction: the first emission (sequence 0) is dropped,
+            # leaving the later two in ascending sequence order.
+            assert [record.sequence for record in engine.records] == [1, 2]
             assert DEFAULT_MAX_RECORDS > 2
         finally:
             engine.close()

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -9,6 +9,7 @@ unavailable.
 from __future__ import annotations
 
 import asyncio
+from importlib.resources import files
 import json
 import threading
 import types
@@ -25,6 +26,7 @@ from crewai.hooks.agent_hooks_engine import (
     _session_id,
     _to_text,
     _transformed_payload,
+    active_engine,
     disable_agent_hooks,
     use_agent_hooks,
 )
@@ -50,6 +52,7 @@ from crewai.hooks.tool_hooks import (
     run_after_tool_call_hooks,
     run_before_tool_call_hooks,
 )
+import jsonschema
 import pytest
 
 
@@ -97,6 +100,8 @@ def _tool_ctx(
     tool_result: str | None = None,
     agent: Any = None,
     crew: Any = None,
+    call_id: str | None = None,
+    was_blocked: bool = False,
 ) -> ToolCallHookContext:
     return ToolCallHookContext(
         tool_name=name,
@@ -105,6 +110,8 @@ def _tool_ctx(
         agent=agent if agent is not None else _agent(),
         crew=crew if crew is not None else _crew(),
         tool_result=tool_result,
+        call_id=call_id,
+        was_blocked=was_blocked,
     )
 
 
@@ -139,7 +146,7 @@ class _DenyAt:
         from agent_hooks import Decision, Verdict
 
         if ctx["interception_point"] == self.point:
-            return Verdict.deny(reason=self.reason)
+            return Verdict(decision=Decision.DENY, reason=self.reason)
         return Verdict(decision=Decision.ALLOW)
 
 
@@ -260,6 +267,15 @@ class TestHelpers:
         crew = _crew(tools=[_tool("a"), _tool("b")])
         assert _registered_tools(crew) == ["a", "b"]
 
+    def test_registered_tools_include_all_crew_agents(self):
+        crew = types.SimpleNamespace(
+            agents=[
+                types.SimpleNamespace(tools=[_tool("search"), _tool("shared")]),
+                types.SimpleNamespace(tools=[_tool("shell"), _tool("shared")]),
+            ]
+        )
+        assert _registered_tools(crew) == ["search", "shared", "shell"]
+
 
 # --- emitter loop internals -------------------------------------------------
 
@@ -294,6 +310,114 @@ class TestEmitterLoop:
 
 @requires_ah
 class TestToolGovernance:
+    def test_litellm_tool_execution_is_governed(self):
+        """A LiteLLM tool request cannot bypass a pre-tool deny."""
+        from crewai.llm import LLM
+
+        invoked = False
+
+        def dangerous_tool() -> str:
+            nonlocal invoked
+            invoked = True
+            return "executed"
+
+        tool_call = types.SimpleNamespace(
+            id="call-1",
+            function=types.SimpleNamespace(name="dangerous_tool", arguments="{}"),
+        )
+        engine = use_agent_hooks(_DenyAt("pre_tool_call", "blocked"))
+        try:
+            llm = LLM(model="gpt-4o-mini", is_litellm=True)
+            llm._handle_tool_call(
+                [tool_call], {"dangerous_tool": dangerous_tool}
+            )
+            assert invoked is False
+        finally:
+            engine.close()
+
+    def test_base_llm_native_tool_execution_is_governed(self):
+        """A provider-native tool cannot bypass a pre-tool deny."""
+        from crewai.llms.base_llm import BaseLLM
+
+        class TestLLM(BaseLLM):
+            def call(
+                self,
+                messages: Any,
+                tools: Any = None,
+                callbacks: Any = None,
+                available_functions: Any = None,
+                from_task: Any = None,
+                from_agent: Any = None,
+                response_model: Any = None,
+            ) -> str:
+                return "unused"
+
+            def execute_native_tool(
+                self,
+                function_name: str,
+                function_args: dict[str, Any],
+                available_functions: dict[str, Any],
+            ) -> str | None:
+                return self._handle_tool_execution(
+                    function_name=function_name,
+                    function_args=function_args,
+                    available_functions=available_functions,
+                )
+
+        invoked = False
+
+        def dangerous_tool() -> str:
+            nonlocal invoked
+            invoked = True
+            return "executed"
+
+        engine = use_agent_hooks(_DenyAt("pre_tool_call", "blocked"))
+        try:
+            llm = TestLLM(model="test")
+            llm.execute_native_tool(
+                function_name="dangerous_tool",
+                function_args={},
+                available_functions={"dangerous_tool": dangerous_tool},
+            )
+            assert invoked is False
+        finally:
+            engine.close()
+
+    def test_base_llm_native_tool_failure_emits_error_context(self):
+        """A failed native tool still emits a correlated error result."""
+        from crewai.llms.base_llm import BaseLLM
+
+        class TestLLM(BaseLLM):
+            def call(
+                self,
+                messages: Any,
+                tools: Any = None,
+                callbacks: Any = None,
+                available_functions: Any = None,
+                from_task: Any = None,
+                from_agent: Any = None,
+                response_model: Any = None,
+            ) -> str:
+                return "unused"
+
+            def execute_native_tool(self, function: Any) -> str | None:
+                return self._handle_tool_execution(
+                    "dangerous_tool", {}, {"dangerous_tool": function}
+                )
+
+        def failing_tool() -> str:
+            raise RuntimeError("failed")
+
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            assert TestLLM(model="test").execute_native_tool(failing_tool) is None
+            post = cap.at("post_tool_call")[0]
+            assert post["tool_result"]["is_error"] is True
+            assert post["tool_call"]["id"]
+        finally:
+            engine.close()
+
     def test_allow_proceeds_unchanged(self):
         engine = use_agent_hooks(_Allow())
         try:
@@ -321,6 +445,49 @@ class TestToolGovernance:
         finally:
             engine.close()
 
+    def test_invalid_tool_transform_shape_blocks_call(self):
+        engine = use_agent_hooks(_TransformAt("pre_tool_call", "invalid"))
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is True
+        finally:
+            engine.close()
+
+    def test_approved_escalation_preserves_prior_transform(self):
+        """An approval must not discard a transform already enforced by the SDK."""
+        from agent_hooks import (
+            ApprovalOutcome,
+            ApprovalResolution,
+            CompositionConfig,
+            Decision,
+            OnApproval,
+            Verdict,
+        )
+
+        class Escalate:
+            def intercept(self, ctx: Any) -> Any:
+                return Verdict.escalate(reason="review transformed call")
+
+        class Approver:
+            def resolve(self, request: Any) -> Any:
+                return ApprovalResolution(
+                    outcome=ApprovalOutcome.APPROVE,
+                    context_identity=request.context_identity,
+                    verdict=Verdict(decision=Decision.ALLOW),
+                )
+
+        engine = use_agent_hooks(
+            _TransformAt("pre_tool_call", {"url": "https://safe"}),
+            Escalate(),
+            resolver=Approver(),
+            composition=CompositionConfig.first_deny(OnApproval.STOP),
+        )
+        try:
+            ctx = _tool_ctx(tool_input={"url": "http://evil"})
+            assert run_before_tool_call_hooks(ctx) is False
+            assert ctx.tool_input == {"url": "https://safe"}
+        finally:
+            engine.close()
+
     def test_post_transform_rewrites_result(self):
         engine = use_agent_hooks(_TransformAt("post_tool_call", "REDACTED"))
         try:
@@ -334,6 +501,24 @@ class TestToolGovernance:
         try:
             ctx = _tool_ctx(tool_result="secret data")
             assert run_after_tool_call_hooks(ctx) == "[blocked by agent-hooks: bad]"
+        finally:
+            engine.close()
+
+    def test_pre_block_does_not_emit_post_tool_record(self):
+        """A blocked pre-tool action has no corresponding agent-hooks post."""
+        engine = use_agent_hooks(_DenyAt("pre_tool_call", "blocked"))
+        try:
+            call_id = "call-1"
+            assert run_before_tool_call_hooks(_tool_ctx(call_id=call_id)) is True
+            run_after_tool_call_hooks(
+                _tool_ctx(
+                    call_id=call_id,
+                    tool_result="blocked",
+                    was_blocked=True,
+                )
+            )
+            points = [record.interception_point.value for record in engine.records]
+            assert points == ["pre_tool_call"]
         finally:
             engine.close()
 
@@ -377,7 +562,12 @@ class TestToolGovernance:
         agent = _agent("agent-A")
         try:
             run_before_tool_call_hooks(
-                _tool_ctx(tool_input={"q": "x"}, agent=agent, crew=crew)
+                _tool_ctx(
+                    tool_input={"q": "x"},
+                    agent=agent,
+                    crew=crew,
+                    call_id="call-1",
+                )
             )
             run_after_tool_call_hooks(
                 _tool_ctx(
@@ -385,11 +575,45 @@ class TestToolGovernance:
                     tool_result="done",
                     agent=agent,
                     crew=crew,
+                    call_id="call-1",
                 )
             )
             pre_id = cap.at("pre_tool_call")[0]["tool_call"]["id"]
             post_id = cap.at("post_tool_call")[0]["tool_call"]["id"]
             assert pre_id == post_id
+        finally:
+            engine.close()
+
+    def test_identical_tool_invocations_get_distinct_correlated_ids(self):
+        """Repeated calls with equal arguments remain distinct audit events."""
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        crew = _crew("crew-1")
+        agent = _agent("agent-A")
+        try:
+            for call_id, result in (("call-1", "first"), ("call-2", "second")):
+                run_before_tool_call_hooks(
+                    _tool_ctx(
+                        tool_input={"q": "x"},
+                        agent=agent,
+                        crew=crew,
+                        call_id=call_id,
+                    )
+                )
+                run_after_tool_call_hooks(
+                    _tool_ctx(
+                        tool_input={"q": "x"},
+                        tool_result=result,
+                        agent=agent,
+                        crew=crew,
+                        call_id=call_id,
+                    )
+                )
+
+            pre_ids = [ctx["tool_call"]["id"] for ctx in cap.at("pre_tool_call")]
+            post_ids = [ctx["tool_call"]["id"] for ctx in cap.at("post_tool_call")]
+            assert pre_ids == post_ids
+            assert len(set(pre_ids)) == 2
         finally:
             engine.close()
 
@@ -399,6 +623,132 @@ class TestToolGovernance:
 
 @requires_ah
 class TestModelGovernance:
+    def test_invalid_pydantic_transform_fails_closed(self):
+        """An invalid transformed model response never restores the original."""
+        from pydantic import BaseModel
+
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        class Response(BaseModel):
+            value: int
+
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_TransformAt("post_model_call", "not-json"))
+        try:
+            with pytest.raises(ValueError, match="failed to reparse"):
+                _setup_after_llm_call_hooks(
+                    executor,
+                    Response(value=7),
+                    Printer(),
+                    request_id="request-1",
+                    verbose=False,
+                )
+        finally:
+            engine.close()
+
+    def test_executor_model_call_ids_correlate(self):
+        """Executor pre/post model records share one request identifier."""
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import (
+            _setup_after_llm_call_hooks,
+            _setup_before_llm_call_hooks,
+        )
+
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hello"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            request_id = "request-1"
+            assert _setup_before_llm_call_hooks(
+                executor, Printer(), request_id=request_id, verbose=False
+            )
+            assert (
+                _setup_after_llm_call_hooks(
+                    executor,
+                    "model response",
+                    Printer(),
+                    request_id=request_id,
+                    verbose=False,
+                )
+                == "model response"
+            )
+            pre = cap.at("pre_model_call")[0]
+            post = cap.at("post_model_call")[0]
+            assert pre["request_id"] == post["request_id"] == request_id
+        finally:
+            engine.close()
+
+    @pytest.mark.asyncio
+    async def test_async_pre_deny_prevents_file_processing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-model deny occurs before async file resolution or upload."""
+        from crewai.llm import LLM
+
+        processed = False
+
+        async def fake_process(messages: Any) -> Any:
+            nonlocal processed
+            processed = True
+            return messages
+
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        monkeypatch.setattr(llm, "_aprocess_message_files", fake_process)
+        engine = use_agent_hooks(_DenyAt("pre_model_call", "blocked"))
+        try:
+            with pytest.raises(ValueError, match="blocked"):
+                await llm.acall("hello")
+            assert processed is False
+        finally:
+            engine.close()
+
+    @pytest.mark.asyncio
+    async def test_direct_async_llm_call_is_governed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct ``LLM.acall`` emits both model-call control points."""
+        from crewai.llm import LLM
+
+        async def fake_response(**kwargs: Any) -> str:
+            return "model response"
+
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        monkeypatch.setattr(llm, "_ahandle_non_streaming_response", fake_response)
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            result = await llm.acall("hello")
+            assert result == "model response"
+            assert len(cap.at("pre_model_call")) == 1
+            assert len(cap.at("post_model_call")) == 1
+            pre = cap.at("pre_model_call")[0]
+            post = cap.at("post_model_call")[0]
+            assert pre["request_id"] == post["request_id"]
+            assert pre["request_id"]
+        finally:
+            engine.close()
+
     def test_pre_deny_raises(self):
         engine = use_agent_hooks(_DenyAt("pre_model_call"))
         try:
@@ -422,6 +772,18 @@ class TestModelGovernance:
             )
             assert ctx.messages == replacement
             assert ctx.messages is original
+        finally:
+            engine.close()
+
+    def test_invalid_model_transform_shape_blocks_call(self):
+        engine = use_agent_hooks(_TransformAt("pre_model_call", {"invalid": True}))
+        try:
+            with pytest.raises(HookAborted):
+                dispatch(
+                    InterceptionPoint.PRE_MODEL_CALL,
+                    _llm_ctx(),
+                    reducer=before_llm_call_reducer,
+                )
         finally:
             engine.close()
 
@@ -457,6 +819,83 @@ class TestModelGovernance:
         finally:
             engine.close()
 
+    def test_executor_structured_tool_calls_reach_governor(self):
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        requested = types.SimpleNamespace(
+            id="provider-call-1",
+            function=types.SimpleNamespace(
+                name="shell", arguments='{"cmd": "rm -rf /"}'
+            ),
+        )
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hi"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            answer = [requested]
+            result = _setup_after_llm_call_hooks(
+                executor,
+                answer,
+                Printer(),
+                request_id="request-1",
+                verbose=False,
+            )
+            assert result is answer
+            seen = cap.at("post_model_call")
+            assert seen[0]["response"]["tool_calls"] == [
+                {
+                    "id": "provider-call-1",
+                    "name": "shell",
+                    "args": {"cmd": "rm -rf /"},
+                }
+            ]
+            assert seen[0]["request_id"] == "request-1"
+        finally:
+            engine.close()
+
+    def test_executor_structured_tool_call_deny_prevents_execution(self):
+        from crewai_core.printer import Printer
+
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        requested = types.SimpleNamespace(
+            id="provider-call-1",
+            function=types.SimpleNamespace(name="shell", arguments="{}"),
+        )
+        executor = types.SimpleNamespace(
+            messages=[{"role": "user", "content": "hi"}],
+            llm=_llm(),
+            iterations=0,
+            agent=_agent(),
+            task=None,
+            crew=_crew(),
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+        )
+        engine = use_agent_hooks(_DenyAt("post_model_call", "tool denied"))
+        try:
+            result = _setup_after_llm_call_hooks(
+                executor,
+                [requested],
+                Printer(),
+                request_id="request-1",
+                verbose=False,
+            )
+            assert result == "[blocked by agent-hooks: tool denied]"
+        finally:
+            engine.close()
+
 
 # --- execution-boundary governance ------------------------------------------
 
@@ -483,12 +922,109 @@ class TestBoundaryGovernance:
         finally:
             engine.close()
 
+    def test_output_transform_replaces_rich_crew_output(self):
+        from crewai.crews.crew_output import CrewOutput
+        from crewai.hooks.contexts import OutputContext
+        from crewai.tasks.task_output import TaskOutput
+
+        engine = use_agent_hooks(
+            _TransformAt("output", "redacted", path="$target.content")
+        )
+        try:
+            original = CrewOutput(
+                raw="secret",
+                json_dict={"secret": True},
+                tasks_output=[
+                    TaskOutput(
+                        description="Return sensitive output",
+                        raw="secret",
+                        json_dict={"secret": True},
+                        agent="tester",
+                    )
+                ],
+            )
+            ctx = OutputContext(crew=_crew(), output=original, payload=original)
+            dispatch(InterceptionPoint.OUTPUT, ctx)
+            assert isinstance(ctx.payload, CrewOutput)
+            assert ctx.payload.raw == "redacted"
+            assert ctx.payload.pydantic is None
+            assert ctx.payload.json_dict is None
+            assert ctx.payload.tasks_output[-1].raw == "redacted"
+            assert ctx.payload.tasks_output[-1].pydantic is None
+            assert ctx.payload.tasks_output[-1].json_dict is None
+            assert original.tasks_output[-1].raw == "secret"
+        finally:
+            engine.close()
+
     def test_execution_start_deny_raises(self):
         engine = use_agent_hooks(_DenyAt("agent_startup"))
         try:
             ctx = ExecutionStartContext(crew=_crew(), inputs={}, payload={})
             with pytest.raises(HookAborted):
                 dispatch(InterceptionPoint.EXECUTION_START, ctx)
+            points = [record.interception_point.value for record in engine.records]
+            assert points == ["agent_startup", "agent_shutdown"]
+        finally:
+            engine.close()
+
+    def test_execution_end_failure_uses_schema_reason_and_does_not_raise(self):
+        from crewai.hooks.contexts import ExecutionEndContext
+
+        cap = _Capture()
+        engine = use_agent_hooks(cap, _DenyAt("agent_shutdown"))
+        crew = _crew()
+        try:
+            dispatch(
+                InterceptionPoint.EXECUTION_START,
+                ExecutionStartContext(crew=crew, inputs={}, payload={}),
+            )
+            dispatch(
+                InterceptionPoint.EXECUTION_END,
+                ExecutionEndContext(crew=crew, status="failed"),
+            )
+            shutdown = cap.at("agent_shutdown")[0]
+            assert shutdown["summary"]["reason"] == "error"
+        finally:
+            engine.close()
+
+    def test_repeated_runs_get_distinct_sessions(self):
+        from crewai.hooks.contexts import ExecutionEndContext
+
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        crew = _crew("crew-1")
+        try:
+            for _ in range(2):
+                dispatch(
+                    InterceptionPoint.EXECUTION_START,
+                    ExecutionStartContext(crew=crew, inputs={}, payload={}),
+                )
+                dispatch(
+                    InterceptionPoint.EXECUTION_END,
+                    ExecutionEndContext(crew=crew),
+                )
+            sessions = [ctx["session"]["id"] for ctx in cap.at("agent_startup")]
+            assert len(set(sessions)) == 2
+        finally:
+            engine.close()
+
+    def test_execution_start_matches_published_schema(self):
+        """The emitted startup context conforms to the SDK's closed schema."""
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            dispatch(
+                InterceptionPoint.EXECUTION_START,
+                ExecutionStartContext(
+                    crew=_crew(), inputs={"topic": "safe"}, payload={"topic": "safe"}
+                ),
+            )
+            context = cap.at("agent_startup")[0]
+            schema_path = files("agent_hooks").joinpath(
+                "schema/agent-context/agent_startup.schema.json"
+            )
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            jsonschema.validate(context, schema)
         finally:
             engine.close()
 
@@ -587,6 +1123,7 @@ class TestEngineLifecycle:
         assert get_governor() is not None
         engine.close()
         assert get_governor() is None
+        assert active_engine() is None
 
     def test_points_subset_limits_governance(self):
         engine = use_agent_hooks(_Allow(), points=[InterceptionPoint.PRE_TOOL_CALL])

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -8,11 +8,15 @@ unavailable.
 
 from __future__ import annotations
 
+import asyncio
+import json
+import threading
 import types
 from typing import Any
 
 from crewai.hooks.agent_hooks_engine import (
     HAS_AGENT_HOOKS,
+    _EmitterLoop,
     _agent_ids,
     _blocked_result,
     _json_safe,
@@ -75,6 +79,10 @@ def _agent(aid: str = "agent-1", role: str = "tester") -> Any:
     return types.SimpleNamespace(id=aid, role=role)
 
 
+def _flow(fid: str = "flow-1") -> Any:
+    return types.SimpleNamespace(id=fid)
+
+
 def _llm(model: str = "gpt-test") -> Any:
     return types.SimpleNamespace(model=model)
 
@@ -87,13 +95,15 @@ def _tool_ctx(
     name: str = "web_search",
     tool_input: dict[str, Any] | None = None,
     tool_result: str | None = None,
+    agent: Any = None,
+    crew: Any = None,
 ) -> ToolCallHookContext:
     return ToolCallHookContext(
         tool_name=name,
         tool_input=tool_input if tool_input is not None else {"q": "x"},
         tool=_tool(name),
-        agent=_agent(),
-        crew=_crew(),
+        agent=agent if agent is not None else _agent(),
+        crew=crew if crew is not None else _crew(),
         tool_result=tool_result,
     )
 
@@ -148,6 +158,27 @@ class _TransformAt:
                 transform=Transform(path=self.path, value=self.value),
             )
         return Verdict(decision=Decision.ALLOW)
+
+
+def _plain(ctx: Any) -> dict[str, Any]:
+    """Render an agent-hooks ``AgentContext`` as a plain nested ``dict``."""
+    return json.loads(json.dumps(dict(ctx), default=str))
+
+
+class _Capture:
+    """Records the exact ``AgentContext`` each interceptor call receives, then allows."""
+
+    def __init__(self) -> None:
+        self.seen: list[dict[str, Any]] = []
+
+    def intercept(self, ctx: Any) -> Any:
+        from agent_hooks import Decision, Verdict
+
+        self.seen.append(_plain(ctx))
+        return Verdict(decision=Decision.ALLOW)
+
+    def at(self, point: str) -> list[dict[str, Any]]:
+        return [c for c in self.seen if c.get("interception_point") == point]
 
 
 # --- helper units (no agent-hooks needed) -----------------------------------
@@ -230,6 +261,34 @@ class TestHelpers:
         assert _registered_tools(crew) == ["a", "b"]
 
 
+# --- emitter loop internals -------------------------------------------------
+
+
+class TestEmitterLoop:
+    def test_close_releases_pending_emission(self):
+        """``close()`` unblocks a thread waiting on a never-resolving emission."""
+        loop = _EmitterLoop()
+        started = threading.Event()
+
+        async def hang() -> None:
+            started.set()
+            await asyncio.Event().wait()  # never resolves
+
+        def worker() -> None:
+            try:
+                loop.run(hang(), None)  # emit_timeout=None -> blocks until close
+            except BaseException:
+                pass
+
+        t = threading.Thread(target=worker, name="pending-emit", daemon=True)
+        t.start()
+        assert started.wait(timeout=5.0), "emission never started"
+
+        loop.close()  # must release the blocked emission
+        t.join(timeout=2.0)
+        assert not t.is_alive()
+
+
 # --- tool-call governance (through the real seam) ---------------------------
 
 
@@ -294,6 +353,46 @@ class TestToolGovernance:
         finally:
             engine.close()
 
+    def test_cyclic_tool_input_fails_closed(self):
+        """A cyclic ``tool_input`` is normalized, not passed through ungoverned.
+
+        A self-referential arg would raise ``RecursionError`` while the context
+        is built; the engine must still let the policy block the call (fail
+        closed) instead of proceeding ungoverned.
+        """
+        engine = use_agent_hooks(_DenyAt("pre_tool_call", "policy: tool blocked"))
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is True  # control deny
+            cyclic: dict[str, Any] = {}
+            cyclic["self"] = cyclic
+            assert run_before_tool_call_hooks(_tool_ctx(tool_input=cyclic)) is True
+        finally:
+            engine.close()
+
+    def test_pre_and_post_tool_call_ids_correlate(self):
+        """The separate pre/post contexts for one invocation share a call id."""
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        crew = _crew("crew-1")
+        agent = _agent("agent-A")
+        try:
+            run_before_tool_call_hooks(
+                _tool_ctx(tool_input={"q": "x"}, agent=agent, crew=crew)
+            )
+            run_after_tool_call_hooks(
+                _tool_ctx(
+                    tool_input={"q": "x"},
+                    tool_result="done",
+                    agent=agent,
+                    crew=crew,
+                )
+            )
+            pre_id = cap.at("pre_tool_call")[0]["tool_call"]["id"]
+            post_id = cap.at("post_tool_call")[0]["tool_call"]["id"]
+            assert pre_id == post_id
+        finally:
+            engine.close()
+
 
 # --- model-call governance (direct-call seam via dispatch) ------------------
 
@@ -338,6 +437,26 @@ class TestModelGovernance:
         finally:
             engine.close()
 
+    def test_post_model_call_exposes_requested_tool_calls(self):
+        """An interceptor at ``post_model_call`` sees the model's tool calls."""
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            requested = [{"id": "tc-1", "name": "shell", "args": {"cmd": "rm -rf /"}}]
+            ctx = types.SimpleNamespace(
+                messages=[{"role": "user", "content": "hi"}],
+                llm=_llm(),
+                agent=_agent(),
+                crew=_crew(),
+                response={"content": "", "tool_calls": requested},
+            )
+            dispatch(InterceptionPoint.POST_MODEL_CALL, ctx)
+            seen = cap.at("post_model_call")
+            assert seen, "post_model_call was not emitted"
+            assert seen[0]["response"]["tool_calls"] == requested
+        finally:
+            engine.close()
+
 
 # --- execution-boundary governance ------------------------------------------
 
@@ -370,6 +489,56 @@ class TestBoundaryGovernance:
             ctx = ExecutionStartContext(crew=_crew(), inputs={}, payload={})
             with pytest.raises(HookAborted):
                 dispatch(InterceptionPoint.EXECUTION_START, ctx)
+        finally:
+            engine.close()
+
+
+# --- session & identity scoping ---------------------------------------------
+
+
+@requires_ah
+class TestSessionScoping:
+    def test_builder_preserves_per_agent_identity(self):
+        """Different agents in one crew keep their own id in the record.
+
+        The first (agent-less) ``EXECUTION_START`` creates the cached session
+        builder; every later emission must still be attributed to the agent
+        that acted, not the session's first agent.
+        """
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        crew = _crew("crew-1")
+        try:
+            dispatch(
+                InterceptionPoint.EXECUTION_START,
+                ExecutionStartContext(crew=crew, inputs={}, payload={}),
+            )
+            run_before_tool_call_hooks(_tool_ctx(agent=_agent("agent-A"), crew=crew))
+            run_before_tool_call_hooks(_tool_ctx(agent=_agent("agent-B"), crew=crew))
+            ids = [c["agent"]["id"] for c in cap.at("pre_tool_call")]
+            assert ids == ["agent-A", "agent-B"]
+        finally:
+            engine.close()
+
+    def test_distinct_flows_get_distinct_sessions(self):
+        """Each flow run maps to its own agent-hooks session."""
+        cap = _Capture()
+        engine = use_agent_hooks(cap)
+        try:
+            dispatch(
+                InterceptionPoint.INPUT,
+                InputContext(
+                    flow=_flow("flow-1"), inputs={"t": "1"}, payload={"t": "1"}
+                ),
+            )
+            dispatch(
+                InterceptionPoint.INPUT,
+                InputContext(
+                    flow=_flow("flow-2"), inputs={"t": "2"}, payload={"t": "2"}
+                ),
+            )
+            sessions = [c["session"]["id"] for c in cap.at("input")]
+            assert sessions == ["flow-1", "flow-2"]
         finally:
             engine.close()
 

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -1,0 +1,467 @@
+"""Tests for the agent-hooks control engine (:mod:`crewai.hooks.agent_hooks_engine`).
+
+Helper-level tests run without agent-hooks installed. Governance tests activate
+the engine and exercise it through crewAI's real interception seams; they are
+skipped when the optional ``agent_hooks`` dependency (and its native core) is
+unavailable.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+from crewai.hooks.agent_hooks_engine import (
+    HAS_AGENT_HOOKS,
+    _agent_ids,
+    _blocked_result,
+    _json_safe,
+    _model_id,
+    _registered_tools,
+    _session_id,
+    _to_text,
+    _transformed_payload,
+    disable_agent_hooks,
+    use_agent_hooks,
+)
+from crewai.hooks.contexts import (
+    ExecutionStartContext,
+    InputContext,
+)
+from crewai.hooks.dispatch import (
+    HookAborted,
+    InterceptionPoint,
+    clear_all,
+    clear_governor,
+    dispatch,
+    get_governor,
+)
+from crewai.hooks.llm_hooks import (
+    LLMCallHookContext,
+    after_llm_call_reducer,
+    before_llm_call_reducer,
+)
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    run_after_tool_call_hooks,
+    run_before_tool_call_hooks,
+)
+import pytest
+
+
+requires_ah = pytest.mark.skipif(
+    not HAS_AGENT_HOOKS, reason="agent-hooks (agent_hooks) is not installed"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Every test starts and ends with an empty registry and no active engine."""
+    clear_all()
+    yield
+    disable_agent_hooks()
+    clear_governor()
+    clear_all()
+
+
+# --- lightweight crewAI-shaped fakes ----------------------------------------
+
+
+def _crew(cid: str = "crew-1", tools: list[Any] | None = None) -> Any:
+    return types.SimpleNamespace(id=cid, tools=list(tools or []))
+
+
+def _agent(aid: str = "agent-1", role: str = "tester") -> Any:
+    return types.SimpleNamespace(id=aid, role=role)
+
+
+def _llm(model: str = "gpt-test") -> Any:
+    return types.SimpleNamespace(model=model)
+
+
+def _tool(name: str) -> Any:
+    return types.SimpleNamespace(name=name)
+
+
+def _tool_ctx(
+    name: str = "web_search",
+    tool_input: dict[str, Any] | None = None,
+    tool_result: str | None = None,
+) -> ToolCallHookContext:
+    return ToolCallHookContext(
+        tool_name=name,
+        tool_input=tool_input if tool_input is not None else {"q": "x"},
+        tool=_tool(name),
+        agent=_agent(),
+        crew=_crew(),
+        tool_result=tool_result,
+    )
+
+
+def _llm_ctx(
+    messages: list[dict[str, Any]] | None = None, response: str | None = None
+) -> LLMCallHookContext:
+    return LLMCallHookContext(
+        messages=messages if messages is not None else [{"role": "user", "content": "hi"}],
+        llm=_llm(),
+        agent=_agent(),
+        crew=_crew(),
+        response=response,
+    )
+
+
+# --- interceptors (agent-hooks) ---------------------------------------------
+
+
+class _Allow:
+    def intercept(self, ctx: Any) -> Any:
+        from agent_hooks import Decision, Verdict
+
+        return Verdict(decision=Decision.ALLOW)
+
+
+class _DenyAt:
+    def __init__(self, point: str, reason: str = "denied") -> None:
+        self.point = point
+        self.reason = reason
+
+    def intercept(self, ctx: Any) -> Any:
+        from agent_hooks import Decision, Verdict
+
+        if ctx["interception_point"] == self.point:
+            return Verdict.deny(reason=self.reason)
+        return Verdict(decision=Decision.ALLOW)
+
+
+class _TransformAt:
+    def __init__(self, point: str, value: Any, path: str = "$target") -> None:
+        self.point = point
+        self.value = value
+        self.path = path
+
+    def intercept(self, ctx: Any) -> Any:
+        from agent_hooks import Decision, Transform, Verdict
+
+        if ctx["interception_point"] == self.point:
+            return Verdict(
+                decision=Decision.TRANSFORM,
+                transform=Transform(path=self.path, value=self.value),
+            )
+        return Verdict(decision=Decision.ALLOW)
+
+
+# --- helper units (no agent-hooks needed) -----------------------------------
+
+
+class TestHelpers:
+    def test_json_safe_passthrough(self):
+        value = {"a": [1, 2.0, "x", True, None]}
+        assert _json_safe(value) == value
+
+    def test_json_safe_non_finite_floats(self):
+        assert _json_safe(float("inf")) == "inf"
+        assert _json_safe(float("nan")) == "nan"
+
+    def test_json_safe_bytes(self):
+        assert _json_safe(b"hi") == "hi"
+
+    def test_json_safe_set_is_listified(self):
+        assert sorted(_json_safe({3, 1, 2})) == [1, 2, 3]
+
+    def test_json_safe_model_dump(self):
+        class Model:
+            def model_dump(self, mode: str = "python") -> dict[str, int]:
+                return {"k": 1}
+
+        assert _json_safe(Model()) == {"k": 1}
+
+    def test_json_safe_unknown_becomes_str(self):
+        class Opaque:
+            pass
+
+        assert isinstance(_json_safe(Opaque()), str)
+
+    def test_json_safe_nested_object(self):
+        class Model:
+            def model_dump(self, mode: str = "python") -> dict[str, Any]:
+                return {"n": 1}
+
+        assert _json_safe({"outer": Model()}) == {"outer": {"n": 1}}
+
+    def test_agent_ids_none(self):
+        assert _agent_ids(None) == ("crewai-agent", None)
+
+    def test_agent_ids_from_id_and_role(self):
+        assert _agent_ids(_agent("a", "r")) == ("a", "r")
+
+    def test_agent_ids_role_fallback(self):
+        agent = types.SimpleNamespace(role="analyst")
+        assert _agent_ids(agent) == ("analyst", "analyst")
+
+    def test_session_id_prefers_crew(self):
+        assert _session_id(crew=_crew("c9")) == "c9"
+
+    def test_session_id_agent_fallback(self):
+        assert _session_id(agent=_agent("a2")) == "agent:a2"
+
+    def test_session_id_default(self):
+        assert _session_id() == "crewai-session"
+
+    def test_model_id(self):
+        assert _model_id(_llm("m")) == "m"
+
+    def test_model_id_unknown(self):
+        assert _model_id(object()) == "unknown"
+
+    def test_blocked_result(self):
+        assert _blocked_result("bad") == "[blocked by agent-hooks: bad]"
+
+    def test_to_text_passthrough_and_json(self):
+        assert _to_text("hi") == "hi"
+        assert _to_text({"a": 1}) == '{"a": 1}'
+
+    def test_transformed_payload_variants(self):
+        assert _transformed_payload({"content": 5, "role": "user"}) == 5
+        assert _transformed_payload({"x": 1}) == {"x": 1}
+        assert _transformed_payload("z") == "z"
+
+    def test_registered_tools(self):
+        crew = _crew(tools=[_tool("a"), _tool("b")])
+        assert _registered_tools(crew) == ["a", "b"]
+
+
+# --- tool-call governance (through the real seam) ---------------------------
+
+
+@requires_ah
+class TestToolGovernance:
+    def test_allow_proceeds_unchanged(self):
+        engine = use_agent_hooks(_Allow())
+        try:
+            ctx = _tool_ctx(tool_input={"q": "x"})
+            assert run_before_tool_call_hooks(ctx) is False
+            assert ctx.tool_input == {"q": "x"}
+        finally:
+            engine.close()
+
+    def test_deny_blocks_call(self):
+        engine = use_agent_hooks(_DenyAt("pre_tool_call", "nope"))
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is True
+        finally:
+            engine.close()
+
+    def test_transform_rewrites_args_in_place(self):
+        engine = use_agent_hooks(_TransformAt("pre_tool_call", {"url": "https://safe"}))
+        try:
+            ctx = _tool_ctx(tool_input={"url": "http://evil"})
+            original = ctx.tool_input
+            run_before_tool_call_hooks(ctx)
+            assert ctx.tool_input == {"url": "https://safe"}
+            assert ctx.tool_input is original  # crewAI requires in-place mutation
+        finally:
+            engine.close()
+
+    def test_post_transform_rewrites_result(self):
+        engine = use_agent_hooks(_TransformAt("post_tool_call", "REDACTED"))
+        try:
+            ctx = _tool_ctx(tool_result="secret data")
+            assert run_after_tool_call_hooks(ctx) == "REDACTED"
+        finally:
+            engine.close()
+
+    def test_post_deny_fails_closed(self):
+        engine = use_agent_hooks(_DenyAt("post_tool_call", "bad"))
+        try:
+            ctx = _tool_ctx(tool_result="secret data")
+            assert run_after_tool_call_hooks(ctx) == "[blocked by agent-hooks: bad]"
+        finally:
+            engine.close()
+
+    def test_native_hook_runs_before_engine(self):
+        """A native before_tool_call hook mutates input; the engine sees it."""
+        from crewai.hooks.dispatch import register
+
+        def widen(ctx: Any) -> None:
+            ctx.tool_input["added"] = True
+
+        register(InterceptionPoint.PRE_TOOL_CALL, widen)
+        engine = use_agent_hooks(_Allow())
+        try:
+            ctx = _tool_ctx(tool_input={"q": "x"})
+            run_before_tool_call_hooks(ctx)
+            assert ctx.tool_input == {"q": "x", "added": True}
+        finally:
+            engine.close()
+
+
+# --- model-call governance (direct-call seam via dispatch) ------------------
+
+
+@requires_ah
+class TestModelGovernance:
+    def test_pre_deny_raises(self):
+        engine = use_agent_hooks(_DenyAt("pre_model_call"))
+        try:
+            with pytest.raises(HookAborted):
+                dispatch(
+                    InterceptionPoint.PRE_MODEL_CALL,
+                    _llm_ctx(),
+                    reducer=before_llm_call_reducer,
+                )
+        finally:
+            engine.close()
+
+    def test_pre_transform_rewrites_messages(self):
+        replacement = [{"role": "user", "content": "safe"}]
+        engine = use_agent_hooks(_TransformAt("pre_model_call", replacement))
+        try:
+            ctx = _llm_ctx(messages=[{"role": "user", "content": "danger"}])
+            original = ctx.messages
+            dispatch(
+                InterceptionPoint.PRE_MODEL_CALL, ctx, reducer=before_llm_call_reducer
+            )
+            assert ctx.messages == replacement
+            assert ctx.messages is original
+        finally:
+            engine.close()
+
+    def test_post_transform_rewrites_response(self):
+        new_response = {"content": "clean", "tool_calls": [], "finish_reason": "stop"}
+        engine = use_agent_hooks(_TransformAt("post_model_call", new_response))
+        try:
+            ctx = _llm_ctx(response="raw")
+            dispatch(
+                InterceptionPoint.POST_MODEL_CALL, ctx, reducer=after_llm_call_reducer
+            )
+            assert ctx.response == "clean"
+        finally:
+            engine.close()
+
+
+# --- execution-boundary governance ------------------------------------------
+
+
+@requires_ah
+class TestBoundaryGovernance:
+    def test_input_deny_raises(self):
+        engine = use_agent_hooks(_DenyAt("input"))
+        try:
+            ctx = InputContext(crew=_crew(), inputs={"t": "x"}, payload={"t": "x"})
+            with pytest.raises(HookAborted):
+                dispatch(InterceptionPoint.INPUT, ctx)
+        finally:
+            engine.close()
+
+    def test_input_transform_replaces_payload(self):
+        engine = use_agent_hooks(
+            _TransformAt("input", {"t": "safe"}, path="$target.content")
+        )
+        try:
+            ctx = InputContext(crew=_crew(), inputs={"t": "x"}, payload={"t": "x"})
+            dispatch(InterceptionPoint.INPUT, ctx)
+            assert ctx.payload == {"t": "safe"}
+        finally:
+            engine.close()
+
+    def test_execution_start_deny_raises(self):
+        engine = use_agent_hooks(_DenyAt("agent_startup"))
+        try:
+            ctx = ExecutionStartContext(crew=_crew(), inputs={}, payload={})
+            with pytest.raises(HookAborted):
+                dispatch(InterceptionPoint.EXECUTION_START, ctx)
+        finally:
+            engine.close()
+
+
+# --- engine lifecycle & configuration ---------------------------------------
+
+
+@requires_ah
+class TestEngineLifecycle:
+    def test_use_agent_hooks_installs_governor(self):
+        engine = use_agent_hooks(_Allow())
+        try:
+            assert get_governor() is not None
+        finally:
+            engine.close()
+
+    def test_records_populated_and_drainable(self):
+        engine = use_agent_hooks(_Allow())
+        try:
+            run_before_tool_call_hooks(_tool_ctx())
+            assert len(engine.records) == 1
+            assert len(engine.take_records()) == 1
+            assert engine.records == []
+        finally:
+            engine.close()
+
+    def test_record_sink_receives_every_decision(self):
+        seen: list[Any] = []
+        engine = use_agent_hooks(_Allow(), record_sink=seen.append)
+        try:
+            run_before_tool_call_hooks(_tool_ctx())
+            assert len(seen) == 1
+        finally:
+            engine.close()
+
+    def test_activate_is_idempotent(self):
+        engine = use_agent_hooks(_Allow())
+        try:
+            engine.activate()
+            assert get_governor() is not None
+        finally:
+            engine.close()
+
+    def test_close_clears_governor(self):
+        engine = use_agent_hooks(_Allow())
+        assert get_governor() is not None
+        engine.close()
+        assert get_governor() is None
+
+    def test_points_subset_limits_governance(self):
+        engine = use_agent_hooks(_Allow(), points=[InterceptionPoint.PRE_TOOL_CALL])
+        try:
+            assert engine.adapter_for(InterceptionPoint.PRE_TOOL_CALL) is not None
+            assert engine.adapter_for(InterceptionPoint.POST_TOOL_CALL) is None
+        finally:
+            engine.close()
+
+    def test_context_manager_activates_and_closes(self):
+        with use_agent_hooks(_Allow()):
+            assert get_governor() is not None
+        assert get_governor() is None
+
+    def test_second_use_supersedes_first(self):
+        first = use_agent_hooks(_Allow())
+        second = use_agent_hooks(_Allow())
+        try:
+            assert get_governor() == second.adapter_for
+        finally:
+            second.close()
+            first.close()
+
+    def test_evaluate_only_records_but_never_blocks(self):
+        from agent_hooks import EnforcementMode
+
+        engine = use_agent_hooks(
+            _DenyAt("pre_tool_call"), mode=EnforcementMode.EVALUATE_ONLY
+        )
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is False
+            assert len(engine.records) == 1
+        finally:
+            engine.close()
+
+    def test_zero_interceptors_fails_closed(self):
+        engine = use_agent_hooks()
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is True
+        finally:
+            engine.close()
+
+
+@pytest.mark.skipif(HAS_AGENT_HOOKS, reason="agent-hooks IS installed")
+def test_use_agent_hooks_raises_actionable_error_without_agent_hooks():
+    with pytest.raises(ImportError, match="agent-hooks"):
+        use_agent_hooks()

--- a/lib/crewai/tests/hooks/test_agent_hooks_engine.py
+++ b/lib/crewai/tests/hooks/test_agent_hooks_engine.py
@@ -18,8 +18,11 @@ import types
 from typing import Any
 
 from crewai.hooks.agent_hooks_engine import (
+    DEFAULT_EMIT_TIMEOUT,
     DEFAULT_MAX_RECORDS,
     HAS_AGENT_HOOKS,
+    AgentHooksEngine,
+    _BoundedCallbackPool,
     _EmitterLoop,
     _agent_ids,
     _blocked_result,
@@ -313,6 +316,46 @@ class TestHelpers:
 
 
 # --- emitter loop internals -------------------------------------------------
+
+
+class TestBoundedCallbackPool:
+    def test_blocking_callback_retains_capacity_until_exit(self):
+        pool = _BoundedCallbackPool(max_workers=1, max_waiters=0)
+        started = threading.Event()
+        release = threading.Event()
+
+        def block() -> None:
+            started.set()
+            release.wait()
+
+        future = pool.submit(block)
+        try:
+            assert started.wait(timeout=2.0)
+            with pytest.raises(RuntimeError, match="admission queue is full"):
+                pool.submit(lambda: None)
+        finally:
+            release.set()
+            future.result(timeout=2.0)
+            pool.close()
+
+    def test_failed_close_is_observable_and_retryable(self):
+        pool = _BoundedCallbackPool(max_workers=1, max_waiters=0)
+        started = threading.Event()
+        release = threading.Event()
+
+        def block() -> None:
+            started.set()
+            release.wait()
+
+        future = pool.submit(block)
+        assert started.wait(timeout=2.0)
+        with pytest.raises(RuntimeError, match="did not stop"):
+            pool.close(timeout=0.01)
+
+        release.set()
+        future.result(timeout=2.0)
+        pool.close(timeout=2.0)
+        assert all(not thread.is_alive() for thread in pool._threads)
 
 
 class TestEmitterLoop:
@@ -2068,6 +2111,57 @@ class TestEngineLifecycle:
         finally:
             engine.close()
 
+    def test_default_emit_timeout_is_finite(self):
+        engine = use_agent_hooks(_Allow())
+        try:
+            assert engine._emit_timeout == DEFAULT_EMIT_TIMEOUT
+        finally:
+            engine.close()
+
+    def test_blocking_sync_interceptor_times_out_closed(self):
+        started = threading.Event()
+        release = threading.Event()
+
+        class BlockingInterceptor:
+            def intercept(self, ctx: Any) -> Any:
+                from agent_hooks import Decision, Verdict
+
+                started.set()
+                release.wait()
+                return Verdict(decision=Decision.ALLOW)
+
+        engine = use_agent_hooks(
+            BlockingInterceptor(), timeout=0.05, emit_timeout=1.0
+        )
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is True
+            assert started.is_set()
+        finally:
+            release.set()
+            engine.close()
+
+    def test_blocking_record_sink_is_bounded_and_observable(self):
+        started = threading.Event()
+        release = threading.Event()
+
+        def sink(record: Any) -> None:
+            started.set()
+            release.wait()
+
+        engine = use_agent_hooks(
+            _Allow(),
+            timeout=0.05,
+            emit_timeout=1.0,
+            record_sink=sink,
+        )
+        try:
+            assert run_before_tool_call_hooks(_tool_ctx()) is False
+            assert started.is_set()
+            assert engine.record_sink_failures == 1
+        finally:
+            release.set()
+            engine.close()
+
     def test_activate_is_idempotent(self):
         engine = use_agent_hooks(_Allow())
         try:
@@ -2101,9 +2195,39 @@ class TestEngineLifecycle:
         second = use_agent_hooks(_Allow())
         try:
             assert get_governor() == second.adapter_for
+            assert first._closed is True
         finally:
             second.close()
             first.close()
+
+    def test_concurrent_activation_keeps_engine_and_governor_consistent(self):
+        first = AgentHooksEngine(_Allow())
+        second = AgentHooksEngine(_Allow())
+        ready = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def activate(engine: AgentHooksEngine) -> None:
+            try:
+                ready.wait()
+                engine.activate()
+            except BaseException as error:
+                errors.append(error)
+
+        first_thread = threading.Thread(target=activate, args=(first,))
+        second_thread = threading.Thread(target=activate, args=(second,))
+        first_thread.start()
+        second_thread.start()
+        first_thread.join(timeout=2.0)
+        second_thread.join(timeout=2.0)
+
+        current = active_engine()
+        assert not first_thread.is_alive()
+        assert not second_thread.is_alive()
+        assert errors == []
+        assert current in (first, second)
+        assert current is not None
+        assert get_governor() == current.adapter_for
+        assert sum(not engine._closed for engine in (first, second)) == 1
 
     def test_evaluate_only_records_but_never_blocks(self):
         from agent_hooks import EnforcementMode

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -306,6 +306,29 @@ class TestLLMHooksIntegration:
         assert text == "final answer"
         assert observed == ["final answer"]
 
+    def test_invalid_pydantic_rewrite_without_governor_restores_original(
+        self, mock_executor
+    ) -> None:
+        """Legacy hooks keep compatibility when no control engine is active."""
+        from pydantic import BaseModel
+
+        from crewai.utilities.agent_utils import _setup_after_llm_call_hooks
+
+        class Response(BaseModel):
+            value: int
+
+        mock_executor.after_llm_call_hooks = [lambda _context: "not-json"]
+        response = Response(value=7)
+
+        result = _setup_after_llm_call_hooks(
+            mock_executor,
+            response,
+            printer=Mock(),
+            verbose=False,
+        )
+
+        assert result is response
+
     def test_unregister_before_hook(self):
         """Test that before hooks can be unregistered."""
         def test_hook(context):

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -436,6 +436,28 @@ class TestLLMHooksIntegration:
         assert ran == ["blocking"]
         assert proceed is False
 
+    @pytest.mark.parametrize("source", ["my-policy", "agent-hooks"])
+    def test_custom_string_abort_source_preserves_legacy_contract(
+        self, mock_executor, source: str
+    ) -> None:
+        """A custom string source is not an agent-hooks ownership marker."""
+        from crewai.hooks.dispatch import HookAborted
+        from crewai.utilities.agent_utils import _setup_before_llm_call_hooks
+
+        def blocking_hook(context):
+            raise HookAborted(reason="custom policy denied", source=source)
+
+        mock_executor.before_llm_call_hooks = [blocking_hook]
+
+        assert (
+            _setup_before_llm_call_hooks(
+                mock_executor,
+                printer=Mock(),
+                verbose=False,
+            )
+            is False
+        )
+
     @pytest.mark.vcr()
     def test_lite_agent_hooks_integration_with_real_llm(self):
         """Test that LiteAgent executes before/after LLM call hooks and prints messages correctly."""

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -21,12 +21,18 @@ from crewai.events.types.tool_usage_events import (
 from crewai.hooks.tool_hooks import (
     ToolCallHookContext,
     clear_after_tool_call_hooks,
+    clear_before_tool_call_hooks,
     register_after_tool_call_hook,
+    register_before_tool_call_hook,
 )
 from crewai.tools import BaseTool
 from crewai.tools.tool_calling import ToolCalling
+from crewai.tools.tool_failure import ToolFailure
 from crewai.tools.tool_usage import ToolUsage
-from crewai.utilities.tool_utils import execute_tool_and_check_finality
+from crewai.utilities.tool_utils import (
+    aexecute_tool_and_check_finality,
+    execute_tool_and_check_finality,
+)
 from pydantic import BaseModel, Field
 import pytest
 
@@ -242,6 +248,144 @@ def test_react_tool_hooks_receive_agent_text_and_raw_cached_typed_output():
         ('{"query":"crew","score":0.7}', SearchOutput(query="crew", score=0.7)),
         ('{"query":"crew","score":0.7}', SearchOutput(query="crew", score=0.7)),
     ]
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_react_empty_args_transform_reaches_cache_and_execution(
+    use_async: bool,
+):
+    class RequiredArgTool(BaseTool):
+        name: str = "required_arg"
+        description: str = "Requires an argument"
+
+        def _run(self, value: str) -> str:
+            return f"executed:{value}"
+
+    tool = RequiredArgTool().to_structured_tool()
+    tools_handler = MagicMock()
+    tools_handler.cache.read.return_value = None
+    tools_handler.last_used_tool = None
+
+    def transform(context: ToolCallHookContext) -> None:
+        context.tool_input["value"] = "safe"
+
+    action = AgentAction(
+        thought="",
+        tool="required_arg",
+        tool_input="{}",
+        text="Action: required_arg\nAction Input: {}",
+    )
+    clear_before_tool_call_hooks()
+    register_before_tool_call_hook(transform)
+    try:
+        if use_async:
+            result = await aexecute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+                tools_handler=tools_handler,
+            )
+        else:
+            result = execute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+                tools_handler=tools_handler,
+            )
+    finally:
+        clear_before_tool_call_hooks()
+
+    assert result.result == "executed:safe"
+    tools_handler.cache.read.assert_called_once_with(
+        tool="required_arg", input='{"value": "safe"}'
+    )
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_react_usage_limit_sets_post_error_status(use_async: bool):
+    class LimitedTool(BaseTool):
+        name: str = "limited"
+        description: str = "Already exhausted"
+        max_usage_count: int | None = 0
+        result_as_answer: bool = True
+
+        def _run(self) -> str:
+            return "must not run"
+
+    tool = LimitedTool().to_structured_tool()
+    seen_errors: list[bool] = []
+
+    def capture(context: ToolCallHookContext) -> None:
+        seen_errors.append(context.is_error)
+
+    action = AgentAction(
+        thought="",
+        tool="limited",
+        tool_input="{}",
+        text="Action: limited\nAction Input: {}",
+    )
+    clear_after_tool_call_hooks()
+    register_after_tool_call_hook(capture)
+    try:
+        if use_async:
+            result = await aexecute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+            )
+        else:
+            result = execute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+            )
+    finally:
+        clear_after_tool_call_hooks()
+
+    assert "usage limit" in result.result
+    assert result.result_as_answer is False
+    assert seen_errors == [True]
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_react_tool_failure_sets_post_error_status(use_async: bool):
+    class ReportingTool(BaseTool):
+        name: str = "reporting"
+        description: str = "Returns a typed failure"
+        result_as_answer: bool = True
+
+        def _run(self) -> ToolFailure:
+            return ToolFailure(message="policy denied", code="policy_denied")
+
+    tool = ReportingTool().to_structured_tool()
+    seen_errors: list[bool] = []
+
+    def capture(context: ToolCallHookContext) -> None:
+        seen_errors.append(context.is_error)
+
+    action = AgentAction(
+        thought="",
+        tool="reporting",
+        tool_input="{}",
+        text="Action: reporting\nAction Input: {}",
+    )
+    clear_after_tool_call_hooks()
+    register_after_tool_call_hook(capture)
+    try:
+        if use_async:
+            result = await aexecute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+            )
+        else:
+            result = execute_tool_and_check_finality(
+                agent_action=action,
+                tools=[tool],
+            )
+    finally:
+        clear_after_tool_call_hooks()
+
+    assert result.result_as_answer is False
+    assert seen_errors == [True]
 
 
 def test_last_raw_result_falls_back_only_until_recorded():

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -15,6 +15,7 @@ from crewai.hooks.tool_hooks import (
     clear_after_tool_call_hooks,
     clear_before_tool_call_hooks,
     register_after_tool_call_hook,
+    register_before_tool_call_hook,
 )
 from crewai.tools.base_tool import BaseTool
 from crewai.utilities.agent_utils import (
@@ -1043,6 +1044,52 @@ class TestParseToolCallArgs:
 
 class TestExecuteSingleNativeToolCall:
     """Tests for execute_single_native_tool_call."""
+
+    def test_transform_precedes_cache_lookup_and_execution(self) -> None:
+        clear_before_tool_call_hooks()
+        clear_after_tool_call_hooks()
+
+        class SearchTool(BaseTool):
+            name: str = "search"
+            description: str = "Search for a query"
+
+            def _run(self, query: str) -> str:
+                return f"executed:{query}"
+
+        def transform(context: ToolCallHookContext) -> None:
+            context.tool_input["query"] = "safe"
+
+        tool = SearchTool()
+        tool_call = MagicMock()
+        tool_call.id = "provider-call-1"
+        tool_call.function.name = "search"
+        tool_call.function.arguments = '{"query": "unsafe"}'
+        tools_handler = MagicMock()
+        tools_handler.cache.read.return_value = None
+
+        register_before_tool_call_hook(transform)
+        try:
+            result = execute_single_native_tool_call(
+                tool_call,
+                available_functions={"search": tool._run},
+                original_tools=[tool],
+                structured_tools=[tool.to_structured_tool()],
+                tools_handler=tools_handler,
+                agent=None,
+                task=None,
+                crew=None,
+                event_source=MagicMock(),
+                printer=None,
+                verbose=False,
+            )
+        finally:
+            clear_before_tool_call_hooks()
+
+        assert result.call_id == "provider-call-1"
+        assert result.result == "executed:safe"
+        tools_handler.cache.read.assert_called_once_with(
+            tool="search", input='{"query": "safe"}'
+        )
 
     def test_typed_tool_output_is_json_agent_text(self) -> None:
         clear_before_tool_call_hooks()

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -15,6 +15,7 @@ from crewai.hooks.tool_hooks import (
     clear_after_tool_call_hooks,
     clear_before_tool_call_hooks,
     register_after_tool_call_hook,
+    register_before_tool_call_hook,
 )
 from crewai.tools.base_tool import BaseTool
 from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
@@ -1319,6 +1320,52 @@ class TestParseToolCallArgs:
 
 class TestExecuteSingleNativeToolCall:
     """Tests for execute_single_native_tool_call."""
+
+    def test_transform_precedes_cache_lookup_and_execution(self) -> None:
+        clear_before_tool_call_hooks()
+        clear_after_tool_call_hooks()
+
+        class SearchTool(BaseTool):
+            name: str = "search"
+            description: str = "Search for a query"
+
+            def _run(self, query: str) -> str:
+                return f"executed:{query}"
+
+        def transform(context: ToolCallHookContext) -> None:
+            context.tool_input["query"] = "safe"
+
+        tool = SearchTool()
+        tool_call = MagicMock()
+        tool_call.id = "provider-call-1"
+        tool_call.function.name = "search"
+        tool_call.function.arguments = '{"query": "unsafe"}'
+        tools_handler = MagicMock()
+        tools_handler.cache.read.return_value = None
+
+        register_before_tool_call_hook(transform)
+        try:
+            result = execute_single_native_tool_call(
+                tool_call,
+                available_functions={"search": tool._run},
+                original_tools=[tool],
+                structured_tools=[tool.to_structured_tool()],
+                tools_handler=tools_handler,
+                agent=None,
+                task=None,
+                crew=None,
+                event_source=MagicMock(),
+                printer=None,
+                verbose=False,
+            )
+        finally:
+            clear_before_tool_call_hooks()
+
+        assert result.call_id == "provider-call-1"
+        assert result.result == "executed:safe"
+        tools_handler.cache.read.assert_called_once_with(
+            tool="search", input='{"query": "safe"}'
+        )
 
     def test_typed_tool_output_is_json_agent_text(self) -> None:
         clear_before_tool_call_hooks()

--- a/uv.lock
+++ b/uv.lock
@@ -1433,7 +1433,7 @@ watson = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
-    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = ">=0.1.0a3" },
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = "==0.1.0a3" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.8.0" },
     { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.8.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "agent-hooks-sdk"
+version = "0.1.0a3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/22/76c1497ba3e56d6d14bccd9c532e80e693d900d8996c8abc854fc452b779/agent_hooks_sdk-0.1.0a3.tar.gz", hash = "sha256:a527a42b23b748e298e9c6f5a80c824b04f57e52a100fd5ab7664e3b194feb62", size = 173376, upload-time = "2026-07-17T09:13:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d1/6b862b959141fb9fb5693484b728817f9f25fdbc05c35ec2184505294ff1/agent_hooks_sdk-0.1.0a3-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:882e7d109bf4c4818c68325d9199e99237ebf74475f792ed91b93f807e15ac48", size = 634755, upload-time = "2026-07-17T09:13:32.551Z" },
+]
+
+[[package]]
 name = "aiobotocore"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1362,6 +1371,9 @@ a2a = [
     { name = "httpx-auth" },
     { name = "httpx-sse" },
 ]
+agent-hooks = [
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
 anthropic = [
     { name = "anthropic" },
 ]
@@ -1421,6 +1433,7 @@ watson = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = ">=0.1.0a3" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.8.0" },
     { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.8.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },
@@ -1477,7 +1490,7 @@ requires-dist = [
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "agent-hooks", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"

--- a/uv.lock
+++ b/uv.lock
@@ -127,11 +127,15 @@ wheels = [
 
 [[package]]
 name = "agent-hooks-sdk"
-version = "0.1.0a3"
+version = "0.1.0a5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/22/76c1497ba3e56d6d14bccd9c532e80e693d900d8996c8abc854fc452b779/agent_hooks_sdk-0.1.0a3.tar.gz", hash = "sha256:a527a42b23b748e298e9c6f5a80c824b04f57e52a100fd5ab7664e3b194feb62", size = 173376, upload-time = "2026-07-17T09:13:34.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f4/191de0300a73b9a78f2914e0e497c96e6ac38db457e20f74fdd6251792c4/agent_hooks_sdk-0.1.0a5.tar.gz", hash = "sha256:4ae452b0a1d51540a1b74b0005b0a51f75fd4b80e9aca1a7403dece4dd6f9e46", size = 130183, upload-time = "2026-08-07T06:14:41.890Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d1/6b862b959141fb9fb5693484b728817f9f25fdbc05c35ec2184505294ff1/agent_hooks_sdk-0.1.0a3-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:882e7d109bf4c4818c68325d9199e99237ebf74475f792ed91b93f807e15ac48", size = 634755, upload-time = "2026-07-17T09:13:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/50/a6bea9691ef69be1c9c70420e84f773ee721c7e60dafc76069564ba88cc9/agent_hooks_sdk-0.1.0a5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d63893d94ccfbdc6422dd217663ed88aedec0ffd560ecfa105187fa9bda79063", size = 598919, upload-time = "2026-08-07T06:14:35.276Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ad/fe8885b3f3f203d48dba46034d3c92dfd207a9bc504d4ba1356bf57f9234/agent_hooks_sdk-0.1.0a5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:fb1d714ed6baf884525a153821d909fb23c2fe27e63f61ae254f06ee6ec351d4", size = 570529, upload-time = "2026-08-07T06:14:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6d/169997cb8ad39fc295854ed25f21171e800298e73e5a12123d3b008149f7/agent_hooks_sdk-0.1.0a5-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a0946af422eadeb3a192a7a856bc40e2b74435ab540dd3586c3cb7939157c91b", size = 626188, upload-time = "2026-08-07T06:14:37.980Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/22/ab5cf6e7fd26e8157637eea4b72a903d1b98dad11872857f32ead29ddcd0/agent_hooks_sdk-0.1.0a5-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a4b53cce9dabf1ee8ffffa4b5f6c6d34d269daa699d468e49fad286f0070d23f", size = 649025, upload-time = "2026-08-07T06:14:39.218Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/d2bb3772abe3b04fc841bc6c667f49adf9ae037c945cbe0d6a8739d419c4/agent_hooks_sdk-0.1.0a5-cp310-abi3-win_amd64.whl", hash = "sha256:777a4cd3803710277e77d9c6abb6d1a2c9d6ce8977167fe47fc57b8e4ff8bc75", size = 479891, upload-time = "2026-08-07T06:14:40.697Z" },
 ]
 
 [[package]]
@@ -1375,7 +1379,7 @@ a2a = [
     { name = "httpx-sse" },
 ]
 agent-hooks = [
-    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "agent-hooks-sdk" },
 ]
 anthropic = [
     { name = "anthropic" },
@@ -1436,7 +1440,7 @@ watson = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
-    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = "==0.1.0a3" },
+    { name = "agent-hooks-sdk", marker = "extra == 'agent-hooks'", specifier = "==0.1.0a5" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.8.0" },
     { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.8.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,15 @@ wheels = [
 ]
 
 [[package]]
+name = "agent-hooks-sdk"
+version = "0.1.0a3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/22/76c1497ba3e56d6d14bccd9c532e80e693d900d8996c8abc854fc452b779/agent_hooks_sdk-0.1.0a3.tar.gz", hash = "sha256:a527a42b23b748e298e9c6f5a80c824b04f57e52a100fd5ab7664e3b194feb62", size = 173376, upload-time = "2026-07-17T09:13:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d1/6b862b959141fb9fb5693484b728817f9f25fdbc05c35ec2184505294ff1/agent_hooks_sdk-0.1.0a3-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:882e7d109bf4c4818c68325d9199e99237ebf74475f792ed91b93f807e15ac48", size = 634755, upload-time = "2026-07-17T09:13:32.551Z" },
+]
+
+[[package]]
 name = "aiobotocore"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,6 +1374,9 @@ a2a = [
     { name = "httpx-auth" },
     { name = "httpx-sse" },
 ]
+agent-hooks = [
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
 anthropic = [
     { name = "anthropic" },
 ]
@@ -1424,6 +1436,7 @@ watson = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = ">=0.1.0a3" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.8.0" },
     { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.8.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },
@@ -1480,7 +1493,7 @@ requires-dist = [
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "agent-hooks", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"

--- a/uv.lock
+++ b/uv.lock
@@ -1436,7 +1436,7 @@ watson = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = "~=0.3.10" },
-    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = ">=0.1.0a3" },
+    { name = "agent-hooks-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'agent-hooks'", specifier = "==0.1.0a3" },
     { name = "aiobotocore", marker = "extra == 'aws'", specifier = "~=3.8.0" },
     { name = "aiobotocore", marker = "extra == 'bedrock'", specifier = "~=3.8.0" },
     { name = "aiocache", extras = ["memcached", "redis"], marker = "extra == 'a2a'", specifier = "~=0.12.3" },


### PR DESCRIPTION
## Summary

Adds `agent-hooks` as an optional, framework-neutral control engine for CrewAI. Policies, content filters, approval gates, and egress guards can be registered once and applied across execution, model, and tool lifecycle points.

- Lazily loads `agent-hooks-sdk` through the `agent-hooks` extra: See: https://github.com/responsibleai/agent-hooks/blob/main/spec/AGENT-HOOKS-0.1.md
- Appends the injected governor after CrewAI global and scoped hooks.
- Applies transforms to the effective target and fails closed on denial, timeout, malformed context, or engine failure.
- Uses per-run sessions and host-owned correlation IDs for auditable pre/post records.
- Covers direct and executor model calls plus CrewAI and native-provider tool paths, with remaining provider-specific exclusions documented explicitly.

## Architecture

```mermaid
flowchart LR
    subgraph Runtime["CrewAI runtime"]
        B["Crew and flow boundaries"]
        M["Model call paths"]
        T["Tool call paths"]
        H["CrewAI hook seams"]
        N["Global and scoped hooks"]
        G["Injected governor<br/>authoritative final hook"]
    end

    subgraph Engine["Optional agent-hooks control engine"]
        A["Point adapter<br/>schema-valid context and correlation"]
        L["Dedicated async emitter loop"]
        I["Registered interceptors<br/>policy, filter, approval, egress"]
        V{"Combined verdict"}
        R["Interception records<br/>buffer or record sink"]
    end

    B --> H
    M --> H
    T --> H
    H --> N --> G
    G --> A --> L --> I --> V
    V -->|allow| P["Proceed unchanged"]
    V -->|transform| X["Apply effective target"]
    V -->|deny, timeout, or error| D["Fail closed"]
    V --> R
```

## How it works

1. `use_agent_hooks(...)` lazily loads the optional SDK, configures the emitter and interceptors, and installs the engine as the process governor.
2. CrewAI global and execution-scoped hooks run first. The governor adapter is appended last for supported lifecycle points.
3. Each adapter validates and normalizes untrusted hook data, adds per-run session and correlation metadata, and submits the context to a dedicated async emitter loop.
4. The combined verdict either allows the action, applies the effective transformed target, or fails closed. Pre-point denial prevents the action; post-point denial replaces the result with a blocked marker.
5. Every decision produces an auditable record available from `engine.records`, `take_records()`, or a configured record sink.

## Coverage

The engine maps CrewAI execution start/end, input/output, model pre/post, and tool pre/post points to the eight `agent-hooks` control points. CrewAI `PRE_STEP` and `POST_STEP` remain native. Direct provider-specific async calls and direct native-provider Pydantic responses are not yet uniformly governed and are documented as exclusions.

## Validation

- `uv run mypy lib/` with and without `agent-hooks-sdk` installed
- `uv run ruff format --check` and `uv run ruff check --no-fix` on changed sources
- `uv lock --check`
- `uv run --package crewai --with "agent-hooks-sdk==0.1.0a3" pytest lib/crewai/tests -q`

