### PR TITLE
fix: correct workspace count in CONTRIBUTING.md and Python version in publish.yml

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ uv run pre-commit install
 
 ## Repository Structure
 
-This is a uv workspace with four packages under `lib/`:
+This is a uv workspace with six packages under `lib/`:
 
 | Package | Path | Description |
 |---------|------|-------------|

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -66,7 +66,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.11.3"
-          python-version: "3.12"
+          python-version: "3.13"
           enable-cache: false
 
       - name: Download artifacts


### PR DESCRIPTION
## Summary

Two small documentation/config fixes reported in issues #6664 and #6662:

### Fix 1: Update workspace package count (#6664)
- **File**: `.github/CONTRIBUTING.md`
- **Change**: `four packages` → `six packages`
- **Reason**: The pyproject.toml defines 6 workspace members under `lib/`:

```yaml
[tool.uv.workspace]
members = [
    "lib/crewai",
    "lib/crewai-tools",
    "lib/devtools",
    "lib/crewai-files",
    "lib/cli",
    "lib/crewai-core",
]
```

### Fix 2: Align publish.yml Python version (#6662)
- **File**: `.github/workflows/publish.yml` (lines 34 and 69)
- **Change**: `python-version: "3.12"` → `python-version: "3.13"`
- **Reason**: Aligns with `.python-version` (3.13) and removes inconsistency

## Checklist
- [x] Follows contributing guidelines
- [x] References related issues