### PR TITLE
fix(mcp): key the tool-list cache on credentials, not just the endpoint

### DIFF
--- a/lib/crewai/src/crewai/mcp/client.py
+++ b/lib/crewai/src/crewai/mcp/client.py
@@ -4,6 +4,8 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from contextlib import AsyncExitStack
 from datetime import datetime
+import hashlib
+import json
 import logging
 import sys
 import time
@@ -713,6 +715,19 @@ class MCPClient:
 
         raise ConnectionError(f"Operation failed: {last_error}")
 
+    @staticmethod
+    def _fingerprint(values: dict[str, str]) -> str:
+        """Hash credential-bearing values for use in a cache key.
+
+        The values are headers and environment variables, so they hold tokens. A
+        digest keeps them out of the key itself, which callers may log, while
+        still distinguishing one set of credentials from another.
+        """
+        if not values:
+            return "-"
+        canonical = json.dumps(values, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
     def _get_cache_key(self, resource_type: str) -> str:
         """Generate cache key for resource.
 
@@ -722,13 +737,25 @@ class MCPClient:
         Returns:
             Cache key string.
         """
-        # Use transport type and URL/command as cache key
+        # The cache is module-level and shared by every client in the process, so
+        # the key must cover everything that can change the server's answer -- not
+        # just where we connect but as whom. Two clients on the same URL with
+        # different Authorization headers see different tool lists, and the same
+        # goes for a stdio server launched with a different API key in its env.
         if isinstance(self.transport, StdioTransport):
-            key = f"stdio:{self.transport.command}:{':'.join(self.transport.args)}"
+            key = (
+                f"stdio:{self.transport.command}:{':'.join(self.transport.args)}"
+                f":{self._fingerprint(self.transport.env)}"
+            )
         elif isinstance(self.transport, HTTPTransport):
-            key = f"http:{self.transport.url}"
+            key = (
+                f"http:{self.transport.url}:{self.transport.streamable}"
+                f":{self._fingerprint(self.transport.headers)}"
+            )
         elif isinstance(self.transport, SSETransport):
-            key = f"sse:{self.transport.url}"
+            key = (
+                f"sse:{self.transport.url}:{self._fingerprint(self.transport.headers)}"
+            )
         else:
             key = f"{self.transport.transport_type}:unknown"
 

--- a/lib/crewai/tests/mcp/test_client_cache_key.py
+++ b/lib/crewai/tests/mcp/test_client_cache_key.py
@@ -1,0 +1,129 @@
+"""Tests for MCPClient's tool-list cache key.
+
+`_mcp_schema_cache` is module-level, so it is shared by every client in the
+process. The key therefore has to cover everything that can change what the
+server answers -- not only *where* we connect but *as whom*.
+"""
+
+import time
+
+import pytest
+
+from crewai.mcp.client import MCPClient, _mcp_schema_cache
+from crewai.mcp.transports.http import HTTPTransport
+from crewai.mcp.transports.sse import SSETransport
+from crewai.mcp.transports.stdio import StdioTransport
+
+
+@pytest.fixture(autouse=True)
+def clear_schema_cache():
+    """The cache is module-level state; don't leak entries between tests."""
+    _mcp_schema_cache.clear()
+    yield
+    _mcp_schema_cache.clear()
+
+
+def _key(transport) -> str:
+    return MCPClient(transport, cache_tools_list=True)._get_cache_key("tools")
+
+
+def test_http_clients_with_different_auth_headers_do_not_share_a_cache_entry():
+    """Two tenants on the same URL must not see each other's tool list.
+
+    `headers={"Authorization": "Bearer ..."}` alongside `cache_tools_list=True` is
+    the documented usage for a remote MCP server, and an MCP server routinely
+    returns a different tool set per caller.
+    """
+    tenant_a = _key(
+        HTTPTransport(
+            url="https://mcp.example.com/mcp",
+            headers={"Authorization": "Bearer TENANT-A"},
+        )
+    )
+    tenant_b = _key(
+        HTTPTransport(
+            url="https://mcp.example.com/mcp",
+            headers={"Authorization": "Bearer TENANT-B"},
+        )
+    )
+
+    assert tenant_a != tenant_b
+
+    # And concretely: what A caches must not be served to B.
+    _mcp_schema_cache[tenant_a] = ([{"name": "tenant_a_only_tool"}], time.time())
+    assert tenant_b not in _mcp_schema_cache
+
+
+def test_stdio_clients_with_different_env_do_not_share_a_cache_entry():
+    """Same command, different credentials in `env` -- also documented usage."""
+    account_1 = _key(
+        StdioTransport(
+            command="python", args=["server.py"], env={"API_KEY": "key-1"}
+        )
+    )
+    account_2 = _key(
+        StdioTransport(
+            command="python", args=["server.py"], env={"API_KEY": "key-2"}
+        )
+    )
+
+    assert account_1 != account_2
+
+
+def test_sse_clients_with_different_auth_headers_do_not_share_a_cache_entry():
+    """SSE takes `headers` too, and had the same defect."""
+    assert _key(
+        SSETransport(url="https://s/sse", headers={"Authorization": "Bearer A"})
+    ) != _key(SSETransport(url="https://s/sse", headers={"Authorization": "Bearer B"}))
+
+
+def test_streamable_flag_changes_the_cache_key():
+    """`streamable` picks a different protocol, so it may yield a different list."""
+    assert _key(HTTPTransport(url="https://s/mcp", streamable=True)) != _key(
+        HTTPTransport(url="https://s/mcp", streamable=False)
+    )
+
+
+def test_identical_transports_still_share_a_cache_entry():
+    """Control: the cache must still hit for genuinely equivalent clients.
+
+    Header order and dict insertion order are not meaningful, so they must not
+    split the key -- otherwise the fix would quietly disable caching.
+    """
+    first = _key(
+        HTTPTransport(
+            url="https://mcp.example.com/mcp",
+            headers={"Authorization": "Bearer T", "X-Trace": "1"},
+        )
+    )
+    second = _key(
+        HTTPTransport(
+            url="https://mcp.example.com/mcp",
+            headers={"X-Trace": "1", "Authorization": "Bearer T"},
+        )
+    )
+
+    assert first == second
+
+
+def test_credentials_are_not_present_verbatim_in_the_cache_key():
+    """Keys get logged and shown in errors, so hash the credential-bearing parts."""
+    secret = "Bearer super-secret-token"
+    key = _key(HTTPTransport(url="https://s/mcp", headers={"Authorization": secret}))
+
+    assert secret not in key
+    assert "super-secret-token" not in key
+
+
+def test_resource_type_still_separates_entries():
+    """Control: the existing per-resource-type separation must be preserved."""
+    client = MCPClient(HTTPTransport(url="https://s/mcp"), cache_tools_list=True)
+
+    assert client._get_cache_key("tools") != client._get_cache_key("prompts")
+
+
+def test_no_credentials_still_yields_a_stable_key():
+    """Control: the common case -- no headers at all -- must be deterministic."""
+    assert _key(HTTPTransport(url="https://s/mcp")) == _key(
+        HTTPTransport(url="https://s/mcp")
+    )


### PR DESCRIPTION
## Summary

`_mcp_schema_cache` (`lib/crewai/src/crewai/mcp/client.py:50`) is a module-level dict, so it is shared by every `MCPClient` in the process. But `_get_cache_key` only covered the endpoint:

```python
if isinstance(self.transport, StdioTransport):
    key = f"stdio:{self.transport.command}:{':'.join(self.transport.args)}"
elif isinstance(self.transport, HTTPTransport):
    key = f"http:{self.transport.url}"
elif isinstance(self.transport, SSETransport):
    key = f"sse:{self.transport.url}"
```

Everything else that changes what the server answers was invisible to it — most importantly **who is asking**. An MCP server routinely returns a different tool set per caller, so two clients on the same URL with different `Authorization` headers shared a single cache entry: whichever connected first populated it, and the second was served the first one's tool list.

```
tenant A key: mcp:http:https://mcp.example.com/mcp:tools
tenant B key: mcp:http:https://mcp.example.com/mcp:tools
SAME KEY? True
after A caches, B's lookup hits: [{'name': 'tenant_a_only_tool'}]
```

Three collisions, all reproduced:

| what differs | collided | why it matters |
|---|---|---|
| `HTTPTransport.headers` / `SSETransport.headers` | yes | `Authorization` — a crew serving two tenants can see the other tenant's tools |
| `StdioTransport.env` | yes | `env={"API_KEY": ...}` selects the account the local server acts as |
| `HTTPTransport.streamable` | yes | picks a different protocol (`STREAMABLE_HTTP` vs `HTTP`), so the response can differ |

## This is the documented usage, not an exotic setup

`docs/edge/en/mcp/overview.mdx` pairs credentials with caching in its own examples — the collision lands squarely on what the docs recommend:

```python
MCPServerHTTP(
    url="https://api.example.com/mcp",
    headers={"Authorization": "Bearer your_token"},
    streamable=True,
    cache_tools_list=True,          # ← same URL + different token = shared entry
)
```

```python
MCPServerStdio(
    command="npx", args=["-y", "@modelcontextprotocol/server-filesystem"],
    env={"API_KEY": "your_key"},
    cache_tools_list=True,
)
```

`headers` is a first-class field on both `MCPServerHTTP` and `MCPServerSSE` (`mcp/config.py:72`, `:109`), documented as *"Optional HTTP headers for authentication or other purposes"*, and `MCPToolResolver._create_transport` (`mcp/tool_resolver.py:296-307`) passes it straight through to the transport. The whole path from `Agent(mcps=[...])` to the cache lookup is normal user flow.

Note `tool_filter` does not mask this: filtering happens in `tool_resolver.py:382` on the list *returned* by `list_tools()`, after the cache has already answered.

## Changes

`_get_cache_key` now includes the credential-bearing fields, plus `streamable`:

```python
if isinstance(self.transport, StdioTransport):
    key = (
        f"stdio:{self.transport.command}:{':'.join(self.transport.args)}"
        f":{self._fingerprint(self.transport.env)}"
    )
elif isinstance(self.transport, HTTPTransport):
    key = (
        f"http:{self.transport.url}:{self.transport.streamable}"
        f":{self._fingerprint(self.transport.headers)}"
    )
elif isinstance(self.transport, SSETransport):
    key = f"sse:{self.transport.url}:{self._fingerprint(self.transport.headers)}"
```

The values are hashed rather than interpolated, because these are tokens and cache keys end up in logs and error messages:

```python
@staticmethod
def _fingerprint(values: dict[str, str]) -> str:
    if not values:
        return "-"
    canonical = json.dumps(values, sort_keys=True, separators=(",", ":"))
    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
```

`sort_keys=True` matters: header dict order is not meaningful, so it must not split the key — otherwise the fix would quietly disable caching for clients that are in fact equivalent. There is a test for exactly that.

Nothing else changed; the cache mechanism, TTL and `cache_tools_list` default are untouched. 31 insertions.

## Validation

New `lib/crewai/tests/mcp/test_client_cache_key.py`, 8 tests. The cache key had no test coverage before this.

| test | guards |
|---|---|
| `test_http_clients_with_different_auth_headers_do_not_share_a_cache_entry` | the main defect; also asserts A's cached entry is not reachable via B's key |
| `test_stdio_clients_with_different_env_do_not_share_a_cache_entry` | stdio credentials |
| `test_sse_clients_with_different_auth_headers_do_not_share_a_cache_entry` | SSE had the same defect |
| `test_streamable_flag_changes_the_cache_key` | protocol selection |
| `test_identical_transports_still_share_a_cache_entry` | **control** — header order must not split the key, i.e. caching still works |
| `test_credentials_are_not_present_verbatim_in_the_cache_key` | tokens stay out of the key |
| `test_resource_type_still_separates_entries` | **control** — existing `tools` vs `prompts` separation preserved |
| `test_no_credentials_still_yields_a_stable_key` | **control** — the no-headers case stays deterministic |

An `autouse` fixture clears `_mcp_schema_cache` around each test, since it is module-level state.

**Control experiment** — `client.py` reverted, tests kept:

```
4 failed, 4 passed

FAILED test_http_clients_with_different_auth_headers_do_not_share_a_cache_entry
FAILED test_stdio_clients_with_different_env_do_not_share_a_cache_entry
FAILED test_sse_clients_with_different_auth_headers_do_not_share_a_cache_entry
FAILED test_streamable_flag_changes_the_cache_key
```

Exactly the four defect tests fail; the four controls stay green. (`test_credentials_are_not_present_verbatim_in_the_cache_key` passing on `main` is correct — credentials were not in the key there because they were not considered at all.) With the fix: **8 passed**.

**No regressions.** `lib/crewai/tests/mcp/`:

| tree | result |
|---|---|
| this branch | 43 passed, 5 failed |
| unmodified `main` | same 5 failures |

The 5 are `test_amp_mcp.py::TestFetchAmpMCPConfigs::*`, identical on `main` with `client.py` reverted — they need network/token state my machine does not have, and are unrelated to this change.

`ruff format`, `ruff check` and `mypy` clean on `client.py`. (The test file sits under `lib/crewai/tests/`, which `pyproject.toml` puts in ruff's `extend-exclude`.)

## One thing I left out

`_retry_operation` (`client.py:682`) has a separate, smaller bug I noticed while reading: `for attempt in range(self.max_retries)` means `max_retries=0` never runs the operation at all and falls through to `raise ConnectionError(f"Operation failed: {last_error}")` with `last_error=None` — you get `Operation failed: None` without a single attempt having been made. It also reads as "attempts" rather than "retries", unlike `task.py:1320` (`max_attempts = self.guardrail_max_retries + 1`).

I left it out to keep this diff focused per `AGENTS.md`. Happy to send it separately, or fold it in here if you would rather have both.

## Duplicate check

Searched open and closed PRs and issues for `_mcp_schema_cache`, `_get_cache_key`, `cache_tools_list`, and `mcp cache` — no existing or overlapping work. Targeting `main`.


<!-- crewai-require-issue-check -->