### PR TITLE
fix: update workspace count from 4 to 6 packages in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ uv run pre-commit install
 
 ## Repository Structure
 
-This is a uv workspace with four packages under `lib/`:
+This is a uv workspace with six packages under `lib/`:
 
 | Package | Path | Description |
 |---------|------|-------------|
@@ -37,6 +37,8 @@ This is a uv workspace with four packages under `lib/`:
 | `crewai-tools` | `lib/crewai-tools/` | Tool integrations |
 | `crewai-files` | `lib/crewai-files/` | File handling |
 | `devtools` | `lib/devtools/` | Internal release tooling |
+| `cli` | `lib/cli/` | CLI tooling |
+| `crewai-core` | `lib/crewai-core/` | Core agent abstractions |
 
 Documentation lives in `docs/` with translations under `docs/{en,ar,ko,pt-BR}/`.
 


### PR DESCRIPTION
## Description

Fixes #6664 - Incorrect number of workspaces in CONTRIBUTING.md

The uv workspace actually contains 6 packages as defined in pyproject.toml:
- lib/crewai
- lib/crewai-tools
- lib/devtools
- lib/crewai-files
- lib/cli
- lib/crewai-core

But CONTRIBUTING.md only listed 4 packages and said 'four packages' instead of 'six packages'.

## Changes

- Updated text from 'four packages' to 'six packages'
- Added missing  and  packages to the table

## Checklist

- [x] Documentation update