### PR TITLE
fix: update workspace count from 4 to 6 packages in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ uv run pre-commit install
 
 ## Repository Structure
 
-This is a uv workspace with four packages under `lib/`:
+This is a uv workspace with six packages under `lib/`:
 
 | Package | Path | Description |
 |---------|------|-------------|
@@ -37,6 +37,8 @@ This is a uv workspace with four packages under `lib/`:
 | `crewai-tools` | `lib/crewai-tools/` | Tool integrations |
 | `crewai-files` | `lib/crewai-files/` | File handling |
 | `devtools` | `lib/devtools/` | Internal release tooling |
+| `cli` | `lib/cli/` | CLI interface |
+| `crewai-core` | `lib/crewai-core/` | Core agents architecture |
 
 Documentation lives in `docs/` with translations under `docs/{en,ar,ko,pt-BR}/`.
 


### PR DESCRIPTION
## Description\n\nFixes #6664 - Incorrect number of workspaces in CONTRIBUTING.md\n\nThe  defines 6 workspace members but the CONTRIBUTING.md only listed 4 packages and stated "four packages".\n\n## Changes\n\n1. Updated the count from "four packages" to "six packages"\n2. Added the missing packages to the table:\n   -  - CLI interface\n   -  - Core agents architecture\n\n## Verification\n\nCompare with  lines 237-245:\n\n\nThis PR aligns the documentation with the actual workspace configuration.