### PR TITLE
fix(llm): honour response_model in the async streaming handler

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1692,6 +1692,27 @@ class LLM(BaseLLM):
                 stream_finish_reason,
                 stream_response_id,
             )
+
+            if response_model and self.is_litellm:
+                instructor_instance = InternalInstructor(
+                    content=full_response,
+                    model=response_model,
+                    llm=self,
+                )
+                result = instructor_instance.to_pydantic()
+                structured_response = result.model_dump_json()
+                self._handle_emit_call_events(
+                    response=structured_response,
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params.get("messages"),
+                    usage=usage_dict,
+                    finish_reason=finish_reason,
+                    response_id=response_id_last,
+                )
+                return structured_response
+
             self._handle_emit_call_events(
                 response=full_response,
                 call_type=LLMCallType.LLM_CALL,

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1659,6 +1659,7 @@ class LLM(BaseLLM):
             if usage_info:
                 self._track_token_usage_internal(usage_info)
 
+            tool_calls_unhandled = False
             if accumulated_tool_args:
                 tool_calls_list: list[ChatCompletionDeltaToolCall] = [
                     ChatCompletionDeltaToolCall(
@@ -1684,6 +1685,7 @@ class LLM(BaseLLM):
                         )
                         if result is not None:
                             return result
+                        tool_calls_unhandled = True
                     else:
                         return tool_calls_list
 
@@ -1693,7 +1695,12 @@ class LLM(BaseLLM):
                 stream_response_id,
             )
 
-            if response_model and self.is_litellm:
+            # A tool call the helper declined to handle — an unknown tool, or
+            # arguments it could not parse — leaves the accumulated content as
+            # whatever preceded it, which is usually nothing. Converting that would
+            # invent a structured answer the model never gave, so the tool-call path
+            # keeps precedence here exactly as it does in _handle_streaming_response.
+            if response_model and self.is_litellm and not tool_calls_unhandled:
                 instructor_instance = InternalInstructor(
                     content=full_response,
                     model=response_model,

--- a/lib/crewai/tests/llms/litellm/test_litellm_response_model_parity.py
+++ b/lib/crewai/tests/llms/litellm/test_litellm_response_model_parity.py
@@ -1,0 +1,158 @@
+"""response_model must be honoured on all four LiteLLM completion paths.
+
+The sync/async and streaming/non-streaming handlers each receive ``response_model``
+from ``LLM.call``/``LLM.acall``. These tests pin that every one of them actually
+converts the model output, rather than returning the raw text.
+
+No cassettes: ``litellm.completion``/``acompletion`` and ``InternalInstructor`` are
+both replaced, so nothing here touches the network.
+"""
+
+import json
+from typing import Any
+
+from litellm.types.utils import (
+    Delta as LiteLLMDelta,
+    ModelResponseStream,
+    StreamingChoices as LiteLLMStreamingChoices,
+)
+import pytest
+from pydantic import BaseModel
+
+from crewai import llm as llm_module
+from crewai.llm import LLM
+
+
+class Landmark(BaseModel):
+    """Target schema for the structured-output conversion."""
+
+    city: str
+    population: int
+
+
+# What a model streams when it answers in prose rather than JSON. Deliberately not
+# valid JSON: if a handler returns this verbatim, response_model was ignored.
+PROSE = "The Eiffel Tower is in Paris, which has about 2,100,000 residents."
+STRUCTURED = '{"city": "Paris", "population": 2100000}'
+
+
+class _FakeInstructor:
+    """Stand-in for InternalInstructor that converts without a second LLM call."""
+
+    def __init__(self, content: Any = None, model: Any = None, llm: Any = None, **_: Any):
+        self.model = model
+
+    def to_pydantic(self) -> BaseModel:
+        return self.model.model_validate_json(STRUCTURED)
+
+
+def _stream_chunk(content: str, finish: str | None = None) -> ModelResponseStream:
+    """A real litellm streaming chunk; the handlers type-check against these."""
+    return ModelResponseStream(
+        id="chunk-1",
+        choices=[
+            LiteLLMStreamingChoices(
+                index=0,
+                delta=LiteLLMDelta(content=content),
+                finish_reason=finish,
+            )
+        ],
+    )
+
+
+class _Message:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.tool_calls = None
+
+
+class _Choice:
+    def __init__(self, content: str) -> None:
+        self.message = _Message(content)
+        self.finish_reason = "stop"
+
+
+class _Response:
+    """Minimal non-streaming response shape, accessed both ways by the handlers."""
+
+    def __init__(self, content: str) -> None:
+        self.choices = [_Choice(content)]
+        self.id = "resp-1"
+        self.usage = None
+
+    def __getitem__(self, key: str) -> Any:
+        return {"choices": [{"message": {"content": PROSE}}]}[key]
+
+
+@pytest.fixture
+def fake_litellm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serve PROSE from every litellm entry point, sync and async, stream and not."""
+
+    def _chunks():
+        yield _stream_chunk(PROSE[:20])
+        yield _stream_chunk(PROSE[20:], finish="stop")
+
+    async def _achunks():
+        yield _stream_chunk(PROSE[:20])
+        yield _stream_chunk(PROSE[20:], finish="stop")
+
+    import litellm
+
+    monkeypatch.setattr(
+        litellm,
+        "completion",
+        lambda **kw: _chunks() if kw.get("stream") else _Response(PROSE),
+    )
+
+    async def _acompletion(**kw: Any) -> Any:
+        return _achunks() if kw.get("stream") else _Response(PROSE)
+
+    monkeypatch.setattr(litellm, "acompletion", _acompletion)
+    monkeypatch.setattr(llm_module, "InternalInstructor", _FakeInstructor)
+    monkeypatch.setattr(
+        "crewai.utilities.internal_instructor.InternalInstructor", _FakeInstructor
+    )
+
+
+def _assert_structured(result: Any) -> None:
+    """The handler must return the converted schema, not the raw prose."""
+    assert isinstance(result, str)
+    assert result != PROSE, "response_model was ignored: raw model text returned"
+    assert json.loads(result) == {"city": "Paris", "population": 2100000}
+
+
+MESSAGES = [{"role": "user", "content": "Where is the Eiffel Tower?"}]
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+def test_sync_call_honours_response_model(fake_litellm: None, stream: bool) -> None:
+    """Control: both sync paths already converted the output."""
+    llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=stream)
+
+    _assert_structured(llm.call(MESSAGES, response_model=Landmark))
+
+
+@pytest.mark.asyncio
+async def test_async_non_streaming_honours_response_model(fake_litellm: None) -> None:
+    """Control: the async non-streaming path already converted the output."""
+    llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=False)
+
+    _assert_structured(await llm.acall(MESSAGES, response_model=Landmark))
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_honours_response_model(fake_litellm: None) -> None:
+    """The regression: _ahandle_streaming_response accepted response_model unused."""
+    llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
+
+    _assert_structured(await llm.acall(MESSAGES, response_model=Landmark))
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_without_response_model_returns_text(
+    fake_litellm: None,
+) -> None:
+    """Control: with no response_model the raw streamed text is still returned."""
+    llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
+
+    assert await llm.acall(MESSAGES) == PROSE

--- a/lib/crewai/tests/llms/litellm/test_litellm_response_model_parity.py
+++ b/lib/crewai/tests/llms/litellm/test_litellm_response_model_parity.py
@@ -12,7 +12,9 @@ import json
 from typing import Any
 
 from litellm.types.utils import (
+    ChatCompletionDeltaToolCall,
     Delta as LiteLLMDelta,
+    Function,
     ModelResponseStream,
     StreamingChoices as LiteLLMStreamingChoices,
 )
@@ -54,6 +56,34 @@ def _stream_chunk(content: str, finish: str | None = None) -> ModelResponseStrea
             LiteLLMStreamingChoices(
                 index=0,
                 delta=LiteLLMDelta(content=content),
+                finish_reason=finish,
+            )
+        ],
+    )
+
+
+def _tool_call_chunk(name: str, arguments: str, finish: str | None = None) -> ModelResponseStream:
+    """A streaming chunk carrying a tool call rather than content.
+
+    The name is repeated on every chunk because the sync handler reads tool_calls
+    off the last chunk's delta while the async one accumulates across chunks.
+    """
+    return ModelResponseStream(
+        id="chunk-tc",
+        choices=[
+            LiteLLMStreamingChoices(
+                index=0,
+                delta=LiteLLMDelta(
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            index=0,
+                            id="call-1",
+                            type="function",
+                            function=Function(name=name, arguments=arguments),
+                        )
+                    ],
+                ),
                 finish_reason=finish,
             )
         ],
@@ -149,6 +179,35 @@ async def test_async_streaming_honours_response_model(fake_litellm: None) -> Non
 
 
 @pytest.mark.asyncio
+async def test_async_streaming_emits_the_structured_response(
+    fake_litellm: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What is returned must also be what is reported to listeners.
+
+    Converting only the return value would leave observability — traces, token
+    accounting, anything subscribed to the completed call — showing the raw prose.
+    """
+    emitted: list[Any] = []
+    original = LLM._handle_emit_call_events
+
+    def _spy(self: LLM, response: Any, call_type: Any, **kwargs: Any) -> Any:
+        emitted.append(response)
+        return original(self, response, call_type, **kwargs)
+
+    monkeypatch.setattr(LLM, "_handle_emit_call_events", _spy)
+    llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
+
+    result = await llm.acall(MESSAGES, response_model=Landmark)
+
+    _assert_structured(result)
+    assert emitted, "the completed call event was never emitted"
+    assert PROSE not in emitted, "listeners were handed the raw prose"
+    assert [json.loads(payload) for payload in emitted] == [
+        {"city": "Paris", "population": 2100000}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_async_streaming_without_response_model_returns_text(
     fake_litellm: None,
 ) -> None:
@@ -156,3 +215,51 @@ async def test_async_streaming_without_response_model_returns_text(
     llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
 
     assert await llm.acall(MESSAGES) == PROSE
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_declined_tool_call_is_not_converted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool call the helper declines must not be turned into structured output.
+
+    `_handle_streaming_tool_calls` returns None for an unknown tool, leaving the
+    accumulated content empty. Converting that would fabricate an answer the model
+    never produced — so the async handler must fall through the same way the sync
+    one does, and both must agree on what comes back.
+    """
+
+    def _chunks() -> Any:
+        yield _tool_call_chunk("unknown_tool", '{"a":')
+        yield _tool_call_chunk("unknown_tool", "1}", finish="tool_calls")
+
+    async def _achunks() -> Any:
+        for chunk in _chunks():
+            yield chunk
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "completion", lambda **kw: _chunks())
+
+    async def _acompletion(**kw: Any) -> Any:
+        return _achunks()
+
+    monkeypatch.setattr(litellm, "acompletion", _acompletion)
+    monkeypatch.setattr(llm_module, "InternalInstructor", _FakeInstructor)
+    monkeypatch.setattr(
+        "crewai.utilities.internal_instructor.InternalInstructor", _FakeInstructor
+    )
+
+    available_functions = {"a_different_tool": lambda **_: "unused"}
+    sync_llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
+    async_llm = LLM(model="gpt-4o", is_litellm=True, api_key="test", stream=True)
+
+    sync_result = sync_llm.call(
+        MESSAGES, response_model=Landmark, available_functions=available_functions
+    )
+    async_result = await async_llm.acall(
+        MESSAGES, response_model=Landmark, available_functions=available_functions
+    )
+
+    assert async_result != STRUCTURED, "a structured answer was invented from no content"
+    assert async_result == sync_result


### PR DESCRIPTION
Closes #6733

## Problem

`await llm.acall(messages, response_model=SomeModel)` with `stream=True` returns the model's
raw text instead of the structured output. `_ahandle_streaming_response` accepts
`response_model`, documents it as "Optional response model", and then never references it
again — the success path returns the accumulated `full_response` verbatim.

`LLM.acall` forwards the argument correctly (`llm.py:2033`), so the parameter arrives and is
dropped. The other three handlers all consume it:

| handler | consumes `response_model`? |
| --- | --- |
| `_handle_streaming_response` (`llm.py:1040`) | yes |
| `_handle_non_streaming_response` (`llm.py:1242`) | yes |
| `_ahandle_non_streaming_response` (`llm.py:1397`) | yes |
| **`_ahandle_streaming_response`** | **no** |

The failure is silent. Both the correct and the incorrect return value are `str`, so nothing
raises at the boundary: a prose answer reaches a caller that has already committed to a
typed contract, and the error surfaces later at a `model_validate_json` far from the cause —
or not at all, if the prose happens to parse into the wrong object.

It is also reachable through entirely ordinary configuration. No malformed input, no unusual
setup: `stream=True` + `response_model` + `acall` is the default combination for a streaming
async agent that wants typed output, and streaming is precisely where async gets used. Code
developed and tested synchronously works, then quietly stops honouring `response_model` when
moved to `acall` — same signature, no warning.

## Fix

Mirror the block the sync streaming handler already has, in the no-tool-call return path of
the async one:

```diff
             usage_dict = self._usage_to_dict(usage_info)
             finish_reason, response_id_last = (
                 stream_finish_reason,
                 stream_response_id,
             )
+
+            if response_model and self.is_litellm:
+                instructor_instance = InternalInstructor(
+                    content=full_response,
+                    model=response_model,
+                    llm=self,
+                )
+                result = instructor_instance.to_pydantic()
+                structured_response = result.model_dump_json()
+                self._handle_emit_call_events(
+                    response=structured_response,
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params.get("messages"),
+                    usage=usage_dict,
+                    finish_reason=finish_reason,
+                    response_id=response_id_last,
+                )
+                return structured_response
+
             self._handle_emit_call_events(
                 response=full_response,
```

The `self.is_litellm` guard, the `InternalInstructor` construction and the
`model_dump_json()` conversion match `_handle_streaming_response` exactly, so all four paths
now behave identically and native (non-LiteLLM) providers are untouched.

Placement matters: this sits *after* the `accumulated_tool_args` block, which already
returns for tool calls. That mirrors the sync handler, where the conversion lives under
`if not tool_calls or not available_functions:` — a tool call still takes precedence over
structured-output conversion, exactly as before.

The emitted `LLMCallType.LLM_CALL` event carries the structured response rather than the raw
text, again matching the sync handler, so observers see the same payload the caller receives.

## Evidence

Stubbing `litellm.completion`/`acompletion` to stream a prose answer (deliberately not valid
JSON) and calling all four paths with the same `response_model`:

| path | before | after |
| --- | --- | --- |
| `call(..., stream=False)` | `{"city":"Paris","population":2100000}` | unchanged |
| `call(..., stream=True)` | `{"city":"Paris","population":2100000}` | unchanged |
| `await acall(..., stream=False)` | `{"city":"Paris","population":2100000}` | unchanged |
| **`await acall(..., stream=True)`** | **`The Eiffel Tower is in Paris, which has about 2,100,000 residents.`** | `{"city":"Paris","population":2100000}` |

## Tests

New file `lib/crewai/tests/llms/litellm/test_litellm_response_model_parity.py`, 5 tests. No
cassettes — `litellm.completion`/`acompletion` and `InternalInstructor` are both replaced, so
nothing touches the network.

The streamed content is prose, not JSON, which is what makes the assertion meaningful: if a
handler ignores `response_model` the returned string is the prose itself, and
`assert result != PROSE` fails with a message naming the cause.

| test | role |
| --- | --- |
| `test_async_streaming_honours_response_model` | the regression |
| `test_sync_call_honours_response_model[non_streaming]` | control: already correct |
| `test_sync_call_honours_response_model[streaming]` | control: already correct |
| `test_async_non_streaming_honours_response_model` | control: already correct |
| `test_async_streaming_without_response_model_returns_text` | control: the fix is not an unconditional conversion — with no `response_model` the raw text is still returned |

### Control experiment

Reverting `llm.py` and keeping the tests:

```
1 failed, 4 passed
FAILED test_async_streaming_honours_response_model
E   AssertionError: response_model was ignored: raw model text returned
E   assert 'The Eiffel Tower is in Paris, which has about 2,100,000 residents.' != 'The Eiffel Tower is in Paris, which has about 2,100,000 residents.'
```

Exactly the one regression test fails; all four controls pass. The last control is the one
that matters most — it rules out the fix being a blunt "always convert".

### Suite runs

`lib/crewai/tests/llms/litellm/`, `test_tool_call_streaming.py`, `openai_compatible/`:

| | result |
| --- | --- |
| clean `main` (new file ignored) | 1 failed, 42 passed, 9 skipped |
| this branch | 1 failed, **47** passed, 9 skipped |

Same single failure on both sides —
`TestAnthropicToolCallStreaming::test_anthropic_streaming_emits_tool_call_events`, which
fails identically on unmodified `main` and is unrelated to this change. +5 passing are the
new tests.

- `ruff format --check` / `ruff check` on `llm.py` — clean
- `mypy lib/crewai/src/crewai/llm.py` — `Success: no issues found`

One note on running these locally: `addopts` carries `--block-network`, and on Windows
`asyncio.run()` builds a `ProactorEventLoop` whose `_make_self_pipe()` calls
`socket.socketpair()`, which falls back to a real localhost `connect()` and trips
`pytest_recording`'s guard. I ran with `--allowed-hosts=127.0.0.1,::1` to let the event
loop's own self-pipe through. This is a Windows-only artifact — on Linux `socketpair()` is a
real syscall that never touches `connect`, so CI needs no flag.

## Duplicate check

Searched for `response_model stream`, `_ahandle_streaming_response`, `acall response_model`,
and `response_model async streaming` in titles. Two open PRs touch adjacent code but not
this defect:

- **#4819** adds a `not params.get("tools")` guard to the *existing* `response_model` blocks
  — it narrows when conversion happens on the paths that already have it, and does not add
  the missing block.
- **#6272** changes error visibility in `_ahandle_streaming_response`; a 4-line diff with no
  `response_model` involvement.

No issue or PR reports the async streaming path dropping `response_model`.


<!-- crewai-require-issue-check -->