### PR TITLE
fix(llm): don't swallow response_model conversion errors on streaming (#6735)

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -365,6 +365,17 @@ class AccumulatedToolArgs(BaseModel):
     function: FunctionArgs = Field(default_factory=FunctionArgs)
 
 
+class StructuredOutputConversionError(Exception):
+    """Raised when converting a completed stream to ``response_model`` fails.
+
+    A conversion failure is distinct from a broken stream: the stream finished
+    successfully, the accumulated text just did not match the requested schema.
+    Raising a dedicated error keeps this out of the partial-response salvage
+    path (which returns the raw text on a mid-stream break), so a caller that
+    asked for a ``BaseModel``-shaped result gets an exception instead of prose.
+    """
+
+
 class LLM(BaseLLM):
     llm_type: Literal["litellm"] = "litellm"
     completion_cost: float | None = None
@@ -1043,8 +1054,16 @@ class LLM(BaseLLM):
                         model=response_model,
                         llm=self,
                     )
-                    result = instructor_instance.to_pydantic()
-                    structured_response = result.model_dump_json()
+                    try:
+                        result = instructor_instance.to_pydantic()
+                        structured_response = result.model_dump_json()
+                    except Exception as conversion_error:
+                        # The stream completed; the text simply did not match
+                        # response_model. Signal this distinctly so it is not
+                        # swallowed by the partial-response salvage path below.
+                        raise StructuredOutputConversionError(
+                            str(conversion_error)
+                        ) from conversion_error
                     usage_dict = self._usage_to_dict(usage_info)
                     self._handle_emit_call_events(
                         response=structured_response,
@@ -1089,6 +1108,10 @@ class LLM(BaseLLM):
             return full_response
 
         except LLMContextLengthExceededError:
+            raise
+        except StructuredOutputConversionError:
+            # response_model conversion of a completed stream failed; do not
+            # salvage the raw text as if the stream had broken.
             raise
         except Exception as e:
             error_msg = str(e)

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -11,8 +11,13 @@ from crewai.events.event_types import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
-from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO, LLM
+from crewai.llm import (
+    CONTEXT_WINDOW_USAGE_RATIO,
+    LLM,
+    StructuredOutputConversionError,
+)
 from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+from crewai.utilities import InternalInstructor
 from crewai.utilities.token_counter_callback import TokenCalcHandler
 from pydantic import BaseModel
 import pytest
@@ -1177,3 +1182,47 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+def test_streaming_response_model_conversion_failure_raises():
+    """A completed stream whose text fails response_model conversion must raise
+    instead of being salvaged as a raw partial response (#6735).
+
+    The salvage branch in ``_handle_streaming_response`` exists to return
+    whatever text arrived before a stream broke mid-flight. A response_model
+    conversion failure is not a broken stream, so it must not be routed there.
+    """
+    llm = LLM(model="gpt-4o-mini", stream=True, is_litellm=True)
+
+    class _Answer(BaseModel):
+        answer: str
+
+    def _prose_stream(**kwargs):
+        return iter(
+            [
+                {
+                    "id": "chunk-1",
+                    "choices": [
+                        {"delta": {"content": "plain prose"}, "finish_reason": None}
+                    ],
+                },
+                {
+                    "id": "chunk-1",
+                    "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                },
+            ]
+        )
+
+    with (
+        patch("crewai.llm.litellm.completion", side_effect=_prose_stream),
+        patch.object(
+            InternalInstructor,
+            "to_pydantic",
+            side_effect=ValueError("schema mismatch"),
+        ),
+    ):
+        with pytest.raises(StructuredOutputConversionError):
+            llm._handle_streaming_response(
+                {"messages": [{"role": "user", "content": "hi"}]},
+                response_model=_Answer,
+            )


### PR DESCRIPTION
## Problem

Fixes #6735.

When `response_model` is set on a streaming call, `_handle_streaming_response` runs the
`InternalInstructor.to_pydantic()` / `model_dump_json()` conversion **inside** the `try`
that wraps chunk consumption. The `except Exception` below that `try` exists to salvage a
partial response from a stream that broke mid-flight — it returns `full_response` whenever
there is text to return.

As a result, a conversion failure is routed through the salvage path: a caller who asked
for a `BaseModel`-shaped result gets the raw prose back, with **no exception** and no signal
that conversion was attempted and failed.

A conversion failure is not a broken stream. The stream completed successfully; the output
just didn't match the schema. Routing it through the salvage path conflates the two.

## Fix

Wrap the `response_model` conversion in its own `try`/`except` that raises a dedicated
`StructuredOutputConversionError`, and re-raise that error before the salvage `except Exception`
— mirroring the existing `except LLMContextLengthExceededError: raise` handling in the same
method. Genuine mid-stream breaks still fall through to the salvage path unchanged.

## Scope note

The issue also references the async handler. On `main`, `_ahandle_streaming_response` does not
currently perform any `response_model` conversion (it returns `full_response` directly), so there
is no conversion-swallow path to fix there today. This PR therefore targets the confirmed sync
path; the async streaming handler ignoring `response_model` entirely is a separate gap and out of
scope here.

## Testing

Added `test_streaming_response_model_conversion_failure_raises`, which drives a clean stream whose
text fails conversion (`to_pydantic` patched to raise) and asserts the method now raises
`StructuredOutputConversionError` instead of returning the prose.

Verified locally against crewai `1.15.9`:

- **Before:** the method returned `'just some prose'` (raw text, no exception).
- **After:** it raises `StructuredOutputConversionError`.
- The success path (conversion succeeds) still returns the structured JSON unchanged.
- `ruff 0.15.1` `check` and `format` are clean on the changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->