### PR TITLE
fix: run before_llm_call hooks on async provider paths

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -449,6 +449,11 @@ class AnthropicCompletion(BaseLLM):
                     self._format_messages_for_anthropic(messages)
                 )
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 completion_params = self._prepare_completion_params(
                     formatted_messages, system_message, tools, available_functions
                 )

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -603,6 +603,11 @@ class AzureCompletion(BaseLLM):
 
                 formatted_messages = self._format_messages_for_azure(messages)
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 completion_params = self._prepare_completion_params(
                     formatted_messages, tools, effective_response_model
                 )

--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -510,6 +510,11 @@ class BedrockCompletion(BaseLLM):
                     messages
                 )
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 body: BedrockConverseRequestBody = {
                     "inferenceConfig": self._get_inference_config(),
                 }

--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -397,6 +397,13 @@ class GeminiCompletion(BaseLLM):
                     self._format_messages_for_gemini(messages)
                 )
 
+                messages_for_hooks = self._convert_contents_to_dict(formatted_content)
+
+                if not self._invoke_before_llm_call_hooks(
+                    messages_for_hooks, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 config = self._prepare_generation_config(
                     system_instruction, tools, effective_response_model
                 )

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -600,6 +600,11 @@ class OpenAICompletion(BaseLLM):
 
                 formatted_messages = self._format_messages(messages)
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 if self._effective_api() == "responses":
                     return await self._acall_responses(
                         messages=formatted_messages,

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 from crewai.hooks import (
@@ -670,3 +672,174 @@ class TestDirectLLMScopedHooks:
             )
 
         assert result == "contains [REDACTED]"
+
+
+def _usage_stub() -> Any:
+    """Token-usage payload accepted by every provider's usage extractor."""
+    return SimpleNamespace(
+        input_tokens=1,
+        output_tokens=1,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        prompt_tokens=1,
+        completion_tokens=1,
+        total_tokens=2,
+    )
+
+
+def _anthropic_response() -> Any:
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="the model answered")],
+        usage=_usage_stub(),
+        stop_reason="end_turn",
+        id="msg_stub",
+    )
+
+
+def _openai_response() -> Any:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="the model answered", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=_usage_stub(),
+        id="cmpl_stub",
+    )
+
+
+def _stub_anthropic_llm(issued: list[str]) -> Any:
+    """A real AnthropicCompletion whose SDK client records every request."""
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model="claude-sonnet-4-5", api_key="stub", stream=False)
+
+    def create(**_kwargs: Any) -> Any:
+        issued.append("sync")
+        return _anthropic_response()
+
+    async def acreate(**_kwargs: Any) -> Any:
+        issued.append("async")
+        return _anthropic_response()
+
+    llm._client = SimpleNamespace(messages=SimpleNamespace(create=create))
+    llm._async_client = SimpleNamespace(messages=SimpleNamespace(create=acreate))
+    return llm
+
+
+def _stub_openai_llm(issued: list[str]) -> Any:
+    """A real OpenAICompletion whose SDK client records every request."""
+    from crewai.llms.providers.openai.completion import OpenAICompletion
+
+    llm = OpenAICompletion(model="gpt-4o", api_key="stub", stream=False)
+
+    def create(**_kwargs: Any) -> Any:
+        issued.append("sync")
+        return _openai_response()
+
+    async def acreate(**_kwargs: Any) -> Any:
+        issued.append("async")
+        return _openai_response()
+
+    llm._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+    llm._async_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=acreate))
+    )
+    return llm
+
+
+class TestBeforeLLMCallHooksOnAsyncPaths:
+    """before_llm_call must gate acall() exactly as it gates call().
+
+    A hook returning False aborts the call. When acall() skipped the hook the
+    request still went out, so a policy check that worked synchronously silently
+    stopped blocking anything once the caller switched to async.
+    """
+
+    @pytest.fixture(params=["openai", "anthropic"])
+    def provider(self, request: pytest.FixtureRequest) -> tuple[Any, list[str]]:
+        issued: list[str] = []
+        if request.param == "openai":
+            return _stub_openai_llm(issued), issued
+        return _stub_anthropic_llm(issued), issued
+
+    def test_sync_call_is_blocked_by_before_hook(
+        self, provider: tuple[Any, list[str]]
+    ) -> None:
+        llm, issued = provider
+        seen: list[int] = []
+        register_before_llm_call_hook(lambda ctx: seen.append(len(ctx.messages)) or False)
+
+        with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+            llm.call("hi")
+
+        assert len(seen) == 1
+        assert issued == []
+
+    @pytest.mark.asyncio
+    async def test_async_call_is_blocked_by_before_hook(
+        self, provider: tuple[Any, list[str]]
+    ) -> None:
+        """The regression: acall() used to issue the request and return the response."""
+        llm, issued = provider
+        seen: list[int] = []
+        register_before_llm_call_hook(lambda ctx: seen.append(len(ctx.messages)) or False)
+
+        with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+            await llm.acall("hi")
+
+        assert len(seen) == 1
+        assert issued == []
+
+    @pytest.mark.asyncio
+    async def test_async_call_runs_before_hook_that_allows(
+        self, provider: tuple[Any, list[str]]
+    ) -> None:
+        """A hook that does not abort observes the messages and the call proceeds."""
+        llm, issued = provider
+        seen: list[list[dict[str, Any]]] = []
+
+        def observe(ctx: LLMCallHookContext) -> None:
+            seen.append(list(ctx.messages))
+
+        register_before_llm_call_hook(observe)
+
+        result = await llm.acall("hi")
+
+        assert result == "the model answered"
+        assert issued == ["async"]
+        assert seen and seen[0][-1]["content"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_async_call_without_hooks_is_unchanged(
+        self, provider: tuple[Any, list[str]]
+    ) -> None:
+        """Negative control: no hook registered, nothing blocked or altered."""
+        llm, issued = provider
+
+        result = await llm.acall("hi")
+
+        assert result == "the model answered"
+        assert issued == ["async"]
+
+    @pytest.mark.asyncio
+    async def test_async_call_before_hook_can_mutate_messages(
+        self, provider: tuple[Any, list[str]]
+    ) -> None:
+        """The hook's messages list is the one handed to the provider."""
+        llm, issued = provider
+        captured: list[list[dict[str, Any]]] = []
+
+        def add_guard_rail(ctx: LLMCallHookContext) -> None:
+            ctx.messages.append({"role": "user", "content": "and be brief"})
+            captured.append(ctx.messages)
+
+        register_before_llm_call_hook(add_guard_rail)
+
+        await llm.acall("hi")
+
+        assert issued == ["async"]
+        assert captured[0][-1] == {"role": "user", "content": "and be brief"}

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -674,6 +674,36 @@ class TestDirectLLMScopedHooks:
         assert result == "contains [REDACTED]"
 
 
+class _Recorder:
+    """Records what each provider client was actually asked to send.
+
+    ``issued`` answers whether a request went out at all (and on which path),
+    which is what the blocking tests need. ``payloads`` keeps the request kwargs
+    so a test can assert on the data the provider received rather than on the
+    in-memory list the hook mutated -- the two are only the same object if the
+    guard passes the real payload through, which is the property under test.
+    """
+
+    def __init__(self) -> None:
+        self.issued: list[str] = []
+        self.payloads: list[dict[str, Any]] = []
+
+    def record(self, path: str, kwargs: dict[str, Any]) -> None:
+        self.issued.append(path)
+        self.payloads.append(kwargs)
+
+    @property
+    def payload_text(self) -> str:
+        """Every recorded payload flattened to text.
+
+        Providers disagree on payload shape (plain dicts, Anthropic content
+        blocks, Gemini ``Content`` objects), and these tests only ask whether a
+        hook's addition is in there, so the repr is searched instead of a
+        per-provider structure being walked.
+        """
+        return repr(self.payloads)
+
+
 def _usage_stub() -> Any:
     """Token-usage payload accepted by every provider's usage extractor."""
     return SimpleNamespace(
@@ -709,18 +739,18 @@ def _openai_response() -> Any:
     )
 
 
-def _stub_anthropic_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+def _stub_anthropic_llm(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real AnthropicCompletion whose SDK client records every request."""
     from crewai.llms.providers.anthropic.completion import AnthropicCompletion
 
     llm = AnthropicCompletion(model="claude-sonnet-4-5", api_key="stub", stream=False)
 
-    def create(**_kwargs: Any) -> Any:
-        issued.append("sync")
+    def create(**kwargs: Any) -> Any:
+        rec.record("sync", kwargs)
         return _anthropic_response()
 
-    async def acreate(**_kwargs: Any) -> Any:
-        issued.append("async")
+    async def acreate(**kwargs: Any) -> Any:
+        rec.record("async", kwargs)
         return _anthropic_response()
 
     llm._client = SimpleNamespace(messages=SimpleNamespace(create=create))
@@ -728,18 +758,18 @@ def _stub_anthropic_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> A
     return llm
 
 
-def _stub_openai_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+def _stub_openai_llm(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real OpenAICompletion whose SDK client records every request."""
     from crewai.llms.providers.openai.completion import OpenAICompletion
 
     llm = OpenAICompletion(model="gpt-4o", api_key="stub", stream=False)
 
-    def create(**_kwargs: Any) -> Any:
-        issued.append("sync")
+    def create(**kwargs: Any) -> Any:
+        rec.record("sync", kwargs)
         return _openai_response()
 
-    async def acreate(**_kwargs: Any) -> Any:
-        issued.append("async")
+    async def acreate(**kwargs: Any) -> Any:
+        rec.record("async", kwargs)
         return _openai_response()
 
     llm._client = SimpleNamespace(
@@ -764,7 +794,7 @@ def _bedrock_response() -> dict[str, Any]:
     }
 
 
-def _stub_bedrock_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+def _stub_bedrock_llm(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real BedrockCompletion whose Converse client records every request."""
     from crewai.llms.providers.bedrock import completion as bedrock_completion
     from crewai.llms.providers.bedrock.completion import BedrockCompletion
@@ -782,12 +812,12 @@ def _stub_bedrock_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any
         stream=False,
     )
 
-    def converse(**_kwargs: Any) -> dict[str, Any]:
-        issued.append("sync")
+    def converse(**kwargs: Any) -> dict[str, Any]:
+        rec.record("sync", kwargs)
         return _bedrock_response()
 
-    async def aconverse(**_kwargs: Any) -> dict[str, Any]:
-        issued.append("async")
+    async def aconverse(**kwargs: Any) -> dict[str, Any]:
+        rec.record("async", kwargs)
         return _bedrock_response()
 
     llm._client = SimpleNamespace(converse=converse)
@@ -818,7 +848,7 @@ def _gemini_response() -> Any:
     )
 
 
-def _stub_gemini_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+def _stub_gemini_llm(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real GeminiCompletion whose genai client records every request.
 
     Gemini exposes one client for both paths (``_get_async_client`` returns
@@ -828,12 +858,12 @@ def _stub_gemini_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
 
     llm = GeminiCompletion(model="gemini-2.0-flash", api_key="stub", stream=False)
 
-    def generate_content(**_kwargs: Any) -> Any:
-        issued.append("sync")
+    def generate_content(**kwargs: Any) -> Any:
+        rec.record("sync", kwargs)
         return _gemini_response()
 
-    async def agenerate_content(**_kwargs: Any) -> Any:
-        issued.append("async")
+    async def agenerate_content(**kwargs: Any) -> Any:
+        rec.record("async", kwargs)
         return _gemini_response()
 
     llm._client = SimpleNamespace(
@@ -859,7 +889,7 @@ def _azure_response() -> Any:
     )
 
 
-def _stub_azure_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+def _stub_azure_llm(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real AzureCompletion whose inference client records every request."""
     from crewai.llms.providers.azure.completion import AzureCompletion
 
@@ -870,12 +900,12 @@ def _stub_azure_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
         stream=False,
     )
 
-    def complete(**_kwargs: Any) -> Any:
-        issued.append("sync")
+    def complete(**kwargs: Any) -> Any:
+        rec.record("sync", kwargs)
         return _azure_response()
 
-    async def acomplete(**_kwargs: Any) -> Any:
-        issued.append("async")
+    async def acomplete(**kwargs: Any) -> Any:
+        rec.record("async", kwargs)
         return _azure_response()
 
     llm._client = SimpleNamespace(complete=complete)
@@ -903,14 +933,14 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
     @pytest.fixture(params=sorted(_PROVIDER_STUBS))
     def provider(
         self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-    ) -> tuple[Any, list[str]]:
-        issued: list[str] = []
-        return _PROVIDER_STUBS[request.param](issued, monkeypatch), issued
+    ) -> tuple[Any, _Recorder]:
+        rec = _Recorder()
+        return _PROVIDER_STUBS[request.param](rec, monkeypatch), rec
 
     def test_sync_call_is_blocked_by_before_hook(
-        self, provider: tuple[Any, list[str]]
+        self, provider: tuple[Any, _Recorder]
     ) -> None:
-        llm, issued = provider
+        llm, rec = provider
         seen: list[int] = []
         register_before_llm_call_hook(lambda ctx: seen.append(len(ctx.messages)) or False)
 
@@ -918,14 +948,14 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
             llm.call("hi")
 
         assert len(seen) == 1
-        assert issued == []
+        assert rec.issued == []
 
     @pytest.mark.asyncio
     async def test_async_call_is_blocked_by_before_hook(
-        self, provider: tuple[Any, list[str]]
+        self, provider: tuple[Any, _Recorder]
     ) -> None:
         """The regression: acall() used to issue the request and return the response."""
-        llm, issued = provider
+        llm, rec = provider
         seen: list[int] = []
         register_before_llm_call_hook(lambda ctx: seen.append(len(ctx.messages)) or False)
 
@@ -933,14 +963,14 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
             await llm.acall("hi")
 
         assert len(seen) == 1
-        assert issued == []
+        assert rec.issued == []
 
     @pytest.mark.asyncio
     async def test_async_call_runs_before_hook_that_allows(
-        self, provider: tuple[Any, list[str]]
+        self, provider: tuple[Any, _Recorder]
     ) -> None:
         """A hook that does not abort observes the messages and the call proceeds."""
-        llm, issued = provider
+        llm, rec = provider
         seen: list[list[dict[str, Any]]] = []
 
         def observe(ctx: LLMCallHookContext) -> None:
@@ -951,39 +981,90 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
         result = await llm.acall("hi")
 
         assert result == "the model answered"
-        assert issued == ["async"]
+        assert rec.issued == ["async"]
         # The content shape differs per provider (a plain string, a list of
         # content blocks, a Gemini part dict), so the prompt is located inside
         # the last message rather than compared to one provider's layout.
         assert seen and "hi" in str(seen[0][-1])
+        # The hook must see the prompt the provider is actually about to be sent,
+        # not a placeholder assembled for the hook's benefit.
+        assert "hi" in rec.payload_text
 
     @pytest.mark.asyncio
     async def test_async_call_without_hooks_is_unchanged(
-        self, provider: tuple[Any, list[str]]
+        self, provider: tuple[Any, _Recorder]
     ) -> None:
         """Negative control: no hook registered, nothing blocked or altered."""
-        llm, issued = provider
+        llm, rec = provider
 
         result = await llm.acall("hi")
 
         assert result == "the model answered"
-        assert issued == ["async"]
+        assert rec.issued == ["async"]
 
     @pytest.mark.asyncio
-    async def test_async_call_before_hook_can_mutate_messages(
-        self, provider: tuple[Any, list[str]]
+    async def test_async_before_hook_mutation_reaches_the_provider_as_on_sync(
+        self, provider: tuple[Any, _Recorder]
     ) -> None:
-        """The hook's messages list is the one handed to the provider."""
-        llm, issued = provider
-        captured: list[list[dict[str, Any]]] = []
+        """A mutation must land in the request, and to the same extent as on sync.
 
-        def add_guard_rail(ctx: LLMCallHookContext) -> None:
-            ctx.messages.append({"role": "user", "content": "and be brief"})
-            captured.append(ctx.messages)
+        Asserting only that ``ctx.messages`` gained an entry would pass even if
+        the guard were handed a copy and ``acall()`` dropped the mutation on the
+        floor, so the check is against the kwargs the stubbed client received.
 
-        register_before_llm_call_hook(add_guard_rail)
+        The comparison is against the *sync* path rather than a hard-coded
+        expectation because whether a mutation propagates at all is a
+        pre-existing per-provider property, not something this change decides:
+        four providers pass the payload list straight to the hook, while Gemini
+        converts its ``Content`` objects to dicts first and so hands over a copy
+        on both paths. Pinning ``async == sync`` states the invariant this PR is
+        responsible for -- acall() gates and forwards exactly as call() does --
+        and would fail if the async guard were ever wired to a different list
+        than its sync twin, without asserting that Gemini's copy is correct.
+        """
+        llm, rec = provider
+        guard_rail = {"role": "user", "content": "and be brief"}
+
+        register_before_llm_call_hook(
+            lambda ctx: ctx.messages.append(guard_rail),  # type: ignore[func-returns-value]
+        )
+
+        llm.call("hi")
+        sync_propagated = "and be brief" in rec.payload_text
+        assert rec.issued == ["sync"]
+
+        rec.issued.clear()
+        rec.payloads.clear()
+
+        await llm.acall("hi")
+        async_propagated = "and be brief" in rec.payload_text
+
+        assert rec.issued == ["async"]
+        assert async_propagated == sync_propagated
+
+    @pytest.mark.asyncio
+    async def test_async_before_hook_mutation_reaches_the_provider(
+        self, provider: tuple[Any, _Recorder]
+    ) -> None:
+        """The four providers that forward the payload list really do forward it.
+
+        The symmetry test above cannot tell "both paths propagate" from "neither
+        does", so it would still pass if a future refactor made every provider
+        hand the guard a copy. This pins the propagating providers by name.
+        Gemini is excluded because its own sync path does not propagate either;
+        that asymmetry is upstream of this change and is left alone.
+        """
+        llm, rec = provider
+        if llm.__class__.__name__ == "GeminiCompletion":
+            pytest.skip("Gemini hands the guard a converted copy on both paths")
+
+        register_before_llm_call_hook(
+            lambda ctx: ctx.messages.append(  # type: ignore[func-returns-value]
+                {"role": "user", "content": "and be brief"}
+            ),
+        )
 
         await llm.acall("hi")
 
-        assert issued == ["async"]
-        assert captured[0][-1] == {"role": "user", "content": "and be brief"}
+        assert rec.issued == ["async"]
+        assert "and be brief" in rec.payload_text

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -709,7 +709,7 @@ def _openai_response() -> Any:
     )
 
 
-def _stub_anthropic_llm(issued: list[str]) -> Any:
+def _stub_anthropic_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real AnthropicCompletion whose SDK client records every request."""
     from crewai.llms.providers.anthropic.completion import AnthropicCompletion
 
@@ -728,7 +728,7 @@ def _stub_anthropic_llm(issued: list[str]) -> Any:
     return llm
 
 
-def _stub_openai_llm(issued: list[str]) -> Any:
+def _stub_openai_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
     """A real OpenAICompletion whose SDK client records every request."""
     from crewai.llms.providers.openai.completion import OpenAICompletion
 
@@ -751,6 +751,147 @@ def _stub_openai_llm(issued: list[str]) -> Any:
     return llm
 
 
+def _bedrock_response() -> dict[str, Any]:
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "the model answered"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+    }
+
+
+def _stub_bedrock_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A real BedrockCompletion whose Converse client records every request."""
+    from crewai.llms.providers.bedrock import completion as bedrock_completion
+    from crewai.llms.providers.bedrock.completion import BedrockCompletion
+
+    # ``acall`` refuses to run at all without aiobotocore, which is an optional
+    # extra. The hook gating under test is upstream of any AWS I/O and the client
+    # below is a stub, so the dependency check is patched rather than installed.
+    monkeypatch.setattr(bedrock_completion, "AIOBOTOCORE_AVAILABLE", True)
+
+    llm = BedrockCompletion(
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        aws_access_key_id="stub",
+        aws_secret_access_key="stub",
+        region_name="us-east-1",
+        stream=False,
+    )
+
+    def converse(**_kwargs: Any) -> dict[str, Any]:
+        issued.append("sync")
+        return _bedrock_response()
+
+    async def aconverse(**_kwargs: Any) -> dict[str, Any]:
+        issued.append("async")
+        return _bedrock_response()
+
+    llm._client = SimpleNamespace(converse=converse)
+    # ``_ensure_async_client`` builds the aiobotocore client inside an exit stack;
+    # marking it initialized makes it return this stub instead.
+    llm._async_client = SimpleNamespace(converse=aconverse)
+    llm._async_client_initialized = True
+    return llm
+
+
+def _gemini_response() -> Any:
+    part = SimpleNamespace(text="the model answered", function_call=None, thought=None)
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(parts=[part], role="model"),
+                finish_reason=None,
+            )
+        ],
+        text="the model answered",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=1,
+            candidates_token_count=1,
+            total_token_count=2,
+            cached_content_token_count=0,
+        ),
+        function_calls=None,
+    )
+
+
+def _stub_gemini_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A real GeminiCompletion whose genai client records every request.
+
+    Gemini exposes one client for both paths (``_get_async_client`` returns
+    ``_get_sync_client``), with the async surface under ``.aio``.
+    """
+    from crewai.llms.providers.gemini.completion import GeminiCompletion
+
+    llm = GeminiCompletion(model="gemini-2.0-flash", api_key="stub", stream=False)
+
+    def generate_content(**_kwargs: Any) -> Any:
+        issued.append("sync")
+        return _gemini_response()
+
+    async def agenerate_content(**_kwargs: Any) -> Any:
+        issued.append("async")
+        return _gemini_response()
+
+    llm._client = SimpleNamespace(
+        models=SimpleNamespace(generate_content=generate_content),
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=agenerate_content)
+        ),
+        vertexai=False,
+    )
+    return llm
+
+
+def _azure_response() -> Any:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="the model answered", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=_usage_stub(),
+        id="azure_stub",
+    )
+
+
+def _stub_azure_llm(issued: list[str], monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A real AzureCompletion whose inference client records every request."""
+    from crewai.llms.providers.azure.completion import AzureCompletion
+
+    llm = AzureCompletion(
+        model="gpt-4o",
+        api_key="stub",
+        endpoint="https://stub.services.ai.azure.com/models",
+        stream=False,
+    )
+
+    def complete(**_kwargs: Any) -> Any:
+        issued.append("sync")
+        return _azure_response()
+
+    async def acomplete(**_kwargs: Any) -> Any:
+        issued.append("async")
+        return _azure_response()
+
+    llm._client = SimpleNamespace(complete=complete)
+    llm._async_client = SimpleNamespace(complete=acomplete)
+    return llm
+
+
+_PROVIDER_STUBS = {
+    "openai": _stub_openai_llm,
+    "anthropic": _stub_anthropic_llm,
+    "bedrock": _stub_bedrock_llm,
+    "gemini": _stub_gemini_llm,
+    "azure": _stub_azure_llm,
+}
+
+
 class TestBeforeLLMCallHooksOnAsyncPaths:
     """before_llm_call must gate acall() exactly as it gates call().
 
@@ -759,12 +900,12 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
     stopped blocking anything once the caller switched to async.
     """
 
-    @pytest.fixture(params=["openai", "anthropic"])
-    def provider(self, request: pytest.FixtureRequest) -> tuple[Any, list[str]]:
+    @pytest.fixture(params=sorted(_PROVIDER_STUBS))
+    def provider(
+        self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[Any, list[str]]:
         issued: list[str] = []
-        if request.param == "openai":
-            return _stub_openai_llm(issued), issued
-        return _stub_anthropic_llm(issued), issued
+        return _PROVIDER_STUBS[request.param](issued, monkeypatch), issued
 
     def test_sync_call_is_blocked_by_before_hook(
         self, provider: tuple[Any, list[str]]
@@ -811,7 +952,10 @@ class TestBeforeLLMCallHooksOnAsyncPaths:
 
         assert result == "the model answered"
         assert issued == ["async"]
-        assert seen and seen[0][-1]["content"] == "hi"
+        # The content shape differs per provider (a plain string, a list of
+        # content blocks, a Gemini part dict), so the prompt is located inside
+        # the last message rather than compared to one provider's layout.
+        assert seen and "hi" in str(seen[0][-1])
 
     @pytest.mark.asyncio
     async def test_async_call_without_hooks_is_unchanged(


### PR DESCRIPTION
## Summary

`before_llm_call` hooks never ran on the async `acall()` path of any native provider. Because `before_llm_call` is the interception point that can **abort** a call, a hook returning `False` did not merely fail to observe the request — the request was actually issued and billed.

This is the `before` counterpart to #6736 / #6737 (`after_llm_call` on async paths), and the more severe half: an `after` hook that is skipped can only fail to rewrite a response, whereas a skipped `before` hook means a call the user explicitly blocked still reached the provider.

Fixes #6739

## Note on sync hooks in `acall()`

This PR runs the existing sync `before_llm_call` contract on `acall()` — same `bool` return, no new async hook type. If a hook already does I/O (logging to an external service, hitting a policy microservice), that already blocks on `call()`, and it will also block the event loop here. That's pre-existing, not something the five `acall()` sites introduce. An async hook variant is a separate API change.

## Root cause

Coverage of `_invoke_before_llm_call_hooks` on `main` (`ebe0082`):

| provider | sync `call()` | async `acall()` (before) | async `acall()` (after this PR) |
| --- | --- | --- | --- |
| `openai/completion.py` | ✅ `:465` | ❌ missing | ✅ `:603` |
| `anthropic/completion.py` | ✅ `:377` | ❌ missing | ✅ `:452` |
| `bedrock/completion.py` | ✅ `:380` | ❌ missing | ✅ `:513` |
| `gemini/completion.py` | ✅ `:316` | ❌ missing | ✅ `:402` |
| `azure/completion.py` | ✅ `:524` | ❌ missing | ✅ `:606` |

~~`llms/base_llm.py` (the LiteLLM fallback) already had the guard on both paths, so users on the fallback path were unaffected -- which is likely why this went unnoticed.~~

**Correction (2026-07-31): that sentence was wrong, in a way that understates the bug.** `llms/base_llm.py` only *defines* `_invoke_before_llm_call_hooks`; it has no callers, and its `acall()` is `raise NotImplementedError`. The LiteLLM fallback is `crewai/llm.py`, and there `call()` guards both hook families (`:1876`, `:1904`) while `acall()` at `:1959` guards **neither**. So the fallback has the same hole as the native providers rather than being the safe path, and nothing in this PR fixes it.

Probe on unmodified `origin/main` (`ebe0082`), with `litellm.completion` / `acompletion` stubbed so the observable is whether a request left the process:

```
blocking before hook (returns False) + rewriting after hook:
  call   before:1 after:0  issued:no     -> ValueError: LLM call blocked by before_llm_call hook
  acall  before:0 after:0  issued:async  -> 'the model said something sensitive'
```

`LLM(model=..., is_litellm=True)` is required to reach it -- without the flag the constructor returns a native provider, which is part of why I read the fallback as covered.

I am leaving that fix out of this PR rather than adding it: it is a different file and a different seam from the five provider `acall()` bodies under review here, and this PR already has review history against its current shape. It will follow separately. Flagging it here because "users on the fallback path were unaffected" is a claim a reviewer could reasonably act on, and it is not true.

## Proof, before any fix was written

A no-network probe that swaps the provider client for a stub recording **whether a request was issued**, so the observable is the HTTP call itself rather than the returned string:

```
anthropic call()       hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
anthropic acall()      hook fired: 0  request issued: ['anthropic-async']  -> returned 'LEAKED'
openai    call()       hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
openai    acall()      hook fired: 0  request issued: ['openai-async']     -> returned 'LEAKED'
```

After this PR, all four rows are identical:

```
anthropic call()       hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
anthropic acall()      hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
openai    call()       hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
openai    acall()      hook fired: 1  request issued: no    -> ValueError: LLM call blocked by before_llm_call hook
```

## The change

Each `acall()` now runs **its own sync twin's guard, verbatim**, at the equivalent point in the body — right after the provider-specific message formatting and before the request parameters are assembled:

```python
if not self._invoke_before_llm_call_hooks(formatted_messages, from_agent):
    raise ValueError("LLM call blocked by before_llm_call hook")
```

Gemini needs the extra line its sync path uses at `:310`, because its formatted payload is `Content` objects rather than dicts:

```python
messages_for_hooks = self._convert_contents_to_dict(formatted_content)
```

Deliberately *not* changed:

- **No new hook-dispatch helper, no shared base-class wrapper.** Each provider formats messages differently and the sync paths already encode the right shape; copying the sync guard keeps the two twins textually comparable, which is what makes the next drift of this kind visible in review.
- **No double dispatch on the agent path.** `_invoke_before_llm_call_hooks` (`llms/base_llm.py:981`) returns `True` immediately when `from_agent is not None`, so the agent-executor dispatch remains the single source and adding the call to `acall()` cannot fire hooks twice.
- **Azure's `responses` delegate** returns before this block when `self.api == "responses"`, delegating to an `OpenAICompletion` — which now carries its own guard, so that path is covered too.

## Tests

`lib/crewai/tests/hooks/test_llm_hooks.py`, new class `TestBeforeLLMCallHooksOnAsyncPaths`, parametrised over `openai` and `anthropic` (10 tests total). The stubbed clients append to an `issued` list, so every assertion is about **whether the request went out**, not just what was returned.

| test | asserts |
| --- | --- |
| `test_sync_call_is_blocked_by_before_hook` | baseline: sync path blocks, `issued == []` |
| `test_async_call_is_blocked_by_before_hook` | **the regression**: `acall()` raises and `issued == []` |
| `test_async_call_runs_before_hook_that_allows` | a non-aborting hook observes the messages and the call proceeds (`issued == ["async"]`) |
| `test_async_call_without_hooks_is_unchanged` | **negative control**: with no hooks registered `acall()` behaves exactly as before |
| `test_async_call_before_hook_can_mutate_messages` | the list the hook receives via `ctx.messages` is the one handed to the provider |

### Control experiment

Reverting only the five source files and keeping the tests fails **exactly** the async-blocking tests and nothing else:

```
6 failed, 30 passed
```

The 6 are the three async-blocking assertions × 2 providers. The sync baseline, the negative control and all 26 pre-existing tests in the file pass unchanged — the tests are pinned to this bug, not to incidental behaviour.

## Verification

| suite | result |
| --- | --- |
| `tests/hooks/test_llm_hooks.py` | **36 passed** (26 pre-existing + 10 new) |
| `tests/llms/anthropic` + `tests/llms/openai` | **216 passed, 1 skipped**, 0 failed |
| `tests/llms/bedrock` + `google` + `azure` + `llms/hooks` | **244 passed, 10 skipped**, 0 failed |
| `ruff format --check` / `ruff check` on all 6 changed files | clean |

The provider suites additionally report Windows-only teardown **errors** (not failures) — `PermissionError: [WinError 32]` from `shutil.rmtree` on `crewai_test_storage/latest_kickoff_task_outputs.db` in `conftest.py:223`. These reproduce on clean `main` and are unrelated to this change; there are zero test failures.
