### PR TITLE
fix(events): track the sync-handler future when async handlers also exist

### DIFF
--- a/lib/crewai/src/crewai/events/event_bus.py
+++ b/lib/crewai/src/crewai/events/event_bus.py
@@ -633,8 +633,13 @@ class CrewAIEventsBus:
                 sync_future = self._sync_executor.submit(
                     ctx.run, self._call_handlers, source, event, sync_handlers, state
                 )
+                # Track unconditionally, as ``replay`` does. ``flush`` only waits
+                # on the tracked set, and callers use it to guarantee handlers
+                # finished before teardown. Tracking only in the sync-only branch
+                # left the sync handlers of a mixed event type unwaited-for.
+                self._track_future(sync_future)
                 if not async_handlers:
-                    return self._track_future(sync_future)
+                    return sync_future
 
         if async_handlers:
             return self._track_future(

--- a/lib/crewai/tests/utilities/events/test_flush.py
+++ b/lib/crewai/tests/utilities/events/test_flush.py
@@ -1,13 +1,15 @@
 """Tests for ``CrewAIEventsBus.flush`` waiting on sync handlers.
 
-``flush`` waits on ``_pending_futures``, so a handler whose future was never
-tracked is invisible to it. ``emit`` used to track the sync-handler future only
-when the event type had no async handlers, so for a mixed event type ``flush``
-returned before the sync handlers had run.
+``flush`` waits on the futures ``emit`` tracked, so a handler whose future was
+never tracked is invisible to it. ``emit`` used to track the sync-handler future
+only when the event type had no async handlers, so for a mixed event type
+``flush`` returned before the sync handlers had run.
 
-Each test asserts on the handler's own completion marker rather than on elapsed
-time, and holds the handler open on a gate so the assertion cannot be won by a
-race.
+Each test asserts through ``flush``'s own contract -- ``False`` on timeout,
+``True`` when every handler finished -- rather than on elapsed time or on the
+bus's internal future set. A handler that is *still gated* must make ``flush``
+time out; only then does releasing the gate and flushing again prove that what
+``flush`` waited for was the handler and not the clock.
 """
 
 import asyncio
@@ -21,43 +23,47 @@ class FlushTestEvent(BaseEvent):
     pass
 
 
-def _tracked_futures() -> set:
-    with crewai_event_bus._futures_lock:
-        return set(crewai_event_bus._pending_futures)
+def test_flush_blocks_on_a_sync_handler_alongside_async_handlers() -> None:
+    """The regression: a mixed event type still has its sync handlers awaited.
 
-
-def test_flush_waits_for_sync_handlers_alongside_async_handlers() -> None:
-    """The regression: a mixed event type still has its sync handlers awaited."""
+    The async handler is allowed to finish first, so a ``flush`` that timed out
+    merely because the async half was still scheduling would not read as a pass.
+    From that point the only unfinished handler is the gated sync one.
+    """
     gate = threading.Event()
+    async_done = threading.Event()
     finished: list[str] = []
 
     with crewai_event_bus.scoped_handlers():
 
         @crewai_event_bus.on(FlushTestEvent)
-        def slow_sync_handler(source: object, event: BaseEvent) -> None:
-            gate.wait(timeout=5.0)
+        def gated_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=10.0)
             finished.append("sync")
 
         @crewai_event_bus.on(FlushTestEvent)
         async def async_handler(source: object, event: BaseEvent) -> None:
             finished.append("async")
+            async_done.set()
 
         crewai_event_bus.emit("test_source", FlushTestEvent(type="mixed"))
 
-        # Release the sync handler only once flush is already blocking, so a
-        # pass cannot come from the handler having finished beforehand.
-        timer = threading.Timer(0.2, gate.set)
-        timer.start()
         try:
-            assert crewai_event_bus.flush(timeout=10.0) is True
+            assert async_done.wait(10.0), "the async handler never ran"
+            assert finished == ["async"]
+
+            # The sync handler is the only thing outstanding, and it cannot
+            # finish. Before the fix its future was never tracked, so flush
+            # found nothing to wait on and returned True here.
+            assert crewai_event_bus.flush(timeout=1.0) is False
         finally:
-            timer.cancel()
             gate.set()
 
-        assert "sync" in finished
+        assert crewai_event_bus.flush(timeout=10.0) is True
+        assert finished == ["async", "sync"]
 
 
-def test_flush_waits_for_sync_handlers_when_there_are_no_async_handlers() -> None:
+def test_flush_blocks_on_a_sync_handler_when_there_are_no_async_handlers() -> None:
     """The sync-only path already waited; pin it so the fix cannot regress it."""
     gate = threading.Event()
     finished: list[str] = []
@@ -65,55 +71,56 @@ def test_flush_waits_for_sync_handlers_when_there_are_no_async_handlers() -> Non
     with crewai_event_bus.scoped_handlers():
 
         @crewai_event_bus.on(FlushTestEvent)
-        def slow_sync_handler(source: object, event: BaseEvent) -> None:
-            gate.wait(timeout=5.0)
+        def gated_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=10.0)
             finished.append("sync")
 
         crewai_event_bus.emit("test_source", FlushTestEvent(type="sync_only"))
 
-        timer = threading.Timer(0.2, gate.set)
-        timer.start()
         try:
-            assert crewai_event_bus.flush(timeout=10.0) is True
+            assert crewai_event_bus.flush(timeout=1.0) is False
+            assert finished == []
         finally:
-            timer.cancel()
             gate.set()
 
+        assert crewai_event_bus.flush(timeout=10.0) is True
         assert finished == ["sync"]
 
 
-def test_emit_tracks_the_sync_future_when_async_handlers_exist() -> None:
-    """Both futures are tracked, not just the async one.
+def test_emit_returns_the_sync_future_only_when_there_are_no_async_handlers() -> None:
+    """The documented return-value contract, unchanged by the tracking fix.
 
-    The handlers are held open for the duration so the done-callback that
-    discards a completed future cannot drop it before the assertion, and the
-    tracked set is compared as a delta because it is shared process-wide.
+    The mixed-case return value is checked by gating the sync handler: the
+    asyncio future for the async half resolves while the sync one cannot, so a
+    future that resolves here is necessarily not the sync future. Comparing it
+    against the earlier sync-only future would not rule out an implementation
+    that returned the *current* mixed sync future.
     """
     gate = threading.Event()
 
     with crewai_event_bus.scoped_handlers():
 
         @crewai_event_bus.on(FlushTestEvent)
-        def slow_sync_handler(source: object, event: BaseEvent) -> None:
-            gate.wait(timeout=5.0)
+        def gated_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=10.0)
 
         @crewai_event_bus.on(FlushTestEvent)
-        async def slow_async_handler(source: object, event: BaseEvent) -> None:
-            await asyncio.get_running_loop().run_in_executor(None, gate.wait, 5.0)
+        async def async_handler(source: object, event: BaseEvent) -> None:
+            return None
 
-        before = _tracked_futures()
+        mixed_future = crewai_event_bus.emit(
+            "test_source", FlushTestEvent(type="mixed")
+        )
+
         try:
-            crewai_event_bus.emit("test_source", FlushTestEvent(type="mixed"))
-            added = _tracked_futures() - before
+            assert mixed_future is not None
+            # Resolves with the sync handler still gated, per the emit docstring.
+            assert mixed_future.result(timeout=10.0) is None
         finally:
             gate.set()
 
-        assert len(added) == 2
         assert crewai_event_bus.flush(timeout=10.0) is True
 
-
-def test_emit_returns_the_sync_future_only_when_there_are_no_async_handlers() -> None:
-    """The documented return-value contract, unchanged by the tracking fix."""
     with crewai_event_bus.scoped_handlers():
 
         @crewai_event_bus.on(FlushTestEvent)
@@ -127,16 +134,22 @@ def test_emit_returns_the_sync_future_only_when_there_are_no_async_handlers() ->
         assert sync_only_future is not None
         assert sync_only_future.result(timeout=10.0) is None
 
+
+def test_flush_waits_for_a_gated_async_handler_too() -> None:
+    """The async half stays tracked, so the fix cannot trade one gap for another."""
+    gate = threading.Event()
+
+    with crewai_event_bus.scoped_handlers():
+
         @crewai_event_bus.on(FlushTestEvent)
-        async def async_handler(source: object, event: BaseEvent) -> None:
-            return None
+        async def gated_async_handler(source: object, event: BaseEvent) -> None:
+            await asyncio.get_running_loop().run_in_executor(None, gate.wait, 10.0)
 
-        mixed_future = crewai_event_bus.emit(
-            "test_source", FlushTestEvent(type="mixed")
-        )
+        crewai_event_bus.emit("test_source", FlushTestEvent(type="async_only"))
 
-        # The asyncio future for the async half, per the ``emit`` docstring.
-        assert mixed_future is not None
-        assert mixed_future is not sync_only_future
-        assert mixed_future.result(timeout=10.0) is None
+        try:
+            assert crewai_event_bus.flush(timeout=1.0) is False
+        finally:
+            gate.set()
 
+        assert crewai_event_bus.flush(timeout=10.0) is True

--- a/lib/crewai/tests/utilities/events/test_flush.py
+++ b/lib/crewai/tests/utilities/events/test_flush.py
@@ -1,0 +1,142 @@
+"""Tests for ``CrewAIEventsBus.flush`` waiting on sync handlers.
+
+``flush`` waits on ``_pending_futures``, so a handler whose future was never
+tracked is invisible to it. ``emit`` used to track the sync-handler future only
+when the event type had no async handlers, so for a mixed event type ``flush``
+returned before the sync handlers had run.
+
+Each test asserts on the handler's own completion marker rather than on elapsed
+time, and holds the handler open on a gate so the assertion cannot be won by a
+race.
+"""
+
+import asyncio
+import threading
+
+from crewai.events.base_events import BaseEvent
+from crewai.events.event_bus import crewai_event_bus
+
+
+class FlushTestEvent(BaseEvent):
+    pass
+
+
+def _tracked_futures() -> set:
+    with crewai_event_bus._futures_lock:
+        return set(crewai_event_bus._pending_futures)
+
+
+def test_flush_waits_for_sync_handlers_alongside_async_handlers() -> None:
+    """The regression: a mixed event type still has its sync handlers awaited."""
+    gate = threading.Event()
+    finished: list[str] = []
+
+    with crewai_event_bus.scoped_handlers():
+
+        @crewai_event_bus.on(FlushTestEvent)
+        def slow_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=5.0)
+            finished.append("sync")
+
+        @crewai_event_bus.on(FlushTestEvent)
+        async def async_handler(source: object, event: BaseEvent) -> None:
+            finished.append("async")
+
+        crewai_event_bus.emit("test_source", FlushTestEvent(type="mixed"))
+
+        # Release the sync handler only once flush is already blocking, so a
+        # pass cannot come from the handler having finished beforehand.
+        timer = threading.Timer(0.2, gate.set)
+        timer.start()
+        try:
+            assert crewai_event_bus.flush(timeout=10.0) is True
+        finally:
+            timer.cancel()
+            gate.set()
+
+        assert "sync" in finished
+
+
+def test_flush_waits_for_sync_handlers_when_there_are_no_async_handlers() -> None:
+    """The sync-only path already waited; pin it so the fix cannot regress it."""
+    gate = threading.Event()
+    finished: list[str] = []
+
+    with crewai_event_bus.scoped_handlers():
+
+        @crewai_event_bus.on(FlushTestEvent)
+        def slow_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=5.0)
+            finished.append("sync")
+
+        crewai_event_bus.emit("test_source", FlushTestEvent(type="sync_only"))
+
+        timer = threading.Timer(0.2, gate.set)
+        timer.start()
+        try:
+            assert crewai_event_bus.flush(timeout=10.0) is True
+        finally:
+            timer.cancel()
+            gate.set()
+
+        assert finished == ["sync"]
+
+
+def test_emit_tracks_the_sync_future_when_async_handlers_exist() -> None:
+    """Both futures are tracked, not just the async one.
+
+    The handlers are held open for the duration so the done-callback that
+    discards a completed future cannot drop it before the assertion, and the
+    tracked set is compared as a delta because it is shared process-wide.
+    """
+    gate = threading.Event()
+
+    with crewai_event_bus.scoped_handlers():
+
+        @crewai_event_bus.on(FlushTestEvent)
+        def slow_sync_handler(source: object, event: BaseEvent) -> None:
+            gate.wait(timeout=5.0)
+
+        @crewai_event_bus.on(FlushTestEvent)
+        async def slow_async_handler(source: object, event: BaseEvent) -> None:
+            await asyncio.get_running_loop().run_in_executor(None, gate.wait, 5.0)
+
+        before = _tracked_futures()
+        try:
+            crewai_event_bus.emit("test_source", FlushTestEvent(type="mixed"))
+            added = _tracked_futures() - before
+        finally:
+            gate.set()
+
+        assert len(added) == 2
+        assert crewai_event_bus.flush(timeout=10.0) is True
+
+
+def test_emit_returns_the_sync_future_only_when_there_are_no_async_handlers() -> None:
+    """The documented return-value contract, unchanged by the tracking fix."""
+    with crewai_event_bus.scoped_handlers():
+
+        @crewai_event_bus.on(FlushTestEvent)
+        def sync_handler(source: object, event: BaseEvent) -> None:
+            return None
+
+        sync_only_future = crewai_event_bus.emit(
+            "test_source", FlushTestEvent(type="sync_only")
+        )
+
+        assert sync_only_future is not None
+        assert sync_only_future.result(timeout=10.0) is None
+
+        @crewai_event_bus.on(FlushTestEvent)
+        async def async_handler(source: object, event: BaseEvent) -> None:
+            return None
+
+        mixed_future = crewai_event_bus.emit(
+            "test_source", FlushTestEvent(type="mixed")
+        )
+
+        # The asyncio future for the async half, per the ``emit`` docstring.
+        assert mixed_future is not None
+        assert mixed_future is not sync_only_future
+        assert mixed_future.result(timeout=10.0) is None
+


### PR DESCRIPTION
## Description

`emit` registered the sync-handler future with `_track_future` only when the event type had no async handlers. `flush` waits on the tracked set, so for a mixed event type it returned `True` with the sync handlers still running.

Fixes #6745

## Root cause

`event_bus.py:628-645` on `main`:

```python
if sync_handlers:
    if event_type is LLMStreamChunkEvent:
        self._call_handlers(source, event, sync_handlers, state)
    else:
        ctx = contextvars.copy_context()
        sync_future = self._sync_executor.submit(
            ctx.run, self._call_handlers, source, event, sync_handlers, state
        )
        if not async_handlers:
            return self._track_future(sync_future)   # <-- only tracked here
```

Tracking was folded into the `return`, so it happened only on the path that returns the sync future. When async handlers also exist, control falls through to the async branch and the sync future is dropped — created, running, and unreachable from `_pending_futures`.

`replay` (`:714-721`) already does the right thing: it calls `_track_future(sync_future)` unconditionally and only *returns* it in the sync-only case. This PR makes `emit` match.

Measured on `main`:

```
sync handlers only       tracked=1  flush->True in 1.00s  marks=['SYNC FINISHED']
sync + async handlers    tracked=1  flush->True in 0.00s  marks=['async finished']
                         1.5s later: marks=['async finished', 'SYNC FINISHED']
```

`flush` returned in 0.00s and the sync handler finished 1.5s afterwards. (`tracked=1` is the async future, whose done-callback had not yet fired; the sync one was never added.)

## Impact

`flush` exists so callers know handlers finished. `crew.py:1950-1953` says so:

```python
# Ensure background memory saves finish (and emit their completed/failed events)
# before the kickoff-completed event below triggers listener teardown/finalization.
crewai_event_bus.flush()
```

Other call sites: `conversational_mixin.py:1223`, `flow/runtime/__init__.py:1351` and `:2498`, and `shutdown(wait=True)` (`:905`), which is `atexit`-registered — so at interpreter exit the executor could be shut down with sync handlers still in flight.

The triggering combination is the documented one: `listeners/tracing/trace_listener.py:400` registers a **sync** handler on `LLMCallCompletedEvent`, and `docs/edge/en/concepts/checkpointing.mdx:274` shows users registering an **async** handler on that same event.

## The change

```python
sync_future = self._sync_executor.submit(
    ctx.run, self._call_handlers, source, event, sync_handlers, state
)
self._track_future(sync_future)
if not async_handlers:
    return sync_future
```

The documented return-value contract is unchanged — `emit`'s docstring (`:585-591`) promises the `ThreadPoolExecutor` future for sync-only handlers and the asyncio future for async or mixed. Only tracking moves; the sync future is still returned exactly when it was before.

## Tests

`lib/crewai/tests/utilities/events/test_flush.py`, new. No existing test emitted an event that had both a sync and an async handler and then asserted on `flush`, which is why the gap survived.

| test | asserts |
| --- | --- |
| `test_flush_waits_for_sync_handlers_alongside_async_handlers` | **the regression**: a mixed event type has its sync handlers awaited by `flush` |
| `test_flush_waits_for_sync_handlers_when_there_are_no_async_handlers` | the sync-only path, which already waited, cannot regress |
| `test_emit_tracks_the_sync_future_when_async_handlers_exist` | both futures reach `_pending_futures`, not just the async one |
| `test_emit_returns_the_sync_future_only_when_there_are_no_async_handlers` | the documented return-value contract still holds |

Two notes for review:

- Each test asserts on the handler's own completion marker, not on elapsed time, and holds the sync handler on a `threading.Event` gate that is released only after `flush` is already blocking. A pass therefore cannot come from the handler having finished early.
- `..._tracks_the_sync_future...` compares the tracked set as a *delta* and keeps both handlers blocked while it reads it. `_pending_futures` belongs to the process-wide singleton bus and `_track_future`'s done-callback discards completed futures, so neither an absolute count nor a read after completion would be meaningful.

### Control experiment

Reverting only `event_bus.py` and keeping the new tests:

| test | on unfixed source |
| --- | --- |
| `..._sync_handlers_alongside_async_handlers` | **failed** |
| `..._tracks_the_sync_future_when_async_handlers_exist` | **failed** |
| `..._when_there_are_no_async_handlers` | passed |
| `..._returns_the_sync_future_only_when...` | passed |

## Verification

| check | result |
| --- | --- |
| `tests/utilities/events/test_flush.py` | **4 passed** |
| `tests/utilities/events/` + `tests/events/` | 226 passed; error/failure set **name-identical** to `main` (9 pre-existing VCR-cassette errors in `test_event_ordering.py`, unchanged) |
| `ruff check` / `ruff format --check` | clean |

## Out of scope

`aemit` runs only async handlers, and its docstring says so explicitly, so a mixed event type emitted through `aemit` skips its sync handlers by design. It has no call sites in `src/`. Left alone here.


<!-- crewai-require-issue-check -->