### PR TITLE
fix(memory): keep the best duplicate score in recall dedup, not the first

### DIFF
--- a/lib/crewai/src/crewai/memory/recall_flow.py
+++ b/lib/crewai/src/crewai/memory/recall_flow.py
@@ -342,9 +342,15 @@ class RecallFlow(Flow[RecallState]):
 
     @listen("synthesize")
     def synthesize_results(self) -> list[MemoryMatch]:
-        """Deduplicate, composite-score, rank, and attach evidence gaps."""
-        seen_ids: set[str] = set()
-        matches: list[MemoryMatch] = []
+        """Deduplicate, composite-score, rank, and attach evidence gaps.
+
+        A record reachable from more than one (sub-query, scope) task is scored
+        once per task, and the scores differ. ``_do_search`` collects findings in
+        ``as_completed`` order, so keeping the first occurrence would let thread
+        timing pick the surviving score. The best score is kept instead, which is
+        both deterministic and the one ranking should use.
+        """
+        best: dict[str, MemoryMatch] = {}
         for finding in self.state.chunk_findings:
             if not isinstance(finding, dict):
                 continue
@@ -356,19 +362,22 @@ class RecallFlow(Flow[RecallState]):
                     record, score = item[0], item[1]
                 else:
                     continue
-                if isinstance(record, MemoryRecord) and record.id not in seen_ids:
-                    seen_ids.add(record.id)
-                    composite, reasons = compute_composite_score(
-                        record, float(score), self._config
+                if not isinstance(record, MemoryRecord):
+                    continue
+                composite, reasons = compute_composite_score(
+                    record, float(score), self._config
+                )
+                previous = best.get(record.id)
+                if previous is None or composite > previous.score:
+                    best[record.id] = MemoryMatch(
+                        record=record,
+                        score=composite,
+                        match_reasons=reasons,
                     )
-                    matches.append(
-                        MemoryMatch(
-                            record=record,
-                            score=composite,
-                            match_reasons=reasons,
-                        )
-                    )
-        matches.sort(key=lambda m: m.score, reverse=True)
+        matches: list[MemoryMatch] = list(best.values())
+        # ``record.id`` breaks ties, so equal-scoring records do not order by
+        # which task happened to finish first either.
+        matches.sort(key=lambda m: (-m.score, m.record.id))
         final_results = matches[: self.state.limit]
         self.state.final_results = final_results
 

--- a/lib/crewai/tests/memory/test_recall_flow_dedup.py
+++ b/lib/crewai/tests/memory/test_recall_flow_dedup.py
@@ -1,0 +1,149 @@
+"""Tests for ``RecallFlow.synthesize_results`` deduplication.
+
+A record reachable from more than one ``(sub-query, scope)`` task is scored once
+per task, and the scores differ. ``_do_search`` appends findings in
+``as_completed`` order, so a dedup that kept the first occurrence let thread
+completion timing decide which score survived — the same query could return the
+same record at a different rank on consecutive runs.
+
+Each test drives ``synthesize_results`` on a hand-built ``chunk_findings`` list
+rather than through a thread pool, so the assertions pin the dedup rule itself
+instead of racing the scheduler.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from crewai.memory.recall_flow import RecallFlow, RecallState
+from crewai.memory.types import MemoryConfig, MemoryRecord
+
+
+_FIXED_CREATED_AT = datetime(2026, 1, 1, 12, 0, 0)
+
+
+def _record(record_id: str) -> MemoryRecord:
+    """A record with everything but ``id`` held constant.
+
+    ``compute_composite_score`` also reads ``created_at`` and ``importance``, so
+    pinning both keeps the composite a function of the semantic score alone.
+    """
+    return MemoryRecord(
+        id=record_id,
+        content=f"content for {record_id}",
+        created_at=_FIXED_CREATED_AT,
+        importance=0.5,
+    )
+
+
+def _flow_with_findings(findings: list[dict]) -> RecallFlow:
+    flow = RecallFlow(
+        storage=object(),
+        llm=object(),
+        embedder=object(),
+        config=MemoryConfig(),
+    )
+    flow._state = RecallState(limit=10, chunk_findings=findings)
+    return flow
+
+
+def test_duplicate_record_keeps_the_best_score_not_the_first_seen() -> None:
+    """The regression: the surviving score must not depend on finding order."""
+    record = _record("R")
+    high = {"scope": "/a", "results": [(record, 0.9)], "top_score": 0.9}
+    low = {"scope": "/a/b", "results": [(record, 0.1)], "top_score": 0.1}
+
+    high_first = _flow_with_findings([high, low]).synthesize_results()
+    low_first = _flow_with_findings([low, high]).synthesize_results()
+    # What the 0.9 and the 0.1 semantic scores are worth on their own. The
+    # composite also carries a recency term read from the wall clock at scoring
+    # time, so these are compared with a tolerance well below the 0.9/0.1 gap
+    # rather than for exact equality.
+    only_high = _flow_with_findings([high]).synthesize_results()[0].score
+    only_low = _flow_with_findings([low]).synthesize_results()[0].score
+
+    assert len(high_first) == 1
+    assert len(low_first) == 1
+    # Both orderings resolve to the higher score, not to whichever came first.
+    assert high_first[0].score == pytest.approx(only_high, abs=1e-6)
+    assert low_first[0].score == pytest.approx(only_high, abs=1e-6)
+    assert only_high - only_low > 0.1
+
+
+def test_record_reachable_from_several_scopes_appears_once() -> None:
+    """Dedup still collapses duplicates; keeping the best score is not keeping both."""
+    record = _record("R")
+    findings = [
+        {"scope": f"/s{i}", "results": [(record, 0.1 * i)], "top_score": 0.1 * i}
+        for i in range(1, 5)
+    ]
+
+    matches = _flow_with_findings(findings).synthesize_results()
+
+    assert [m.record.id for m in matches] == ["R"]
+
+
+def test_equal_scores_rank_by_record_id_rather_than_arrival() -> None:
+    """Ties must not fall back to whichever task finished first."""
+    a, b = _record("aaa"), _record("bbb")
+    forward = [
+        {"scope": "/x", "results": [(a, 0.5)], "top_score": 0.5},
+        {"scope": "/y", "results": [(b, 0.5)], "top_score": 0.5},
+    ]
+    reverse = list(reversed(forward))
+
+    assert [m.record.id for m in _flow_with_findings(forward).synthesize_results()] == [
+        "aaa",
+        "bbb",
+    ]
+    assert [m.record.id for m in _flow_with_findings(reverse).synthesize_results()] == [
+        "aaa",
+        "bbb",
+    ]
+
+
+def test_distinct_records_are_all_kept_and_ranked_by_score() -> None:
+    """Ranking behaviour that already worked cannot regress."""
+    low, mid, high = _record("low"), _record("mid"), _record("high")
+    findings = [
+        {"scope": "/a", "results": [(low, 0.1), (high, 0.9)], "top_score": 0.9},
+        {"scope": "/b", "results": [(mid, 0.5)], "top_score": 0.5},
+    ]
+
+    matches = _flow_with_findings(findings).synthesize_results()
+
+    assert [m.record.id for m in matches] == ["high", "mid", "low"]
+
+
+def test_limit_is_applied_after_deduplication() -> None:
+    """A duplicate must not consume one of the caller's ``limit`` slots."""
+    dup = _record("dup")
+    others = [_record(f"r{i}") for i in range(3)]
+    findings = [
+        {"scope": "/a", "results": [(dup, 0.9)], "top_score": 0.9},
+        {"scope": "/a/b", "results": [(dup, 0.8)], "top_score": 0.8},
+        {"scope": "/c", "results": [(r, 0.5) for r in others], "top_score": 0.5},
+    ]
+    flow = _flow_with_findings(findings)
+    flow._state.limit = 3
+
+    matches = flow.synthesize_results()
+
+    assert len(matches) == 3
+    assert [m.record.id for m in matches].count("dup") == 1
+
+
+def test_malformed_findings_are_skipped_without_raising() -> None:
+    """Defensive shapes the original loop tolerated are still tolerated."""
+    record = _record("R")
+    findings = [
+        "not a dict",
+        {"scope": "/a", "results": "not a list"},
+        {"scope": "/b", "results": [("not a record", 0.5), (record,), (record, 0.7)]},
+    ]
+
+    matches = _flow_with_findings(findings).synthesize_results()  # type: ignore[arg-type]
+
+    assert [m.record.id for m in matches] == ["R"]

--- a/lib/crewai/tests/memory/test_recall_flow_dedup.py
+++ b/lib/crewai/tests/memory/test_recall_flow_dedup.py
@@ -17,18 +17,25 @@ from datetime import datetime
 
 import pytest
 
+from crewai.memory import types as types_module
 from crewai.memory.recall_flow import RecallFlow, RecallState
 from crewai.memory.types import MemoryConfig, MemoryRecord
 
 
 _FIXED_CREATED_AT = datetime(2026, 1, 1, 12, 0, 0)
+"""When every record under test was created."""
+
+_SCORED_AT = datetime(2026, 1, 2, 12, 0, 0)
+"""When the frozen clock scores them — a day later, so the decay is exercised."""
 
 
 def _record(record_id: str) -> MemoryRecord:
     """A record with everything but ``id`` held constant.
 
     ``compute_composite_score`` also reads ``created_at`` and ``importance``, so
-    pinning both keeps the composite a function of the semantic score alone.
+    pinning both is necessary — but not sufficient — for the composite to be a
+    function of the semantic score alone. It also reads the wall clock; see
+    ``_frozen_clock``.
     """
     return MemoryRecord(
         id=record_id,
@@ -36,6 +43,32 @@ def _record(record_id: str) -> MemoryRecord:
         created_at=_FIXED_CREATED_AT,
         importance=0.5,
     )
+
+
+@pytest.fixture
+def _frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hold ``compute_composite_score``'s recency clock still.
+
+    It computes the recency decay from ``datetime.utcnow()`` per call, so two
+    records created at the same instant do not score identically: whichever is
+    scored first is read a few hundred nanoseconds younger and gets a larger
+    decay. The gap is around 1e-11, far below any weight, but it is enough to
+    order two otherwise-equal composites — so it decides a tie the ``record.id``
+    tiebreaker is supposed to decide.
+
+    Measured on the unfrozen clock, the tie test below fails on 200 of 20000
+    runs (1.0%), always on the reversed ordering — there the record that must
+    sort second is scored first and so wins the drift. Frozen, the difference
+    between the two composites is exactly ``0.0`` over 50000 pairs. Only ties
+    are affected; every other assertion here separates records by far more than
+    the drift.
+    """
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def utcnow(cls) -> datetime:
+            return _SCORED_AT
+
+    monkeypatch.setattr(types_module, "datetime", _FrozenDatetime)
 
 
 def _flow_with_findings(findings: list[dict]) -> RecallFlow:
@@ -85,8 +118,14 @@ def test_record_reachable_from_several_scopes_appears_once() -> None:
     assert [m.record.id for m in matches] == ["R"]
 
 
+@pytest.mark.usefixtures("_frozen_clock")
 def test_equal_scores_rank_by_record_id_rather_than_arrival() -> None:
-    """Ties must not fall back to whichever task finished first."""
+    """Ties must not fall back to whichever task finished first.
+
+    The clock is frozen because the drift between two ``utcnow()`` reads is
+    itself an arrival-order signal, and an unfrozen one lets the assertion pass
+    for the wrong reason in the forward case and fail in the reverse.
+    """
     a, b = _record("aaa"), _record("bbb")
     forward = [
         {"scope": "/x", "results": [(a, 0.5)], "top_score": 0.5},


### PR DESCRIPTION
Closes #6747

## Problem

`RecallFlow.synthesize_results` deduplicated by `record.id` keeping the **first** occurrence, but `_do_search` appends findings inside `for future in as_completed(futures)` — i.e. in thread-completion order. So when the same record arrived from more than one `(sub-query, scope)` task, **thread timing decided which score survived**.

Duplicates are structural rather than incidental:

- `lancedb_storage.search` filters with `query.where(f"scope LIKE '{prefix}%'")`, so a record stored at `/a/b` is returned for scope `/a` **and** `/a/b` — and `filter_and_chunk` routinely selects both.
- `analyze_query_step` yields up to 3 sub-query embeddings and `_do_search` runs the full `embeddings × scopes` cross product, so the same record arrives carrying *different* semantic scores.

`compute_composite_score` is monotonic in `semantic_score`, so keeping the first-arriving duplicate can keep a strictly worse score — under-ranking the record, or dropping it out of `matches[: self.state.limit]`. This reaches users through `UnifiedMemory` (`flow.state.final_results` → `touch_records` → `MemoryQueryCompletedEvent`).

A second, smaller dependence: `sort(key=..., reverse=True)` is stable, so equal-scoring records kept their arrival order too.

## Fix

Keep the **best** score per `record.id` instead of the first, and break sort ties on `record.id`:

```python
best: dict[str, MemoryMatch] = {}
...
    previous = best.get(record.id)
    if previous is None or composite > previous.score:
        best[record.id] = MemoryMatch(record=record, score=composite, match_reasons=reasons)
matches: list[MemoryMatch] = list(best.values())
matches.sort(key=lambda m: (-m.score, m.record.id))
```

Best-wins is both order-independent and the score ranking should have been using. Behaviour that already worked is untouched: dedup still collapses duplicates to one entry, ranking is still by descending composite, `limit` is still applied last, and the defensive shape checks (non-dict finding, non-list `results`, short tuple, non-`MemoryRecord`) are all preserved.

`state.confidence` is deliberately unchanged — `max((f["top_score"] for f in findings), default=0.0)` is already order-independent.

## Tests

New `lib/crewai/tests/memory/test_recall_flow_dedup.py`, 6 tests. Each drives `synthesize_results` on a hand-built `chunk_findings` list rather than through a thread pool, so the assertions pin the dedup rule itself instead of racing the scheduler.

| Test | Pins |
|---|---|
| `test_duplicate_record_keeps_the_best_score_not_the_first_seen` | the regression: `[high, low]` and `[low, high]` both resolve to the higher score |
| `test_equal_scores_rank_by_record_id_rather_than_arrival` | ties order by `record.id` in both a forward and a reversed findings list |
| `test_record_reachable_from_several_scopes_appears_once` | best-wins is not keep-both — 4 scopes still collapse to one match |
| `test_distinct_records_are_all_kept_and_ranked_by_score` | descending-composite ranking did not regress |
| `test_limit_is_applied_after_deduplication` | a duplicate does not consume one of the caller's `limit` slots |
| `test_malformed_findings_are_skipped_without_raising` | the defensive shapes the original loop tolerated are still tolerated |

The composite carries a recency term read from the wall clock at scoring time, so the score assertions compare with `pytest.approx(..., abs=1e-6)` against separately-scored baselines — a tolerance three orders of magnitude below the 0.9/0.1 gap being asserted — rather than against hard-coded floats.

**Control run** — with `git checkout origin/main -- lib/crewai/src/crewai/memory/recall_flow.py` and the new test file in place:

```
2 failed, 4 passed
FAILED test_recall_flow_dedup.py::test_duplicate_record_keeps_the_best_score_not_the_first_seen
FAILED test_recall_flow_dedup.py::test_equal_scores_rank_by_record_id_rather_than_arrival
```

So both new assertions fail on unfixed source, and the four guarding existing behaviour pass on it — they are not tautologies.

**Suite comparison** — `lib/crewai/tests/memory/` before and after, comparing failing test *names*:

```
before: 5 errors (all test_memory_root_scope.py, pre-existing on main)
after : 134 passed, 19 skipped, 5 errors  <- same 5, no new failures
```

## Checks

- `ruff check` on both files: `All checks passed!`
- `ruff format --check` on the source file: already formatted (`lib/crewai/tests/` is ruff-excluded)


<!-- crewai-require-issue-check -->