### PR TITLE
fix: run before/after_llm_call hooks on the LiteLLM fallback's acall()

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2015,6 +2015,9 @@ class LLM(BaseLLM):
                         msg_role: Literal["assistant"] = "assistant"
                         message["role"] = msg_role
 
+            if not self._invoke_before_llm_call_hooks(messages, from_agent):
+                raise ValueError("LLM call blocked by before_llm_call hook")
+
             with suppress_warnings():
                 if callbacks and len(callbacks) > 0:
                     self.set_callbacks(callbacks)
@@ -2024,7 +2027,16 @@ class LLM(BaseLLM):
                     )
 
                     if self._effective_stream():
-                        return await self._ahandle_streaming_response(
+                        result = await self._ahandle_streaming_response(
+                            params=params,
+                            callbacks=callbacks,
+                            available_functions=available_functions,
+                            from_task=from_task,
+                            from_agent=from_agent,
+                            response_model=response_model,
+                        )
+                    else:
+                        result = await self._ahandle_non_streaming_response(
                             params=params,
                             callbacks=callbacks,
                             available_functions=available_functions,
@@ -2033,14 +2045,12 @@ class LLM(BaseLLM):
                             response_model=response_model,
                         )
 
-                    return await self._ahandle_non_streaming_response(
-                        params=params,
-                        callbacks=callbacks,
-                        available_functions=available_functions,
-                        from_task=from_task,
-                        from_agent=from_agent,
-                        response_model=response_model,
-                    )
+                    if isinstance(result, str):
+                        result = self._invoke_after_llm_call_hooks(
+                            messages, result, from_agent
+                        )
+
+                    return result
                 except LLMContextLengthExceededError:
                     raise
                 except Exception as e:

--- a/lib/crewai/tests/hooks/test_llm_hooks.py
+++ b/lib/crewai/tests/hooks/test_llm_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import Mock
 
 from crewai.hooks import (
@@ -670,3 +671,121 @@ class TestDirectLLMScopedHooks:
             )
 
         assert result == "contains [REDACTED]"
+
+
+def _litellm_response(text: str = "the model answered") -> Any:
+    """A litellm ModelResponse, which uses attribute access rather than a dict."""
+    from litellm.types.utils import ModelResponse
+
+    return ModelResponse(
+        **{
+            "choices": [
+                {
+                    "message": {"content": text, "role": "assistant"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    )
+
+
+class TestLLMHooksOnTheLiteLLMFallbackAsyncPath:
+    """``crewai.llm.LLM`` -- the fallback -- must gate ``acall()`` as it gates ``call()``.
+
+    The fallback is reached whenever no native provider matches the model, and by
+    ``is_litellm=True``. Its ``call()`` ran both hook families; ``acall()`` ran
+    neither, so a policy hook that blocked synchronously let the request out once
+    the caller switched to async, and a redaction hook stopped rewriting.
+
+    ``base_llm.BaseLLM`` only defines the two ``_invoke_*`` helpers -- its own
+    ``acall`` raises ``NotImplementedError`` -- so this class is the only place
+    the fallback's async seam can be covered.
+    """
+
+    @pytest.fixture
+    def stub_litellm(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Replace both litellm entry points, recording which one was reached."""
+        import litellm
+
+        issued: list[str] = []
+
+        def completion(*_args: Any, **_kwargs: Any) -> Any:
+            issued.append("sync")
+            return _litellm_response()
+
+        async def acompletion(*_args: Any, **_kwargs: Any) -> Any:
+            issued.append("async")
+            return _litellm_response()
+
+        monkeypatch.setattr(litellm, "completion", completion)
+        monkeypatch.setattr(litellm, "acompletion", acompletion)
+        return issued
+
+    @staticmethod
+    def _fallback_llm() -> Any:
+        """``is_litellm=True`` is required: without it the constructor returns a
+        native provider, and the fallback's own seam is never exercised."""
+        from crewai.llm import LLM
+
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=False)
+        assert type(llm) is LLM, f"expected the fallback, got {type(llm).__name__}"
+        return llm
+
+    def test_sync_call_is_blocked_by_before_hook(self, stub_litellm: list[str]) -> None:
+        register_before_llm_call_hook(lambda ctx: False)
+
+        with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+            self._fallback_llm().call("hi")
+
+        assert stub_litellm == []
+
+    @pytest.mark.asyncio
+    async def test_async_call_is_blocked_by_before_hook(
+        self, stub_litellm: list[str]
+    ) -> None:
+        """The regression, and the reason it matters: the request went out.
+
+        ``issued == []`` is the load-bearing assertion. Asserting only that the
+        call raised would also pass on an implementation that ran the hook after
+        the provider had already been paid.
+        """
+        register_before_llm_call_hook(lambda ctx: False)
+
+        with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+            await self._fallback_llm().acall("hi")
+
+        assert stub_litellm == []
+
+    @pytest.mark.asyncio
+    async def test_async_call_runs_after_hook(self, stub_litellm: list[str]) -> None:
+        """A response-rewriting hook applies on the async path too."""
+        register_after_llm_call_hook(lambda ctx: "REDACTED BY HOOK")
+
+        result = await self._fallback_llm().acall("hi")
+
+        assert result == "REDACTED BY HOOK"
+        assert stub_litellm == ["async"]
+
+    @pytest.mark.asyncio
+    async def test_async_call_before_hook_sees_the_messages(
+        self, stub_litellm: list[str]
+    ) -> None:
+        seen: list[list[dict[str, Any]]] = []
+        register_before_llm_call_hook(lambda ctx: seen.append(list(ctx.messages)))
+
+        result = await self._fallback_llm().acall("hi")
+
+        assert result == "the model answered"
+        assert stub_litellm == ["async"]
+        assert seen and seen[0][-1]["content"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_async_call_without_hooks_is_unchanged(
+        self, stub_litellm: list[str]
+    ) -> None:
+        """Negative control: the seam is inert when nothing is registered."""
+        result = await self._fallback_llm().acall("hi")
+
+        assert result == "the model answered"
+        assert stub_litellm == ["async"]


### PR DESCRIPTION
## Summary

`crewai/llm.py` is the LiteLLM fallback, used whenever no native provider matches the model and whenever `is_litellm=True` is passed. Its `call()` dispatches both LLM hook families; its `acall()` dispatched **neither**.

Because `before_llm_call` is the only interception point that can *abort* a call, a hook returning `False` on the async path did not merely fail to observe the request -- the request was issued and billed. `after_llm_call` silently stopped rewriting, so a redaction hook handed back the raw response.

Related to #6739 but a distinct seam. See the note on scope below.

## Root cause

On `main` (`ebe0082`), in `lib/crewai/src/crewai/llm.py`:

| method | `before_llm_call` | `after_llm_call` |
| --- | --- | --- |
| `call()` (`:1820`) | ✅ `:1876` | ✅ `:1904` |
| `acall()` (`:1959`) | ❌ | ❌ |

`llms/base_llm.py` is not the fallback and does not cover this: it only *defines* `_invoke_before_llm_call_hooks` and `_invoke_after_llm_call_hooks`, has no callers of either, and its own `acall()` is `raise NotImplementedError`.

## Proof, before any fix was written

No network. `litellm.completion` / `litellm.acompletion` are replaced with stubs that record **whether a request left the process**, so the observable is the provider call rather than the returned string:

```
blocking before_llm_call hook (returns False) + rewriting after hook:
  call   before:1 after:0  issued:no     -> ValueError: LLM call blocked by before_llm_call hook
  acall  before:0 after:0  issued:async  -> 'the model said something sensitive'

observing-only before hook + rewriting after hook:
  call   before:1 after:1  issued:sync   -> 'REDACTED BY HOOK'
  acall  before:0 after:0  issued:async  -> 'the model said something sensitive'
```

`LLM(model=..., is_litellm=True)` is required to reach this class -- without the flag the constructor returns a native provider. That is probably part of why the gap persisted: the obvious way to construct an `LLM` does not exercise it.

After this PR all four rows match their sync counterpart.

## The change

`acall()` now mirrors `call()` exactly. The guard sits at the same point -- after the `o1` role rewrite, before `_prepare_completion_params`:

```python
if not self._invoke_before_llm_call_hooks(messages, from_agent):
    raise ValueError("LLM call blocked by before_llm_call hook")
```

and the two handler branches bind to `result` instead of returning directly, so the `after` dispatch has a join point:

```python
if self._effective_stream():
    result = await self._ahandle_streaming_response(...)
else:
    result = await self._ahandle_non_streaming_response(...)

if isinstance(result, str):
    result = self._invoke_after_llm_call_hooks(messages, result, from_agent)

return result
```

That restructuring is why the source diff is 28 lines rather than two inserted ones: the async body had `return await ...` in each branch and no single place to dispatch from. The `isinstance(result, str)` guard is the sync path's, verbatim -- a tool-call result is not a response string and is not offered to the hook.

No double dispatch on the agent path: `_invoke_before_llm_call_hooks` returns `True` immediately when `from_agent is not None`, so the agent executor's dispatch remains the single source for agent-driven calls.

## Scope, and why this is separate from #6737 / #6740

Same defect class, three different seams:

| PR | seam | count |
| --- | --- | --- |
| #6737 | native providers' `_ahandle_*` response handlers (`after`) | 8 handlers |
| #6740 | native providers' `acall()` bodies (`before`) | 5 providers |
| this | the LiteLLM fallback's `acall()` (`before` **and** `after`) | 1 method |

Neither open PR touches `llm.py`, and this one touches neither provider file. Keeping it separate also keeps `git blame` honest about which seam each change fixed.

#6740's description asserted that this path "already had the guard on both paths." That was wrong, and it understated the bug -- it is corrected in that PR's body, since a reviewer could reasonably have acted on it.

## Tests

`TestLLMHooksOnTheLiteLLMFallbackAsyncPath` in `tests/hooks/test_llm_hooks.py`, 5 tests.

The blocking test asserts `issued == []`, not just that a `ValueError` was raised. A test asserting only on the exception would also pass on an implementation that ran the hook *after* the provider had already been paid, which is the failure mode that makes this worth fixing.

```
$ pytest tests/hooks/test_llm_hooks.py
31 passed

$ pytest tests/hooks/
137 passed, 5 errors        # 132 passed, 5 errors on a clean tree

$ git stash push lib/crewai/src/crewai/llm.py     # tests unchanged
$ pytest tests/hooks/test_llm_hooks.py -k LiteLLMFallback
3 failed, 2 passed
    test_async_call_is_blocked_by_before_hook   DID NOT RAISE ValueError
    test_async_call_runs_after_hook             'the model answered' != 'REDACTED BY HOOK'
    test_async_call_before_hook_sees_the_messages   assert ([])
```

The two that pass either way are deliberate: one exercises the sync path, which was never broken, and one is a no-hook negative control proving the seam is inert when nothing is registered.

The 5 errors are pre-existing Windows tempdir-cleanup failures at teardown in `test_crew_scoped_hooks.py` and `test_interception_conformance.py`, identical on an unmodified tree.

`ruff check` and `ruff format --check` clean on both files.

<!-- crewai-require-issue-check -->