### PR TITLE
feat(tools): add Truth Bear GAUGE tools (official-source signals, offline-verifiable, no API key)

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -204,6 +204,11 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_gauge_tool.truthbear_gauge_tool import (
+    TruthBearCatalogTool,
+    TruthBearCoverageTool,
+    TruthBearRecordTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.wait_tool.wait_tool import WaitTool
@@ -321,6 +326,9 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TruthBearCatalogTool",
+    "TruthBearCoverageTool",
+    "TruthBearRecordTool",
     "VisionTool",
     "WaitTool",
     "WeaviateVectorSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -208,6 +208,11 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_gauge_tool.truthbear_gauge_tool import (
+    TruthBearCatalogTool,
+    TruthBearCoverageTool,
+    TruthBearRecordTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.url_read_tool.url_read_tool import URLReadTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
@@ -328,6 +333,9 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TruthBearCatalogTool",
+    "TruthBearCoverageTool",
+    "TruthBearRecordTool",
     "URLReadTool",
     "VisionTool",
     "WaitTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -191,6 +191,11 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_gauge_tool.truthbear_gauge_tool import (
+    TruthBearCatalogTool,
+    TruthBearCoverageTool,
+    TruthBearRecordTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
 from crewai_tools.tools.wait_tool.wait_tool import WaitTool

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -195,6 +195,11 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_gauge_tool.truthbear_gauge_tool import (
+    TruthBearCatalogTool,
+    TruthBearCoverageTool,
+    TruthBearRecordTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.url_read_tool.url_read_tool import URLReadTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
@@ -1,0 +1,137 @@
+# 🐻 Truth Bear GAUGE Tools — Usage Examples
+
+### 🔧 Tool Initialization
+
+```python
+from crewai_tools import (
+    TruthBearCoverageTool,
+    TruthBearCatalogTool,
+    TruthBearRecordTool,
+)
+```
+
+---
+
+### Example 1: Check a signal line before spending anything
+
+```python
+tool = TruthBearCoverageTool()
+print(tool.run(signal_id="hydrology.river-level"))
+```
+
+```json
+{
+  "found": true,
+  "totals": {
+    "signal_ids": 1,
+    "industries": 1,
+    "distinct_entities": 10,
+    "freshness": { "fresh": 10, "recent": 0, "stale": 0 }
+  },
+  "signals": [
+    {
+      "signal_id": "hydrology.river-level",
+      "industry": "hydrology",
+      "entities_count": 10,
+      "freshness_counts": { "fresh": 10, "recent": 0, "stale": 0 },
+      "update_status": "on_schedule"
+    }
+  ]
+}
+```
+
+---
+
+### Example 2: An unknown signal is reported, not raised
+
+```python
+tool = TruthBearCoverageTool()
+print(tool.run(signal_id="not.a.real.signal"))
+```
+
+```json
+{
+  "found": false,
+  "signal_id": "not.a.real.signal",
+  "hint": "List valid signal ids with the Truth Bear GAUGE catalog tool."
+}
+```
+
+---
+
+### Example 3: Find a valid entity for a signal line
+
+`signal_id` and `entity` must be used as a pair, so look the entity up first.
+
+```python
+tool = TruthBearCatalogTool()
+print(tool.run(signal_id="hydrology.river-level"))
+```
+
+Returns the 10 monitored gauges for that line with their human-readable names, for example
+`06893000` — *Missouri River at Kansas City, MO*.
+
+Calling it with no filter is rejected on purpose:
+
+```python
+tool.run()          # ValueError: Provide either signal_id or industry -
+                    # the unfiltered catalog is ~1.5 MB.
+```
+
+---
+
+### Example 4: Request a paid record — the tool never pays
+
+```python
+tool = TruthBearRecordTool()
+print(tool.run(signal_id="hydrology.river-level", entity="06893000"))
+```
+
+```json
+{
+  "payment_required": true,
+  "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
+  "challenge": {
+    "x402Version": 1,
+    "accepts": [
+      {
+        "scheme": "exact",
+        "network": "base",
+        "maxAmountRequired": "10000",
+        "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "payTo": "0x…",
+        "resource": "https://aeml-x402.zeabur.app/gauge"
+      }
+    ]
+  }
+}
+```
+
+Settle that challenge with your own x402 client and retry the same URL to receive the record.
+
+---
+
+### Example 5: Inside a Crew
+
+```python
+from crewai import Agent, Crew, Task
+from crewai_tools import TruthBearCoverageTool, TruthBearCatalogTool
+
+analyst = Agent(
+    role="Environmental screening analyst",
+    goal="Report whether a river gauge reading is routine or unusual, citing the official source",
+    backstory="You never state a conclusion the official record does not support.",
+    tools=[TruthBearCoverageTool(), TruthBearCatalogTool()],
+)
+
+task = Task(
+    description=(
+        "Check whether the hydrology.river-level line is covered and current, then list the "
+        "gauges available on it."
+    ),
+    expected_output="Coverage status, freshness counts, and the list of monitored gauges.",
+    agent=analyst,
+)
+
+Crew(agents=[analyst], tasks=[task]).kickoff()
+```

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
@@ -89,25 +89,22 @@ print(tool.run(signal_id="hydrology.river-level", entity="06893000"))
 
 ```json
 {
-  "payment_required": true,
-  "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
-  "challenge": {
-    "x402Version": 1,
-    "accepts": [
-      {
-        "scheme": "exact",
-        "network": "base",
-        "maxAmountRequired": "10000",
-        "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        "payTo": "0x…",
-        "resource": "https://aeml-x402.zeabur.app/gauge"
-      }
-    ]
-  }
+  "x402Version": 1,
+  "error": "X-PAYMENT header is required",
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "base",
+      "maxAmountRequired": "10000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x…",
+      "resource": "https://aeml-x402.zeabur.app/gauge"
+    }
+  ]
 }
 ```
 
-Settle that challenge with your own x402 client and retry the same URL to receive the record.
+The tool returns the x402 challenge unchanged. Settle it with your own x402 client and retry the same URL to receive the record.
 
 ---
 

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/Examples.md
@@ -1,6 +1,6 @@
 # 🐻 Truth Bear GAUGE Tools — Usage Examples
 
-### 🔧 Tool Initialization
+## 🔧 Tool Initialization
 
 ```python
 from crewai_tools import (
@@ -12,7 +12,7 @@ from crewai_tools import (
 
 ---
 
-### Example 1: Check a signal line before spending anything
+## Example 1: Check a signal line before spending anything
 
 ```python
 tool = TruthBearCoverageTool()
@@ -42,7 +42,7 @@ print(tool.run(signal_id="hydrology.river-level"))
 
 ---
 
-### Example 2: An unknown signal is reported, not raised
+## Example 2: An unknown signal is reported, not raised
 
 ```python
 tool = TruthBearCoverageTool()
@@ -59,9 +59,9 @@ print(tool.run(signal_id="not.a.real.signal"))
 
 ---
 
-### Example 3: Find a valid entity for a signal line
+## Example 3: Find a valid entity for a signal line
 
-`signal_id` and `entity` must be used as a pair, so look the entity up first.
+The record tool requires `signal_id` and `entity` as a pair, so use this catalog lookup (filtered by `signal_id` or `industry`) to find valid entities first.
 
 ```python
 tool = TruthBearCatalogTool()
@@ -80,7 +80,7 @@ tool.run()          # ValueError: Provide either signal_id or industry -
 
 ---
 
-### Example 4: Request a paid record — the tool never pays
+## Example 4: Request a paid record — the tool never pays
 
 ```python
 tool = TruthBearRecordTool()
@@ -111,7 +111,7 @@ Settle that challenge with your own x402 client and retry the same URL to receiv
 
 ---
 
-### Example 5: Inside a Crew
+## Example 5: Inside a Crew
 
 ```python
 from crewai import Agent, Crew, Task

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/README.md
@@ -1,0 +1,85 @@
+# 🐻 Truth Bear GAUGE Tools
+
+Three tools for querying **Truth Bear GAUGE**, a pay-per-call source of official-record signals.
+Sources are official government records and named registries — USGS, NOAA, NWS, EPA, SEC EDGAR,
+openFDA, EIA, BLS, FAA, US CBP, USTR, USITC and the Federal Register, plus IMF PortWatch and
+UNFCCC feeds.
+
+Two of the three tools are free and need no API key, no account and no signup. The third is paid
+over [x402](https://x402.org) and **returns the payment challenge rather than settling it** — no
+key material or funds are touched by this package.
+
+---
+
+## Description
+
+Each record is stated against the **official threshold ladder published by the source agency**
+rather than a scale invented by the vendor, and carries a **same-season percentile** so an agent
+can tell a routine reading from an unusual one. Every paid record also ships a canonical sha256
+`record_hash` that can be recomputed offline from the delivered payload, so an agent does not have
+to trust the endpoint it just paid.
+
+The service is **descriptive only**: no forecast, no recommendation, no adjudication.
+
+| Tool | Cost | Purpose |
+| ---- | ---- | ------- |
+| `TruthBearCoverageTool` | free | Does a signal line exist, how many objects it covers, how fresh those readings are, and whether the source agency is on schedule or overdue |
+| `TruthBearCatalogTool` | free | Which entity ids are valid for a signal line — `signal_id` and `entity` must be used as a pair |
+| `TruthBearRecordTool` | paid (x402) | Requests one official record; returns the HTTP 402 payment challenge untouched |
+
+---
+
+## Arguments
+
+### `TruthBearCoverageTool`
+
+| Argument | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| `signal_id` | `str` | ❌ | Signal id in `genus.species` form, e.g. `"hydrology.river-level"`. Omit for a summary across all 185 signal lines. |
+
+### `TruthBearCatalogTool`
+
+| Argument | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| `signal_id` | `str` | ⚠️ | Filter to one signal line, e.g. `"hydrology.river-level"`. |
+| `industry` | `str` | ⚠️ | Filter to one industry, e.g. `"hydrology"`, `"airquality"`, `"macro"`. |
+
+⚠️ **One of the two is required.** The unfiltered catalog response is about 1.5 MB, which would
+flood an agent's context window, so a call with neither filter is rejected rather than served.
+
+### `TruthBearRecordTool`
+
+| Argument | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| `signal_id` | `str` | ✅ | Signal id, e.g. `"hydrology.river-level"`. |
+| `entity` | `str` | ✅ | Monitored object id **paired with** `signal_id`, e.g. `"06893000"`. Get valid pairs from `TruthBearCatalogTool`. |
+
+---
+
+## Installation
+
+No extra installation step. The tools use the Python standard library (`urllib`, `json`) plus
+`pydantic`, which `crewai-tools` already depends on.
+
+```python
+from crewai_tools import (
+    TruthBearCoverageTool,
+    TruthBearCatalogTool,
+    TruthBearRecordTool,
+)
+```
+
+---
+
+## Behaviour worth knowing
+
+- **A miss is not an error.** An unknown `signal_id` comes back as HTTP 200 with an empty
+  `signals` list; `TruthBearCoverageTool` converts that to an explicit `{"found": false}` so an
+  agent does not mistake an empty answer for a failed call.
+- **402 is a price quote, not a failure.** `TruthBearRecordTool` hands the challenge back intact —
+  network, asset, amount and recipient — so an x402-capable wallet elsewhere in your stack can
+  settle it and retry the same URL.
+- **Charging is bound to HTTP 200.** A paid query with no data answers 422 and is not billed.
+- **Freshness is explicit.** Coverage reports `fresh` / `recent` / `stale` counts and an
+  `update_status` of `on_schedule`, `overdue` or `not_published`, measured against the cadence the
+  source agency itself declares.

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/README.md
@@ -24,7 +24,7 @@ The service is **descriptive only**: no forecast, no recommendation, no adjudica
 | Tool | Cost | Purpose |
 | ---- | ---- | ------- |
 | `TruthBearCoverageTool` | free | Does a signal line exist, how many objects it covers, how fresh those readings are, and whether the source agency is on schedule or overdue |
-| `TruthBearCatalogTool` | free | Which entity ids are valid for a signal line — `signal_id` and `entity` must be used as a pair |
+| `TruthBearCatalogTool` | free | Which entity ids are valid for a signal line — filter by `signal_id` or `industry` (one required) |
 | `TruthBearRecordTool` | paid (x402) | Requests one official record; returns the HTTP 402 payment challenge untouched |
 
 ---

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
@@ -1,0 +1,175 @@
+"""Truth Bear GAUGE tools for CrewAI.
+
+Official-source signal records (US federal agencies and named registries) with a
+canonical record_hash the caller can recompute offline.
+
+Design notes for reviewers:
+  * Standard library only - this adds no dependency to crewai-tools.
+  * No API key, no account, no signup. The two tools here use the free tier.
+  * Neither tool holds or spends funds. The paid record endpoint answers HTTP 402
+    with an x402 challenge; that challenge is handed back to the caller untouched
+    and settling it is the caller's own wallet's job.
+  * The catalog endpoint returns ~1.5 MB unfiltered, so a filter is required here
+    rather than optional - an unfiltered dump would flood an agent's context.
+"""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import ClassVar, List, Optional, Type
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field, model_validator
+
+BASE_URL = "https://aeml-x402.zeabur.app"
+REQUEST_TIMEOUT = 20
+
+
+def _get_json(path: str, params: Optional[dict] = None) -> dict:
+    url = f"{BASE_URL}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {"raw": body[:2000]}
+        # In x402 a 402 is not a failure, it is the price quote. Return it intact.
+        return {"http_status": exc.code, **payload}
+
+
+class TruthBearCoverageInput(BaseModel):
+    signal_id: Optional[str] = Field(
+        None,
+        description=(
+            "Optional. A signal id in genus.species ASCII form, e.g. "
+            "'hydrology.river-level', 'airquality.aqi', 'macro.unemployment'. "
+            "Omit to get the summary across all 185 signal lines."
+        ),
+    )
+
+
+class TruthBearCoverageTool(BaseTool):
+    """Free: does this signal exist, how many objects, how fresh, is it on schedule."""
+
+    name: str = "Truth Bear GAUGE coverage check"
+    description: str = (
+        "Free check, no key: for a signal line, report whether it exists, how many monitored "
+        "objects it covers, how many of those readings are fresh / recent / stale, whether the "
+        "source agency is on schedule or overdue, and the latest observation time. Use this "
+        "before paying for a record, to confirm the line is covered and current. Sources are "
+        "official government records and named registries (USGS, NOAA, NWS, EPA, SEC EDGAR, "
+        "openFDA, EIA, BLS and others). An unknown signal id comes back with an empty signals "
+        "list rather than an error."
+    )
+    args_schema: Type[BaseModel] = TruthBearCoverageInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: Optional[str] = None) -> str:
+        params = {"summary": "1"}
+        if signal_id:
+            params["signal_id"] = signal_id
+        data = _get_json("/gauge/coverage", params)
+        signals = data.get("signals") or []
+        if signal_id and not signals:
+            return json.dumps(
+                {
+                    "found": False,
+                    "signal_id": signal_id,
+                    "hint": "List valid signal ids with the Truth Bear GAUGE catalog tool.",
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {"found": True, "totals": data.get("totals"), "signals": signals},
+            ensure_ascii=False,
+        )
+
+
+class TruthBearCatalogInput(BaseModel):
+    signal_id: Optional[str] = Field(
+        None, description="Filter to one signal line, e.g. 'hydrology.river-level'."
+    )
+    industry: Optional[str] = Field(
+        None, description="Filter to one industry, e.g. 'hydrology', 'airquality', 'macro'."
+    )
+
+    @model_validator(mode="after")
+    def _require_a_filter(self):
+        # The unfiltered catalog is ~1.5 MB. Returning that to an agent would blow its
+        # context window, so a filter is required rather than merely recommended.
+        if not self.signal_id and not self.industry:
+            raise ValueError("Provide either signal_id or industry - the unfiltered catalog is ~1.5 MB.")
+        return self
+
+
+class TruthBearCatalogTool(BaseTool):
+    """Free: which entity ids are valid for a signal line."""
+
+    name: str = "Truth Bear GAUGE catalog lookup"
+    description: str = (
+        "Free lookup, no key: list the monitored object ids (entities) that are valid for a "
+        "given signal line or industry, with their human-readable names. signal_id and entity "
+        "must be used as a pair, so call this to get a valid entity before requesting a record. "
+        "One of signal_id or industry is required."
+    )
+    args_schema: Type[BaseModel] = TruthBearCatalogInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: Optional[str] = None, industry: Optional[str] = None) -> str:
+        args = TruthBearCatalogInput(signal_id=signal_id, industry=industry)
+        params = {}
+        if args.signal_id:
+            params["signal_id"] = args.signal_id
+        if args.industry:
+            params["industry"] = args.industry
+        return json.dumps(_get_json("/gauge/catalog", params), ensure_ascii=False)
+
+
+class TruthBearRecordInput(BaseModel):
+    signal_id: str = Field(..., description="Signal id, e.g. 'hydrology.river-level'.")
+    entity: str = Field(
+        ...,
+        description="Monitored object id PAIRED WITH signal_id, e.g. '06893000'. Get valid "
+        "pairs from the Truth Bear GAUGE catalog tool.",
+    )
+
+
+class TruthBearRecordTool(BaseTool):
+    """Paid record - returns the x402 payment challenge, never settles it."""
+
+    name: str = "Truth Bear GAUGE official record (paid, x402)"
+    description: str = (
+        "Request one official-source record for a signal_id and entity pair: the current reading, "
+        "the official threshold band published by the source agency, a same-season percentile, and "
+        "a canonical sha256 record_hash that can be recomputed offline so the answer does not have "
+        "to be taken on trust. This endpoint is paid: it answers HTTP 402 with an x402 payment "
+        "challenge stating network, asset, amount and recipient. THIS TOOL DOES NOT PAY. It returns "
+        "the challenge unchanged so an x402-capable wallet in your own stack can settle it and "
+        "retry. Charging is bound to HTTP 200 - if there is no data you are not billed."
+    )
+    args_schema: Type[BaseModel] = TruthBearRecordInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: str, entity: str) -> str:
+        args = TruthBearRecordInput(signal_id=signal_id, entity=entity)
+        data = _get_json("/gauge", {"signal_id": args.signal_id, "entity": args.entity})
+        if data.get("http_status") == 402:
+            return json.dumps(
+                {
+                    "payment_required": True,
+                    "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
+                    "challenge": {k: v for k, v in data.items() if k != "http_status"},
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(data, ensure_ascii=False)

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
@@ -42,6 +42,8 @@ def _get_json(path: str, params: Optional[dict] = None) -> tuple:
         except json.JSONDecodeError:
             payload = {"raw": body[:2000]}
         return exc.code, payload
+    except urllib.error.URLError as exc:
+        return 0, {"transport_error": str(exc.reason)}
 
 
 class TruthBearCoverageInput(BaseModel):

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
@@ -1,0 +1,185 @@
+"""Truth Bear GAUGE tools for CrewAI.
+
+Official-source signal records (US federal agencies and named registries) with a
+canonical record_hash the caller can recompute offline.
+
+Design notes for reviewers:
+  * Standard library only - this adds no dependency to crewai-tools.
+  * No API key, no account, no signup. The two tools here use the free tier.
+  * Neither tool holds or spends funds. The paid record endpoint answers HTTP 402
+    with an x402 challenge; that challenge is handed back to the caller untouched
+    and settling it is the caller's own wallet's job.
+  * The catalog endpoint returns ~1.5 MB unfiltered, so a filter is required here
+    rather than optional - an unfiltered dump would flood an agent's context.
+"""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import ClassVar, List, Optional, Type
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field, model_validator
+
+BASE_URL = "https://aeml-x402.zeabur.app"
+REQUEST_TIMEOUT = 20
+
+
+def _get_json(path: str, params: Optional[dict] = None) -> dict:
+    """Fetch JSON from a GAUGE API endpoint, returning x402 challenges intact."""
+    url = f"{BASE_URL}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {"raw": body[:2000]}
+        # In x402 a 402 is not a failure, it is the price quote. Return it intact.
+        return {"http_status": exc.code, **payload}
+
+
+class TruthBearCoverageInput(BaseModel):
+    """Input schema for the coverage check tool."""
+
+    signal_id: Optional[str] = Field(
+        None,
+        description=(
+            "Optional. A signal id in genus.species ASCII form, e.g. "
+            "'hydrology.river-level', 'airquality.aqi', 'macro.unemployment'. "
+            "Omit to get the summary across all 185 signal lines."
+        ),
+    )
+
+
+class TruthBearCoverageTool(BaseTool):
+    """Free: does this signal exist, how many objects, how fresh, is it on schedule."""
+
+    name: str = "Truth Bear GAUGE coverage check"
+    description: str = (
+        "Free check, no key: for a signal line, report whether it exists, how many monitored "
+        "objects it covers, how many of those readings are fresh / recent / stale, whether the "
+        "source agency is on schedule or overdue, and the latest observation time. Use this "
+        "before paying for a record, to confirm the line is covered and current. Sources are "
+        "official government records and named registries (USGS, NOAA, NWS, EPA, SEC EDGAR, "
+        "openFDA, EIA, BLS and others). An unknown signal id comes back with an empty signals "
+        "list rather than an error."
+    )
+    args_schema: Type[BaseModel] = TruthBearCoverageInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: Optional[str] = None) -> str:
+        """Return freshness and object count for a signal line, or all lines."""
+        params = {"summary": "1"}
+        if signal_id:
+            params["signal_id"] = signal_id
+        data = _get_json("/gauge/coverage", params)
+        signals = data.get("signals") or []
+        if signal_id and not signals:
+            return json.dumps(
+                {
+                    "found": False,
+                    "signal_id": signal_id,
+                    "hint": "List valid signal ids with the Truth Bear GAUGE catalog tool.",
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {"found": True, "totals": data.get("totals"), "signals": signals},
+            ensure_ascii=False,
+        )
+
+
+class TruthBearCatalogInput(BaseModel):
+    """Input schema for the catalog lookup tool."""
+
+    signal_id: Optional[str] = Field(
+        None, description="Filter to one signal line, e.g. 'hydrology.river-level'."
+    )
+    industry: Optional[str] = Field(
+        None, description="Filter to one industry, e.g. 'hydrology', 'airquality', 'macro'."
+    )
+
+    @model_validator(mode="after")
+    def _require_a_filter(self):
+        # The unfiltered catalog is ~1.5 MB. Returning that to an agent would blow its
+        # context window, so a filter is required rather than merely recommended.
+        if not self.signal_id and not self.industry:
+            raise ValueError("Provide either signal_id or industry - the unfiltered catalog is ~1.5 MB.")
+        return self
+
+
+class TruthBearCatalogTool(BaseTool):
+    """Free: which entity ids are valid for a signal line."""
+
+    name: str = "Truth Bear GAUGE catalog lookup"
+    description: str = (
+        "Free lookup, no key: list the monitored object ids (entities) that are valid for a "
+        "given signal line or industry, with their human-readable names. signal_id and entity "
+        "must be used as a pair, so call this to get a valid entity before requesting a record. "
+        "One of signal_id or industry is required."
+    )
+    args_schema: Type[BaseModel] = TruthBearCatalogInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: Optional[str] = None, industry: Optional[str] = None) -> str:
+        """Return entity ids valid for the given signal line or industry."""
+        args = TruthBearCatalogInput(signal_id=signal_id, industry=industry)
+        params = {}
+        if args.signal_id:
+            params["signal_id"] = args.signal_id
+        if args.industry:
+            params["industry"] = args.industry
+        return json.dumps(_get_json("/gauge/catalog", params), ensure_ascii=False)
+
+
+class TruthBearRecordInput(BaseModel):
+    """Input schema for the paid record tool."""
+
+    signal_id: str = Field(..., description="Signal id, e.g. 'hydrology.river-level'.")
+    entity: str = Field(
+        ...,
+        description="Monitored object id PAIRED WITH signal_id, e.g. '06893000'. Get valid "
+        "pairs from the Truth Bear GAUGE catalog tool.",
+    )
+
+
+class TruthBearRecordTool(BaseTool):
+    """Paid record - returns the x402 payment challenge, never settles it."""
+
+    name: str = "Truth Bear GAUGE official record (paid, x402)"
+    description: str = (
+        "Request one official-source record for a signal_id and entity pair: the current reading, "
+        "the official threshold band published by the source agency, a same-season percentile, and "
+        "a canonical sha256 record_hash that can be recomputed offline so the answer does not have "
+        "to be taken on trust. This endpoint is paid: it answers HTTP 402 with an x402 payment "
+        "challenge stating network, asset, amount and recipient. THIS TOOL DOES NOT PAY. It returns "
+        "the challenge unchanged so an x402-capable wallet in your own stack can settle it and "
+        "retry. Charging is bound to HTTP 200 - if there is no data you are not billed."
+    )
+    args_schema: Type[BaseModel] = TruthBearRecordInput
+    package_dependencies: List[str] = []
+    env_vars: List[EnvVar] = []
+
+    def _run(self, signal_id: str, entity: str) -> str:
+        """Fetch the record and return data or an x402 payment challenge."""
+        args = TruthBearRecordInput(signal_id=signal_id, entity=entity)
+        data = _get_json("/gauge", {"signal_id": args.signal_id, "entity": args.entity})
+        if data.get("http_status") == 402:
+            return json.dumps(
+                {
+                    "payment_required": True,
+                    "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
+                    "challenge": {k: v for k, v in data.items() if k != "http_status"},
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(data, ensure_ascii=False)

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
@@ -26,23 +26,22 @@ BASE_URL = "https://aeml-x402.zeabur.app"
 REQUEST_TIMEOUT = 20
 
 
-def _get_json(path: str, params: Optional[dict] = None) -> dict:
-    """Fetch JSON from a GAUGE API endpoint, returning x402 challenges intact."""
+def _get_json(path: str, params: Optional[dict] = None) -> tuple:
+    """Return (http_status, payload_dict).  Callers decide what each status means."""
     url = f"{BASE_URL}{path}"
     if params:
         url = f"{url}?{urllib.parse.urlencode(params)}"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            return resp.status, json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
             payload = {"raw": body[:2000]}
-        # In x402 a 402 is not a failure, it is the price quote. Return it intact.
-        return {"http_status": exc.code, **payload}
+        return exc.code, payload
 
 
 class TruthBearCoverageInput(BaseModel):
@@ -80,7 +79,12 @@ class TruthBearCoverageTool(BaseTool):
         params = {"summary": "1"}
         if signal_id:
             params["signal_id"] = signal_id
-        data = _get_json("/gauge/coverage", params)
+        status, data = _get_json("/gauge/coverage", params)
+        if status != 200:
+            return json.dumps(
+                {"error": True, "http_status": status, "detail": data},
+                ensure_ascii=False,
+            )
         signals = data.get("signals") or []
         if signal_id and not signals:
             return json.dumps(
@@ -138,7 +142,13 @@ class TruthBearCatalogTool(BaseTool):
             params["signal_id"] = args.signal_id
         if args.industry:
             params["industry"] = args.industry
-        return json.dumps(_get_json("/gauge/catalog", params), ensure_ascii=False)
+        status, data = _get_json("/gauge/catalog", params)
+        if status != 200:
+            return json.dumps(
+                {"error": True, "http_status": status, "detail": data},
+                ensure_ascii=False,
+            )
+        return json.dumps(data, ensure_ascii=False)
 
 
 class TruthBearRecordInput(BaseModel):
@@ -172,14 +182,19 @@ class TruthBearRecordTool(BaseTool):
     def _run(self, signal_id: str, entity: str) -> str:
         """Fetch the record and return data or an x402 payment challenge."""
         args = TruthBearRecordInput(signal_id=signal_id, entity=entity)
-        data = _get_json("/gauge", {"signal_id": args.signal_id, "entity": args.entity})
-        if data.get("http_status") == 402:
+        status, data = _get_json("/gauge", {"signal_id": args.signal_id, "entity": args.entity})
+        if status == 402:
             return json.dumps(
                 {
                     "payment_required": True,
                     "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
-                    "challenge": {k: v for k, v in data.items() if k != "http_status"},
+                    "challenge": data,
                 },
+                ensure_ascii=False,
+            )
+        if status != 200:
+            return json.dumps(
+                {"error": True, "http_status": status, "detail": data},
                 ensure_ascii=False,
             )
         return json.dumps(data, ensure_ascii=False)

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_gauge_tool/truthbear_gauge_tool.py
@@ -186,14 +186,7 @@ class TruthBearRecordTool(BaseTool):
         args = TruthBearRecordInput(signal_id=signal_id, entity=entity)
         status, data = _get_json("/gauge", {"signal_id": args.signal_id, "entity": args.entity})
         if status == 402:
-            return json.dumps(
-                {
-                    "payment_required": True,
-                    "note": "Settle this x402 challenge with your own wallet, then retry the same URL.",
-                    "challenge": data,
-                },
-                ensure_ascii=False,
-            )
+            return json.dumps(data, ensure_ascii=False)
         if status != 200:
             return json.dumps(
                 {"error": True, "http_status": status, "detail": data},

--- a/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
+++ b/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
@@ -1,0 +1,133 @@
+import io
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools import (
+    TruthBearCatalogTool,
+    TruthBearCoverageTool,
+    TruthBearRecordTool,
+)
+
+
+def _ok(payload):
+    """Mock a successful urlopen context manager returning `payload` as JSON."""
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    ctx = MagicMock()
+    ctx.__enter__.return_value = response
+    return ctx
+
+
+def _http_error(status, payload):
+    """Mock an HTTPError whose body is JSON - this is how a 402 challenge arrives."""
+    return urllib.error.HTTPError(
+        url="https://aeml-x402.zeabur.app/gauge",
+        code=status,
+        msg="Payment Required",
+        hdrs=None,
+        fp=io.BytesIO(json.dumps(payload).encode("utf-8")),
+    )
+
+
+COVERAGE_HIT = {
+    "totals": {"signal_ids": 1, "distinct_entities": 10},
+    "signals": [
+        {
+            "signal_id": "hydrology.river-level",
+            "industry": "hydrology",
+            "entities_count": 10,
+            "freshness_counts": {"fresh": 10, "recent": 0, "stale": 0},
+            "update_status": "on_schedule",
+        }
+    ],
+}
+
+COVERAGE_MISS = {"totals": {"signal_ids": 0, "distinct_entities": 0}, "signals": []}
+
+
+@patch("urllib.request.urlopen")
+def test_coverage_hit(mock_urlopen):
+    mock_urlopen.return_value = _ok(COVERAGE_HIT)
+    result = json.loads(TruthBearCoverageTool().run(signal_id="hydrology.river-level"))
+    assert result["found"] is True
+    assert result["signals"][0]["signal_id"] == "hydrology.river-level"
+    assert result["signals"][0]["update_status"] == "on_schedule"
+
+
+@patch("urllib.request.urlopen")
+def test_coverage_miss_is_reported_not_raised(mock_urlopen):
+    """An unknown signal comes back as HTTP 200 with an empty list, not an error.
+
+    The tool must turn that into an explicit found:false, otherwise an agent can
+    mistake an empty answer for a failed call.
+    """
+    mock_urlopen.return_value = _ok(COVERAGE_MISS)
+    result = json.loads(TruthBearCoverageTool().run(signal_id="not.a.real.signal"))
+    assert result["found"] is False
+    assert result["signal_id"] == "not.a.real.signal"
+
+
+@patch("urllib.request.urlopen")
+def test_catalog_filtered(mock_urlopen):
+    payload = {
+        "signals": [
+            {
+                "signal_id": "hydrology.river-level",
+                "entities": [
+                    {"entity": "06893000", "name": "Missouri River at Kansas City, MO"}
+                ],
+            }
+        ]
+    }
+    mock_urlopen.return_value = _ok(payload)
+    result = json.loads(TruthBearCatalogTool().run(signal_id="hydrology.river-level"))
+    assert result["signals"][0]["entities"][0]["entity"] == "06893000"
+
+
+def test_catalog_requires_a_filter():
+    """The unfiltered catalog is ~1.5 MB and would flood an agent's context."""
+    with pytest.raises(ValueError):
+        TruthBearCatalogTool().run()
+
+
+@patch("urllib.request.urlopen")
+def test_record_returns_402_challenge_intact(mock_urlopen):
+    """402 is a price quote, not a failure - it must reach the caller unflattened."""
+    challenge = {
+        "x402Version": 1,
+        "error": "X-PAYMENT header is required",
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base",
+                "maxAmountRequired": "10000",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0x2d16a243ba9fAcC6AC85519d5efad2149DC4C6c3",
+            }
+        ],
+    }
+    mock_urlopen.side_effect = _http_error(402, challenge)
+    result = json.loads(
+        TruthBearRecordTool().run(signal_id="hydrology.river-level", entity="06893000")
+    )
+    assert result["payment_required"] is True
+    accepts = result["challenge"]["accepts"][0]
+    assert accepts["network"] == "base"
+    assert accepts["maxAmountRequired"] == "10000"
+    assert accepts["payTo"].startswith("0x")
+    # the tool must not have swallowed the challenge into a generic error string
+    assert "error" not in result
+
+
+@patch("urllib.request.urlopen")
+def test_record_passes_through_a_paid_success(mock_urlopen):
+    payload = {"signal_id": "hydrology.river-level", "record_hash": "a" * 64}
+    mock_urlopen.return_value = _ok(payload)
+    result = json.loads(
+        TruthBearRecordTool().run(signal_id="hydrology.river-level", entity="06893000")
+    )
+    assert result["record_hash"] == "a" * 64
+    assert "payment_required" not in result

--- a/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
+++ b/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
@@ -142,3 +142,13 @@ def test_record_passes_through_a_paid_success(mock_urlopen):
     )
     assert result["record_hash"] == "a" * 64
     assert "payment_required" not in result
+
+
+@patch("urllib.request.urlopen")
+def test_coverage_transport_error(mock_urlopen):
+    """DNS / connection / TLS failures must return a structured error, not crash."""
+    mock_urlopen.side_effect = urllib.error.URLError("Name or service not known")
+    result = json.loads(TruthBearCoverageTool().run(signal_id="hydrology.river-level"))
+    assert result.get("error") is True
+    assert result["http_status"] == 0
+    assert "transport_error" in result["detail"]

--- a/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
+++ b/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
@@ -88,6 +88,25 @@ def test_catalog_filtered(mock_urlopen):
     assert result["signals"][0]["entities"][0]["entity"] == "06893000"
 
 
+@patch("urllib.request.urlopen")
+def test_catalog_filtered_by_industry(mock_urlopen):
+    """The catalog tool accepts industry as an alternative filter to signal_id."""
+    payload = {
+        "signals": [
+            {
+                "signal_id": "hydrology.river-level",
+                "entities": [
+                    {"entity": "06893000", "name": "Missouri River at Kansas City, MO"}
+                ],
+            }
+        ]
+    }
+    mock_urlopen.return_value = _ok(payload)
+    result = json.loads(TruthBearCatalogTool().run(industry="hydrology"))
+    assert result["signals"][0]["signal_id"] == "hydrology.river-level"
+    assert result["signals"][0]["entities"][0]["entity"] == "06893000"
+
+
 def test_catalog_requires_a_filter():
     """The unfiltered catalog is ~1.5 MB and would flood an agent's context."""
     with pytest.raises(ValueError):
@@ -96,7 +115,7 @@ def test_catalog_requires_a_filter():
 
 @patch("urllib.request.urlopen")
 def test_record_returns_402_challenge_intact(mock_urlopen):
-    """402 is a price quote, not a failure - it must reach the caller unflattened."""
+    """402 is a price quote, not a failure - the x402 challenge must pass through unchanged."""
     challenge = {
         "x402Version": 1,
         "error": "X-PAYMENT header is required",
@@ -114,13 +133,8 @@ def test_record_returns_402_challenge_intact(mock_urlopen):
     result = json.loads(
         TruthBearRecordTool().run(signal_id="hydrology.river-level", entity="06893000")
     )
-    assert result["payment_required"] is True
-    accepts = result["challenge"]["accepts"][0]
-    assert accepts["network"] == "base"
-    assert accepts["maxAmountRequired"] == "10000"
-    assert accepts["payTo"].startswith("0x")
-    # the tool must not have swallowed the challenge into a generic error string
-    assert "error" not in result
+    # the complete x402 challenge must be preserved exactly as the server sent it
+    assert result == challenge
 
 
 @patch("urllib.request.urlopen")
@@ -135,13 +149,13 @@ def test_coverage_server_error_is_not_found_false(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_record_passes_through_a_paid_success(mock_urlopen):
+    """A successful paid record must be returned exactly as the API sent it."""
     payload = {"signal_id": "hydrology.river-level", "record_hash": "a" * 64}
     mock_urlopen.return_value = _ok(payload)
     result = json.loads(
         TruthBearRecordTool().run(signal_id="hydrology.river-level", entity="06893000")
     )
-    assert result["record_hash"] == "a" * 64
-    assert "payment_required" not in result
+    assert result == payload
 
 
 @patch("urllib.request.urlopen")

--- a/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
+++ b/lib/crewai-tools/tests/tools/truthbear_gauge_tool_test.py
@@ -16,6 +16,7 @@ def _ok(payload):
     """Mock a successful urlopen context manager returning `payload` as JSON."""
     response = MagicMock()
     response.read.return_value = json.dumps(payload).encode("utf-8")
+    response.status = 200
     ctx = MagicMock()
     ctx.__enter__.return_value = response
     return ctx
@@ -120,6 +121,16 @@ def test_record_returns_402_challenge_intact(mock_urlopen):
     assert accepts["payTo"].startswith("0x")
     # the tool must not have swallowed the challenge into a generic error string
     assert "error" not in result
+
+
+@patch("urllib.request.urlopen")
+def test_coverage_server_error_is_not_found_false(mock_urlopen):
+    """A 500 from /gauge/coverage must not be misreported as found:false."""
+    mock_urlopen.side_effect = _http_error(500, {"error": "internal server error"})
+    result = json.loads(TruthBearCoverageTool().run(signal_id="hydrology.river-level"))
+    assert result.get("error") is True
+    assert result["http_status"] == 500
+    assert "found" not in result
 
 
 @patch("urllib.request.urlopen")

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -26660,6 +26660,260 @@
       }
     },
     {
+      "description": "Free lookup, no key: list the monitored object ids (entities) that are valid for a given signal line or industry, with their human-readable names. signal_id and entity must be used as a pair, so call this to get a valid entity before requesting a record. One of signal_id or industry is required.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE catalog lookup",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Free: which entity ids are valid for a signal line.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearCatalogTool",
+        "type": "object"
+      },
+      "name": "TruthBearCatalogTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter to one industry, e.g. 'hydrology', 'airquality', 'macro'.",
+            "title": "Industry"
+          },
+          "signal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter to one signal line, e.g. 'hydrology.river-level'.",
+            "title": "Signal Id"
+          }
+        },
+        "title": "TruthBearCatalogInput",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Free check, no key: for a signal line, report whether it exists, how many monitored objects it covers, how many of those readings are fresh / recent / stale, whether the source agency is on schedule or overdue, and the latest observation time. Use this before paying for a record, to confirm the line is covered and current. Sources are official government records and named registries (USGS, NOAA, NWS, EPA, SEC EDGAR, openFDA, EIA, BLS and others). An unknown signal id comes back with an empty signals list rather than an error.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE coverage check",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Free: does this signal exist, how many objects, how fresh, is it on schedule.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearCoverageTool",
+        "type": "object"
+      },
+      "name": "TruthBearCoverageTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "signal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional. A signal id in genus.species ASCII form, e.g. 'hydrology.river-level', 'airquality.aqi', 'macro.unemployment'. Omit to get the summary across all 185 signal lines.",
+            "title": "Signal Id"
+          }
+        },
+        "title": "TruthBearCoverageInput",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Request one official-source record for a signal_id and entity pair: the current reading, the official threshold band published by the source agency, a same-season percentile, and a canonical sha256 record_hash that can be recomputed offline so the answer does not have to be taken on trust. This endpoint is paid: it answers HTTP 402 with an x402 payment challenge stating network, asset, amount and recipient. THIS TOOL DOES NOT PAY. It returns the challenge unchanged so an x402-capable wallet in your own stack can settle it and retry. Charging is bound to HTTP 200 - if there is no data you are not billed.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE official record (paid, x402)",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Paid record - returns the x402 payment challenge, never settles it.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearRecordTool",
+        "type": "object"
+      },
+      "name": "TruthBearRecordTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "entity": {
+            "description": "Monitored object id PAIRED WITH signal_id, e.g. '06893000'. Get valid pairs from the Truth Bear GAUGE catalog tool.",
+            "title": "Entity",
+            "type": "string"
+          },
+          "signal_id": {
+            "description": "Signal id, e.g. 'hydrology.river-level'.",
+            "title": "Signal Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "signal_id",
+          "entity"
+        ],
+        "title": "TruthBearRecordInput",
+        "type": "object"
+      }
+    },
+    {
       "description": "This tool uses OpenAI's Vision API to describe the contents of an image.",
       "env_vars": [
         {

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -26974,6 +26974,16 @@
             "title": "Signal Id"
           }
         },
+        "anyOf": [
+          {
+            "properties": {"signal_id": {"type": "string"}},
+            "required": ["signal_id"]
+          },
+          {
+            "properties": {"industry": {"type": "string"}},
+            "required": ["industry"]
+          }
+        ],
         "title": "TruthBearCatalogInput",
         "type": "object"
       }

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -7960,7 +7960,7 @@
         ],
         "properties": {
           "action": {
-            "description": "The filesystem action to perform: 'read' (returns file contents); 'write' (create or replace a file with content); 'append' (append content to an existing file \u2014 use this for writing large files in chunks to avoid hitting tool-call size limits); 'list' (lists a directory); 'delete' (removes a file/dir); 'mkdir' (creates a directory); 'info' (returns file metadata); 'exists' (returns whether a path exists); 'move' (rename or relocate a file/dir; requires 'destination'); 'find' (grep file CONTENTS recursively; requires 'pattern'); 'search' (find files by NAME pattern; requires 'pattern'); 'chmod' (change permissions/owner/group; pass at least one of 'mode', 'owner', 'group'); 'replace' (find-and-replace text across files; requires 'paths', 'pattern', and 'replacement').",
+            "description": "The filesystem action to perform: 'read' (returns file contents); 'write' (create or replace a file with content); 'append' (append content to an existing file — use this for writing large files in chunks to avoid hitting tool-call size limits); 'list' (lists a directory); 'delete' (removes a file/dir); 'mkdir' (creates a directory); 'info' (returns file metadata); 'exists' (returns whether a path exists); 'move' (rename or relocate a file/dir; requires 'destination'); 'find' (grep file CONTENTS recursively; requires 'pattern'); 'search' (find files by NAME pattern; requires 'pattern'); 'chmod' (change permissions/owner/group; pass at least one of 'mode', 'owner', 'group'); 'replace' (find-and-replace text across files; requires 'paths', 'pattern', and 'replacement').",
             "enum": [
               "read",
               "write",
@@ -9894,7 +9894,7 @@
       "run_params_schema": {
         "properties": {
           "action": {
-            "description": "The filesystem action to perform: 'read' (returns file contents), 'write' (create or replace a file with content), 'append' (append content to an existing file \u2014 use this for writing large files in chunks to avoid hitting tool-call size limits), 'list' (lists a directory), 'delete' (removes a file/dir), 'mkdir' (creates a directory), 'info' (returns file metadata), 'exists' (returns a boolean for whether the path exists).",
+            "description": "The filesystem action to perform: 'read' (returns file contents), 'write' (create or replace a file with content), 'append' (append content to an existing file — use this for writing large files in chunks to avoid hitting tool-call size limits), 'list' (lists a directory), 'delete' (removes a file/dir), 'mkdir' (creates a directory), 'info' (returns file metadata), 'exists' (returns a boolean for whether the path exists).",
             "enum": [
               "read",
               "write",
@@ -16381,7 +16381,7 @@
       }
     },
     {
-      "description": "Converts natural language to SQL queries and executes them against a database. Read-only by default \u2014 only SELECT/SHOW/DESCRIBE/EXPLAIN queries (and read-only CTEs) are allowed unless configured with allow_dml=True.",
+      "description": "Converts natural language to SQL queries and executes them against a database. Read-only by default — only SELECT/SHOW/DESCRIBE/EXPLAIN queries (and read-only CTEs) are allowed unless configured with allow_dml=True.",
       "env_vars": [],
       "humanized_name": "NL2SQLTool",
       "init_params_schema": {
@@ -16432,7 +16432,7 @@
             "type": "string"
           }
         },
-        "description": "Tool that converts natural language to SQL and executes it against a database.\n\nBy default the tool operates in **read-only mode**: only SELECT, SHOW,\nDESCRIBE, EXPLAIN, and read-only CTEs (WITH \u2026 SELECT) are permitted.  Write\noperations (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, \u2026) are\nblocked unless ``allow_dml=True`` is set explicitly or the environment\nvariable ``CREWAI_NL2SQL_ALLOW_DML=true`` is present.\n\nWritable CTEs (``WITH d AS (DELETE \u2026) SELECT \u2026``) and\n``EXPLAIN ANALYZE <write-stmt>`` are treated as write operations and are\nblocked in read-only mode.\n\nThe ``_fetch_all_available_columns`` helper uses parameterised queries so\nthat table names coming from the database catalogue cannot be used as an\ninjection vector.",
+        "description": "Tool that converts natural language to SQL and executes it against a database.\n\nBy default the tool operates in **read-only mode**: only SELECT, SHOW,\nDESCRIBE, EXPLAIN, and read-only CTEs (WITH … SELECT) are permitted.  Write\noperations (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, …) are\nblocked unless ``allow_dml=True`` is set explicitly or the environment\nvariable ``CREWAI_NL2SQL_ALLOW_DML=true`` is present.\n\nWritable CTEs (``WITH d AS (DELETE …) SELECT …``) and\n``EXPLAIN ANALYZE <write-stmt>`` are treated as write operations and are\nblocked in read-only mode.\n\nThe ``_fetch_all_available_columns`` helper uses parameterised queries so\nthat table names coming from the database catalogue cannot be used as an\ninjection vector.",
         "properties": {
           "allow_dml": {
             "default": false,
@@ -26882,6 +26882,260 @@
           "query"
         ],
         "title": "TavilySearchToolSchema",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Free lookup, no key: list the monitored object ids (entities) that are valid for a given signal line or industry, with their human-readable names. signal_id and entity must be used as a pair, so call this to get a valid entity before requesting a record. One of signal_id or industry is required.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE catalog lookup",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Free: which entity ids are valid for a signal line.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearCatalogTool",
+        "type": "object"
+      },
+      "name": "TruthBearCatalogTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter to one industry, e.g. 'hydrology', 'airquality', 'macro'.",
+            "title": "Industry"
+          },
+          "signal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter to one signal line, e.g. 'hydrology.river-level'.",
+            "title": "Signal Id"
+          }
+        },
+        "title": "TruthBearCatalogInput",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Free check, no key: for a signal line, report whether it exists, how many monitored objects it covers, how many of those readings are fresh / recent / stale, whether the source agency is on schedule or overdue, and the latest observation time. Use this before paying for a record, to confirm the line is covered and current. Sources are official government records and named registries (USGS, NOAA, NWS, EPA, SEC EDGAR, openFDA, EIA, BLS and others). An unknown signal id comes back with an empty signals list rather than an error.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE coverage check",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Free: does this signal exist, how many objects, how fresh, is it on schedule.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearCoverageTool",
+        "type": "object"
+      },
+      "name": "TruthBearCoverageTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "signal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional. A signal id in genus.species ASCII form, e.g. 'hydrology.river-level', 'airquality.aqi', 'macro.unemployment'. Omit to get the summary across all 185 signal lines.",
+            "title": "Signal Id"
+          }
+        },
+        "title": "TruthBearCoverageInput",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Request one official-source record for a signal_id and entity pair: the current reading, the official threshold band published by the source agency, a same-season percentile, and a canonical sha256 record_hash that can be recomputed offline so the answer does not have to be taken on trust. This endpoint is paid: it answers HTTP 402 with an x402 payment challenge stating network, asset, amount and recipient. THIS TOOL DOES NOT PAY. It returns the challenge unchanged so an x402-capable wallet in your own stack can settle it and retry. Charging is bound to HTTP 200 - if there is no data you are not billed.",
+      "env_vars": [],
+      "humanized_name": "Truth Bear GAUGE official record (paid, x402)",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Paid record - returns the x402 payment challenge, never settles it.",
+        "properties": {},
+        "required": [],
+        "title": "TruthBearRecordTool",
+        "type": "object"
+      },
+      "name": "TruthBearRecordTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "properties": {
+          "entity": {
+            "description": "Monitored object id PAIRED WITH signal_id, e.g. '06893000'. Get valid pairs from the Truth Bear GAUGE catalog tool.",
+            "title": "Entity",
+            "type": "string"
+          },
+          "signal_id": {
+            "description": "Signal id, e.g. 'hydrology.river-level'.",
+            "title": "Signal Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "signal_id",
+          "entity"
+        ],
+        "title": "TruthBearRecordInput",
         "type": "object"
       }
     },


### PR DESCRIPTION
## What this adds

Three tools for querying Truth Bear GAUGE, a pay-per-call source of official-record signals (US federal agencies and named registries: USGS, NOAA, NWS, EPA, SEC EDGAR, openFDA, EIA, BLS, FAA, US CBP, USTR, USITC, Federal Register, plus IMF PortWatch and UNFCCC feeds).

| Tool | Cost | What it does |
|---|---|---|
| `TruthBearCoverageTool` | free | Does this signal line exist, how many objects it covers, how fresh those readings are, and whether the source agency is on schedule or overdue |
| `TruthBearCatalogTool` | free | Which entity ids are valid for a signal line (`signal_id` and `entity` must be used as a pair) |
| `TruthBearRecordTool` | paid, x402 | Requests one official record; returns the HTTP 402 payment challenge untouched |

## Why it may be useful here

Every paid record ships a canonical sha256 `record_hash` that the caller can recompute offline from the delivered payload, so an agent does not have to trust the endpoint it just paid. Readings are stated against the **official threshold ladder published by the source agency** rather than a scale we invented, and each record carries a same-season percentile so an agent can tell routine from unusual.

The service is descriptive only: no forecast, no recommendation, no adjudication.

## Notes for reviewers

- **No new dependency.** Standard library only (`urllib`, `json`) plus `pydantic`, which crewai-tools already requires.
- **No API key, no account, no signup** for the two free tools.
- **This PR adds no code that moves money.** `TruthBearRecordTool` returns the x402 challenge (network, asset, amount, recipient) to the caller and stops. Settling it is the caller's own wallet's job; nothing here holds keys or signs anything.
- **The catalog filter is required, not optional.** The unfiltered catalog response is about 1.5 MB, which would flood an agent's context, so `TruthBearCatalogTool` rejects a call with neither `signal_id` nor `industry`.
- A "not found" is an empty `signals` list with HTTP 200, not an error — the tool converts that to an explicit `{"found": false}` so the agent does not mistake an empty answer for a failed call.
- Charging on the paid endpoint is bound to HTTP 200. A query with no data returns 422 and is not billed.
- `tool.specs.json` was regenerated with `python -m crewai_tools.generate_tool_specs`; the diff is additive only (96 → 99 tools).

## Testing

`tests/tools/truthbear_gauge_tool_test.py` covers the three tools with mocked HTTP: coverage hit, coverage miss (empty `signals`), the required-filter guard on the catalog tool, the 402 challenge being returned intact rather than raised as an error, and a paid success passing through unchanged.

```
6 passed
```

Run under this repo's own pytest configuration, including `--block-network`, so the mocks are verified to make no real network calls.

The endpoint behaviour the tools rely on was also verified against the live service before opening this PR: coverage returns 1 signal for a valid id and 0 for an unknown one; a filtered catalog response is 1.8 KB with 10 entities; the paid endpoint answers 402 with a well-formed `accepts` entry carrying network, asset, payTo and amount.
