### PR TITLE
docs: highlight MongoDB in tools overview

### DIFF
--- a/docs/edge/en/tools/overview.mdx
+++ b/docs/edge/en/tools/overview.mdx
@@ -43,7 +43,7 @@ CrewAI provides an extensive library of pre-built tools to enhance your agents' 
     href="/en/tools/database-data/overview"
     color="#8B5CF6"
   >
-    Connect to SQL databases, vector stores, and data warehouses. Query MySQL, PostgreSQL, Snowflake, Qdrant, and Weaviate.
+    Connect to databases, vector stores, and data warehouses. Query MySQL, PostgreSQL, MongoDB, Snowflake, Qdrant, and Weaviate.
   </Card>
 
   <Card
@@ -87,7 +87,7 @@ CrewAI provides an extensive library of pre-built tools to enhance your agents' 
 
 Need a specific tool? Here are some popular choices:
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="RAG Tool" icon="image" href="/en/tools/ai-ml/ragtool">
     Implement Retrieval-Augmented Generation
   </Card>
@@ -97,6 +97,9 @@ Need a specific tool? Here are some popular choices:
   <Card title="File Read" icon="file" href="/en/tools/file-document/filereadtool">
     Read any file type
   </Card>
+  <Card title="Directory Read" icon="folder-open" href="/en/tools/file-document/directoryreadtool">
+    List and read directory contents
+  </Card>
   <Card title="Scrape Website" icon="globe" href="/en/tools/web-scraping/scrapewebsitetool">
     Extract web content
   </Card>
@@ -105,6 +108,9 @@ Need a specific tool? Here are some popular choices:
   </Card>
   <Card title="S3 Reader" icon="cloud" href="/en/tools/cloud-storage/s3readertool">
     Access AWS S3 files
+  </Card>
+  <Card title="MongoDB Vector Search" icon="database" href="/en/tools/database-data/mongodbvectorsearchtool">
+    Run vector similarity queries on MongoDB
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Summary
Updated the Tools Overview page to mention MongoDB alongside the other supported data stores:

- Added a **MongoDB Vector Search** card to the Quick Access group, linking to the existing `MongoDBVectorSearchTool` page.
- Added MongoDB to the Database & Data category description, and generalized "SQL databases" to "databases".
- Rebalanced the Quick Access group to a 2-column layout and added a **Directory Read** card so the grid fills evenly. This is a placeholder, could change this card to something else.

## Validation

- Previewed the changes locally with Mintlify
- Verified both new card links resolve to existing pages (`database-data/mongodbvectorsearchtool`, `file-document/directoryreadtool`)
- Icons used (`database`, `folder-open`) are standard Font Awesome names already in use elsewhere on the page


<!-- crewai-require-issue-check -->