### PR TITLE
docs: add MongoDB to the Available Tools list

### DIFF
--- a/docs/edge/en/concepts/tools.mdx
+++ b/docs/edge/en/concepts/tools.mdx
@@ -145,6 +145,7 @@ Here is a list of the available tools and their descriptions:
 | **JSONSearchTool**               | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
 | **LlamaIndexTool**               | Enables the use of LlamaIndex tools.                                                           |
 | **MDXSearchTool**                | A RAG tool tailored for searching within Markdown (MDX) files, useful for documentation.       |
+| **MongoDBVectorSearchTool**      | A RAG tool for performing vector similarity search on MongoDB collections, with support for creating and managing vector search indexes. |
 | **PDFSearchTool**                | A RAG tool aimed at searching within PDF documents, ideal for processing scanned documents.    |
 | **PGSearchTool**                 | A RAG tool optimized for searching within PostgreSQL databases, suitable for database queries. |
 | **Vision Tool**                  | A tool for generating images using the DALL-E API.                                             |

--- a/docs/edge/en/concepts/tools.mdx
+++ b/docs/edge/en/concepts/tools.mdx
@@ -145,7 +145,7 @@ Here is a list of the available tools and their descriptions:
 | **JSONSearchTool**               | A RAG tool designed for searching within JSON files, catering to structured data handling.     |
 | **LlamaIndexTool**               | Enables the use of LlamaIndex tools.                                                           |
 | **MDXSearchTool**                | A RAG tool tailored for searching within Markdown (MDX) files, useful for documentation.       |
-| **MongoDBVectorSearchTool**      | A RAG tool for performing vector similarity search on MongoDB collections, with support for creating and managing vector search indexes. |
+| **MongoDBVectorSearchTool**      | A RAG tool for vector similarity search on MongoDB Atlas collections, with optional helpers to create and manage vector search indexes. |
 | **PDFSearchTool**                | A RAG tool aimed at searching within PDF documents, ideal for processing scanned documents.    |
 | **PGSearchTool**                 | A RAG tool optimized for searching within PostgreSQL databases, suitable for database queries. |
 | **Vision Tool**                  | A tool for generating images using the DALL-E API.                                             |


### PR DESCRIPTION
## Summary
Added **MongoDBVectorSearchTool** to the Available CrewAI Tools table on the Tools concept page, so the tool is discoverable from core concepts and not only from the tools reference section.

## Validation

- Previewed the changes locally with Mintlify
- Confirmed the table renders correctly with the new row
- Verified the tool has an existing reference page at `en/tools/database-data/mongodbvectorsearchtool`


<!-- crewai-require-issue-check -->