### PR TITLE
fix(a2a): clean up cancellation tasks and Redis pubsub

### DIFF
--- a/lib/crewai/src/crewai/a2a/utils/task.py
+++ b/lib/crewai/src/crewai/a2a/utils/task.py
@@ -159,10 +159,19 @@ def cancellable(
             try:
                 client = cache.client
                 pubsub = client.pubsub()
-                await pubsub.subscribe(f"cancel:{task_id}")
-                async for message in pubsub.listen():
-                    if message["type"] == "message":
-                        return True
+                try:
+                    await pubsub.subscribe(f"cancel:{task_id}")
+                    async for message in pubsub.listen():
+                        if message["type"] == "message":
+                            return True
+                finally:
+                    try:
+                        await pubsub.aclose()
+                    except (OSError, ConnectionError) as e:
+                        logger.warning(
+                            "Failed to close cancel watcher Redis pubsub",
+                            extra={"task_id": task_id, "error": str(e)},
+                        )
             except (OSError, ConnectionError) as e:
                 logger.warning(
                     "Cancel watcher Redis error, falling back to polling",
@@ -182,14 +191,13 @@ def cancellable(
 
             if cancel_watch in done:
                 execute_task.cancel()
-                try:
-                    await execute_task
-                except asyncio.CancelledError:
-                    pass
                 raise asyncio.CancelledError(f"Task {task_id} was cancelled")
-            cancel_watch.cancel()
             return execute_task.result()
         finally:
+            for task in (execute_task, cancel_watch):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(execute_task, cancel_watch, return_exceptions=True)
             await cache.delete(f"cancel:{task_id}")
 
     return wrapper

--- a/lib/crewai/tests/a2a/utils/test_task.py
+++ b/lib/crewai/tests/a2a/utils/test_task.py
@@ -142,6 +142,61 @@ class TestCancellableDecorator:
 
         assert result == 11
 
+    @pytest.mark.asyncio
+    async def test_closes_pubsub_after_execution(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Redis pubsub is closed when execution finishes first."""
+        subscribed = asyncio.Event()
+        cache = MagicMock()
+        cache.delete = AsyncMock()
+        pubsub = MagicMock()
+        pubsub.subscribe = AsyncMock(side_effect=lambda _: subscribed.set())
+        pubsub.aclose = AsyncMock()
+
+        async def listen() -> Any:
+            await asyncio.Event().wait()
+            yield
+
+        pubsub.listen = listen
+        cache.client.pubsub.return_value = pubsub
+
+        @cancellable
+        async def my_func(context: RequestContext) -> str:
+            await subscribed.wait()
+            return "completed"
+
+        with patch("crewai.a2a.utils.task.caches.get", return_value=cache):
+            result = await my_func(mock_context)
+
+        assert result == "completed"
+        pubsub.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_wrapper_cancellation_stops_execution(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Cancelling the wrapper also stops the wrapped function."""
+        started = asyncio.Event()
+        stopped = asyncio.Event()
+
+        @cancellable
+        async def slow_func(context: RequestContext) -> None:
+            try:
+                started.set()
+                await asyncio.Event().wait()
+            finally:
+                stopped.set()
+
+        wrapper_task = asyncio.create_task(slow_func(mock_context))
+        await started.wait()
+        wrapper_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await wrapper_task
+
+        assert stopped.is_set()
+
 
 class TestExecute:
     """Tests for the execute function."""


### PR DESCRIPTION
## Summary

- close the Redis pubsub used by the A2A cancellation watcher
- cancel and await both child tasks during every exit path
- add regression coverage for normal completion and caller-driven cancellation

## Problem

The `cancellable` decorator spawned an execution task and a cancellation watcher, but its cleanup only deleted the cancellation flag. On normal completion it cancelled the watcher without awaiting it, and when the wrapper itself was cancelled it left both child tasks running. The Redis watcher also created a dedicated pubsub connection without closing it.

That could retain one watcher task and one pubsub connection after a normal Redis-backed execution, or leave the execution task, watcher, and pubsub alive after caller cancellation.

## Fix

The wrapper now owns the complete lifecycle of both child tasks in a `finally` block: unfinished tasks are cancelled and both are awaited with `asyncio.gather(..., return_exceptions=True)` before the cancellation flag is removed. The Redis watcher closes pubsub in its own `finally` block and logs connection-level close failures without masking the task result.

This follows Python's [`asyncio` cancellation guidance](https://docs.python.org/3.12/library/asyncio-task.html#task-cancellation) to perform cleanup in `finally`, and redis-py's [explicit async resource cleanup guidance](https://redis.readthedocs.io/en/latest/examples/asyncio_examples.html).

No public API or cancellation semantics change.

## Impact

Eliminates up to three residual async resources per caller-cancelled Redis-backed execution (the execution task, watcher task, and pubsub connection), and two after normal Redis-backed completion (watcher plus pubsub).

## Tests

- `pytest -n 0 lib/crewai/tests/a2a/utils/test_task.py -q` — 18 passed
- `pytest -n 0 lib/crewai/tests/a2a/utils -q` — 39 passed
- `ruff format --check` — passed
- `ruff check` — passed
- targeted `mypy` — passed
- `git diff --check` — passed


<!-- crewai-require-issue-check -->