### PR TITLE
fix: stop double-counting tool usage, halving max_usage_count

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -419,7 +419,9 @@ class ToolUsage:
                     if available_tool and hasattr(
                         available_tool, "_increment_usage_count"
                     ):
-                        available_tool._increment_usage_count()
+                        # The tool's own invoke()/ainvoke() already incremented
+                        # the count; incrementing again here double-counts and
+                        # halves the effective max_usage_count.
                         if (
                             hasattr(available_tool, "max_usage_count")
                             and available_tool.max_usage_count is not None
@@ -670,7 +672,9 @@ class ToolUsage:
                     if available_tool and hasattr(
                         available_tool, "_increment_usage_count"
                     ):
-                        available_tool._increment_usage_count()
+                        # The tool's own invoke()/ainvoke() already incremented
+                        # the count; incrementing again here double-counts and
+                        # halves the effective max_usage_count.
                         if (
                             hasattr(available_tool, "max_usage_count")
                             and available_tool.max_usage_count is not None

--- a/lib/crewai/tests/tools/test_tool_usage_limit.py
+++ b/lib/crewai/tests/tools/test_tool_usage_limit.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from crewai.tools import BaseTool, tool
+from crewai.tools.tool_calling import ToolCalling
 from crewai.tools.tool_usage import ToolUsage
 
 
@@ -149,3 +150,44 @@ def test_tool_usage_with_toolusage_class():
     
     result3 = tool_usage._check_usage_limit(tool, "Limited Tool")
     assert "has reached its usage limit of 2 times" in result3
+
+
+def test_tool_usage_use_does_not_double_count():
+    """A tool run through ToolUsage.use() must increment its usage count once
+    per call, not twice. Previously invoke() and ToolUsage._use both
+    incremented, halving the effective max_usage_count."""
+    runs = {"n": 0}
+
+    class CountingTool(BaseTool):
+        name: str = "counter"
+        description: str = "counts"
+        max_usage_count: int = 2
+
+        def _run(self, x: int) -> str:
+            runs["n"] += 1
+            return f"got {x}"
+
+    structured = CountingTool().to_structured_tool()
+
+    tool_usage = ToolUsage(
+        tools_handler=None,
+        tools=[structured],
+        task=None,
+        function_calling_llm=None,
+        agent=None,
+        action=None,
+    )
+
+    tool_usage.use(calling=ToolCalling(tool_name="counter", arguments={"x": 1}), tool_string="")
+    assert structured.current_usage_count == 1
+
+    tool_usage.use(calling=ToolCalling(tool_name="counter", arguments={"x": 2}), tool_string="")
+    assert structured.current_usage_count == 2
+
+    # Both calls actually executed (the limit did not block the second one).
+    assert runs["n"] == 2
+
+    # The third call is over the limit and must not execute the tool.
+    tool_usage.use(calling=ToolCalling(tool_name="counter", arguments={"x": 3}), tool_string="")
+    assert runs["n"] == 2
+    assert structured.current_usage_count == 2


### PR DESCRIPTION
## Summary

A tool configured with `max_usage_count=N` is blocked after only **N/2** successful calls because its usage count is incremented twice per call.

```python
tool = MyTool(max_usage_count=2)   # expect 2 uses
# through an agent / ToolUsage: only 1 call runs, then:
# "Tool 'MyTool' has reached its usage limit of 2 times and cannot be used anymore."
```

## Root cause

`CrewStructuredTool.invoke()` and `ainvoke()` already call `self._increment_usage_count()` (co-located with the `has_reached_max_usage_count()` check). `ToolUsage._use` / `_ause` run the tool via that same `invoke()`/`ainvoke()`, then increment the **same tool object** a second time via `available_tool._increment_usage_count()`. So `current_usage_count` rises by 2 on every successful (non-cached) call.

The two increments were introduced by separate PRs (#3362 added the one in `structured_tool.py`; #4258 added the one in `tool_usage.py`), so this is a merge-time regression.

## Fix

Remove the redundant increment in `ToolUsage._use`/`_ause`, keeping the authoritative one inside `invoke()`/`ainvoke()` where it is paired with the limit check. The `elif` branch — for tools that expose `current_usage_count` but have **no** self-incrementing `invoke` — still increments manually and is unchanged.

## Verification

```
max_usage_count = 2
# before: call 1 -> count=2 (runs once), call 2 -> blocked
# after:  call 1 -> count=1, call 2 -> count=2 (runs twice), call 3 -> blocked
```

Added `test_tool_usage_use_does_not_double_count` which drives the real `ToolUsage.use()` path and asserts the tool runs exactly `max_usage_count` times. Fails on `main`, passes with the fix.

```
pytest lib/crewai/tests/tools/test_tool_usage_limit.py   # 8 passed
```
ruff clean.

This fix was developed with AI assistance; I verified the double-count and the fix end-to-end with the reproduction above and reviewed every line.

<!-- crewai-require-issue-check -->