### PR TITLE
fix(anthropic): count billed cache tokens in token usage (#6768)

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1971,10 +1971,19 @@ class AnthropicCompletion(BaseLLM):
             cache_creation_tokens = (
                 getattr(usage, "cache_creation_input_tokens", 0) or 0
             )
+            # Anthropic reports cache reads/writes as counters *separate* from
+            # ``input_tokens``, and bills both (writes at 1.25x, reads at 0.1x).
+            # Other providers (OpenAI, Gemini) already fold cached tokens into
+            # their prompt count and expose the cached figure as a breakdown, so
+            # report the billed input here to match. Leaving them out made
+            # ``total_tokens`` undercount every prompt-cached request.
+            billed_input_tokens = (
+                input_tokens + cache_read_tokens + cache_creation_tokens
+            )
             result: dict[str, Any] = {
-                "input_tokens": input_tokens,
+                "input_tokens": billed_input_tokens,
                 "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": billed_input_tokens + output_tokens,
                 "cached_prompt_tokens": cache_read_tokens,
                 "cache_creation_tokens": cache_creation_tokens,
             }

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -1653,11 +1653,68 @@ def test_anthropic_cache_creation_tokens_extraction():
     mock_response.model = None
 
     usage = llm._extract_anthropic_token_usage(mock_response)
-    assert usage["input_tokens"] == 100
+    # Anthropic keeps cache reads/writes out of ``input_tokens``; both are
+    # billed, so the reported prompt count is the billed input (100 + 30 + 20)
+    # and the total covers every billed token.
+    assert usage["input_tokens"] == 150
     assert usage["output_tokens"] == 50
-    assert usage["total_tokens"] == 150
+    assert usage["total_tokens"] == 200
     assert usage["cached_prompt_tokens"] == 30
     assert usage["cache_creation_tokens"] == 20
+
+
+def test_anthropic_total_tokens_includes_cache_tokens():
+    """Cache reads/writes are billed, so they must reach total_tokens.
+
+    Regression test for the undercount reported in #6768: ``total_tokens`` was
+    ``input_tokens + output_tokens``, which omitted both Anthropic cache
+    counters and made the field unusable for cost estimation on any cached
+    workload.
+    """
+    llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="test response")]
+    mock_response.usage = MagicMock(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=30,
+        cache_creation_input_tokens=20,
+    )
+    mock_response.stop_reason = None
+    mock_response.model = None
+
+    usage = llm._extract_anthropic_token_usage(mock_response)
+    llm._track_token_usage_internal(usage)
+    summary = llm.get_token_usage_summary()
+
+    # The shared normalizer recomputes the total as prompt + completion, so the
+    # billed input has to be in ``input_tokens`` for the total to survive it.
+    assert summary.total_tokens == 200
+    assert summary.prompt_tokens == 150
+    assert summary.completion_tokens == 50
+    assert summary.cached_prompt_tokens == 30
+    assert summary.cache_creation_tokens == 20
+
+
+def test_anthropic_total_tokens_unchanged_without_cache():
+    """A request that touches no cache keeps input + output as the total."""
+    llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="test response")]
+    mock_response.usage = MagicMock(
+        input_tokens=40,
+        output_tokens=20,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    mock_response.stop_reason = None
+    mock_response.model = None
+
+    usage = llm._extract_anthropic_token_usage(mock_response)
+    assert usage["input_tokens"] == 40
+    assert usage["total_tokens"] == 60
 
 
 def test_anthropic_missing_cache_fields_default_to_zero():


### PR DESCRIPTION
Fixes #6768.

## Problem

Anthropic reports cache reads (`cache_read_input_tokens`) and cache writes (`cache_creation_input_tokens`) as counters that are **separate** from `input_tokens`, and bills both (writes at 1.25×, reads at 0.1×). `_extract_anthropic_token_usage` captured both values and surfaced them individually, but left them out of the totals — so every prompt-cached request reported a `total_tokens` well below what was billed, and the undercount grew with cache hit rate.

## Why the one-line fix in the issue isn't enough

The issue points at `total_tokens: input_tokens + output_tokens`. Fixing only that line does **not** change what users actually read (`llm._token_usage` / `get_token_usage_summary()`), because `UsageMetrics.from_provider_dict` discards the provider's total and recomputes it:

```python
return cls(
    total_tokens=prompt_tokens + completion_tokens,   # provider total_tokens ignored
    ...
)
```

Verified against `main`:

```
provider dict total_tokens : 200      # after the issue's suggested one-line fix
UsageMetrics.total_tokens  : 150      # unchanged
```

So the cache tokens have to be part of the **prompt count** to survive normalization.

## Fix

Report the *billed* input from the Anthropic extractor:

```python
billed_input_tokens = input_tokens + cache_read_tokens + cache_creation_tokens
```

`cached_prompt_tokens` and `cache_creation_tokens` stay as they are, now as a breakdown of that prompt count. This is the convention the other providers already follow — OpenAI's `prompt_tokens` and Gemini's `prompt_token_count` both include cached tokens and expose the cached figure separately — and it is exactly what `from_provider_dict` assumes. It also keeps the change inside the Anthropic provider: no shared normalizer change, so OpenAI/Gemini/Azure numbers are untouched.

## Verification

Ran an old-vs-new harness against the installed `crewai==1.15.9`, whose `completion.py`, `usage_metrics.py` and `base_llm.py` are byte-identical to `main`:

| case (input / output / cache read / cache write) | `total_tokens` before | after |
|---|---|---|
| 100 / 50 / 30 / 20 | 150 | **200** |
| 40 / 20 / 0 / 0 | 60 | 60 |
| missing cache fields (`None`) | 60 | 60 |
| 10 / 5 / 0 / 200 (cache write only) | 15 | **215** |

Non-cached requests are unaffected; the two cached rows were undercounting 50 and 200 billed tokens respectively.

Tests (run against the patched module, then re-run against unpatched `main` to confirm they actually guard the regression):

- `test_anthropic_total_tokens_includes_cache_tokens` — new; asserts end-to-end through `_track_token_usage_internal` → `get_token_usage_summary()`, which is the path the issue's repro reads.
- `test_anthropic_total_tokens_unchanged_without_cache` — new; pins the no-cache path.
- `test_anthropic_cache_creation_tokens_extraction` — existing; its `input_tokens`/`total_tokens` numbers moved to 150/200. That test's subject is cache-field *extraction* (`cached_prompt_tokens == 30`, `cache_creation_tokens == 20`, both unchanged); the totals were incidental and encoded the undercount.
- `test_anthropic_missing_cache_fields_default_to_zero` — existing, unchanged, still passes.

```
4 passed          # patched
2 failed, 2 passed  # unpatched main — the two cache tests fail
```

`ruff==0.15.1 format --check` clean; `ruff check` output on the touched file is identical to `main`.

## Note

If you'd rather `input_tokens` keep mirroring the raw Anthropic field, the alternative is to have `from_provider_dict` honor an explicit provider `total_tokens`. I did not take that route: it is shared code, and Gemini's `total_token_count` includes thinking tokens, so honoring it there would move Gemini's numbers too — a bigger change than this issue calls for. Happy to switch if you prefer that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
