### PR TITLE
fix(anthropic): include cache tokens in total usage

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1974,7 +1974,12 @@ class AnthropicCompletion(BaseLLM):
             result: dict[str, Any] = {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": (
+                    input_tokens
+                    + output_tokens
+                    + cache_read_tokens
+                    + cache_creation_tokens
+                ),
                 "cached_prompt_tokens": cache_read_tokens,
                 "cache_creation_tokens": cache_creation_tokens,
             }

--- a/lib/crewai/src/crewai/types/usage_metrics.py
+++ b/lib/crewai/src/crewai/types/usage_metrics.py
@@ -145,12 +145,18 @@ class UsageMetrics(BaseModel):
             if isinstance(details, dict):
                 cached_prompt_tokens = _coerce_int(details.get("cached_tokens"))
 
+        cache_creation_tokens = _coerce_int(usage_data.get("cache_creation_tokens"))
+        total_tokens = prompt_tokens + completion_tokens
+        if "input_tokens" in usage_data:
+            # Anthropic reports cache reads and writes separately from input_tokens.
+            total_tokens += cached_prompt_tokens + cache_creation_tokens
+
         return cls(
-            total_tokens=prompt_tokens + completion_tokens,
+            total_tokens=total_tokens,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             cached_prompt_tokens=cached_prompt_tokens,
             reasoning_tokens=_coerce_int(usage_data.get("reasoning_tokens")),
-            cache_creation_tokens=_coerce_int(usage_data.get("cache_creation_tokens")),
+            cache_creation_tokens=cache_creation_tokens,
             successful_requests=1,
         )

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -549,7 +549,12 @@ def test_anthropic_token_usage_tracking():
     with patch.object(llm._client.messages, 'create') as mock_create:
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="test response")]
-        mock_response.usage = MagicMock(input_tokens=50, output_tokens=25)
+        mock_response.usage = MagicMock(
+            input_tokens=50,
+            output_tokens=25,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
         mock_create.return_value = mock_response
 
         result = llm.call("Hello")
@@ -1368,7 +1373,12 @@ def _dict_tool_use_response():
             "input": {"query": "CrewAI"},
         }
     ]
-    mock_response.usage = MagicMock(input_tokens=10, output_tokens=2)
+    mock_response.usage = MagicMock(
+        input_tokens=10,
+        output_tokens=2,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
     mock_response.stop_reason = "tool_use"
     mock_response.id = "msg_123"
     return mock_response
@@ -1486,7 +1496,12 @@ def test_anthropic_object_tool_use_blocks_require_id():
             input={"query": "CrewAI"},
         )
     ]
-    mock_response.usage = MagicMock(input_tokens=10, output_tokens=2)
+    mock_response.usage = MagicMock(
+        input_tokens=10,
+        output_tokens=2,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
     mock_response.stop_reason = "tool_use"
     mock_response.id = "msg_123"
 
@@ -1583,7 +1598,12 @@ def test_anthropic_dict_tool_use_blocks_work_in_follow_up_conversation():
     initial_response = _dict_tool_use_response()
     final_response = MagicMock()
     final_response.content = [types.SimpleNamespace(text="Final answer")]
-    final_response.usage = MagicMock(input_tokens=4, output_tokens=3)
+    final_response.usage = MagicMock(
+        input_tokens=4,
+        output_tokens=3,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
     final_response.stop_reason = "end_turn"
     final_response.id = "msg_final"
     mock_client = MagicMock()
@@ -1638,7 +1658,7 @@ def test_tool_search_saves_input_tokens():
 
 
 def test_anthropic_cache_creation_tokens_extraction():
-    """Test that cache_creation_input_tokens are extracted from Anthropic responses."""
+    """Test that Anthropic cache tokens are extracted and included in the total."""
     llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
 
     mock_response = MagicMock()
@@ -1655,9 +1675,15 @@ def test_anthropic_cache_creation_tokens_extraction():
     usage = llm._extract_anthropic_token_usage(mock_response)
     assert usage["input_tokens"] == 100
     assert usage["output_tokens"] == 50
-    assert usage["total_tokens"] == 150
+    assert usage["total_tokens"] == 200
     assert usage["cached_prompt_tokens"] == 30
     assert usage["cache_creation_tokens"] == 20
+
+    llm._track_token_usage_internal(usage)
+    summary = llm.get_token_usage_summary()
+    assert summary.total_tokens == 200
+    assert summary.cached_prompt_tokens == 30
+    assert summary.cache_creation_tokens == 20
 
 
 def test_anthropic_missing_cache_fields_default_to_zero():

--- a/lib/crewai/tests/test_flow_usage_metrics.py
+++ b/lib/crewai/tests/test_flow_usage_metrics.py
@@ -162,6 +162,23 @@ class TestUsageDictToMetrics:
                     successful_requests=1,
                 ),
             ),
+            # Anthropic cache counters are separate from input_tokens and are billed.
+            (
+                {
+                    "input_tokens": 12,
+                    "output_tokens": 8,
+                    "cached_prompt_tokens": 30,
+                    "cache_creation_tokens": 20,
+                },
+                UsageMetrics(
+                    prompt_tokens=12,
+                    completion_tokens=8,
+                    total_tokens=70,
+                    cached_prompt_tokens=30,
+                    cache_creation_tokens=20,
+                    successful_requests=1,
+                ),
+            ),
             # Native Gemini provider emits prompt_token_count/candidates_token_count
             (
                 {
@@ -201,6 +218,7 @@ class TestUsageDictToMetrics:
             "extended_keys",
             "garbage",
             "anthropic_aliases",
+            "anthropic_cache_tokens",
             "gemini_aliases",
             "openai_nested_cached",
         ],


### PR DESCRIPTION
## Summary

- include Anthropic cache-read and cache-creation tokens in provider-level total usage
- preserve the cache-inclusive total through shared UsageMetrics normalization and Flow aggregation
- keep OpenAI-style cached prompt accounting unchanged by applying the extra counters only to the Anthropic input_tokens shape

## Problem

Anthropic reports cache reads and cache writes separately from input_tokens. CrewAI exposed those counters but calculated total_tokens from input_tokens + output_tokens only, substantially undercounting cached workloads. The shared UsageMetrics normalizer then recomputed the same incomplete total, so public LLM summaries and Flow metrics were affected as well.

## Testing

- 76 Anthropic provider and Flow usage tests passed
- 29 usage-shape and LLM usage-event tests passed
- ruff check passed for all changed files
- ruff format --check passed for changed source files
- git diff --check passed
- two independent Codex review passes; the first identified the shared normalizer gap, which is covered by the final tests

Fixes #6768