### PR TITLE
fix(conversational): persist the assistant reply from custom @listen routes (#6766)

### DIFF
--- a/lib/crewai/src/crewai/experimental/conversational_mixin.py
+++ b/lib/crewai/src/crewai/experimental/conversational_mixin.py
@@ -153,6 +153,9 @@ class _ConversationalMixin:
         def kickoff(self, *args: Any, **kwargs: Any) -> Any:
             pass
 
+        def _persist_state_snapshot(self, label: str) -> None:
+            pass
+
         @property
         def method_outputs(self) -> list[Any]:
             pass
@@ -330,6 +333,11 @@ class _ConversationalMixin:
                 and self._is_public_turn_result(result)
             ):
                 self.append_assistant_message(self._stringify_result(result))
+                # ``@persist`` snapshots state per method *inside* kickoff(),
+                # so this append lands after the last snapshot and would never
+                # reach the backend. Re-snapshot so custom ``@listen`` routes
+                # persist their reply like the built-in routes do.
+                self._persist_state_snapshot("handle_turn")
         except Exception as exc:
             failed_event = ConversationTurnFailedEvent(
                 type="conversation_turn_failed",
@@ -419,6 +427,7 @@ class _ConversationalMixin:
                     and self._is_public_turn_result(result)
                 ):
                     self.append_assistant_message(self._stringify_result(result))
+                    self._persist_state_snapshot("stream_turn")
             except HumanFeedbackPending as exc:
                 return exc
             except Exception as exc:

--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -2932,6 +2932,22 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             if method_definition.persist is not None
             else self._definition.persist
         )
+        self._persist_state_snapshot(str(method_name), persist_definition)
+
+    def _persist_state_snapshot(
+        self,
+        label: str,
+        persist_definition: FlowPersistenceDefinition | None = None,
+    ) -> None:
+        """Save the current state under ``label`` when persistence is enabled.
+
+        ``persist_definition`` defaults to the flow-level ``@persist`` config,
+        which is what callers outside method execution need, e.g. a
+        conversational turn that appends its assistant reply after
+        ``kickoff()`` has already taken the last per-method snapshot.
+        """
+        if persist_definition is None:
+            persist_definition = self._definition.persist
         if persist_definition is None or not persist_definition.enabled:
             return
 
@@ -2946,7 +2962,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             else self._persist_backend_for(persist_definition)
         )
         PersistenceDecorator.persist_state(
-            self, method_name, backend, verbose=persist_definition.verbose
+            self, label, backend, verbose=persist_definition.verbose
         )
 
     def _persist_backend_for(

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -1620,6 +1620,86 @@ class TestHandleTurnReplyFallback:
         assert assistant_messages == ["computed reply"]
 
 
+class TestPersistedReplyFromCustomRoute:
+    """Regression tests for #6766: ``@persist`` snapshots state per method
+    *inside* ``kickoff()``, so ``handle_turn``'s fallback append — the only
+    thing that records the reply of a custom ``@listen`` route that just
+    returns a string — landed after the last snapshot and never reached the
+    backend. Built-in routes were unaffected because they append inside the
+    method body. Run each turn on a fresh instance (the web-server pattern)
+    and the assistant side of the conversation silently disappeared.
+    """
+
+    @staticmethod
+    def _greet_flow(persistence: Any) -> type[ConversationalFlow]:
+        from crewai.flow.persistence import persist
+
+        @persist(persistence)
+        class GreetFlow(ConversationalFlow):
+            def route_turn(self, context: dict[str, Any]) -> str | None:
+                return "GREET"
+
+            @listen("GREET")
+            def greet(self) -> str:
+                return "hello from the custom route"  # returns without appending
+
+        return GreetFlow
+
+    def test_custom_route_reply_survives_a_fresh_instance(self, tmp_path) -> None:
+        from crewai.flow.persistence import SQLiteFlowPersistence
+
+        persistence = SQLiteFlowPersistence(str(tmp_path / "conversation.db"))
+        greet_flow = self._greet_flow(persistence)
+
+        session_id = str(uuid4())
+        greet_flow().handle_turn("hi", session_id=session_id)
+        second_turn = greet_flow()
+        second_turn.handle_turn("hi again", session_id=session_id)
+
+        # Turn 1's reply must come back from disk, not just from memory.
+        assert [message.role for message in second_turn.state.messages] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+
+        restored = persistence.load_state(session_id)
+        assert restored is not None
+        assert [message["role"] for message in restored["messages"]] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+
+    def test_no_duplicate_reply_when_handler_appends_itself(self, tmp_path) -> None:
+        from crewai.flow.persistence import SQLiteFlowPersistence, persist
+
+        persistence = SQLiteFlowPersistence(str(tmp_path / "conversation.db"))
+
+        @persist(persistence)
+        class EchoFlow(ConversationalFlow):
+            def route_turn(self, context: dict[str, Any]) -> str | None:
+                return "ECHO"
+
+            @listen("ECHO")
+            def echo(self) -> str:
+                reply = "echo"
+                self.append_assistant_message(reply)  # handler DOES append
+                return reply
+
+        session_id = str(uuid4())
+        EchoFlow().handle_turn("hi", session_id=session_id)
+
+        restored = persistence.load_state(session_id)
+        assert restored is not None
+        assert [message["role"] for message in restored["messages"]] == [
+            "user",
+            "assistant",
+        ]
+
+
 class TestFalsyRouteTurnFallback:
     """A falsy ``route_turn()`` must never replay a previous turn's intent.
 


### PR DESCRIPTION
### Summary

Fixes #6766. Replies produced by a custom `@listen` route never reached the persistence backend, so across turns run on fresh `Flow` instances (the normal web-server pattern) the assistant side of the conversation silently disappeared and the agent could no longer recall its own prior statements.

### Root cause

`@persist` snapshots state per method *inside* `kickoff()`. `handle_turn()` appends the assistant reply **after** `kickoff()` returns:

```python
result = self.kickoff(inputs={"id": sid}, **kickoff_kwargs)
if result is not None and not self._assistant_reply_appended and self._is_public_turn_result(result):
    self.append_assistant_message(self._stringify_result(result))
```

That fallback append is the only thing recording the reply of a custom route that just returns a string, and it lands after the final snapshot. The built-in `converse_turn` is unaffected because it calls `append_assistant_message()` inside the method body, so its reply is part of that method's snapshot.

### Fix

Take one more snapshot right after the fallback append. `Flow._persist_method_completion()` is split so the snapshot half is reusable as `_persist_state_snapshot(label, persist_definition=None)`, defaulting to the flow-level `@persist` config; `handle_turn()` and `stream_turn()` call it after appending. When no `@persist` is configured it is a no-op, and handlers that append their own reply are untouched (the existing `_assistant_reply_appended` guard already skips the fallback).

### Verification

Ran against `crewai==1.15.9`, whose `conversational_mixin.py` and `flow/runtime/__init__.py` are byte-identical to `main`.

Issue repro (LLM router replaced with an overridden `route_turn()` so no API call is needed), before:

```
turn 2 in-memory : ['user', 'user', 'assistant']

--- what actually persisted ---
  route_conversation     ['user']
  do_greet               ['user']
  route_conversation     ['user', 'user']
  do_greet               ['user', 'user']
final persisted roles: ['user', 'user']   FAIL
```

after:

```
turn 2 in-memory : ['user', 'assistant', 'user', 'assistant']

--- what actually persisted ---
  route_conversation     ['user']
  do_greet               ['user']
  handle_turn            ['user', 'assistant']
  route_conversation     ['user', 'assistant', 'user']
  do_greet               ['user', 'assistant', 'user']
  handle_turn            ['user', 'assistant', 'user', 'assistant']
final persisted roles: ['user', 'assistant', 'user', 'assistant']   PASS
```

Test suites (`test_flow_conversation.py`, `test_flow_persistence.py`, `test_flow_persistence_factory.py`, `test_flow_from_definition.py`): 207 passed, 21 skipped, with the single pre-existing failure `TestDeferredFlowLifecycleEvents::test_finalize_batch_is_idempotent` also failing unpatched on `main`.

The new `TestPersistedReplyFromCustomRoute::test_custom_route_reply_survives_a_fresh_instance` fails without the fix and passes with it; the companion test asserts a handler that appends its own reply still persists exactly one assistant message.

`ruff==0.15.1 check`/`format` with the repo `pyproject.toml`: no new findings (the 4 `I001` reported are pre-existing and reproduce unpatched when the files are linted outside the full source tree).

---
AI-assisted, human reviewed.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->