### PR TITLE
fix(flow): explain the route-label/method-name collision in the self-listen error (#6767)

### DIFF
--- a/lib/crewai/src/crewai/flow/flow_definition.py
+++ b/lib/crewai/src/crewai/flow/flow_definition.py
@@ -775,7 +775,10 @@ class FlowDefinition(BaseModel):
         for method_name, method in self.methods.items():
             if _condition_references(method.listen, method_name):
                 raise ValueError(
-                    f"methods.{method_name}.listen must not reference itself"
+                    f"methods.{method_name}.listen must not reference itself. "
+                    + _self_reference_hint(
+                        method_name, conversational=self.conversational is not None
+                    )
                 )
         return self
 
@@ -874,6 +877,21 @@ def _validate_step_list(steps: list[FlowEachStepDefinition], *, field: str) -> N
         if name in seen:
             raise ValueError(f"{field} step names must be unique: {name!r}")
         seen.add(name)
+
+
+def _self_reference_hint(name: str, *, conversational: bool) -> str:
+    """Explain why a listen label matching the method's own name is rejected."""
+    if conversational:
+        return (
+            f"In a conversational flow {name!r} is both a router route label and a "
+            "method name, and the two share one trigger namespace, so the method "
+            "would re-trigger itself once it finishes. Rename the handler and keep "
+            f'@listen("{name}") as the route label.'
+        )
+    return (
+        "A method's completion is itself a trigger, so listening for its own name "
+        "would re-trigger it forever. Listen for the method that should precede it."
+    )
 
 
 def _condition_references(condition: FlowDefinitionCondition | None, name: str) -> bool:

--- a/lib/crewai/tests/test_flow_definition.py
+++ b/lib/crewai/tests/test_flow_definition.py
@@ -437,6 +437,46 @@ def test_flow_definition_serializes_conversational_config():
     assert conversational.router.fallback_intent == "end"
 
 
+def test_self_referential_listen_explains_the_collision():
+    class SelfListeningFlow(Flow):
+        @start()
+        def begin(self):
+            return "begin"
+
+        @listen("step")
+        def step(self):
+            return "step"
+
+    with pytest.raises(ValidationError) as excinfo:
+        SelfListeningFlow()
+
+    message = str(excinfo.value)
+    assert "methods.step.listen must not reference itself" in message
+    assert "re-trigger it forever" in message
+
+
+def test_conversational_self_referential_listen_names_the_route_collision():
+    @ConversationConfig(
+        router=RouterConfig(
+            route_descriptions={"create_video": "User wants a new video."}
+        )
+    )
+    class ChatFlow(Flow):
+        conversational = True
+
+        @listen("create_video")
+        def create_video(self):
+            return "made a video"
+
+    with pytest.raises(ValidationError) as excinfo:
+        ChatFlow()
+
+    message = str(excinfo.value)
+    assert "methods.create_video.listen must not reference itself" in message
+    assert "both a router route label and a method name" in message
+    assert "Rename the handler" in message
+
+
 def test_flow_definition_uses_collapsed_conversational_router_start():
     class ChatFlow(Flow):
         conversational = True


### PR DESCRIPTION
Fixes #6767.

## What's going on

In a conversational `Flow`, the string passed to `@listen("...")` is a router **route label**. `FlowDefinition._validate_trigger_namespace` also uses that field for method-to-method triggers, so naming a handler after the route it serves — the naming everyone reaches for first — fails at instantiation with:

```
Value error, methods.create_video.listen must not reference itself
```

which sends you looking for a self-referential trigger you never wrote.

## Why the guard has to stay

The issue offered two options; I went with the second (explain the collision) because separating the namespaces would reintroduce the infinite loop the guard exists to prevent.

Route labels and method names are genuinely one trigger namespace at runtime. After a listener runs, `_execute_single_listener` calls `_execute_listeners(listener_name, ...)` (`flow/runtime/__init__.py`), so a method that listens for its own name re-triggers itself on every completion. The engine already knows this — the `max_method_calls` `RecursionError` says *"This commonly happens when a @listen label matches the method's own name."* Allowing `@listen("create_video")` on `def create_video` would just trade an instantiation-time error for a runtime loop that burns `max_method_calls` LLM turns first.

## The change

Keep rejecting it, but say why, and tailor the explanation to the flow kind:

**Conversational flow** (new):
```
methods.create_video.listen must not reference itself. In a conversational flow
'create_video' is both a router route label and a method name, and the two share
one trigger namespace, so the method would re-trigger itself once it finishes.
Rename the handler and keep @listen("create_video") as the route label.
```

**Regular flow** (new):
```
methods.step.listen must not reference itself. A method's completion is itself a
trigger, so listening for its own name would re-trigger it forever. Listen for
the method that should precede it.
```

Validation behaviour is unchanged — same flows are accepted and rejected, only the message text is new.

## Verification

Reproduced the issue's snippet verbatim against `crewai` 1.15.9, whose `flow_definition.py`, `conversational_definition.py` and `flow/dsl/_utils.py` are byte-identical to `main`, then re-ran it with the patch applied.

- Two regression tests added to `lib/crewai/tests/test_flow_definition.py` (one per branch). Both fail on `main` and pass with the fix.
- Full `test_flow_definition.py`: 61 passed.
- `ruff==0.15.1 format --config pyproject.toml`: already formatted. `ruff check` reports one pre-existing `I001` on this file that is present on `main` unchanged, so I left the import block alone rather than churning it into the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->