### PR TITLE
docs: fix HITL webhook signature headers and payload format

### DIFF
--- a/docs/edge/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/edge/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/edge/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/edge/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/edge/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/edge/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/edge/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/edge/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.10.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.10.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.10.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.10.1/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.1/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.10.1/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.1/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.10.1/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.10.1/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.11.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.11.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.11.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.11.1/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.1/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.11.1/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.1/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.11.1/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.11.1/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.12.0/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.0/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.12.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.12.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.12.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.12.1/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.1/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.12.1/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.1/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.12.1/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.1/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.12.1/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.1/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.12.2/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.2/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.12.2/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.2/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.12.2/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.2/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.12.2/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.12.2/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.13.0/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.13.0/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.13.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.13.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.13.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.13.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.13.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.13.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.0/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.0/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.1/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.1/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.1/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.1/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.1/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.1/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.1/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.1/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.2/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.2/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.2/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.2/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.2/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.2/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.2/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.2/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.3/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.3/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.3/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.3/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.3/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.3/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.3/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.3/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.4/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.4/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.4/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.4/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.4/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.4/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.4/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.4/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.5/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.5/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.5/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.5/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.5/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.5/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.5/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.5/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.6/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.6/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.6/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.6/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.6/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.6/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.6/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.6/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.14.7/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.7/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.14.7/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.7/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.14.7/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.7/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.14.7/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.14.7/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.0/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.0/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.0/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.0/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.0/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.0/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.0/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.0/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.1/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.1/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.1/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.1/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.1/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.1/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.1/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.1/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.2/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.2/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.2/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.2/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.2/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.2/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.2/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.2/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.3/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.3/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.3/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.3/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.3/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.3/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.3/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.3/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.4/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.4/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.4/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.4/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.4/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.4/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.4/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.4/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 

--- a/docs/v1.15.5/ar/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.5/ar/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ class ContentApprovalFlow(Flow):
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | الترويسة | الوصف |
 |--------|-------------|
-| `X-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
+| `X-CrewAI-Signature` | توقيع HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | الطابع الزمني Unix عند توقيع الطلب |
 
 #### التحقق
 

--- a/docs/v1.15.5/en/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.5/en/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ All webhooks receive a JSON payload with this structure:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Please review this article for publication.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Please review this article for publication.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Each webhook request includes these headers:
 
 | Header | Description |
 |--------|-------------|
-| `X-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
-| `X-Timestamp` | Unix timestamp when the request was signed |
+| `X-CrewAI-Signature` | HMAC-SHA256 signature: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Unix timestamp when the request was signed |
 
 #### Verification
 

--- a/docs/v1.15.5/ko/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.5/ko/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Flow가 인간 피드백을 위해 일시 중지되면, 요청 데이터를 자�
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "이 기사의 게시를 검토해 주세요.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "이 기사의 게시를 검토해 주세요.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Content-Type: application/json
 
 | 헤더 | 설명 |
 |------|------|
-| `X-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
-| `X-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
+| `X-CrewAI-Signature` | HMAC-SHA256 서명: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | 요청이 서명된 Unix 타임스탬프 |
 
 #### 검증
 

--- a/docs/v1.15.5/pt-BR/enterprise/features/flow-hitl-management.mdx
+++ b/docs/v1.15.5/pt-BR/enterprise/features/flow-hitl-management.mdx
@@ -387,27 +387,26 @@ Todos os webhooks recebem um payload JSON com esta estrutura:
 
 ```json
 {
-  "event": "new_request",
-  "request": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "flow_id": "flow_abc123",
-    "method_name": "review_article",
-    "message": "Por favor, revise este artigo para publicação.",
-    "emit_options": ["approved", "rejected", "request_changes"],
-    "state": {
-      "article_id": 12345,
-      "author": "john@example.com",
-      "category": "technology"
-    },
-    "metadata": {},
-    "created_at": "2026-01-14T12:00:00Z"
+  "event_type": "new_request",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "pending",
+  "flow_id": "flow_abc123",
+  "method_name": "review_article",
+  "message": "Por favor, revise este artigo para publicação.",
+  "output": "Content to review...",
+  "emit": ["approved", "rejected", "request_changes"],
+  "state": {
+    "article_id": 12345,
+    "author": "john@example.com",
+    "category": "technology"
   },
-  "deployment": {
-    "id": 456,
-    "name": "Content Review Flow",
-    "organization_id": 789
-  },
-  "callback_url": "https://api.crewai.com/...",
+  "metadata": {},
+  "created_at": "2026-01-14T12:00:00Z",
+  "callback_url": "https://app.crewai.com/crewai_plus/api/v1/human_feedback_requests/{id}/respond?token={response_token}",
+  "response_token": "secure-token-string",
+  "deployment_id": 456,
+  "deployment_name": "Content Review Flow",
+  "organization_id": 789,
   "assigned_to_email": "reviewer@company.com"
 }
 ```
@@ -445,8 +444,8 @@ Cada requisição de webhook inclui estes headers:
 
 | Header | Descrição |
 |--------|-----------|
-| `X-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
-| `X-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
+| `X-CrewAI-Signature` | Assinatura HMAC-SHA256: `sha256=<hex_digest>` |
+| `X-CrewAI-Timestamp` | Timestamp Unix de quando a requisição foi assinada |
 
 #### Verificação
 


### PR DESCRIPTION
## Summary

Fixes mismatches between the HITL webhook documentation and the actual implementation in `crewai-plus` (`HumanFeedback::WebhookNotifierJob`).

## Changes

### 1. Signature header names
| | Docs (before) | Implementation (correct) |
|---|---|---|
| Signature | `X-Signature` | `X-CrewAI-Signature` |
| Timestamp | `X-Timestamp` | `X-CrewAI-Timestamp` |

### 2. Payload structure
**Before (docs):** Nested format with `event`, `request`, and `deployment` wrapper objects.

**After (matches implementation):** Flat payload with all fields at the top level.

### 3. Field name corrections
| Docs (before) | Implementation (correct) |
|---|---|
| `event` | `event_type` |
| `emit_options` (nested in `request`) | `emit` (top-level) |
| N/A | `status`, `output`, `response_token`, `deployment_id`, `deployment_name`, `organization_id` |

## Context

Reported by Pedro Moura who hit a 401 when validating webhook signatures because the header names didn't match, and found the payload format diverged from the docs.

Updates all 88 doc files across versions and translations (edge, v1.10.0–v1.15.5, en/ko/pt-BR/ar).