### PR TITLE
fix: don't drop an empty final task output from crew result

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1910,7 +1910,10 @@ class Crew(FlowTrackable, BaseModel):
         if not task_outputs:
             raise ValueError("No task outputs available to create crew output.")
 
-        valid_outputs = [t for t in task_outputs if t.raw]
+        # Exclude skipped tasks (e.g. conditional tasks whose condition was not
+        # met) rather than filtering on truthiness, so a task that legitimately
+        # produced an empty output is still selected as the final output.
+        valid_outputs = [t for t in task_outputs if not t.skipped]
         if not valid_outputs:
             raise ValueError("No valid task outputs available to create crew output.")
         final_task_output = valid_outputs[-1]

--- a/lib/crewai/src/crewai/tasks/conditional_task.py
+++ b/lib/crewai/src/crewai/tasks/conditional_task.py
@@ -65,4 +65,5 @@ class ConditionalTask(Task):
             raw="",
             agent=self.agent.role if self.agent else "",
             output_format=OutputFormat.RAW,
+            skipped=True,
         )

--- a/lib/crewai/src/crewai/tasks/task_output.py
+++ b/lib/crewai/src/crewai/tasks/task_output.py
@@ -44,6 +44,11 @@ class TaskOutput(BaseModel):
     output_format: OutputFormat = Field(
         description="Output format of the task", default=OutputFormat.RAW
     )
+    skipped: bool = Field(
+        description="Whether the task was skipped (e.g. a conditional task whose "
+        "condition was not met) rather than executed",
+        default=False,
+    )
     messages: list[LLMMessage] = Field(
         description="Messages of the task", default_factory=list
     )

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -3696,6 +3696,50 @@ def test_conditional_task_last_task_when_conditional_is_false(researcher, writer
     assert result.raw == "Hi"
 
 
+def test_create_crew_output_keeps_empty_final_task_output(researcher):
+    """A final task that legitimately produces an empty output must be returned
+    as the crew output, not silently replaced by an earlier task's output."""
+    crew = Crew(
+        agents=[researcher],
+        tasks=[Task(description="d", expected_output="e", agent=researcher)],
+    )
+
+    def ran(raw: str) -> TaskOutput:
+        return TaskOutput(
+            description="d", raw=raw, agent="r", output_format=OutputFormat.RAW
+        )
+
+    # Final task's empty output is selected, not the earlier non-empty one.
+    result = crew._create_crew_output([ran("FIRST"), ran("")])
+    assert result.raw == ""
+
+    # A single task returning an empty output does not raise.
+    result = crew._create_crew_output([ran("")])
+    assert result.raw == ""
+
+
+def test_create_crew_output_skips_skipped_conditional_task(researcher, writer):
+    """A skipped conditional task (skipped=True) must be excluded from output
+    selection, so the last executed task's output is used."""
+    crew = Crew(
+        agents=[researcher, writer],
+        tasks=[Task(description="d", expected_output="e", agent=researcher)],
+    )
+    ran = TaskOutput(
+        description="d", raw="REAL", agent="r", output_format=OutputFormat.RAW
+    )
+    skipped = ConditionalTask(
+        description="c",
+        expected_output="e",
+        condition=lambda _: False,
+        agent=writer,
+    ).get_skipped_task_output()
+    assert skipped.skipped is True
+
+    result = crew._create_crew_output([ran, skipped])
+    assert result.raw == "REAL"
+
+
 def test_conditional_task_requirement_breaks_when_task_async(researcher, writer):
     def my_condition(context):
         return context.get("some_value") > 10


### PR DESCRIPTION
## Summary

When the final task in a crew legitimately produces an **empty** output, the crew returns an *earlier* task's output instead — or crashes if the only task returned empty.

```python
# 2-task sequential crew; final task's TaskOutput.raw == ""
result = crew.kickoff()
result.raw   # -> "FIRST TASK RESULT"  (the earlier task; expected "")

# single task that returns ""
crew.kickoff()  # -> ValueError: No valid task outputs available to create crew output.
```

## Root cause

`Crew._create_crew_output` selected the final output with a truthiness filter:

```python
valid_outputs = [t for t in task_outputs if t.raw]
```

That filter was introduced in #1937 to skip the empty `TaskOutput` a **skipped conditional task** produces. But it can't tell a skipped task apart from a task that ran and produced an empty string, so it drops both — and `valid_outputs[-1]` then returns the wrong task (or the list is empty and it raises).

## Fix

Distinguish the two cases explicitly instead of by truthiness:

- Add `TaskOutput.skipped: bool = False`.
- `ConditionalTask.get_skipped_task_output()` sets `skipped=True`.
- `_create_crew_output` filters on `not t.skipped`.

Skipped conditional tasks are still excluded (so #1937's behavior is preserved), while a task that genuinely produced an empty output is kept as the crew result.

## Testing

Added `test_create_crew_output_keeps_empty_final_task_output` (empty final output is returned; single empty task doesn't raise) and `test_create_crew_output_skips_skipped_conditional_task` (skipped conditional still excluded). The existing `test_conditional_task_last_task_when_conditional_is_false` (#1937) still passes.

```
pytest lib/crewai/tests/test_crew.py -k 'create_crew_output or conditional_is_false'   # passed
```
No new ruff findings vs. main.

This fix was developed with AI assistance; I verified the behavior and the fix (including that #1937's conditional-skip case is preserved) and reviewed every line.

<!-- crewai-require-issue-check -->