### PR TITLE
fix: validate chunk_overlap < chunk_size in knowledge sources

### DIFF
--- a/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
 
 from crewai.knowledge.storage.base_knowledge_storage import BaseKnowledgeStorage
 from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
@@ -27,6 +28,21 @@ class BaseKnowledgeSource(BaseModel, ABC):
     storage: BaseKnowledgeStorage | None = Field(default=None)
     metadata: dict[str, Any] = Field(default_factory=dict)  # Currently unused
     collection_name: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_chunk_settings(self) -> Self:
+        """Ensure chunk_overlap is smaller than chunk_size.
+
+        Otherwise the step in ``_chunk_text`` (``chunk_size - chunk_overlap``)
+        becomes zero or negative, which either drops the document silently
+        (empty range) or raises ``ValueError: range() arg 3 must not be zero``.
+        """
+        if self.chunk_overlap >= self.chunk_size:
+            raise ValueError(
+                f"chunk_overlap ({self.chunk_overlap}) must be smaller than "
+                f"chunk_size ({self.chunk_size})."
+            )
+        return self
 
     @abstractmethod
     def validate_content(self) -> Any:

--- a/lib/crewai/tests/knowledge/test_knowledge.py
+++ b/lib/crewai/tests/knowledge/test_knowledge.py
@@ -636,3 +636,16 @@ def test_hash_based_id_generation_with_doc_id_in_metadata(mock_vector_db):
     for doc_id in result_without_doc_id.ids:
         assert len(doc_id) == 64, "ID should be 64 characters"
         assert all(c in "0123456789abcdef" for c in doc_id), "ID should be hex"
+
+
+def test_knowledge_source_rejects_overlap_not_smaller_than_size():
+    """chunk_overlap >= chunk_size must fail fast, not silently drop the
+    document (empty range) or crash inside _chunk_text."""
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        StringKnowledgeSource(content="x", chunk_size=100, chunk_overlap=150)
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        StringKnowledgeSource(content="x", chunk_size=200, chunk_overlap=200)
+
+    # A valid configuration is unaffected.
+    source = StringKnowledgeSource(content="x", chunk_size=100, chunk_overlap=20)
+    assert source.chunk_overlap == 20


### PR DESCRIPTION
## Summary

Knowledge sources chunk text with:

```python
range(0, len(text), self.chunk_size - self.chunk_overlap)
```

`chunk_size` and `chunk_overlap` are both user-settable with no cross-field check, so when `chunk_overlap >= chunk_size` the step is `<= 0`:

- `chunk_overlap > chunk_size` → negative step → **empty range → the document is silently dropped** (never embedded or saved).
- `chunk_overlap == chunk_size` → step `0` → **`ValueError: range() arg 3 must not be zero`** crashes ingestion with an opaque message.

```python
StringKnowledgeSource(content=..., chunk_size=100, chunk_overlap=150)  # doc silently dropped
StringKnowledgeSource(content=..., chunk_size=200, chunk_overlap=200)  # opaque range() crash
```

## Fix

Add a `model_validator` on `BaseKnowledgeSource` (where both fields are defined, so it covers every source type) that fails fast with a clear message:

```
chunk_overlap (150) must be smaller than chunk_size (100).
```

Valid configurations — including the defaults (`chunk_size=4000`, `chunk_overlap=200`) — are unaffected.

## Testing

Added `test_knowledge_source_rejects_overlap_not_smaller_than_size` (both `>` and `==` cases raise; a valid config still constructs). Fails on `main`, passes with the fix. ruff clean.

This fix was developed with AI assistance; I verified the silent-drop and crash behaviors and the fix, and reviewed every line.

<!-- crewai-require-issue-check -->