### PR TITLE
feat(tools): add LLMSandboxTool for self-hosted code execution

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -26,6 +26,9 @@ Documentation = "https://docs.crewai.com"
 
 
 [project.optional-dependencies]
+llm-sandbox = [
+    "llm-sandbox[docker]>=0.3.43",
+]
 scrapfly-sdk = [
     "scrapfly-sdk>=0.8.19",
 ]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -80,6 +80,10 @@ from crewai_tools.tools.e2b_sandbox_tool import (
     E2BFileTool,
     E2BPythonTool,
 )
+from crewai_tools.tools.llm_sandbox_tool import (
+    DEFAULT_RUNTIME_CONFIGS,
+    LLMSandboxTool,
+)
 from crewai_tools.tools.exa_tools.exa_search_tool import EXASearchTool, ExaSearchTool
 from crewai_tools.tools.file_read_tool.file_read_tool import FileReadTool
 from crewai_tools.tools.file_writer_tool.file_writer_tool import FileWriterTool
@@ -262,8 +266,10 @@ __all__ = [
     "DirectorySearchTool",
     "E2BExecTool",
     "E2BFileTool",
+    "DEFAULT_RUNTIME_CONFIGS",
     "E2BPythonTool",
     "EXASearchTool",
+    "LLMSandboxTool",
     "EnterpriseActionTool",
     "ExaSearchTool",
     "FileCompressorTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/README.md
@@ -1,0 +1,69 @@
+# LLMSandboxTool
+
+Runs agent-authored code in an isolated container on infrastructure you already
+operate, using [llm-sandbox](https://github.com/vndee/llm-sandbox).
+
+Unlike `E2BPythonTool` and the Daytona sandbox tools, there is no API key and no
+per-execution cost — code runs on your Docker, Podman or Kubernetes and never
+leaves your machines. Supports Python, JavaScript, Java, C++, Go, R and Ruby.
+
+## Installation
+
+```bash
+uv add crewai-tools --extra llm-sandbox
+```
+
+Requires a container runtime; Docker by default.
+
+## Usage
+
+```python
+from crewai import Agent
+from crewai_tools import LLMSandboxTool
+
+agent = Agent(
+    role="Data Analyst",
+    goal="Answer quantitative questions by writing and running code",
+    backstory="You prefer computing an answer over estimating one.",
+    tools=[LLMSandboxTool()],
+)
+```
+
+Another language, backend, or a pre-baked image:
+
+```python
+LLMSandboxTool(lang="ruby")
+LLMSandboxTool(backend="kubernetes")
+LLMSandboxTool(image="my-registry/python-with-pandas:1.0")
+```
+
+## Security
+
+`DEFAULT_RUNTIME_CONFIGS` applies unless you pass `runtime_configs`:
+
+```python
+{
+    "network_mode": "none",
+    "mem_limit": "512m",
+    "pids_limit": 128,
+    "cap_drop": ["ALL"],
+    "cap_add": ["DAC_OVERRIDE"],
+    "security_opt": ["no-new-privileges:true"],
+}
+```
+
+Verified inside the container: `CapEff` is `0000000000000002` and outbound
+connections fail.
+
+- **`DAC_OVERRIDE` is kept deliberately.** llm-sandbox copies the source file
+  into the container; without it that file is unreadable and every run fails.
+- **`read_only: True` is unsupported.** Docker rejects the code copy against a
+  read-only rootfs, tmpfs on the workdir or not.
+- **No package-installation argument.** The default network isolation would
+  block it, and letting a model choose arbitrary PyPI packages executes
+  `setup.py` at install time. Use `image=` instead.
+
+This is container isolation, not VM isolation: it inherits the threat model of
+the chosen backend and makes no kernel-level guarantee. For deliberately
+adversarial code, pair it with a hardened runtime such as gVisor or Kata
+Containers.

--- a/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/__init__.py
@@ -1,0 +1,10 @@
+from crewai_tools.tools.llm_sandbox_tool.llm_sandbox_tool import (
+    DEFAULT_RUNTIME_CONFIGS,
+    LLMSandboxTool,
+)
+
+
+__all__ = [
+    "DEFAULT_RUNTIME_CONFIGS",
+    "LLMSandboxTool",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/llm_sandbox_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/llm_sandbox_tool/llm_sandbox_tool.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+from builtins import type as type_
+from typing import Any
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
+
+
+logger = logging.getLogger(__name__)
+
+# Dropping every capability breaks execution on its own: llm-sandbox copies the
+# source file into the container, and without DAC_OVERRIDE it cannot be read.
+# Everything else stays dropped -- CapEff is 0000000000000002 inside.
+#
+# read_only is deliberately absent: Docker rejects the code copy against a
+# read-only rootfs ("container rootfs is marked read-only"), with or without a
+# tmpfs on the workdir.
+DEFAULT_RUNTIME_CONFIGS: dict[str, Any] = {
+    "network_mode": "none",
+    "mem_limit": "512m",
+    "pids_limit": 128,
+    "cap_drop": ["ALL"],
+    "cap_add": ["DAC_OVERRIDE"],
+    "security_opt": ["no-new-privileges:true"],
+}
+
+
+class LLMSandboxToolSchema(BaseModel):
+    """Input schema for LLMSandboxTool."""
+
+    code: str = Field(
+        ...,
+        description=(
+            "Source to execute, complete and self-contained. Print anything you "
+            "want returned -- only stdout comes back."
+        ),
+    )
+
+
+class LLMSandboxTool(BaseTool):
+    """Run agent-authored code in a self-hosted container.
+
+    Unlike the E2B and Daytona sandbox tools, execution happens on container
+    infrastructure the user already runs -- Docker, Podman or Kubernetes -- so
+    there is no API key, no per-execution cost, and code never leaves their
+    machines. Backed by `llm-sandbox <https://github.com/vndee/llm-sandbox>`_.
+
+    Hardened by default: no network, capped memory and pids, every Linux
+    capability dropped except DAC_OVERRIDE, and no-new-privileges set. Pass
+    `runtime_configs` to change that.
+
+    This is container isolation, not VM isolation: it inherits the threat model
+    of the backend in use and makes no kernel-level guarantee. For deliberately
+    adversarial code, pair it with a hardened runtime such as gVisor or Kata.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str = "LLM Sandbox"
+    description: str = (
+        "Execute code in an isolated, self-hosted container and return whatever "
+        "it prints to stdout. Supports Python, JavaScript, Java, C++, Go, R and "
+        "Ruby. Use this for calculations, data processing, and anything easier "
+        "to compute than to reason about. Always print the result."
+    )
+    args_schema: type_[BaseModel] = LLMSandboxToolSchema
+
+    package_dependencies: list[str] = Field(default_factory=lambda: ["llm-sandbox"])
+
+    lang: str = Field(
+        default="python",
+        description="Language to execute: python, javascript, java, cpp, go, r or ruby.",
+    )
+    backend: str = Field(
+        default="docker",
+        description="Container backend: docker, podman, kubernetes or micromamba.",
+    )
+    image: str | None = Field(
+        default=None,
+        description=(
+            "Optional custom image. The tool exposes no package-installation "
+            "argument: the default network isolation would block it, and letting "
+            "a model choose arbitrary PyPI packages runs setup.py at install "
+            "time. Pre-bake dependencies into an image instead."
+        ),
+    )
+    timeout: float = Field(default=30.0, description="Seconds before an execution is aborted.")
+    keep_template: bool = Field(
+        default=True,
+        description=(
+            "Keep the base image after the session closes. Setting this False "
+            "re-pulls the image on every call."
+        ),
+    )
+    runtime_configs: dict[str, Any] = Field(
+        default_factory=lambda: dict(DEFAULT_RUNTIME_CONFIGS),
+        description="Container settings passed to the backend. Defaults to a hardened set.",
+    )
+    verbose_session: bool = Field(default=False, description="Emit llm-sandbox session logs.")
+
+    def _session_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "lang": self.lang,
+            "backend": self.backend,
+            "verbose": self.verbose_session,
+            "keep_template": self.keep_template,
+            "runtime_configs": self.runtime_configs,
+        }
+        if self.image is not None:
+            kwargs["image"] = self.image
+        return kwargs
+
+    def _run(self, code: str) -> str:
+        try:
+            from llm_sandbox import SandboxSession
+        except ImportError as exc:
+            msg = (
+                "llm-sandbox is not installed. Install it with "
+                "`uv add llm-sandbox[docker]` or `pip install 'llm-sandbox[docker]'`."
+            )
+            raise ImportError(msg) from exc
+
+        from llm_sandbox.exceptions import SandboxError
+
+        try:
+            with SandboxSession(**self._session_kwargs()) as session:
+                result = session.run(code, timeout=self.timeout)
+                exit_code, stdout, stderr = (
+                    result.exit_code,
+                    result.stdout,
+                    result.stderr,
+                )
+        except SandboxError:
+            # Logged rather than returned: the message can carry the DOCKER_HOST
+            # socket path, which is host reconnaissance for a model that may be
+            # acting on injected input.
+            logger.exception("llm-sandbox execution failed")
+            return "sandbox error: execution environment unavailable"
+
+        if exit_code != 0:
+            return f"exit {exit_code}\n{stderr or stdout}".strip()
+        return stdout.strip() or "(no output)"

--- a/lib/crewai-tools/tests/tools/test_llm_sandbox_tool.py
+++ b/lib/crewai-tools/tests/tools/test_llm_sandbox_tool.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai_tools import DEFAULT_RUNTIME_CONFIGS, LLMSandboxTool
+
+
+def _mock_session(exit_code=0, stdout="", stderr=""):
+    result = MagicMock(exit_code=exit_code, stdout=stdout, stderr=stderr)
+    session = MagicMock()
+    session.run.return_value = result
+    ctx = MagicMock()
+    ctx.__enter__.return_value = session
+    ctx.__exit__.return_value = False
+    return ctx, session
+
+
+def test_tool_metadata():
+    tool = LLMSandboxTool()
+    assert tool.name == "LLM Sandbox"
+    assert "llm-sandbox" in tool.package_dependencies
+
+
+def test_schema_exposes_only_code():
+    # A package-installation argument here would let the model choose arbitrary
+    # PyPI packages, which executes setup.py at install time.
+    props = LLMSandboxTool().args_schema.model_json_schema()["properties"]
+    assert set(props) == {"code"}
+
+
+def test_defaults_are_hardened():
+    assert DEFAULT_RUNTIME_CONFIGS["network_mode"] == "none"
+    assert DEFAULT_RUNTIME_CONFIGS["cap_drop"] == ["ALL"]
+    assert DEFAULT_RUNTIME_CONFIGS["security_opt"] == ["no-new-privileges:true"]
+    assert "mem_limit" in DEFAULT_RUNTIME_CONFIGS
+    assert "pids_limit" in DEFAULT_RUNTIME_CONFIGS
+
+
+def test_defaults_omit_unsupported_flags():
+    # read_only makes Docker reject the code copy llm-sandbox performs.
+    assert "read_only" not in DEFAULT_RUNTIME_CONFIGS
+    # cap_drop=ALL alone leaves that copied file unreadable.
+    assert DEFAULT_RUNTIME_CONFIGS["cap_add"] == ["DAC_OVERRIDE"]
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_run_returns_stdout(mock_cls):
+    ctx, _ = _mock_session(stdout="42\n")
+    mock_cls.return_value = ctx
+    assert LLMSandboxTool()._run(code="print(6 * 7)") == "42"
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_run_reports_failure(mock_cls):
+    ctx, _ = _mock_session(exit_code=1, stderr="Traceback: boom")
+    mock_cls.return_value = ctx
+    out = LLMSandboxTool()._run(code="raise ValueError")
+    assert out.startswith("exit 1")
+    assert "boom" in out
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_run_handles_empty_output(mock_cls):
+    ctx, _ = _mock_session(stdout="  ")
+    mock_cls.return_value = ctx
+    assert LLMSandboxTool()._run(code="x = 1") == "(no output)"
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_hardening_reaches_the_session(mock_cls):
+    ctx, _ = _mock_session(stdout="ok")
+    mock_cls.return_value = ctx
+    LLMSandboxTool()._run(code="print('ok')")
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["runtime_configs"] == DEFAULT_RUNTIME_CONFIGS
+    # Without this the image is deleted on close and re-pulled every call.
+    assert kwargs["keep_template"] is True
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_config_is_forwarded(mock_cls):
+    ctx, session = _mock_session(stdout="ok")
+    mock_cls.return_value = ctx
+    LLMSandboxTool(lang="ruby", backend="podman", timeout=5.0)._run(code="puts 1")
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["lang"] == "ruby"
+    assert kwargs["backend"] == "podman"
+    assert session.run.call_args.kwargs["timeout"] == 5.0
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_sandbox_errors_do_not_leak_host_detail(mock_cls):
+    from llm_sandbox.exceptions import SandboxError
+
+    mock_cls.side_effect = SandboxError("unix:///Users/someone/.docker/run/docker.sock")
+    out = LLMSandboxTool()._run(code="print(1)")
+    assert out == "sandbox error: execution environment unavailable"
+    assert "docker.sock" not in out
+
+
+def test_image_is_omitted_when_unset():
+    assert "image" not in LLMSandboxTool()._session_kwargs()
+    assert LLMSandboxTool(image="custom:1.0")._session_kwargs()["image"] == "custom:1.0"


### PR DESCRIPTION
Adds a sandbox tool that runs agent-authored code on container infrastructure the user already operates, via [llm-sandbox](https://github.com/vndee/llm-sandbox). Docker, Podman and Kubernetes backends; Python, JavaScript, Java, C++, Go, R and Ruby.

## Why

`crewai_tools` currently has two sandbox options and both depend on a hosted service — `E2BPythonTool` requires `E2B_API_KEY`, Daytona likewise. This adds the self-hosted case: **no API key, no per-execution cost, and code never leaves the user's machines.**

That matters for data-governance constraints, air-gapped evaluation, and high-volume batch work where per-call pricing dominates.

## Usage

```python
from crewai import Agent
from crewai_tools import LLMSandboxTool

agent = Agent(
    role="Data Analyst",
    goal="Answer quantitative questions by writing and running code",
    tools=[LLMSandboxTool()],
)
```

```python
LLMSandboxTool(lang="ruby")
LLMSandboxTool(backend="kubernetes")
LLMSandboxTool(image="my-registry/python-with-pandas:1.0")
```

## Hardened by default

```python
{
    "network_mode": "none",
    "mem_limit": "512m",
    "pids_limit": 128,
    "cap_drop": ["ALL"],
    "cap_add": ["DAC_OVERRIDE"],
    "security_opt": ["no-new-privileges:true"],
}
```

Verified in a running container: `CapEff` is `0000000000000002` (DAC_OVERRIDE only) and outbound connections fail.

Three choices that may look odd on review, all deliberate:

- **`DAC_OVERRIDE` is kept.** llm-sandbox copies the source file into the container; dropping it makes that file unreadable and every run fails with `[Errno 13] Permission denied`.
- **`read_only: True` is not used.** Docker rejects the code copy against a read-only rootfs (`container rootfs is marked read-only`), with or without a tmpfs on the workdir.
- **The schema exposes only `code`.** A package-installation argument would let a model choose arbitrary PyPI packages, which executes `setup.py` at install time — and the default network isolation would block it anyway. Use `image=` to pre-bake dependencies.

The README states plainly that this is container isolation, not VM isolation, and points at gVisor/Kata for adversarial workloads.

## Tests

11 tests, **no container required** — `SandboxSession` is mocked. They cover metadata, output handling for success/failure/empty, that the hardening reaches the session, that `keep_template` is set (without it the image is re-pulled every call), config forwarding, and two regression guards: the schema stays single-parameter, and a `SandboxError` does not leak the `DOCKER_HOST` socket path back to the model.

Also verified end to end against real Docker: executes correctly, egress blocked, capabilities as above.

Registered in `crewai_tools/__init__.py` and added as an optional extra in `lib/crewai-tools/pyproject.toml`.

I maintain llm-sandbox and will maintain this tool.


<!-- crewai-require-issue-check -->