### PR TITLE
fix(llm): strip cache-breakpoint marker in the litellm path (#6789)

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2326,6 +2326,23 @@ class LLM(BaseLLM):
                     "Invalid message format. Each message must be a dict with 'role' and 'content' keys"
                 )
 
+        # Drop the provider-agnostic cache-breakpoint marker before it reaches
+        # litellm. The litellm path has no consumer for it, and providers with
+        # strict message schemas (e.g. Mistral) reject the unknown field with a
+        # validation error. Native providers strip it in BaseLLM._format_messages;
+        # the litellm path does not go through that method, so strip it here.
+        # Copy each carrying message so the caller's reused buffer (the agent
+        # ReAct loop) keeps its markers for later iterations.
+        from crewai.llms.cache import CACHE_BREAKPOINT_KEY
+
+        if any(CACHE_BREAKPOINT_KEY in msg for msg in messages):
+            messages = [
+                {k: v for k, v in msg.items() if k != CACHE_BREAKPOINT_KEY}
+                if CACHE_BREAKPOINT_KEY in msg
+                else msg
+                for msg in messages
+            ]
+
         if "o1" in self.model.lower():
             formatted_messages = []
             for msg in messages:

--- a/lib/crewai/tests/llms/test_prompt_cache.py
+++ b/lib/crewai/tests/llms/test_prompt_cache.py
@@ -189,3 +189,37 @@ class TestNonAnthropicStripsMarker:
         formatted = llm._format_messages(messages)
         for m in formatted:
             assert CACHE_BREAKPOINT_KEY not in m
+
+
+class TestLiteLLMStripsMarker:
+    """The litellm fallback path (crewai.llm.LLM) does not go through
+    BaseLLM._format_messages, so it must strip the cache-breakpoint marker
+    itself — otherwise the unknown field leaks to litellm and providers with
+    strict message schemas (e.g. Mistral) reject the request. See #6789.
+    """
+
+    def test_provider_format_strips_marker(self) -> None:
+        from crewai.llm import LLM
+
+        llm = LLM(model="mistral/mistral-large-latest", is_litellm=True)
+        messages = [
+            mark_cache_breakpoint({"role": "system", "content": "stable system"}),
+            mark_cache_breakpoint({"role": "user", "content": "hi"}),
+        ]
+        formatted = llm._format_messages_for_provider(messages)
+        for m in formatted:
+            assert CACHE_BREAKPOINT_KEY not in m
+        # Caller's buffer keeps its markers for later ReAct-loop iterations.
+        assert messages[0][CACHE_BREAKPOINT_KEY] is True
+        assert messages[1][CACHE_BREAKPOINT_KEY] is True
+
+    def test_unmarked_messages_pass_through(self) -> None:
+        from crewai.llm import LLM
+
+        llm = LLM(model="mistral/mistral-large-latest", is_litellm=True)
+        messages = [
+            {"role": "system", "content": "no marker"},
+            {"role": "user", "content": "hi"},
+        ]
+        formatted = llm._format_messages_for_provider(messages)
+        assert formatted == messages


### PR DESCRIPTION
## Problem

Fixes #6789.

A `mistral/*` LLM works via a direct `llm.call("Say hello")`, but the same LLM attached to an Agent fails during `crew.kickoff()` with:

```
litellm.BadRequestError: MistralException
{"type":"extra_forbidden","loc":["body","messages",0,"system","cache_breakpoint"],
 "msg":"Extra inputs are not permitted"}
```

## Root cause

The agent executor marks the stable-prefix messages with a provider-agnostic `cache_breakpoint` flag (`crew_agent_executor.py`, via `mark_cache_breakpoint`). Adapters are expected to translate that marker into their own cache directive, or strip it:

- **Native providers** (`is_litellm=False`) strip it in `BaseLLM._format_messages`.
- **The litellm fallback path** (`crewai.llm.LLM`, used for `mistral/*`, and anything not in `SUPPORTED_NATIVE_PROVIDERS`) does **not** go through `_format_messages` — it builds the wire payload in `_format_messages_for_provider`, which never removed the marker.

So for litellm-routed models the unknown `cache_breakpoint` key leaked straight into the request. Providers that tolerate extra message fields (OpenAI) silently ignore it; Mistral validates strictly and rejects it. Direct `llm.call()` doesn't hit it because it doesn't carry the executor's markers.

## Fix

Strip `CACHE_BREAKPOINT_KEY` at the top of `LLM._format_messages_for_provider`, mirroring what the native path already does. Only the messages that actually carry the marker are copied, so the executor's reused message buffer keeps its markers for later ReAct-loop iterations (the same invariant `TestBaseFormatDoesNotMutate` guards for the native path).

## Tests

New `TestLiteLLMStripsMarker` in `test_prompt_cache.py`:
- `test_provider_format_strips_marker` — marker is gone from the wire payload, and the caller's buffer still has it. Fails on `main`, passes with the fix.
- `test_unmarked_messages_pass_through` — no marker ⇒ payload unchanged.

Full `test_prompt_cache.py` passes (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->