### PR TITLE
fix(flow): report the real CEL error for failures inside map literals

### DIFF
--- a/lib/crewai/src/crewai/flow/expressions.py
+++ b/lib/crewai/src/crewai/flow/expressions.py
@@ -21,6 +21,25 @@ _CEL_MACROS_WITH_LOCAL_BINDINGS = frozenset(
 )
 
 
+def _find_cel_eval_error(value: Any) -> Exception | None:
+    from celpy.evaluation import CELEvalError
+
+    if isinstance(value, CELEvalError):
+        return value
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if (error := _find_cel_eval_error(key)) is not None:
+                return error
+            if (error := _find_cel_eval_error(item)) is not None:
+                return error
+        return None
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if (error := _find_cel_eval_error(item)) is not None:
+                return error
+    return None
+
+
 def _stringify_cel_value(value: Any) -> str:
     from celpy.adapter import CELJSONEncoder
 
@@ -336,6 +355,8 @@ class Expression:
                 Expression._compile_cel(expression, environment=environment)
             )
             result = program.evaluate(cast(Context, json_to_cel(context)))
+            if (eval_error := _find_cel_eval_error(result)) is not None:
+                raise eval_error
             return json.loads(json.dumps(result, cls=CELJSONEncoder))
         except Exception as e:
             raise ExpressionError(

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -2952,6 +2952,52 @@ def test_expression_template_empty_context_overrides_stored_context():
         expression.render_template({})
 
 
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "{'a': 1/0}",
+        "{'a': 1, 'b': state.missing}",
+        "{'a': {'b': 1/0}}",
+        "{'a': [1/0]}",
+    ],
+)
+def test_expression_raises_for_cel_eval_error_returned_as_data(expression):
+    """celpy returns a map literal holding a CELEvalError instead of raising it."""
+    from crewai.flow.expressions import Expression, ExpressionError
+
+    with pytest.raises(ExpressionError, match="failed to evaluate CEL expression"):
+        Expression(expression, context={"state": {"score": 90}}).evaluate()
+
+
+def test_expression_nested_cel_eval_error_reports_underlying_cause():
+    from crewai.flow.expressions import Expression, ExpressionError
+
+    expression = Expression("{'a': 1/0}", context={"state": {}})
+
+    with pytest.raises(ExpressionError, match="modulus or divide by zero"):
+        expression.evaluate()
+
+
+def test_expression_keeps_short_circuited_cel_errors():
+    """Errors that CEL logic intentionally silences must still evaluate."""
+    from crewai.flow.expressions import Expression
+
+    context = {"state": {"tags": ["a", "b"]}}
+
+    assert Expression("{'ok': false && 1/0 == 1}", context=context).evaluate() == {
+        "ok": False
+    }
+    assert Expression("{'ok': true || 1/0 == 1}", context=context).evaluate() == {
+        "ok": True
+    }
+    assert (
+        Expression(
+            "state.tags.exists(t, t == 'a' || 1/0 == 1)", context=context
+        ).evaluate()
+        is True
+    )
+
+
 def test_expression_action_can_route_like_if_else():
     yaml_str = f"""
 schema: crewai.flow/v1


### PR DESCRIPTION
## What

Flow CEL expressions that fail inside a map literal now report the actual error. 
Before, a bad value in a map reported an internal serialization error:

```
${{'status': 1/0}}
```
→ failed to evaluate CEL expression: `Object of type CELEvalError is not JSON serializable`

Now it reports the cause, matching what the same expression reports on its own:

```
${{'status': 1/0}}
```
→ failed to evaluate CEL expression: ('modulus or divide by zero', ...)

This affects any failure nested in a map — division by zero, a missing `state` field, a bad conversion — which previously gave no indication of what was wrong.

## Why

`celpy` raises evaluation errors that land at the top level of a result, but a map literal keeps the failed value in place and returns it. List literals propagate the error; maps don't. That returned error object reached `json.dumps`, which turned a clear CEL failure into an opaque serialization message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CEL error handling in `expressions.py` with focused tests; no auth, persistence, or API surface changes.
> 
> **Overview**
> Flow CEL evaluation now **detects `CELEvalError` objects nested inside map (and list) results** from `celpy` and re-raises them before JSON serialization, so failures like divide-by-zero or missing `state` fields surface as **`ExpressionError` with the underlying cause** instead of an opaque “not JSON serializable” message.
> 
> A recursive **`_find_cel_eval_error`** helper walks dict keys/values and list/tuple elements after `program.evaluate()`. **Short-circuited** failures (`&&`, `||`, `exists`) that CEL never evaluates are unchanged and still succeed.
> 
> Tests add coverage for map/nested/list error shapes, message content for nested divide-by-zero, and guards that intentional short-circuiting still evaluates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167911f5d26e3a4e84132c50e7a9ee336f9b6d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->