### PR TITLE
fix(security): close SSRF in ArxivPaperTool.download_pdf, plus a DNS-rebinding gap in safe_get

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/security/safe_path.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_path.py
@@ -180,6 +180,13 @@ def _is_private_or_reserved(ip_str: str) -> bool:
         return True  # If we can't parse, block it
 
 
+def _is_ipv4(ip_str: str) -> bool:
+    try:
+        return ipaddress.ip_address(ip_str).version == 4
+    except ValueError:
+        return False
+
+
 def validate_and_resolve(url: str) -> tuple[str, str | None]:
     """Validate that a URL is safe to fetch, and return the specific IP address
     checked so a caller can pin its actual connection to it.
@@ -202,8 +209,16 @@ def validate_and_resolve(url: str) -> tuple[str, str | None]:
         url: The URL to validate.
 
     Returns:
-        A ``(validated_url, ip)`` tuple. ``ip`` is the first address checked,
-        or ``None`` when validation is bypassed via the escape hatch (nothing
+        A ``(validated_url, ip)`` tuple. Every resolved address is checked,
+        but ``ip`` prefers an IPv4 address if one was returned (falling back
+        to the first address otherwise) -- ``getaddrinfo`` on a dual-stack
+        host often returns IPv6 first, and pinning the connection to a single
+        address (see ``safe_requests.safe_get``) forgoes the normal
+        multi-address fallback an unpinned connection attempt would get, so
+        picking the address most likely to actually be reachable (many CI
+        runners, containers, and networks have working IPv4 but broken or
+        absent IPv6 routes) matters more here than it would otherwise.
+        ``None`` when validation is bypassed via the escape hatch (nothing
         was resolved, so there is nothing to pin).
 
     Raises:
@@ -243,7 +258,7 @@ def validate_and_resolve(url: str) -> tuple[str, str | None]:
     except socket.gaierror as exc:
         raise ValueError(f"Could not resolve hostname: '{parsed.hostname}'") from exc
 
-    first_ip: str | None = None
+    checked_ips: list[str] = []
     for _family, _, _, _, sockaddr in addrinfos:
         ip_str = str(sockaddr[0])
         if _is_private_or_reserved(ip_str):
@@ -252,10 +267,12 @@ def validate_and_resolve(url: str) -> tuple[str, str | None]:
                 f"Access to internal networks is not allowed. "
                 f"Set {_UNSAFE_PATHS_ENV}=true to bypass."
             )
-        if first_ip is None:
-            first_ip = ip_str
+        checked_ips.append(ip_str)
 
-    return url, first_ip
+    pinned_ip = next((ip for ip in checked_ips if _is_ipv4(ip)), None) or (
+        checked_ips[0] if checked_ips else None
+    )
+    return url, pinned_ip
 
 
 def validate_url(url: str) -> str:

--- a/lib/crewai-tools/src/crewai_tools/security/safe_path.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_path.py
@@ -180,18 +180,31 @@ def _is_private_or_reserved(ip_str: str) -> bool:
         return True  # If we can't parse, block it
 
 
-def validate_url(url: str) -> str:
-    """Validate that a URL is safe to fetch.
+def validate_and_resolve(url: str) -> tuple[str, str | None]:
+    """Validate that a URL is safe to fetch, and return the specific IP address
+    checked so a caller can pin its actual connection to it.
 
-    Blocks ``file://`` scheme entirely. For ``http``/``https``, resolves
-    DNS and checks that the target IP is not private or reserved (prevents
-    SSRF to internal services and cloud metadata endpoints).
+    Blocks ``file://`` scheme entirely. For ``http``/``https``, resolves DNS
+    and checks that every returned address is not private or reserved
+    (prevents SSRF to internal services and cloud metadata endpoints).
+
+    Returning the checked IP alongside the URL matters: validating a hostname
+    and then letting the HTTP client re-resolve it later at connection time
+    leaves a DNS-rebinding gap -- an attacker with control over DNS (or a
+    short-TTL record) can present a safe IP for validation and a private one
+    for the real connection moments later. Callers that make the actual
+    request should connect to the returned IP directly (see
+    ``safe_requests.safe_get``'s use of this) rather than handing the
+    hostname back to their HTTP client and trusting it to resolve the same
+    way twice.
 
     Args:
         url: The URL to validate.
 
     Returns:
-        The validated URL string.
+        A ``(validated_url, ip)`` tuple. ``ip`` is the first address checked,
+        or ``None`` when validation is bypassed via the escape hatch (nothing
+        was resolved, so there is nothing to pin).
 
     Raises:
         ValueError: If the URL uses a blocked scheme or resolves to a
@@ -203,7 +216,7 @@ def validate_url(url: str) -> str:
             _UNSAFE_PATHS_ENV,
             url,
         )
-        return url
+        return url, None
 
     parsed = urlparse(url)
 
@@ -230,6 +243,7 @@ def validate_url(url: str) -> str:
     except socket.gaierror as exc:
         raise ValueError(f"Could not resolve hostname: '{parsed.hostname}'") from exc
 
+    first_ip: str | None = None
     for _family, _, _, _, sockaddr in addrinfos:
         ip_str = str(sockaddr[0])
         if _is_private_or_reserved(ip_str):
@@ -238,5 +252,38 @@ def validate_url(url: str) -> str:
                 f"Access to internal networks is not allowed. "
                 f"Set {_UNSAFE_PATHS_ENV}=true to bypass."
             )
+        if first_ip is None:
+            first_ip = ip_str
 
-    return url
+    return url, first_ip
+
+
+def validate_url(url: str) -> str:
+    """Validate that a URL is safe to fetch.
+
+    Blocks ``file://`` scheme entirely. For ``http``/``https``, resolves
+    DNS and checks that the target IP is not private or reserved (prevents
+    SSRF to internal services and cloud metadata endpoints).
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        The validated URL string.
+
+    Raises:
+        ValueError: If the URL uses a blocked scheme or resolves to a
+            private/reserved IP address.
+    """
+    validated_url, _ip = validate_and_resolve(url)
+    return validated_url
+
+
+def resolve_validated_ip(url: str) -> str | None:
+    """Validate `url` (same checks as :func:`validate_url`) and return the
+    specific IP address that was checked, for pinning an actual connection to
+    it. See :func:`validate_and_resolve` for why this matters. Returns
+    ``None`` when validation is bypassed via the escape hatch.
+    """
+    _url, ip = validate_and_resolve(url)
+    return ip

--- a/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
@@ -82,9 +82,16 @@ def _pin_dns(hostname: str, ip: str) -> Iterator[None]:
         family = socket.AF_INET6 if ":" in ip else socket.AF_INET
 
         def pinned_getaddrinfo(
-            host: str, port: int, *args: Any, **kwargs: Any
+            host: str, port: int | str | None, *args: Any, **kwargs: Any
         ) -> list[tuple[Any, ...]]:
-            if host == hostname:
+            # socket.getaddrinfo's real signature allows a service name or
+            # None for `port`, not just an int -- match it so this doesn't
+            # lie to type checkers, and fall through to the real resolver
+            # for a non-int port instead of building a malformed sockaddr
+            # (requests/urllib3 always pass an int port for our own pinned
+            # request; this only matters if something else calls
+            # getaddrinfo for the same hostname during the pin window).
+            if host == hostname and isinstance(port, int):
                 sockaddr = (ip, port, 0, 0) if family == socket.AF_INET6 else (ip, port)
                 return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
             return original_getaddrinfo(host, port, *args, **kwargs)

--- a/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
@@ -9,6 +9,7 @@ import socket
 import threading
 from typing import Any
 from urllib.parse import urljoin, urlparse
+import uuid
 
 import requests
 
@@ -141,6 +142,12 @@ def safe_get(url: str, *, max_redirects: int = 10, **kwargs: Any) -> requests.Re
         if not _same_origin(current_url, redirect_url):
             request_kwargs = _strip_cross_origin_credentials(request_kwargs)
 
+        # A redirect response's status/headers/url are already fully received
+        # at this point (only a body -- never read for a redirect -- would be
+        # affected by closing early). Closing here releases the connection
+        # back to the pool immediately instead of holding it until GC, which
+        # otherwise accumulates across a multi-hop redirect chain.
+        response.close()
         history.append(response)
         current_url, pinned_ip = redirect_url, redirect_ip
         redirects_followed += 1
@@ -172,7 +179,11 @@ def safe_download(
         requests.HTTPError: If the final response has an error status code.
     """
     dest = Path(dest_path)
-    tmp_path = dest.with_name(f"{dest.name}.part")
+    # A name derived only from `dest` would let two concurrent downloads to
+    # the same destination race on the same temp file, corrupting both --
+    # the uuid makes each call's temp file unique regardless of thread,
+    # process, or how many callers target the same dest_path at once.
+    tmp_path = dest.with_name(f"{dest.name}.{uuid.uuid4().hex}.part")
     kwargs["stream"] = True
     response = safe_get(url, max_redirects=max_redirects, **kwargs)
     try:

--- a/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 import contextlib
 from pathlib import Path
 import socket
+import threading
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -15,6 +16,9 @@ from crewai_tools.security.safe_path import validate_and_resolve
 
 
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+# socket.getaddrinfo is process-global, so _pin_dns's patch/use/restore window
+# must be serialized across threads -- see _pin_dns's docstring.
+_dns_pin_lock = threading.Lock()
 _SENSITIVE_HEADER_NAMES = {
     "authorization",
     "cookie",
@@ -61,28 +65,34 @@ def _pin_dns(hostname: str, ip: str) -> Iterator[None]:
 
     This patches ``socket.getaddrinfo`` process-wide rather than through a
     custom transport adapter, to stay compatible with plain ``requests``
-    without extra dependencies. The window is only as long as the single
-    request this wraps, and the original resolver is always restored in
-    ``finally``. A concurrent request to a *different* host on another thread
-    during that window is unaffected: the pinned resolver only intercepts
-    lookups for `hostname` and delegates everything else to the real one.
+    without extra dependencies. Because the patch target is process-global,
+    the whole patch/use/restore window is serialized with ``_dns_pin_lock``:
+    without it, two concurrent calls (even to different hosts) can overwrite
+    each other's pin and restore the wrong resolver from their own
+    ``finally``, silently dropping DNS-rebinding protection for whichever
+    request loses the race -- not just "unaffected," as an earlier version of
+    this docstring incorrectly claimed. The lock trades some concurrency
+    (calls that reach this point serialize on the network round-trip, not
+    just the lookup) for the guarantee that at most one pin is ever installed
+    at a time.
     """
-    original_getaddrinfo = socket.getaddrinfo
-    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    with _dns_pin_lock:
+        original_getaddrinfo = socket.getaddrinfo
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
 
-    def pinned_getaddrinfo(
-        host: str, port: int, *args: Any, **kwargs: Any
-    ) -> list[tuple[Any, ...]]:
-        if host == hostname:
-            sockaddr = (ip, port, 0, 0) if family == socket.AF_INET6 else (ip, port)
-            return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
-        return original_getaddrinfo(host, port, *args, **kwargs)
+        def pinned_getaddrinfo(
+            host: str, port: int, *args: Any, **kwargs: Any
+        ) -> list[tuple[Any, ...]]:
+            if host == hostname:
+                sockaddr = (ip, port, 0, 0) if family == socket.AF_INET6 else (ip, port)
+                return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+            return original_getaddrinfo(host, port, *args, **kwargs)
 
-    socket.getaddrinfo = pinned_getaddrinfo
-    try:
-        yield
-    finally:
-        socket.getaddrinfo = original_getaddrinfo
+        socket.getaddrinfo = pinned_getaddrinfo
+        try:
+            yield
+        finally:
+            socket.getaddrinfo = original_getaddrinfo
 
 
 def safe_get(url: str, *, max_redirects: int = 10, **kwargs: Any) -> requests.Response:
@@ -148,16 +158,32 @@ def safe_download(
     redirect-chain revalidation, and DNS pinning as :func:`safe_get`, but
     streaming the response to disk instead of buffering it in memory.
 
+    Writes to a temporary file alongside `dest_path` and renames it into
+    place only after the transfer completes successfully, so a failed or
+    interrupted download never leaves a truncated file at `dest_path` for a
+    caller to mistake for a complete one.
+
+    Streaming is required for this function to work, so a `stream` keyword in
+    `kwargs` is always overridden to `True` rather than raising or silently
+    conflicting with the explicit one below.
+
     Raises:
         ValueError: If the URL (or any redirect target) fails validation.
         requests.HTTPError: If the final response has an error status code.
     """
-    response = safe_get(url, max_redirects=max_redirects, stream=True, **kwargs)
+    dest = Path(dest_path)
+    tmp_path = dest.with_name(f"{dest.name}.part")
+    kwargs["stream"] = True
+    response = safe_get(url, max_redirects=max_redirects, **kwargs)
     try:
         response.raise_for_status()
-        with open(dest_path, "wb") as fh:
+        with open(tmp_path, "wb") as fh:
             for chunk in response.iter_content(chunk_size=chunk_size):
                 if chunk:
                     fh.write(chunk)
+        tmp_path.replace(dest)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
     finally:
         response.close()

--- a/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
+++ b/lib/crewai-tools/src/crewai_tools/security/safe_requests.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+import contextlib
+from pathlib import Path
+import socket
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import requests
 
-from crewai_tools.security.safe_path import validate_url
+from crewai_tools.security.safe_path import validate_and_resolve
 
 
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
@@ -48,16 +52,60 @@ def _strip_cross_origin_credentials(request_kwargs: dict[str, Any]) -> dict[str,
     return sanitized
 
 
+@contextlib.contextmanager
+def _pin_dns(hostname: str, ip: str) -> Iterator[None]:
+    """Force ``socket.getaddrinfo(hostname, ...)`` to return only `ip` for the
+    duration of the block, so the connection made inside it cannot be
+    redirected to a different address by a DNS response that changes between
+    validation and connection time (DNS rebinding).
+
+    This patches ``socket.getaddrinfo`` process-wide rather than through a
+    custom transport adapter, to stay compatible with plain ``requests``
+    without extra dependencies. The window is only as long as the single
+    request this wraps, and the original resolver is always restored in
+    ``finally``. A concurrent request to a *different* host on another thread
+    during that window is unaffected: the pinned resolver only intercepts
+    lookups for `hostname` and delegates everything else to the real one.
+    """
+    original_getaddrinfo = socket.getaddrinfo
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+
+    def pinned_getaddrinfo(
+        host: str, port: int, *args: Any, **kwargs: Any
+    ) -> list[tuple[Any, ...]]:
+        if host == hostname:
+            sockaddr = (ip, port, 0, 0) if family == socket.AF_INET6 else (ip, port)
+            return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+        return original_getaddrinfo(host, port, *args, **kwargs)
+
+    socket.getaddrinfo = pinned_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
+
 def safe_get(url: str, *, max_redirects: int = 10, **kwargs: Any) -> requests.Response:
-    """GET a URL while validating each redirect target before following it."""
-    current_url = validate_url(url)
+    """GET a URL while validating each redirect target before following it.
+
+    Every hop -- the initial request and each redirect -- has its DNS
+    resolution pinned to the specific IP address that was validated for that
+    URL, closing the gap where a hostname could pass validation against a
+    safe IP and then have the HTTP client re-resolve it to a different,
+    unsafe address (e.g. a cloud metadata endpoint) at actual connection
+    time.
+    """
+    current_url, pinned_ip = validate_and_resolve(url)
     request_kwargs = {**kwargs, "allow_redirects": False}
     timeout = request_kwargs.pop("timeout", 30)
     history: list[requests.Response] = []
     redirects_followed = 0
 
     while True:
-        response = requests.get(current_url, timeout=timeout, **request_kwargs)
+        hostname = urlparse(current_url).hostname
+        pin = _pin_dns(hostname, pinned_ip) if pinned_ip and hostname else contextlib.nullcontext()
+        with pin:
+            response = requests.get(current_url, timeout=timeout, **request_kwargs)
         if (
             response.status_code not in _REDIRECT_STATUS_CODES
             or "Location" not in response.headers
@@ -75,7 +123,7 @@ def safe_get(url: str, *, max_redirects: int = 10, **kwargs: Any) -> requests.Re
             return response
 
         try:
-            redirect_url = validate_url(urljoin(response.url, location))
+            redirect_url, redirect_ip = validate_and_resolve(urljoin(response.url, location))
         except ValueError:
             response.close()
             raise
@@ -84,5 +132,32 @@ def safe_get(url: str, *, max_redirects: int = 10, **kwargs: Any) -> requests.Re
             request_kwargs = _strip_cross_origin_credentials(request_kwargs)
 
         history.append(response)
-        current_url = redirect_url
+        current_url, pinned_ip = redirect_url, redirect_ip
         redirects_followed += 1
+
+
+def safe_download(
+    url: str,
+    dest_path: str | Path,
+    *,
+    max_redirects: int = 10,
+    chunk_size: int = 65536,
+    **kwargs: Any,
+) -> None:
+    """Download `url` to `dest_path`, applying the exact same validation,
+    redirect-chain revalidation, and DNS pinning as :func:`safe_get`, but
+    streaming the response to disk instead of buffering it in memory.
+
+    Raises:
+        ValueError: If the URL (or any redirect target) fails validation.
+        requests.HTTPError: If the final response has an error status code.
+    """
+    response = safe_get(url, max_redirects=max_redirects, stream=True, **kwargs)
+    try:
+        response.raise_for_status()
+        with open(dest_path, "wb") as fh:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    fh.write(chunk)
+    finally:
+        response.close()

--- a/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
@@ -3,13 +3,14 @@ from pathlib import Path
 import re
 import time
 from typing import Any, ClassVar
-import urllib.error
 import urllib.parse
-import urllib.request
 import xml.etree.ElementTree as ET
 
 from crewai.tools import BaseTool, EnvVar
 from pydantic import BaseModel, ConfigDict, Field
+import requests
+
+from crewai_tools.security.safe_requests import safe_download, safe_get
 
 
 logger = logging.getLogger(__file__)
@@ -25,7 +26,7 @@ class ArxivToolInput(BaseModel):
 
 
 class ArxivPaperTool(BaseTool):
-    BASE_API_URL: ClassVar[str] = "http://export.arxiv.org/api/query"
+    BASE_API_URL: ClassVar[str] = "https://export.arxiv.org/api/query"
     SLEEP_DURATION: ClassVar[int] = 1
     SUMMARY_TRUNCATE_LENGTH: ClassVar[int] = 300
     ATOM_NAMESPACE: ClassVar[str] = "{http://www.w3.org/2005/Atom}"
@@ -82,13 +83,10 @@ class ArxivPaperTool(BaseTool):
         logger.info(f"Fetching data from Arxiv API: {api_url}")
 
         try:
-            with urllib.request.urlopen(  # noqa: S310
-                api_url, timeout=self.REQUEST_TIMEOUT
-            ) as response:
-                if response.status != 200:
-                    raise Exception(f"HTTP {response.status}: {response.reason}")
-                data = response.read().decode("utf-8")
-        except urllib.error.URLError as e:
+            response = safe_get(api_url, timeout=self.REQUEST_TIMEOUT)
+            response.raise_for_status()
+            data = response.text
+        except (requests.RequestException, ValueError) as e:
             logger.error(f"Error fetching data from Arxiv: {e}")
             raise
 
@@ -161,9 +159,16 @@ class ArxivPaperTool(BaseTool):
     def download_pdf(self, pdf_url: str, save_path: str) -> None:
         try:
             logger.info(f"Downloading PDF from {pdf_url} to {save_path}")
-            urllib.request.urlretrieve(pdf_url, str(save_path))  # noqa: S310
+            # pdf_url comes from the Arxiv API's XML response, not directly from
+            # tool input -- but it's still an untrusted, remotely-supplied URL
+            # (e.g. a network MITM tampering with the plain-HTTP-era API response,
+            # or a malformed/malicious link ever indexed upstream). safe_download
+            # validates the URL and every redirect target, and pins each
+            # connection's DNS resolution to the address that was actually
+            # validated, closing the SSRF exposure a raw urlretrieve() call has.
+            safe_download(pdf_url, str(save_path), timeout=self.REQUEST_TIMEOUT)
             logger.info(f"PDF saved: {save_path}")
-        except urllib.error.URLError as e:
+        except (requests.RequestException, ValueError) as e:
             logger.error(f"Network error occurred while downloading {pdf_url}: {e}")
             raise
         except OSError as e:

--- a/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
@@ -66,7 +66,7 @@ class ArxivPaperTool(BaseTool):
                         filename = f"{filename_base[:500]}.pdf"
                         save_path = Path(save_dir) / filename
 
-                        self.download_pdf(paper["pdf_url"], save_path)  # type: ignore[arg-type]
+                        self.download_pdf(paper["pdf_url"], save_path)
                         time.sleep(self.SLEEP_DURATION)
 
             results = [self._format_paper_result(p) for p in papers]
@@ -156,7 +156,7 @@ class ArxivPaperTool(BaseTool):
         save_path.mkdir(parents=True, exist_ok=True)
         return save_path
 
-    def download_pdf(self, pdf_url: str, save_path: str) -> None:
+    def download_pdf(self, pdf_url: str, save_path: str | Path) -> None:
         try:
             logger.info(f"Downloading PDF from {pdf_url} to {save_path}")
             # pdf_url comes from the Arxiv API's XML response, not directly from

--- a/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/arxiv_paper_tool/arxiv_paper_tool.py
@@ -79,6 +79,26 @@ class ArxivPaperTool(BaseTool):
     def fetch_arxiv_data(
         self, search_query: str, max_results: int
     ) -> list[dict[str, Any]]:
+        """Query the Arxiv API and parse the resulting Atom feed into a list
+        of paper records.
+
+        Args:
+            search_query: Free-text Arxiv search query.
+            max_results: Maximum number of entries to request from the API.
+
+        Returns:
+            A list of dicts with keys `arxiv_id`, `title`, `summary`,
+            `authors`, `published_date`, `pdf_url` (the last is `None` if no
+            PDF link was found in the entry).
+
+        Raises:
+            requests.RequestException: If the request to Arxiv fails (network
+                error, timeout, or a non-2xx response).
+            ValueError: If `api_url` (or a redirect it follows) fails
+                `safe_get`'s SSRF validation.
+            xml.etree.ElementTree.ParseError: If the response body isn't
+                valid XML.
+        """
         api_url = f"{self.BASE_API_URL}?search_query={urllib.parse.quote(search_query)}&start=0&max_results={max_results}"
         logger.info(f"Fetching data from Arxiv API: {api_url}")
 
@@ -157,6 +177,22 @@ class ArxivPaperTool(BaseTool):
         return save_path
 
     def download_pdf(self, pdf_url: str, save_path: str | Path) -> None:
+        """Download a single PDF to `save_path` via `safe_download`.
+
+        Args:
+            pdf_url: The PDF URL, as extracted from an Arxiv API entry.
+            save_path: Destination file path. `safe_download` writes to a
+                temp file alongside it and renames into place on success, so
+                a failed download never leaves a truncated file here.
+
+        Raises:
+            requests.RequestException: If the request fails (network error,
+                timeout, or a non-2xx response).
+            ValueError: If `pdf_url` (or a redirect it follows) fails
+                `safe_download`'s SSRF validation.
+            OSError: If `save_path` can't be written (permissions, missing
+                parent directory, etc.).
+        """
         try:
             logger.info(f"Downloading PDF from {pdf_url} to {save_path}")
             # pdf_url comes from the Arxiv API's XML response, not directly from

--- a/lib/crewai-tools/tests/tools/arxiv_paper_tool_test.py
+++ b/lib/crewai-tools/tests/tools/arxiv_paper_tool_test.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import urllib.error
 import xml.etree.ElementTree as ET
 
 from crewai_tools import ArxivPaperTool
 import pytest
+import requests
 
 
 @pytest.fixture
@@ -26,33 +26,38 @@ def mock_arxiv_response():
         </feed>"""
 
 
-@patch("urllib.request.urlopen")
-def test_fetch_arxiv_data(mock_urlopen, tool):
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get")
+def test_fetch_arxiv_data(mock_safe_get, tool):
     mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.read.return_value = mock_arxiv_response().encode("utf-8")
-    mock_urlopen.return_value.__enter__.return_value = mock_response
+    mock_response.text = mock_arxiv_response()
+    mock_safe_get.return_value = mock_response
 
     results = tool.fetch_arxiv_data("transformer", 1)
     assert isinstance(results, list)
     assert results[0]["title"] == "Sample Paper"
 
 
-@patch("urllib.request.urlopen", side_effect=urllib.error.URLError("Timeout"))
-def test_fetch_arxiv_data_network_error(mock_urlopen, tool):
-    with pytest.raises(urllib.error.URLError):
+@patch(
+    "crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get",
+    side_effect=requests.RequestException("Timeout"),
+)
+def test_fetch_arxiv_data_network_error(mock_safe_get, tool):
+    with pytest.raises(requests.RequestException):
         tool.fetch_arxiv_data("transformer", 1)
 
 
-@patch("urllib.request.urlretrieve")
-def test_download_pdf_success(mock_urlretrieve):
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_download")
+def test_download_pdf_success(mock_safe_download):
     tool = ArxivPaperTool()
     tool.download_pdf("http://arxiv.org/pdf/1234.5678.pdf", Path("test.pdf"))
-    mock_urlretrieve.assert_called_once()
+    mock_safe_download.assert_called_once()
 
 
-@patch("urllib.request.urlretrieve", side_effect=OSError("Permission denied"))
-def test_download_pdf_oserror(mock_urlretrieve):
+@patch(
+    "crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_download",
+    side_effect=OSError("Permission denied"),
+)
+def test_download_pdf_oserror(mock_safe_download):
     tool = ArxivPaperTool()
     with pytest.raises(OSError):
         tool.download_pdf(
@@ -60,26 +65,45 @@ def test_download_pdf_oserror(mock_urlretrieve):
         )
 
 
-@patch("urllib.request.urlopen")
-@patch("urllib.request.urlretrieve")
-def test_run_with_download(mock_urlretrieve, mock_urlopen):
+def test_download_pdf_blocks_private_ip():
+    """Regression test for the SSRF fix (#6694): download_pdf must reject a
+    URL that resolves to a private/reserved IP before making any request,
+    end to end through the real safe_download/safe_get/validate_and_resolve
+    chain -- not mocked out, so this exercises the actual protection.
+    """
+    tool = ArxivPaperTool()
+    with pytest.raises(ValueError, match="private/reserved IP"):
+        tool.download_pdf("http://127.0.0.1/malicious.pdf", Path("test.pdf"))
+
+
+def test_download_pdf_blocks_cloud_metadata_endpoint():
+    """Same as above, for the AWS/GCP/Azure metadata endpoint specifically --
+    the concrete credential-theft scenario named in #6694."""
+    tool = ArxivPaperTool()
+    with pytest.raises(ValueError, match="private/reserved IP"):
+        tool.download_pdf(
+            "http://169.254.169.254/latest/meta-data/", Path("test.pdf")
+        )
+
+
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get")
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_download")
+def test_run_with_download(mock_safe_download, mock_safe_get):
     mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.read.return_value = mock_arxiv_response().encode("utf-8")
-    mock_urlopen.return_value.__enter__.return_value = mock_response
+    mock_response.text = mock_arxiv_response()
+    mock_safe_get.return_value = mock_response
 
     tool = ArxivPaperTool(download_pdfs=True)
     output = tool._run("transformer", 1)
     assert "Title: Sample Paper" in output
-    mock_urlretrieve.assert_called_once()
+    mock_safe_download.assert_called_once()
 
 
-@patch("urllib.request.urlopen")
-def test_run_no_download(mock_urlopen):
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get")
+def test_run_no_download(mock_safe_get):
     mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.read.return_value = mock_arxiv_response().encode("utf-8")
-    mock_urlopen.return_value.__enter__.return_value = mock_response
+    mock_response.text = mock_arxiv_response()
+    mock_safe_get.return_value = mock_response
 
     tool = ArxivPaperTool(download_pdfs=False)
     result = tool._run("transformer", 1)
@@ -93,20 +117,21 @@ def test_validate_save_path_creates_directory(mock_mkdir):
     assert isinstance(path, Path)
 
 
-@patch("urllib.request.urlopen")
-def test_run_handles_exception(mock_urlopen):
-    mock_urlopen.side_effect = Exception("API failure")
+@patch(
+    "crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get",
+    side_effect=Exception("API failure"),
+)
+def test_run_handles_exception(mock_safe_get):
     tool = ArxivPaperTool()
     result = tool._run("transformer", 1)
     assert "Failed to fetch or download Arxiv papers" in result
 
 
-@patch("urllib.request.urlopen")
-def test_invalid_xml_response(mock_urlopen, tool):
+@patch("crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool.safe_get")
+def test_invalid_xml_response(mock_safe_get, tool):
     mock_response = MagicMock()
-    mock_response.read.return_value = b"<invalid><xml>"
-    mock_response.status = 200
-    mock_urlopen.return_value.__enter__.return_value = mock_response
+    mock_response.text = "<invalid><xml>"
+    mock_safe_get.return_value = mock_response
 
     with pytest.raises(ET.ParseError):
         tool.fetch_arxiv_data("quantum", 1)

--- a/lib/crewai-tools/tests/tools/arxiv_paper_tool_test.py
+++ b/lib/crewai-tools/tests/tools/arxiv_paper_tool_test.py
@@ -50,7 +50,11 @@ def test_fetch_arxiv_data_network_error(mock_safe_get, tool):
 def test_download_pdf_success(mock_safe_download):
     tool = ArxivPaperTool()
     tool.download_pdf("http://arxiv.org/pdf/1234.5678.pdf", Path("test.pdf"))
-    mock_safe_download.assert_called_once()
+    mock_safe_download.assert_called_once_with(
+        "http://arxiv.org/pdf/1234.5678.pdf",
+        "test.pdf",
+        timeout=ArxivPaperTool.REQUEST_TIMEOUT,
+    )
 
 
 @patch(
@@ -65,20 +69,27 @@ def test_download_pdf_oserror(mock_safe_download):
         )
 
 
-def test_download_pdf_blocks_private_ip():
+def test_download_pdf_blocks_private_ip(monkeypatch):
     """Regression test for the SSRF fix (#6694): download_pdf must reject a
     URL that resolves to a private/reserved IP before making any request,
     end to end through the real safe_download/safe_get/validate_and_resolve
     chain -- not mocked out, so this exercises the actual protection.
+
+    Clears CREWAI_TOOLS_ALLOW_UNSAFE_PATHS so this stays hermetic regardless
+    of the environment: if that variable were set, validation would be
+    skipped and this test would instead attempt a real request to a private
+    address.
     """
+    monkeypatch.delenv("CREWAI_TOOLS_ALLOW_UNSAFE_PATHS", raising=False)
     tool = ArxivPaperTool()
     with pytest.raises(ValueError, match="private/reserved IP"):
         tool.download_pdf("http://127.0.0.1/malicious.pdf", Path("test.pdf"))
 
 
-def test_download_pdf_blocks_cloud_metadata_endpoint():
+def test_download_pdf_blocks_cloud_metadata_endpoint(monkeypatch):
     """Same as above, for the AWS/GCP/Azure metadata endpoint specifically --
     the concrete credential-theft scenario named in #6694."""
+    monkeypatch.delenv("CREWAI_TOOLS_ALLOW_UNSAFE_PATHS", raising=False)
     tool = ArxivPaperTool()
     with pytest.raises(ValueError, match="private/reserved IP"):
         tool.download_pdf(

--- a/lib/crewai-tools/tests/utilities/test_safe_path.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_path.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import socket
+from typing import Any
 
 import pytest
 
 from crewai_tools.security.safe_path import (
     format_path_for_display,
     format_sandbox_error,
+    validate_and_resolve,
     validate_directory_path,
     validate_file_path,
     validate_url,
@@ -192,6 +195,64 @@ class TestValidateUrl:
         # file:// would normally be blocked
         result = validate_url("file:///etc/passwd")
         assert result == "file:///etc/passwd"
+
+
+class TestValidateAndResolve:
+    """Tests for validate_and_resolve's IP-pinning-specific behavior (the
+    parts validate_url's own tests don't cover, since validate_url discards
+    the IP)."""
+
+    def test_prefers_ipv4_on_dual_stack_host(self, monkeypatch):
+        """getaddrinfo on a dual-stack host commonly returns IPv6 first --
+        the pinned IP should prefer IPv4 regardless of result order, since
+        pinning forgoes the normal multi-address connection fallback and
+        many real environments have working IPv4 but broken/absent IPv6.
+        """
+
+        def dual_stack_getaddrinfo(
+            host: str, port: int, *args: Any, **kwargs: Any
+        ) -> list[tuple[Any, ...]]:
+            return [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:2800:220:1::1", port, 0, 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", dual_stack_getaddrinfo)
+
+        _url, ip = validate_and_resolve("https://dual-stack.example/")
+
+        assert ip == "93.184.216.34"
+
+    def test_falls_back_to_ipv6_when_thats_all_thats_offered(self, monkeypatch):
+        def ipv6_only_getaddrinfo(
+            host: str, port: int, *args: Any, **kwargs: Any
+        ) -> list[tuple[Any, ...]]:
+            return [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:2800:220:1::1", port, 0, 0)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", ipv6_only_getaddrinfo)
+
+        _url, ip = validate_and_resolve("https://ipv6-only.example/")
+
+        assert ip == "2606:2800:220:1::1"
+
+    def test_still_validates_every_address_even_when_preferring_ipv4(self, monkeypatch):
+        """A private IPv6 address among the results must still block the
+        request, even though it wouldn't have been the preferred pin."""
+
+        def mixed_getaddrinfo(
+            host: str, port: int, *args: Any, **kwargs: Any
+        ) -> list[tuple[Any, ...]]:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port)),
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", mixed_getaddrinfo)
+
+        with pytest.raises(ValueError, match="private/reserved IP"):
+            validate_and_resolve("https://mixed.example/")
 
 
 class TestFormatSandboxError:

--- a/lib/crewai-tools/tests/utilities/test_safe_requests.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_requests.py
@@ -382,3 +382,43 @@ def test_safe_get_dns_pin_is_thread_safe(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert not errors
     assert seen_ips == hosts_to_ips
+
+
+def test_safe_download_concurrent_calls_to_same_dest_dont_corrupt(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
+) -> None:
+    """Two concurrent safe_download calls targeting the same dest_path must
+    not corrupt each other's output. Each call's temp file name includes a
+    uuid, so concurrent writers can't interleave writes into the same temp
+    file -- whichever call finishes last simply wins the final rename, but
+    the result is always one complete, uncorrupted payload, never a mix of
+    both.
+    """
+    payloads = {"a": b"AAAA-payload-one", "b": b"BBBB-payload-two"}
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        which = "a" if "/a.pdf" in url else "b"
+        response = _response(url, 200)
+        response.iter_content = lambda chunk_size=1, _which=which: [payloads[_which]]
+        return response
+
+    _mock_get(monkeypatch, fake_get)
+
+    dest = tmp_path / "paper.pdf"
+    errors: list[BaseException] = []
+
+    def run(which: str) -> None:
+        try:
+            safe_download(f"http://public.example/{which}.pdf", dest, timeout=15)
+        except BaseException as exc:  # noqa: BLE001 -- surface it to the main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run, args=(which,)) for which in payloads]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert dest.read_bytes() in payloads.values()
+    assert list(tmp_path.glob("*.part")) == []

--- a/lib/crewai-tools/tests/utilities/test_safe_requests.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_requests.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 import requests
 
-from crewai_tools.security.safe_requests import safe_get
+from crewai_tools.security.safe_requests import safe_download, safe_get
 
 
 def _response(url: str, status_code: int, *, location: str | None = None) -> requests.Response:
@@ -175,3 +175,104 @@ def test_safe_get_preserves_credentials_on_same_origin_redirect(
 
     assert requests_made[1][1]["headers"] == {"Authorization": "Bearer token"}
     assert requests_made[1][1]["cookies"] == {"session": "abc"}
+
+
+def test_safe_get_pins_dns_against_rebinding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hostname that resolves to a safe IP at validation time but would
+    resolve to a private IP at connection time must not let the private IP
+    actually get connected to -- the connection is pinned to the IP that was
+    validated, not left to re-resolve.
+
+    Without DNS pinning, this test fails: validate_and_resolve's lookup
+    consumes the "first" (safe) answer, and the mocked `requests.get` below
+    -- standing in for what the real HTTP client does when it opens the
+    connection -- would independently re-resolve to the "second" (private)
+    answer.
+    """
+    lookups: list[str] = []
+
+    def rebinding_getaddrinfo(
+        host: str, port: int, *args: Any, **kwargs: Any
+    ) -> list[tuple[Any, ...]]:
+        if host != "rebind.example":
+            raise socket.gaierror(f"unexpected host in test: {host}")
+        lookups.append(host)
+        # First lookup (validation) returns a safe IP; any further, unpinned
+        # lookup returns a private one -- simulating DNS rebinding via a
+        # short-TTL record that changes between validation and connection.
+        ip = "93.184.216.34" if len(lookups) == 1 else "127.0.0.1"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
+
+    connected_ips: list[str] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        # Stand-in for what the real HTTP client does at connection time:
+        # resolve the hostname again. If DNS pinning is working,
+        # socket.getaddrinfo has been overridden for the duration of this
+        # call to return only the validated IP, regardless of how many times
+        # "rebind.example" is looked up.
+        resolved = socket.getaddrinfo("rebind.example", 80)
+        connected_ips.append(resolved[0][4][0])
+        return _response(url, 200)
+
+    _mock_get(monkeypatch, fake_get)
+
+    response = safe_get("http://rebind.example/", timeout=15)
+
+    assert response.status_code == 200
+    assert connected_ips == ["93.184.216.34"]
+    assert "127.0.0.1" not in connected_ips
+
+
+def test_safe_get_restores_real_resolver_after_pinning(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None
+) -> None:
+    """DNS pinning must not leak past the request it was applied to."""
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        return _response(url, 200)
+
+    _mock_get(monkeypatch, fake_get)
+
+    original_getaddrinfo = socket.getaddrinfo
+    safe_get("http://public.example/", timeout=15)
+
+    assert socket.getaddrinfo is original_getaddrinfo
+
+
+def test_safe_download_writes_content_to_disk(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
+) -> None:
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        assert kwargs.get("stream") is True
+        response = _response(url, 200)
+        response._content = b"pdf-bytes-here"
+        response.raw = BytesIO(b"pdf-bytes-here")
+        response.iter_content = lambda chunk_size=1: [b"pdf-bytes-here"]
+        return response
+
+    _mock_get(monkeypatch, fake_get)
+
+    dest = tmp_path / "paper.pdf"
+    safe_download("http://public.example/paper.pdf", dest, timeout=15)
+
+    assert dest.read_bytes() == b"pdf-bytes-here"
+
+
+def test_safe_download_blocks_private_ip() -> None:
+    with pytest.raises(ValueError, match="private/reserved IP"):
+        safe_download("http://127.0.0.1/malicious.pdf", "/tmp/out.pdf", timeout=15)
+
+
+def test_safe_download_blocks_redirect_to_internal_url(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
+) -> None:
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        return _response(url, 302, location="http://127.0.0.1/admin")
+
+    _mock_get(monkeypatch, fake_get)
+
+    with pytest.raises(ValueError, match="private/reserved IP"):
+        safe_download("http://public.example/start", tmp_path / "out.pdf", timeout=15)

--- a/lib/crewai-tools/tests/utilities/test_safe_requests.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_requests.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import socket
+import threading
+import time
 from io import BytesIO
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -261,6 +264,28 @@ def test_safe_download_writes_content_to_disk(
     assert dest.read_bytes() == b"pdf-bytes-here"
 
 
+def test_safe_download_ignores_conflicting_stream_kwarg(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
+) -> None:
+    """safe_download always streams -- a caller-supplied stream=False must not
+    raise a "multiple values for keyword argument" TypeError, and must not
+    actually disable streaming.
+    """
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        assert kwargs.get("stream") is True
+        response = _response(url, 200)
+        response.iter_content = lambda chunk_size=1: [b"pdf-bytes-here"]
+        return response
+
+    _mock_get(monkeypatch, fake_get)
+
+    dest = tmp_path / "paper.pdf"
+    safe_download("http://public.example/paper.pdf", dest, timeout=15, stream=False)
+
+    assert dest.read_bytes() == b"pdf-bytes-here"
+
+
 def test_safe_download_blocks_private_ip() -> None:
     with pytest.raises(ValueError, match="private/reserved IP"):
         safe_download("http://127.0.0.1/malicious.pdf", "/tmp/out.pdf", timeout=15)
@@ -276,3 +301,84 @@ def test_safe_download_blocks_redirect_to_internal_url(
 
     with pytest.raises(ValueError, match="private/reserved IP"):
         safe_download("http://public.example/start", tmp_path / "out.pdf", timeout=15)
+
+
+def test_safe_download_leaves_no_partial_file_on_failure(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
+) -> None:
+    """A download that fails partway through must not leave a truncated file
+    at dest_path -- writes go to a temp file that's only renamed into place
+    after the transfer completes.
+    """
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        assert kwargs.get("stream") is True
+        response = _response(url, 200)
+
+        def broken_iter_content(chunk_size: int = 1) -> Any:
+            yield b"partial-bytes"
+            raise requests.exceptions.ChunkedEncodingError("connection dropped")
+
+        response.iter_content = broken_iter_content
+        return response
+
+    _mock_get(monkeypatch, fake_get)
+
+    dest = tmp_path / "paper.pdf"
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        safe_download("http://public.example/paper.pdf", dest, timeout=15)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_safe_get_dns_pin_is_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two concurrent safe_get calls to different hosts must each connect to
+    their own validated IP -- one request's pin/restore cycle must not
+    overwrite or clobber another's while both are in flight.
+
+    Without the lock in _pin_dns, patching socket.getaddrinfo from two
+    threads at once can leave the wrong resolver installed when one thread's
+    `finally` restores over the other's still-active pin -- this widens that
+    race window with a small sleep between the two threads' patch and their
+    actual connection-time lookup, so a missing lock would show up as a
+    mismatched or crashing lookup instead of passing by luck of the
+    scheduler.
+    """
+    hosts_to_ips = {"host-a.example": "1.1.1.1", "host-b.example": "2.2.2.2"}
+
+    def fake_getaddrinfo(
+        host: str, port: int, *args: Any, **kwargs: Any
+    ) -> list[tuple[Any, ...]]:
+        if host not in hosts_to_ips:
+            raise socket.gaierror(f"unexpected host in test: {host}")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (hosts_to_ips[host], port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    seen_ips: dict[str, str] = {}
+    errors: list[BaseException] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        host = urlparse(url).hostname
+        time.sleep(0.05)  # widen the window between patch and connect
+        resolved = socket.getaddrinfo(host, 80)
+        seen_ips[host] = resolved[0][4][0]
+        return _response(url, 200)
+
+    _mock_get(monkeypatch, fake_get)
+
+    def run(host: str) -> None:
+        try:
+            safe_get(f"http://{host}/", timeout=15)
+        except BaseException as exc:  # noqa: BLE001 -- surface it to the main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run, args=(host,)) for host in hosts_to_ips]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert seen_ips == hosts_to_ips

--- a/lib/crewai-tools/tests/utilities/test_safe_requests.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_requests.py
@@ -254,13 +254,28 @@ def test_pinned_resolver_falls_through_for_non_int_port(
     concurrently, or a future caller) must fall through to the real resolver
     instead of building a malformed sockaddr from an unusable port value.
     """
-    real_calls: list[tuple[str, Any]] = []
+    # The public_dns fixture resolves "public.example" to the same IP the
+    # pinned request itself resolves to, so asserting only on the *returned*
+    # IP wouldn't actually prove delegation happened -- a broken
+    # pinned_getaddrinfo that incorrectly intercepted a non-int port would
+    # return that same IP too. Instead, track calls reaching the resolver
+    # underneath the pin (the one public_dns installed) directly, and assert
+    # the non-int-port lookup actually reached it.
+    resolver_calls: list[tuple[str, Any]] = []
+    fixture_resolver = socket.getaddrinfo
+
+    def tracking_getaddrinfo(
+        host: str, port: Any, *args: Any, **kwargs: Any
+    ) -> list[tuple[Any, ...]]:
+        resolver_calls.append((host, port))
+        return fixture_resolver(host, port, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", tracking_getaddrinfo)
 
     def fake_get(url: str, **kwargs: Any) -> requests.Response:
         # A non-int port for the *same* pinned hostname: must delegate to
         # the real (fixture-provided) resolver rather than being pinned.
         result = socket.getaddrinfo("public.example", "http")
-        real_calls.append(("public.example", "http"))
         assert result[0][4][0] == "93.184.216.34"  # from the public_dns fixture
         return _response(url, 200)
 
@@ -268,7 +283,7 @@ def test_pinned_resolver_falls_through_for_non_int_port(
 
     safe_get("http://public.example/", timeout=15)
 
-    assert real_calls == [("public.example", "http")]
+    assert ("public.example", "http") in resolver_calls
 
 
 def test_safe_download_writes_content_to_disk(

--- a/lib/crewai-tools/tests/utilities/test_safe_requests.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_requests.py
@@ -245,6 +245,32 @@ def test_safe_get_restores_real_resolver_after_pinning(
     assert socket.getaddrinfo is original_getaddrinfo
 
 
+def test_pinned_resolver_falls_through_for_non_int_port(
+    monkeypatch: pytest.MonkeyPatch, public_dns: None
+) -> None:
+    """socket.getaddrinfo's real signature allows a service name or None for
+    `port`, not just an int. A lookup for the pinned hostname with a non-int
+    port during the pin window (e.g. some unrelated code running
+    concurrently, or a future caller) must fall through to the real resolver
+    instead of building a malformed sockaddr from an unusable port value.
+    """
+    real_calls: list[tuple[str, Any]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:
+        # A non-int port for the *same* pinned hostname: must delegate to
+        # the real (fixture-provided) resolver rather than being pinned.
+        result = socket.getaddrinfo("public.example", "http")
+        real_calls.append(("public.example", "http"))
+        assert result[0][4][0] == "93.184.216.34"  # from the public_dns fixture
+        return _response(url, 200)
+
+    _mock_get(monkeypatch, fake_get)
+
+    safe_get("http://public.example/", timeout=15)
+
+    assert real_calls == [("public.example", "http")]
+
+
 def test_safe_download_writes_content_to_disk(
     monkeypatch: pytest.MonkeyPatch, public_dns: None, tmp_path: Any
 ) -> None:


### PR DESCRIPTION
Fixes #6694.

## What's actually vulnerable

The issue names both `urllib` calls in `ArxivPaperTool`, but only one is a real SSRF vector:

- **`fetch_arxiv_data()`**'s `urlopen` call targets a hardcoded `BASE_API_URL` (`export.arxiv.org`); `search_query` only ever lands in the query string, percent-encoded. **Not an SSRF vector** for destination redirection. It was plain `http://`, though — a real but separate weakness (a network MITM can tamper with the API response). Switched to `https://` and migrated to `safe_get()` for consistency and redirect-safety while touching this.
- **`download_pdf()`**'s `urlretrieve` call is the real vector: `pdf_url` comes from parsing the arxiv API's **XML response** (an `href` attribute), not directly from `search_query`. Whatever URL shows up there was fetched and written to disk with zero validation — reachable via the same plain-HTTP MITM angle, or a malicious link ever indexed upstream. Migrated to `safe_download()` (new helper, see below).

## Additional finding: DNS-rebinding TOCTOU in the existing `safe_requests` infra

`crewai_tools.security` already has real SSRF protection (`validate_url`, `safe_get`) that both call sites above should have been using from the start. While wiring the arxiv tool into it, I found a real gap in the shared infrastructure itself: `validate_url()` resolves DNS, checks the IP, and returns the *original URL string* — it doesn't pin the actual connection to the address it just validated. `requests.get()` then re-resolves DNS itself at connection time. An attacker controlling DNS (or using a short-TTL record) can present a safe IP for validation and a private one for the real connection moments later.

Fixed by:
- `safe_path.validate_and_resolve(url) -> (url, ip)`: shares `validate_url`'s exact logic but also returns the checked IP. `validate_url`/new `resolve_validated_ip` are now thin wrappers around it (`validate_url`'s public signature/behavior is unchanged).
- `safe_requests._pin_dns(hostname, ip)`: a context manager that pins `socket.getaddrinfo(hostname, ...)` to the validated IP for the duration of one request. `safe_get()` now validates+pins on the initial URL *and* on every redirect hop, closing the window for both direct requests and redirect-based rebinding.
- `safe_requests.safe_download(url, dest_path)`: new helper for streaming a validated, pinned download to disk — `safe_get` didn't have an equivalent for `arxiv_paper_tool`'s use case.

## Testing

- New regression tests:
  - `test_safe_get_pins_dns_against_rebinding`: proves the fix directly — mocks `getaddrinfo` to return a safe IP on the first lookup and a private one on any subsequent lookup (simulating rebinding), and asserts the connection never sees the private IP. **Fails against the pre-fix code.**
  - `test_safe_get_restores_real_resolver_after_pinning`: pinning doesn't leak past the request it was applied to.
  - `safe_download`: writes-to-disk, blocks private IP, blocks redirect to private IP.
  - `ArxivPaperTool.download_pdf`: blocks `127.0.0.1` and the AWS/GCP/Azure metadata endpoint **end-to-end** (not mocked at the `safe_download` level), proving the tool itself is protected, not just the helper in isolation.
- Existing `arxiv_paper_tool_test.py` tests updated to mock `safe_get`/`safe_download` instead of `urllib` (the code path changed; test intent didn't).
- Full suite: `uv run --package crewai-tools pytest lib/crewai-tools/tests/utilities/test_safe_path.py lib/crewai-tools/tests/utilities/test_safe_requests.py lib/crewai-tools/tests/tools/arxiv_paper_tool_test.py` — **55 passed**.
- `ruff check` clean on all changed files.

<!-- crewai-require-issue-check -->