### PR TITLE
fix(ci): correctly skip code CI for docs-only PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,8 +16,13 @@ jobs:
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
+          # Exclusion-only patterns match every non-excluded file under the
+          # default "some" quantifier. Require all patterns (including "**")
+          # so docs-only / markdown-only PRs correctly set code=false.
+          predicate-quantifier: every
           filters: |
             code:
+              - '**'
               - '!docs/**'
               - '!**/*.md'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,13 @@ jobs:
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
+          # Exclusion-only patterns match every non-excluded file under the
+          # default "some" quantifier. Require all patterns (including "**")
+          # so docs-only / markdown-only PRs correctly set code=false.
+          predicate-quantifier: every
           filters: |
             code:
+              - '**'
               - '!docs/**'
               - '!**/*.md'
 

--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -16,8 +16,13 @@ jobs:
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
+          # Exclusion-only patterns match every non-excluded file under the
+          # default "some" quantifier. Require all patterns (including "**")
+          # so docs-only / markdown-only PRs correctly set code=false.
+          predicate-quantifier: every
           filters: |
             code:
+              - '**'
               - '!docs/**'
               - '!**/*.md'
 

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -12,8 +12,40 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # Exclusion-only patterns match every non-excluded file under the
+          # default "some" quantifier. Require all patterns (including "**")
+          # so docs-only / markdown-only PRs correctly set code=false.
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+      - name: Set code output
+        id: set
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
   pip-audit:
     name: pip-audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`dorny/paths-filter` was configured with exclusion-only patterns (`!docs/**`, `!**/*.md`) and no positive include. Under the default `some` quantifier, a bare negation matches every path that is *not* in the excluded set — so docs-only PRs still got `code=true` and ran the full test/typecheck/lint matrix.

## Changes

- **tests / type-checker / linter**: add `'**'` include and `predicate-quantifier: every` so a file must match all patterns (everything except docs and markdown).
- **vulnerability-scan**: add the same path filter on `pull_request`; schedule and `push` to `main` still always run pip-audit.

## Expected behavior

| PR changes | `code` | tests / typecheck / lint / pip-audit |
|---|---|---|
| Only `docs/**` or `*.md` | `false` | skipped |
| Any other code path | `true` | runs |
| Schedule / push to main (vuln scan) | `true` | runs |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8b8b2e0-fd3f-408f-8832-0c1a0f7c252b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8b8b2e0-fd3f-408f-8832-0c1a0f7c252b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

