### PR TITLE
fix(anthropic): include cache tokens in totals

### DIFF
--- a/docs/edge/en/concepts/crews.mdx
+++ b/docs/edge/en/concepts/crews.mdx
@@ -322,7 +322,7 @@ Caches can be employed to store the results of tools' execution, making the proc
 
 After the crew execution, you can access the `usage_metrics` attribute to view the language model (LLM) usage metrics for all tasks executed by the crew. This provides insights into operational efficiency and areas for improvement.
 
-`total_tokens` is the sum of normalized input and output tokens; for Anthropic, normalized input includes uncached, cache-read, and cache-creation input tokens, while `cached_prompt_tokens` and `cache_creation_tokens` expose those cache categories separately and should not be added again.
+Across providers, `total_tokens` is normalized as `prompt_tokens + completion_tokens`. Breakdown fields such as `cached_prompt_tokens`, `cache_creation_tokens`, and `reasoning_tokens` are already represented in those normalized totals and should not be added again. Provider adapters account for API-specific usage shapes; for example, Anthropic prompt usage combines uncached, cache-read, and cache-creation input tokens.
 
 ```python Code
 # Access the crew's usage metrics

--- a/docs/edge/en/concepts/crews.mdx
+++ b/docs/edge/en/concepts/crews.mdx
@@ -322,6 +322,8 @@ Caches can be employed to store the results of tools' execution, making the proc
 
 After the crew execution, you can access the `usage_metrics` attribute to view the language model (LLM) usage metrics for all tasks executed by the crew. This provides insights into operational efficiency and areas for improvement.
 
+`total_tokens` is the sum of normalized input and output tokens; for Anthropic, normalized input includes uncached, cache-read, and cache-creation input tokens, while `cached_prompt_tokens` and `cache_creation_tokens` expose those cache categories separately and should not be added again.
+
 ```python Code
 # Access the crew's usage metrics
 crew = Crew(agents=[agent1, agent2], tasks=[task1, task2])

--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1971,10 +1971,13 @@ class AnthropicCompletion(BaseLLM):
             cache_creation_tokens = (
                 getattr(usage, "cache_creation_input_tokens", 0) or 0
             )
+            total_input_tokens = (
+                input_tokens + cache_read_tokens + cache_creation_tokens
+            )
             result: dict[str, Any] = {
-                "input_tokens": input_tokens,
+                "input_tokens": total_input_tokens,
                 "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": total_input_tokens + output_tokens,
                 "cached_prompt_tokens": cache_read_tokens,
                 "cache_creation_tokens": cache_creation_tokens,
             }

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -1657,14 +1657,13 @@ def test_anthropic_cache_creation_tokens_extraction():
     mock_response.stop_reason = None
     mock_response.model = None
 
-    usage = llm._extract_anthropic_token_usage(mock_response)
-    assert usage["input_tokens"] == 150
-    assert usage["output_tokens"] == 50
-    assert usage["total_tokens"] == 200
-    assert usage["cached_prompt_tokens"] == 30
-    assert usage["cache_creation_tokens"] == 20
+    with (
+        patch.object(llm._client.messages, "create", return_value=mock_response),
+        patch("crewai.llms.base_llm.crewai_event_bus.emit"),
+    ):
+        result = llm.call("Hello")
 
-    llm._track_token_usage_internal(usage)
+    assert result == "test response"
     summary = llm.get_token_usage_summary()
     assert summary.prompt_tokens == 150
     assert summary.completion_tokens == 50

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -549,7 +549,12 @@ def test_anthropic_token_usage_tracking():
     with patch.object(llm._client.messages, 'create') as mock_create:
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="test response")]
-        mock_response.usage = MagicMock(input_tokens=50, output_tokens=25)
+        mock_response.usage = MagicMock(
+            input_tokens=50,
+            output_tokens=25,
+            cache_read_input_tokens=None,
+            cache_creation_input_tokens=None,
+        )
         mock_create.return_value = mock_response
 
         result = llm.call("Hello")
@@ -1653,11 +1658,19 @@ def test_anthropic_cache_creation_tokens_extraction():
     mock_response.model = None
 
     usage = llm._extract_anthropic_token_usage(mock_response)
-    assert usage["input_tokens"] == 100
+    assert usage["input_tokens"] == 150
     assert usage["output_tokens"] == 50
-    assert usage["total_tokens"] == 150
+    assert usage["total_tokens"] == 200
     assert usage["cached_prompt_tokens"] == 30
     assert usage["cache_creation_tokens"] == 20
+
+    llm._track_token_usage_internal(usage)
+    summary = llm.get_token_usage_summary()
+    assert summary.prompt_tokens == 150
+    assert summary.completion_tokens == 50
+    assert summary.total_tokens == 200
+    assert summary.cached_prompt_tokens == 30
+    assert summary.cache_creation_tokens == 20
 
 
 def test_anthropic_missing_cache_fields_default_to_zero():


### PR DESCRIPTION
## Summary

- include Anthropic cache reads and cache writes in normalized input and total token counts
- preserve cache read and cache creation counters as separate usage dimensions
- cover both provider extraction and the final UsageMetrics summary

Closes #6788

## Testing

- targeted Anthropic token usage tests: 3 passed
- Ruff check: passed
- Ruff format check: passed
- Mypy on the changed provider: passed

## AI assistance

Developed with AI assistance and reviewed and tested by the contributor. External contributors cannot apply labels in this repository, so I have requested the required llm-generated label in a comment below.