### PR TITLE
fix(mcp): preserve original tool name for external MCP servers

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -252,6 +252,7 @@ class MCPToolResolver:
                         tool_name=tool_name,
                         tool_schema=schema,
                         server_name=server_name,
+                        original_tool_name=schema.get("original_name", tool_name),
                     )
                     tools.append(wrapper)
                 except Exception as e:
@@ -615,15 +616,18 @@ class MCPToolResolver:
 
                 schemas = {}
                 for tool in tools_result.tools:
+                    sanitized_name = sanitize_tool_name(tool.name)
+
                     args_schema = None
                     if hasattr(tool, "inputSchema") and tool.inputSchema:
                         args_schema = self._json_schema_to_pydantic(
-                            sanitize_tool_name(tool.name), tool.inputSchema
+                            sanitized_name, tool.inputSchema
                         )
 
-                    schemas[sanitize_tool_name(tool.name)] = {
+                    schemas[sanitized_name] = {
                         "description": getattr(tool, "description", ""),
                         "args_schema": args_schema,
+                        "original_name": tool.name,
                     }
                 return schemas
 

--- a/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
+++ b/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
@@ -22,14 +22,17 @@ class MCPToolWrapper(BaseTool):
         tool_name: str,
         tool_schema: dict[str, Any],
         server_name: str,
+        original_tool_name: str | None = None,
     ):
         """Initialize the MCP tool wrapper.
 
         Args:
             mcp_server_params: Parameters for connecting to the MCP server
-            tool_name: Original name of the tool on the MCP server
+            tool_name: Name of the tool, which may have been sanitized
             tool_schema: Schema information for the tool
             server_name: Name of the MCP server for prefixing
+            original_tool_name: Original name of the tool on the MCP server.
+                Defaults to ``tool_name`` when the two are identical.
         """
         prefixed_name = f"{server_name}_{tool_name}"
 
@@ -48,7 +51,7 @@ class MCPToolWrapper(BaseTool):
         super().__init__(**kwargs)
 
         self._mcp_server_params = mcp_server_params
-        self._original_tool_name = tool_name
+        self._original_tool_name = original_tool_name or tool_name
         self._server_name = server_name
 
     @property

--- a/lib/crewai/tests/mcp/test_tool_resolver_external.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_external.py
@@ -1,0 +1,198 @@
+"""Tests for MCPToolResolver external (streamable-HTTP) resolution paths."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from crewai.agent.core import Agent
+from crewai.mcp.tool_resolver import MCPToolResolver
+
+
+SERVER_URL = "https://mcp.example.com/mcp"
+
+
+@pytest.fixture
+def agent():
+    return Agent(
+        role="Test Agent",
+        goal="Test goal",
+        backstory="Test backstory",
+    )
+
+
+@pytest.fixture
+def resolver(agent):
+    return MCPToolResolver(agent=agent, logger=agent._logger)
+
+
+class _FakeSession:
+    """Minimal stand-in for ``mcp.ClientSession``."""
+
+    def __init__(self, tools):
+        self._tools = tools
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def initialize(self):
+        return None
+
+    async def list_tools(self):
+        return SimpleNamespace(tools=self._tools)
+
+
+class _FakeTransport:
+    async def __aenter__(self):
+        return (None, None, None)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _discover(resolver, tools):
+    with (
+        patch("mcp.ClientSession", lambda *a, **k: _FakeSession(tools)),
+        patch(
+            "mcp.client.streamable_http.streamablehttp_client",
+            lambda *a, **k: _FakeTransport(),
+        ),
+    ):
+        return asyncio.run(resolver._discover_mcp_tools(SERVER_URL))
+
+
+class TestDiscoverMcpToolsPreservesOriginalName:
+    def test_schema_keys_are_sanitized(self, resolver):
+        schemas = _discover(
+            resolver,
+            [SimpleNamespace(name="resolve-library-id", description="", inputSchema=None)],
+        )
+
+        assert set(schemas) == {"resolve_library_id"}
+
+    def test_schema_retains_unsanitized_server_side_name(self, resolver):
+        schemas = _discover(
+            resolver,
+            [SimpleNamespace(name="resolve-library-id", description="", inputSchema=None)],
+        )
+
+        assert schemas["resolve_library_id"]["original_name"] == "resolve-library-id"
+
+    def test_names_needing_no_sanitization_are_unchanged(self, resolver):
+        schemas = _discover(
+            resolver, [SimpleNamespace(name="search", description="", inputSchema=None)]
+        )
+
+        assert schemas["search"]["original_name"] == "search"
+
+    def test_description_is_preserved(self, resolver):
+        schemas = _discover(
+            resolver,
+            [SimpleNamespace(name="query-docs", description="Search docs", inputSchema=None)],
+        )
+
+        assert schemas["query_docs"]["description"] == "Search docs"
+
+
+class TestResolveExternalOriginalName:
+    """The name sent to ``session.call_tool`` must be the server's own name."""
+
+    def _resolve_one(self, resolver, schema):
+        with patch.object(
+            MCPToolResolver, "_get_mcp_tool_schemas", return_value={"resolve_library_id": schema}
+        ):
+            return resolver._resolve_external(SERVER_URL)
+
+    def test_hyphenated_name_is_used_for_server_calls(self, resolver):
+        tools = self._resolve_one(
+            resolver,
+            {
+                "description": "Resolve a library id",
+                "args_schema": None,
+                "original_name": "resolve-library-id",
+            },
+        )
+
+        assert len(tools) == 1
+        assert tools[0].original_tool_name == "resolve-library-id"
+
+    def test_agent_facing_name_stays_sanitized(self, resolver):
+        """Sanitization still protects the name exposed for LLM function calling."""
+        tools = self._resolve_one(
+            resolver,
+            {
+                "description": "Resolve a library id",
+                "args_schema": None,
+                "original_name": "resolve-library-id",
+            },
+        )
+
+        assert "-" not in tools[0].name
+
+    def test_falls_back_to_tool_name_when_original_absent(self, resolver):
+        """Schemas cached by an older version carry no ``original_name``."""
+        tools = self._resolve_one(
+            resolver, {"description": "Resolve a library id", "args_schema": None}
+        )
+
+        assert tools[0].original_tool_name == "resolve_library_id"
+
+    def test_specific_tool_selector_still_matches_sanitized_name(self, resolver):
+        """``url#tool`` filtering compares against sanitized keys and must keep working."""
+        schema = {
+            "description": "Resolve a library id",
+            "args_schema": None,
+            "original_name": "resolve-library-id",
+        }
+        with patch.object(
+            MCPToolResolver,
+            "_get_mcp_tool_schemas",
+            return_value={"resolve_library_id": schema, "query_docs": dict(schema)},
+        ):
+            tools = resolver._resolve_external(f"{SERVER_URL}#resolve-library-id")
+
+        assert len(tools) == 1
+        assert tools[0].original_tool_name == "resolve-library-id"
+
+
+class TestMCPToolWrapperOriginalName:
+    def test_defaults_to_tool_name_when_not_supplied(self):
+        from crewai.tools.mcp_tool_wrapper import MCPToolWrapper
+
+        wrapper = MCPToolWrapper(
+            mcp_server_params={"url": SERVER_URL},
+            tool_name="search",
+            tool_schema={"description": "d", "args_schema": None},
+            server_name="example",
+        )
+
+        assert wrapper.original_tool_name == "search"
+
+    def test_explicit_original_name_takes_precedence(self):
+        from crewai.tools.mcp_tool_wrapper import MCPToolWrapper
+
+        wrapper = MCPToolWrapper(
+            mcp_server_params={"url": SERVER_URL},
+            tool_name="resolve_library_id",
+            tool_schema={"description": "d", "args_schema": None},
+            server_name="example",
+            original_tool_name="resolve-library-id",
+        )
+
+        assert wrapper.original_tool_name == "resolve-library-id"
+        assert wrapper.name == "example_resolve_library_id"
+
+
+class TestResolveExternalLogging:
+    def test_warns_when_specific_tool_not_found(self, resolver):
+        mock_log = MagicMock()
+        resolver._logger = MagicMock(log=mock_log)
+
+        with patch.object(MCPToolResolver, "_get_mcp_tool_schemas", return_value={}):
+            tools = resolver._resolve_external(f"{SERVER_URL}#missing-tool")
+
+        assert tools == []
+        assert any(call.args[0] == "warning" for call in mock_log.call_args_list)


### PR DESCRIPTION
> **AI-generated contribution.** Authored with Claude Code and labelled `llm-generated` per
> `CONTRIBUTING.md`. Reviewed and verified against a live MCP server before submission.

## Problem

Tool names are sanitized during discovery over streamable HTTP, and the **sanitized** name is
then sent back to the server as the name to invoke. Any server-side tool whose name contains a
hyphen is therefore unreachable.

Concretely, with Context7:

```python
agent = Agent(..., mcps=["https://mcp.context7.com/mcp"])
```

`resolve-library-id` is discovered, then invoked as `resolve_library_id`, and the server
responds with an unknown-tool error.

Reproduced against the live server on `main`:

```
BEFORE   agent-facing='mcp_context7_com_mcp_resolve_library_id'  sent-to-server='resolve_library_id'  ✗
AFTER    agent-facing='mcp_context7_com_mcp_resolve_library_id'  sent-to-server='resolve-library-id'  ✓
```

## Cause

`_discover_mcp_tools` keys its schema dict by `sanitize_tool_name(tool.name)` and discards the
original:

```python
schemas[sanitize_tool_name(tool.name)] = {
    "description": getattr(tool, "description", ""),
    "args_schema": args_schema,
}
```

By the time `_resolve_external` builds the wrapper, the original name no longer exists, so the
sanitized key is passed as `MCPToolWrapper(tool_name=...)`. That parameter's own docstring
describes it as *"Original name of the tool on the MCP server"*, and `_run` forwards it verbatim
to `session.call_tool`.

## Fix

The native path already solves this — `_resolve_native` reads `original_name` off the tool
definition and passes `original_tool_name=` to `MCPNativeTool`. This applies the same pattern to
the external path so the two are consistent:

1. `_discover_mcp_tools` keeps `original_name` alongside the sanitized key.
2. `MCPToolWrapper.__init__` gains `original_tool_name: str | None = None`, mirroring
   `MCPNativeTool.__init__`, and stores `original_tool_name or tool_name`.
3. `_resolve_external` passes it through.

Eight added lines of source.

## Compatibility

- **Agent-facing names are unchanged.** Sanitization still governs the name exposed for LLM
  function calling; only the name used to *invoke* the tool changes. There is a test asserting
  no hyphen leaks into `tool.name`.
- **`original_tool_name` defaults to `tool_name`**, so existing callers and schemas cached by a
  previous version behave exactly as before.
- **`url#tool` selection still compares sanitized names**, covered by a test.

## Tests

New `lib/crewai/tests/mcp/test_tool_resolver_external.py` — 11 tests covering discovery,
resolution, wrapper construction and the warning path. There was previously no external-path
test module.

Verified the tests are meaningful by reverting only the source changes:

```
without fix   5 failed, 6 passed
with fix     11 passed
```

The 6 that pass either way are the invariants the fix must not break.

Checks run locally:

```
uv run pytest lib/crewai/tests/mcp/ -q        51 passed
uv run pytest lib/crewai/tests/tools/ -q     279 passed
uv run ruff check <changed files>             All checks passed
uv run ruff format --diff <changed files>     already formatted
uv run mypy <changed files>                   Success: no issues found
```
