### PR TITLE
fix: clear CodeQL incomplete URL substring sanitization alerts

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/rag/data_types.py
+++ b/lib/crewai-tools/src/crewai_tools/rag/data_types.py
@@ -135,7 +135,8 @@ class DataTypes:
 
             if "docs" in url.netloc or ("docs" in url.path and url.scheme != "file"):
                 return DataType.DOCS_SITE
-            if "github.com" in url.netloc:
+            hostname = (url.hostname or "").lower()
+            if hostname == "github.com" or hostname.endswith(".github.com"):
                 return DataType.GITHUB
 
             return DataType.WEBSITE

--- a/lib/crewai-tools/tests/rag/test_data_types.py
+++ b/lib/crewai-tools/tests/rag/test_data_types.py
@@ -1,32 +1,32 @@
-"""Tests for DataType content classification."""
+"""Tests for DataTypes content classification."""
 
-from crewai_tools.rag.data_types import DataType
+from crewai_tools.rag.data_types import DataType, DataTypes
 
 
-class TestDataTypeFromContentGitHub:
+class TestDataTypesFromContentGitHub:
     """GitHub URL detection must use hostname matching, not substrings."""
 
     def test_github_com_url(self) -> None:
         assert (
-            DataType.from_content("https://github.com/crewai/crewai")
+            DataTypes.from_content("https://github.com/crewai/crewai")
             == DataType.GITHUB
         )
 
     def test_github_subdomain_url(self) -> None:
         assert (
-            DataType.from_content("https://gist.github.com/user/abc")
+            DataTypes.from_content("https://gist.github.com/user/abc")
             == DataType.GITHUB
         )
 
     def test_spoofed_github_hostname_is_website(self) -> None:
         # Substring checks like `"github.com" in netloc` would misclassify this.
         assert (
-            DataType.from_content("https://github.com.evil.example/crewai")
+            DataTypes.from_content("https://github.com.evil.example/crewai")
             == DataType.WEBSITE
         )
 
     def test_github_in_path_is_not_github(self) -> None:
         assert (
-            DataType.from_content("https://example.com/github.com/repo")
+            DataTypes.from_content("https://example.com/github.com/repo")
             == DataType.WEBSITE
         )

--- a/lib/crewai-tools/tests/rag/test_data_types.py
+++ b/lib/crewai-tools/tests/rag/test_data_types.py
@@ -1,0 +1,32 @@
+"""Tests for DataType content classification."""
+
+from crewai_tools.rag.data_types import DataType
+
+
+class TestDataTypeFromContentGitHub:
+    """GitHub URL detection must use hostname matching, not substrings."""
+
+    def test_github_com_url(self) -> None:
+        assert (
+            DataType.from_content("https://github.com/crewai/crewai")
+            == DataType.GITHUB
+        )
+
+    def test_github_subdomain_url(self) -> None:
+        assert (
+            DataType.from_content("https://gist.github.com/user/abc")
+            == DataType.GITHUB
+        )
+
+    def test_spoofed_github_hostname_is_website(self) -> None:
+        # Substring checks like `"github.com" in netloc` would misclassify this.
+        assert (
+            DataType.from_content("https://github.com.evil.example/crewai")
+            == DataType.WEBSITE
+        )
+
+    def test_github_in_path_is_not_github(self) -> None:
+        assert (
+            DataType.from_content("https://example.com/github.com/repo")
+            == DataType.WEBSITE
+        )

--- a/lib/crewai-tools/tests/tools/stagehand_tool_test.py
+++ b/lib/crewai-tools/tests/tools/stagehand_tool_test.py
@@ -163,8 +163,14 @@ def test_navigate_command(mock_run, stagehand_tool):
         command_type="navigate",
     )
 
-    # Assertions
-    assert "https://example.com" in result
+    # Assertions — compare the full mocked result (avoid URL substring checks)
+    assert result == "Successfully navigated to https://example.com"
+    mock_run.assert_called_once_with(
+        stagehand_tool,
+        instruction="Go to example.com",
+        url="https://example.com",
+        command_type="navigate",
+    )
 
 
 @patch(

--- a/lib/crewai/tests/llms/test_tool_call_streaming.py
+++ b/lib/crewai/tests/llms/test_tool_call_streaming.py
@@ -38,18 +38,33 @@ def get_temperature_tool_schema() -> dict[str, Any]:
 
 @pytest.fixture
 def mock_emit() -> MagicMock:
-    """Mock the event bus emit function."""
-    from crewai.events.event_bus import CrewAIEventsBus
+    """Mock the singleton event bus emit used by LLM providers.
 
-    with patch.object(CrewAIEventsBus, "emit") as mock:
-        yield mock
+    Patch the singleton instance (not only the class) so a leftover
+    instance-level ``emit`` from other tests cannot shadow the mock.
+    """
+    from crewai.events.event_bus import CrewAIEventsBus, crewai_event_bus
+
+    with (
+        patch.object(CrewAIEventsBus, "emit") as class_mock,
+        patch.object(crewai_event_bus, "emit", new=class_mock),
+    ):
+        yield class_mock
+
+
+def _event_from_emit_call(call: Any) -> Any:
+    """Return the event argument from an emit mock call."""
+    event = call.kwargs.get("event")
+    if event is None and len(call.args) >= 2:
+        event = call.args[1]
+    return event
 
 
 def get_tool_call_events(mock_emit: MagicMock) -> list[LLMStreamChunkEvent]:
     """Extract tool call streaming events from mock emit calls."""
     tool_call_events = []
     for call in mock_emit.call_args_list:
-        event = call[1].get("event") if len(call) > 1 else None
+        event = _event_from_emit_call(call)
         if isinstance(event, LLMStreamChunkEvent) and event.call_type == LLMCallType.TOOL_CALL:
             tool_call_events.append(event)
     return tool_call_events
@@ -59,7 +74,7 @@ def get_all_stream_events(mock_emit: MagicMock) -> list[LLMStreamChunkEvent]:
     """Extract all streaming events from mock emit calls."""
     stream_events = []
     for call in mock_emit.call_args_list:
-        event = call[1].get("event") if len(call) > 1 else None
+        event = _event_from_emit_call(call)
         if isinstance(event, LLMStreamChunkEvent):
             stream_events.append(event)
     return stream_events


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes open CodeQL `py/incomplete-url-substring-sanitization` findings that still match on `main`, and unblocks CI flakes in tool-call streaming tests.

### CodeQL fixes

1. **`DataTypes.from_content`** (`lib/crewai-tools/src/crewai_tools/rag/data_types.py`)
   - Replace `"github.com" in url.netloc` with hostname checks via `urlparse`.
2. **Stagehand navigate test** (`lib/crewai-tools/tests/tools/stagehand_tool_test.py`)
   - Replace URL substring assertion with exact mocked-result equality.
3. **Tests** for real vs spoofed GitHub hostnames.

### CI flake fix

`tests/llms/test_tool_call_streaming.py` failed in CI with empty tool-call event lists (unrelated to the CodeQL changes). The emit mock only patched `CrewAIEventsBus.emit` on the class, which can be shadowed by an instance-level `crewai_event_bus.emit`. The fixture now patches both, and event extraction reads kwargs/args explicitly.

## Validation

- Local CodeQL Incomplete URL substring sanitization: **0 results**
- `pytest lib/crewai-tools/tests/rag/test_data_types.py`: **4 passed**
- `GITHUB_ACTIONS=true pytest lib/crewai/tests/llms/test_tool_call_streaming.py`: **8 passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54462d24-3d91-49d5-890d-208477adc33e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54462d24-3d91-49d5-890d-208477adc33e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

