### PR TITLE
chore(ci): group uv patch/minor Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which 
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -8,9 +5,22 @@ updates:
   - package-ecosystem: uv
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
     groups:
       security-updates:
         applies-to: security-updates
         patterns:
           - "*"
+      patch-minor-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - patch
+          - minor
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Add a patch-minor-updates group for routine version bumps while keeping the existing security-updates grouping. Ignore sever-major updates so breaking upgrades stay manual.