### PR TITLE
feat(cli): unify scaffolding under `crewai create <resource>`

### DIFF
--- a/docs/edge/en/concepts/cli.mdx
+++ b/docs/edge/en/concepts/cli.mdx
@@ -36,23 +36,72 @@ crewai [COMMAND] [OPTIONS] [ARGUMENTS]
 
 ### 1. Create
 
-Create a new crew or flow.
+Create a new crew, flow, tool, skill, or template project.
 
 ```shell Terminal
 crewai create [OPTIONS] TYPE NAME
 ```
 
-- `TYPE`: Choose between "crew" or "flow"
-- `NAME`: Name of the crew or flow
+- `TYPE`: `crew`, `flow`, `tool`, `skill`, or `template`
+- `NAME`: Name of the project, tool handle, skill, or template
 
-Example:
+#### Crew
 
 ```shell Terminal
 crewai create crew my_new_crew
-crewai create flow my_new_flow
+crewai create crew my_new_crew --classic
 ```
 
 By default, `crewai create crew` creates a JSON-first crew project with `crew.jsonc` and `agents/*.jsonc`. Use `crewai create crew my_new_crew --classic` only when you want the older Python/YAML scaffold with `crew.py`, `config/agents.yaml`, and `config/tasks.yaml`.
+
+#### Flow
+
+```shell Terminal
+crewai create flow my_new_flow
+crewai create flow my_new_flow --declarative
+```
+
+#### Tool
+
+Scaffold a custom tool repository:
+
+```shell Terminal
+crewai create tool my_tool
+```
+
+#### Skill
+
+Scaffold an agent skill. Inside a crew project (where `pyproject.toml` exists), the skill is created under `./skills/`:
+
+```shell Terminal
+crewai create skill my-skill
+crewai create skill my-skill --no-project
+```
+
+Use `--no-project` to create the skill in the current directory instead of `./skills/`.
+
+#### Template
+
+Add a remote project template to the current directory:
+
+```shell Terminal
+crewai create template my-template
+crewai create template my-template --output-dir custom_dir
+```
+
+Use `--output-dir` to override the output folder name (defaults to the template name).
+
+#### Deprecated create aliases
+
+These older commands still work but print a yellow deprecation warning. Prefer the `crewai create <type>` forms above.
+
+| Deprecated | Use instead |
+| :--- | :--- |
+| `crewai tool create <handle>` | `crewai create tool <handle>` |
+| `crewai skill create <name>` | `crewai create skill <name>` |
+| `crewai template add <name>` | `crewai create template <name>` |
+
+Lifecycle commands are unchanged — for example `crewai tool install`, `crewai skill publish`, and `crewai template list` stay under their resource groups.
 
 ### 2. Version
 

--- a/docs/edge/en/concepts/skills.mdx
+++ b/docs/edge/en/concepts/skills.mdx
@@ -32,10 +32,10 @@ You often need **both**: skills for expertise, tools for action. They are config
 The CLI is the supported way to create a skill — it scaffolds the directory layout and a valid `SKILL.md` for you:
 
 ```shell Terminal
-crewai skill create code-review
+crewai create skill code-review
 ```
 
-Inside a crew project (where `pyproject.toml` lives) this creates `./skills/code-review/`; outside a project it creates `./code-review/` in the current directory (you can force that behavior with `--no-project`):
+Inside a crew project (where `pyproject.toml` lives) this creates `./skills/code-review/`; outside a project it creates `./code-review/` in the current directory (you can force that behavior with `--no-project` on `crewai create skill`):
 
 ```
 skills/
@@ -178,12 +178,16 @@ agent = Agent(
 
 ## Creating, Publishing, and Installing Skills
 
-Skills have a full lifecycle managed by the CLI: **create them with `crewai skill create`, publish them with `crewai skill publish`** — hand-rolling directories works for local experiments, but the CLI is the intended workflow and keeps your skill layout and frontmatter valid.
+Skills have a full lifecycle managed by the CLI: **create them with `crewai create skill`, publish them with `crewai skill publish`** — hand-rolling directories works for local experiments, but the CLI is the intended workflow and keeps your skill layout and frontmatter valid.
+
+<Note>
+  `crewai skill create` is deprecated and still works with a warning. Use `crewai create skill` instead.
+</Note>
 
 ### Create
 
 ```shell Terminal
-crewai skill create my-skill
+crewai create skill my-skill
 ```
 
 Scaffolds the directory (into `./skills/` inside a crew project) with a template `SKILL.md`, plus empty `scripts/`, `references/`, and `assets/` directories. Edit `SKILL.md` to define the instructions.

--- a/docs/edge/en/guides/coding-tools/agents-md.mdx
+++ b/docs/edge/en/guides/coding-tools/agents-md.mdx
@@ -21,8 +21,12 @@ crewai create crew my_crew
 crewai create flow my_flow
 
 # Tool repository
-crewai tool create my_tool
+crewai create tool my_tool
 ```
+
+<Note>
+  `crewai tool create` is deprecated and still works with a warning. Use `crewai create tool` instead.
+</Note>
 
 ## Tool Setup: Point Assistants to AGENTS.md
 

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -19,6 +19,7 @@ from crewai_cli.utils import (
     enable_prompt_line_editing,
     is_dmn_mode_enabled,
     read_toml,
+    warn_deprecated_command,
 )
 
 
@@ -137,7 +138,10 @@ def uv(uv_args: tuple[str, ...]) -> None:
 
 @crewai.command()
 @click.argument(
-    "type", required=False, default=None, type=click.Choice(["crew", "flow"])
+    "type",
+    required=False,
+    default=None,
+    type=click.Choice(["crew", "flow", "tool"]),
 )
 @click.argument("name", required=False, default=None)
 @click.option("--provider", type=str, help="The provider to use for the crew")
@@ -160,7 +164,7 @@ def create(
     classic: bool = False,
     declarative: bool = False,
 ) -> None:
-    """Create a new crew, or flow."""
+    """Create a new crew, flow, or tool."""
     dmn_mode = is_dmn_mode_enabled()
     if not type:
         if dmn_mode:
@@ -191,7 +195,15 @@ def create(
         )
     if dmn_mode:
         skip_provider = True
-    if type == "crew":
+    if type == "tool":
+        if declarative or classic or provider is not None or skip_provider:
+            raise click.UsageError(
+                "Crew and flow options cannot be used with tool projects."
+            )
+        from crewai_cli.tools.main import ToolCommand
+
+        ToolCommand().create(name)
+    elif type == "crew":
         if declarative:
             raise click.UsageError("--declarative can only be used with flow projects")
         if classic:
@@ -207,7 +219,7 @@ def create(
 
         create_flow(name, declarative=declarative)
     else:
-        click.secho("Error: Invalid type. Must be 'crew' or 'flow'.", fg="red")
+        click.secho("Error: Invalid type. Must be 'crew', 'flow', or 'tool'.", fg="red")
 
 
 @crewai.command()
@@ -652,6 +664,8 @@ def tool() -> None:
 @tool.command(name="create")
 @click.argument("handle")
 def tool_create(handle: str) -> None:
+    """[Deprecated: use `crewai create tool`] Create a custom tool project."""
+    warn_deprecated_command(old="crewai tool create", new="crewai create tool")
     from crewai_cli.tools.main import ToolCommand
 
     tool_cmd = ToolCommand()

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -141,7 +141,7 @@ def uv(uv_args: tuple[str, ...]) -> None:
     "type",
     required=False,
     default=None,
-    type=click.Choice(["crew", "flow", "tool", "skill"]),
+    type=click.Choice(["crew", "flow", "tool", "skill", "template"]),
 )
 @click.argument("name", required=False, default=None)
 @click.option("--provider", type=str, help="The provider to use for the crew")
@@ -164,6 +164,13 @@ def uv(uv_args: tuple[str, ...]) -> None:
     flag_value=False,
     help="Skill only: create in current dir instead of ./skills/",
 )
+@click.option(
+    "-o",
+    "--output-dir",
+    type=str,
+    default=None,
+    help="Template only: directory name for the template (defaults to template name)",
+)
 def create(
     type: str | None,
     name: str | None,
@@ -172,8 +179,9 @@ def create(
     classic: bool = False,
     declarative: bool = False,
     in_project: bool = True,
+    output_dir: str | None = None,
 ) -> None:
-    """Create a new crew, flow, tool, or skill."""
+    """Create a new crew, flow, tool, skill, or template."""
     dmn_mode = is_dmn_mode_enabled()
     if not type:
         if dmn_mode:
@@ -206,6 +214,8 @@ def create(
         skip_provider = True
     if not in_project and type != "skill":
         raise click.UsageError("--no-project can only be used with skill projects.")
+    if output_dir is not None and type != "template":
+        raise click.UsageError("--output-dir can only be used with template projects.")
     if type == "tool":
         if declarative or classic or provider is not None or skip_provider:
             raise click.UsageError(
@@ -222,6 +232,13 @@ def create(
         from crewai_cli.skills.main import SkillCommand
 
         SkillCommand().create(name, in_project=in_project)
+    elif type == "template":
+        if declarative or classic or provider is not None or skip_provider:
+            raise click.UsageError(
+                "Crew and flow options cannot be used with template projects."
+            )
+        template_cmd = TemplateCommand()
+        template_cmd.add_template(name, output_dir)
     elif type == "crew":
         if declarative:
             raise click.UsageError("--declarative can only be used with flow projects")
@@ -239,7 +256,7 @@ def create(
         create_flow(name, declarative=declarative)
     else:
         click.secho(
-            "Error: Invalid type. Must be 'crew', 'flow', 'tool', or 'skill'.",
+            "Error: Invalid type. Must be 'crew', 'flow', 'tool', 'skill', or 'template'.",
             fg="red",
         )
 
@@ -803,7 +820,8 @@ def template_list() -> None:
     help="Directory name for the template (defaults to template name)",
 )
 def template_add(name: str, output_dir: str | None) -> None:
-    """Add a template to the current directory."""
+    """[Deprecated: use `crewai create template`] Add a template to the current directory."""
+    warn_deprecated_command(old="crewai template add", new="crewai create template")
     template_cmd = TemplateCommand()
     template_cmd.add_template(name, output_dir)
 

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -214,7 +214,7 @@ def create(
             click.style(f"  Name of your {type}", fg="cyan", bold=True),
             prompt_suffix=click.style(" › ", fg="bright_white"),  # noqa: RUF001
         )
-    if dmn_mode:
+    if dmn_mode and type == "crew":
         skip_provider = True
     if not in_project and type != "skill":
         raise click.UsageError("--no-project can only be used with skill projects.")

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -141,7 +141,7 @@ def uv(uv_args: tuple[str, ...]) -> None:
     "type",
     required=False,
     default=None,
-    type=click.Choice(["crew", "flow", "tool"]),
+    type=click.Choice(["crew", "flow", "tool", "skill"]),
 )
 @click.argument("name", required=False, default=None)
 @click.option("--provider", type=str, help="The provider to use for the crew")
@@ -156,6 +156,14 @@ def uv(uv_args: tuple[str, ...]) -> None:
     is_flag=True,
     help="Create a declarative Flow project instead of a Python Flow project",
 )
+@click.option(
+    "--no-project",
+    "in_project",
+    is_flag=True,
+    default=True,
+    flag_value=False,
+    help="Skill only: create in current dir instead of ./skills/",
+)
 def create(
     type: str | None,
     name: str | None,
@@ -163,8 +171,9 @@ def create(
     skip_provider: bool = False,
     classic: bool = False,
     declarative: bool = False,
+    in_project: bool = True,
 ) -> None:
-    """Create a new crew, flow, or tool."""
+    """Create a new crew, flow, tool, or skill."""
     dmn_mode = is_dmn_mode_enabled()
     if not type:
         if dmn_mode:
@@ -195,6 +204,8 @@ def create(
         )
     if dmn_mode:
         skip_provider = True
+    if not in_project and type != "skill":
+        raise click.UsageError("--no-project can only be used with skill projects.")
     if type == "tool":
         if declarative or classic or provider is not None or skip_provider:
             raise click.UsageError(
@@ -203,6 +214,14 @@ def create(
         from crewai_cli.tools.main import ToolCommand
 
         ToolCommand().create(name)
+    elif type == "skill":
+        if declarative or classic or provider is not None or skip_provider:
+            raise click.UsageError(
+                "Crew and flow options cannot be used with skill projects."
+            )
+        from crewai_cli.skills.main import SkillCommand
+
+        SkillCommand().create(name, in_project=in_project)
     elif type == "crew":
         if declarative:
             raise click.UsageError("--declarative can only be used with flow projects")
@@ -219,7 +238,10 @@ def create(
 
         create_flow(name, declarative=declarative)
     else:
-        click.secho("Error: Invalid type. Must be 'crew', 'flow', or 'tool'.", fg="red")
+        click.secho(
+            "Error: Invalid type. Must be 'crew', 'flow', 'tool', or 'skill'.",
+            fg="red",
+        )
 
 
 @crewai.command()
@@ -716,6 +738,8 @@ def skill() -> None:
     help="Create skill in current dir instead of ./skills/",
 )
 def skill_create(name: str, in_project: bool) -> None:
+    """[Deprecated: use `crewai create skill`] Create a new agent skill."""
+    warn_deprecated_command(old="crewai skill create", new="crewai create skill")
     from crewai_cli.skills.main import SkillCommand
 
     skill_cmd = SkillCommand()

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -187,7 +187,8 @@ def create(
         if dmn_mode:
             raise click.UsageError(
                 "TYPE is required when CREWAI_DMN is set. "
-                "Use `crewai create crew <name>` or `crewai create flow <name>`."
+                "Use `crewai create <type> <name>` where type is one of: "
+                "crew, flow, tool, skill, template."
             )
         from crewai_cli.tui_picker import pick
 
@@ -197,6 +198,9 @@ def create(
                 "flow",
                 "A deterministic workflow with full control over agents and crews",
             ),
+            ("tool", "A custom tool for the CrewAI Tool Repository"),
+            ("skill", "An agent skill with instructions and optional assets"),
+            ("template", "A remote project template from the CrewAI gallery"),
         ]
         type = pick("What would you like to create?", options)
         if type is None:

--- a/lib/cli/src/crewai_cli/utils.py
+++ b/lib/cli/src/crewai_cli/utils.py
@@ -44,8 +44,17 @@ __all__ = [
     "render_template",
     "tree_copy",
     "tree_find_and_replace",
+    "warn_deprecated_command",
     "write_env_file",
 ]
+
+
+def warn_deprecated_command(*, old: str, new: str) -> None:
+    """Print a yellow deprecation warning for a legacy CLI command path."""
+    click.secho(
+        f"Warning: The command '{old}' is deprecated. Use '{new}' instead.",
+        fg="yellow",
+    )
 
 
 console = Console()

--- a/lib/cli/tests/test_cli.py
+++ b/lib/cli/tests/test_cli.py
@@ -228,6 +228,7 @@ def test_create_requires_type_in_dmn_mode(runner):
 
     assert result.exit_code == 2
     assert "TYPE is required when CREWAI_DMN is set" in result.output
+    assert "crew, flow, tool, skill, template" in result.output
 
 
 def test_create_requires_name_in_dmn_mode(runner):

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -170,3 +170,30 @@ def test_create_crew_rejects_output_dir_flag(mock_template_command_cls, runner):
     assert result.exit_code == 2, result.output
     assert "--output-dir can only be used with template projects." in result.output
     mock_template_command_cls.return_value.add_template.assert_not_called()
+
+
+@mock.patch("crewai_cli.cli.enable_prompt_line_editing")
+@mock.patch("crewai_cli.cli.click.prompt", return_value="picked-tool")
+@mock.patch("crewai_cli.tui_picker.pick", return_value="tool")
+@mock.patch("crewai_cli.tools.main.ToolCommand")
+def test_create_picker_supports_tool_skill_and_template(
+    mock_tool_command_cls,
+    mock_pick,
+    mock_prompt,
+    mock_enable_prompt,
+    runner,
+):
+    result = runner.invoke(create, [])
+
+    assert result.exit_code == 0, result.output
+    mock_pick.assert_called_once()
+    picker_options = mock_pick.call_args[0][1]
+    assert {option[0] for option in picker_options} == {
+        "crew",
+        "flow",
+        "tool",
+        "skill",
+        "template",
+    }
+    mock_prompt.assert_called_once()
+    mock_tool_command_cls.return_value.create.assert_called_once_with("picked-tool")

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -43,3 +43,63 @@ def test_create_tool_rejects_crew_and_flow_flags(mock_tool_command_cls, runner, 
     assert result.exit_code == 2, result.output
     assert "Crew and flow options cannot be used with tool projects." in result.output
     mock_tool_command_cls.return_value.create.assert_not_called()
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+def test_create_skill_invokes_skill_command(mock_skill_command_cls, runner):
+    result = runner.invoke(create, ["skill", "my-skill"])
+
+    assert result.exit_code == 0, result.output
+    mock_skill_command_cls.return_value.create.assert_called_once_with(
+        "my-skill", in_project=True
+    )
+    assert "deprecated" not in result.output.lower()
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+def test_create_skill_no_project_flag(mock_skill_command_cls, runner):
+    result = runner.invoke(create, ["skill", "my-skill", "--no-project"])
+
+    assert result.exit_code == 0, result.output
+    mock_skill_command_cls.return_value.create.assert_called_once_with(
+        "my-skill", in_project=False
+    )
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+def test_skill_create_is_deprecated_and_still_works(mock_skill_command_cls, runner):
+    result = runner.invoke(crewai, ["skill", "create", "my-skill"])
+
+    assert result.exit_code == 0, result.output
+    mock_skill_command_cls.return_value.create.assert_called_once_with(
+        "my-skill", in_project=True
+    )
+    assert (
+        "Warning: The command 'crewai skill create' is deprecated. "
+        "Use 'crewai create skill' instead."
+        in result.output
+    )
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+@pytest.mark.parametrize(
+    "extra_args",
+    [["--classic"], ["--declarative"], ["--provider", "openai"], ["--skip_provider"]],
+)
+def test_create_skill_rejects_crew_and_flow_flags(
+    mock_skill_command_cls, runner, extra_args
+):
+    result = runner.invoke(create, ["skill", "my-skill", *extra_args])
+
+    assert result.exit_code == 2, result.output
+    assert "Crew and flow options cannot be used with skill projects." in result.output
+    mock_skill_command_cls.return_value.create.assert_not_called()
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+def test_create_crew_rejects_no_project_flag(mock_skill_command_cls, runner):
+    result = runner.invoke(create, ["crew", "my-crew", "--no-project"])
+
+    assert result.exit_code == 2, result.output
+    assert "--no-project can only be used with skill projects." in result.output
+    mock_skill_command_cls.return_value.create.assert_not_called()

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -103,3 +103,70 @@ def test_create_crew_rejects_no_project_flag(mock_skill_command_cls, runner):
     assert result.exit_code == 2, result.output
     assert "--no-project can only be used with skill projects." in result.output
     mock_skill_command_cls.return_value.create.assert_not_called()
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+def test_create_template_invokes_template_command(mock_template_command_cls, runner):
+    result = runner.invoke(create, ["template", "my-template"])
+
+    assert result.exit_code == 0, result.output
+    mock_template_command_cls.return_value.add_template.assert_called_once_with(
+        "my-template", None
+    )
+    assert "deprecated" not in result.output.lower()
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+def test_create_template_output_dir_flag(mock_template_command_cls, runner):
+    result = runner.invoke(
+        create, ["template", "my-template", "--output-dir", "custom_dir"]
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_template_command_cls.return_value.add_template.assert_called_once_with(
+        "my-template", "custom_dir"
+    )
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+def test_template_add_is_deprecated_and_still_works(mock_template_command_cls, runner):
+    result = runner.invoke(
+        crewai, ["template", "add", "my-template", "--output-dir", "custom_dir"]
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_template_command_cls.return_value.add_template.assert_called_once_with(
+        "my-template", "custom_dir"
+    )
+    assert (
+        "Warning: The command 'crewai template add' is deprecated. "
+        "Use 'crewai create template' instead."
+        in result.output
+    )
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+@pytest.mark.parametrize(
+    "extra_args",
+    [["--classic"], ["--declarative"], ["--provider", "openai"], ["--skip_provider"]],
+)
+def test_create_template_rejects_crew_and_flow_flags(
+    mock_template_command_cls, runner, extra_args
+):
+    result = runner.invoke(create, ["template", "my-template", *extra_args])
+
+    assert result.exit_code == 2, result.output
+    assert (
+        "Crew and flow options cannot be used with template projects."
+        in result.output
+    )
+    mock_template_command_cls.return_value.add_template.assert_not_called()
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+def test_create_crew_rejects_output_dir_flag(mock_template_command_cls, runner):
+    result = runner.invoke(create, ["crew", "my-crew", "--output-dir", "custom_dir"])
+
+    assert result.exit_code == 2, result.output
+    assert "--output-dir can only be used with template projects." in result.output
+    mock_template_command_cls.return_value.add_template.assert_not_called()

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -220,7 +220,7 @@ def test_create_skill_works_in_dmn_mode(mock_skill_command_cls, runner):
     )
 
 
-@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+@mock.patch("crewai_cli.cli.TemplateCommand")
 def test_create_template_works_in_dmn_mode(mock_template_command_cls, runner):
     result = runner.invoke(create, ["template", "my-template"], env=_DMN_ENV)
 

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -1,0 +1,45 @@
+"""Tests for unified `crewai create <resource>` scaffolding commands."""
+
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from crewai_cli.cli import create, crewai
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@mock.patch("crewai_cli.tools.main.ToolCommand")
+def test_create_tool_invokes_tool_command(mock_tool_command_cls, runner):
+    result = runner.invoke(create, ["tool", "my_tool"])
+
+    assert result.exit_code == 0, result.output
+    mock_tool_command_cls.return_value.create.assert_called_once_with("my_tool")
+    assert "deprecated" not in result.output.lower()
+
+
+@mock.patch("crewai_cli.tools.main.ToolCommand")
+def test_tool_create_is_deprecated_and_still_works(mock_tool_command_cls, runner):
+    result = runner.invoke(crewai, ["tool", "create", "my_tool"])
+
+    assert result.exit_code == 0, result.output
+    mock_tool_command_cls.return_value.create.assert_called_once_with("my_tool")
+    assert (
+        "Warning: The command 'crewai tool create' is deprecated. "
+        "Use 'crewai create tool' instead."
+        in result.output
+    )
+
+
+@mock.patch("crewai_cli.tools.main.ToolCommand")
+@pytest.mark.parametrize("extra_args", [["--classic"], ["--declarative"], ["--provider", "openai"], ["--skip_provider"]])
+def test_create_tool_rejects_crew_and_flow_flags(mock_tool_command_cls, runner, extra_args):
+    result = runner.invoke(create, ["tool", "my_tool", *extra_args])
+
+    assert result.exit_code == 2, result.output
+    assert "Crew and flow options cannot be used with tool projects." in result.output
+    mock_tool_command_cls.return_value.create.assert_not_called()

--- a/lib/cli/tests/test_create_unified.py
+++ b/lib/cli/tests/test_create_unified.py
@@ -197,3 +197,34 @@ def test_create_picker_supports_tool_skill_and_template(
     }
     mock_prompt.assert_called_once()
     mock_tool_command_cls.return_value.create.assert_called_once_with("picked-tool")
+
+
+_DMN_ENV = {"CREWAI_DMN": "True"}
+
+
+@mock.patch("crewai_cli.tools.main.ToolCommand")
+def test_create_tool_works_in_dmn_mode(mock_tool_command_cls, runner):
+    result = runner.invoke(create, ["tool", "my_tool"], env=_DMN_ENV)
+
+    assert result.exit_code == 0, result.output
+    mock_tool_command_cls.return_value.create.assert_called_once_with("my_tool")
+
+
+@mock.patch("crewai_cli.skills.main.SkillCommand")
+def test_create_skill_works_in_dmn_mode(mock_skill_command_cls, runner):
+    result = runner.invoke(create, ["skill", "my-skill"], env=_DMN_ENV)
+
+    assert result.exit_code == 0, result.output
+    mock_skill_command_cls.return_value.create.assert_called_once_with(
+        "my-skill", in_project=True
+    )
+
+
+@mock.patch("crewai_cli.remote_template.main.TemplateCommand")
+def test_create_template_works_in_dmn_mode(mock_template_command_cls, runner):
+    result = runner.invoke(create, ["template", "my-template"], env=_DMN_ENV)
+
+    assert result.exit_code == 0, result.output
+    mock_template_command_cls.return_value.add_template.assert_called_once_with(
+        "my-template", None
+    )


### PR DESCRIPTION
## Summary

Unifies CLI scaffolding commands under the existing `crewai create <resource>` pattern. All old commands remain working and print a yellow deprecation warning pointing to the new canonical path. No breaking changes.

### Command changes

| Deprecated (still works + warns) | New canonical command |
|----------------------------------|----------------------|
| `crewai tool create <handle>` | `crewai create tool <handle>` |
| `crewai skill create <name> [--no-project]` | `crewai create skill <name> [--no-project]` |
| `crewai template add <name> [-o OUTPUT_DIR]` | `crewai create template <name> [-o OUTPUT_DIR]` |

### Unchanged (already canonical or intentionally left as-is)

| Command | Status |
|---------|--------|
| `crewai create crew <name> [--classic] [--provider ...]` | Already canonical |
| `crewai create flow <name> [--declarative]` | Already canonical |
| `crewai tool install\|publish` | Unchanged (lifecycle) |
| `crewai skill install\|publish\|list` | Unchanged (lifecycle) |
| `crewai template list` | Unchanged (lifecycle) |
| `crewai flow add-crew` | Out of scope for this PR |

### Other UX updates

- **Interactive picker**: bare `crewai create` now offers crew, flow, tool, skill, and template
- **CREWAI_DMN error**: missing `TYPE` now lists all supported types (`crew`, `flow`, `tool`, `skill`, `template`)
- **Docs**: updated `docs/edge/en/concepts/cli.mdx`, `skills.mdx`, and `agents-md.mdx`

### Deprecation warning format

```text
Warning: The command 'crewai tool create' is deprecated. Use 'crewai create tool' instead.
```

## Test plan

- [x] `uv run pytest lib/cli/tests/test_create_unified.py -q` (23 tests)
- [x] `uv run pytest lib/cli/tests/test_cli.py -q -k create`
- [x] `uv run pytest lib/cli/tests/skills/test_cli_commands.py -q`
- [ ] Manual: `crewai create tool my_tool` scaffolds a tool project
- [ ] Manual: `crewai tool create my_tool` prints deprecation warning and still works
- [ ] Manual: same check for skill and template deprecated aliases