### PR TITLE
ci: report required test check names on non-code PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,11 +122,25 @@ jobs:
             .venv
           key: uv-main-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
 
+  # Report the required check names (tests 3.10–3.13) when the matrix is skipped.
+  # Branch protection expects these names; a skipped matrix never reports them.
+  tests-skip:
+    name: tests (${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: Skip non-code change
+        run: echo "Non-code change, skipping tests"
+
   # Summary job to provide single status for branch protection
   tests:
     name: tests
     runs-on: ubuntu-latest
-    needs: [changes, tests-matrix]
+    needs: [changes, tests-matrix, tests-skip]
     if: always()
     steps:
       - name: Check results

--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -76,11 +76,25 @@ jobs:
             .venv
           key: uv-main-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
 
+  # Report the required check names when the matrix is skipped.
+  # Branch protection expects these names; a skipped matrix never reports them.
+  type-checker-skip:
+    name: type-checker (${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Skip non-code change
+        run: echo "Non-code change, skipping type checks"
+
   # Summary job to provide single status for branch protection
   type-checker:
     name: type-checker
     runs-on: ubuntu-latest
-    needs: [changes, type-checker-matrix]
+    needs: [changes, type-checker-matrix, type-checker-skip]
     if: always()
     steps:
       - name: Check results


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Skipped matrix jobs never post status for branch-protection check names like `tests (3.10)`. On Actions-only / docs-only PRs those required checks hang forever as "Expected — Waiting for status to be reported."

- Add lightweight `tests-skip` and `type-checker-skip` jobs that use the same names (`tests (3.10)`–`tests (3.13)`, etc.) and succeed when `code != true`
- Wire them into the summary jobs so non-code PRs still get a green required status without running the Python matrix

Follow-up to #6818.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56b40363-13e7-452d-8bb7-c4150ec7c1bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56b40363-13e7-452d-8bb7-c4150ec7c1bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

