### PR TITLE
fix(llm): infer native provider from name patterns for unprefixed models

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -659,6 +659,17 @@ class LLM(BaseLLM):
         if model in AZURE_MODELS:
             return "azure"
 
+        # Models absent from the constants lists (new releases, "latest"
+        # aliases) still fall back to provider naming patterns, as this
+        # method's docstring describes and the sibling
+        # _validate_model_in_constants already does. Only providers whose
+        # prefixes are unambiguous are checked here; bedrock ("." in name)
+        # and azure (gpt-/o-series) patterns overlap other providers and are
+        # left to the explicit-provider path.
+        for provider in ("anthropic", "gemini"):
+            if cls._matches_provider_pattern(model, provider):
+                return provider
+
         return "openai"
 
     @classmethod

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -662,13 +662,17 @@ class LLM(BaseLLM):
         # Models absent from the constants lists (new releases, "latest"
         # aliases) still fall back to provider naming patterns, as this
         # method's docstring describes and the sibling
-        # _validate_model_in_constants already does. Only providers whose
-        # prefixes are unambiguous are checked here; bedrock ("." in name)
-        # and azure (gpt-/o-series) patterns overlap other providers and are
-        # left to the explicit-provider path.
-        for provider in ("anthropic", "gemini"):
-            if cls._matches_provider_pattern(model, provider):
-                return provider
+        # _validate_model_in_constants already does. bedrock ("." in name)
+        # and azure (gpt-/o-series) patterns overlap other providers, so
+        # they are left to the explicit-provider path.
+        # Only unambiguous prefixes fall through here: the "anthropic."
+        # prefix that _matches_provider_pattern also accepts is Bedrock's
+        # namespaced form and stays on the explicit "bedrock/" path.
+        if model.lower().startswith("claude-"):
+            return "anthropic"
+
+        if cls._matches_provider_pattern(model, "gemini"):
+            return "gemini"
 
         return "openai"
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -974,6 +974,30 @@ def test_validate_model_in_constants():
         is True
     )
 
+
+def test_infer_provider_from_model_falls_back_to_patterns():
+    """Unprefixed models not in the constants lists still infer their provider
+    from naming patterns, matching this method's docstring and the behavior of
+    _validate_model_in_constants.
+
+    Regression test for #6813: a bare ``claude-*`` id offered by
+    ``crewai create`` (e.g. ``claude-sonnet-4-6``) is not in ANTHROPIC_MODELS,
+    so it fell through to the ``"openai"`` default and built the wrong client.
+    """
+    # In-constants ids keep resolving exactly as before.
+    assert LLM._infer_provider_from_model("gpt-4o") == "openai"
+    assert LLM._infer_provider_from_model("claude-opus-4-0") == "anthropic"
+    assert LLM._infer_provider_from_model("gemini-2.5-pro") == "gemini"
+
+    # Not in constants but matching a provider pattern -> correct provider.
+    assert LLM._infer_provider_from_model("claude-sonnet-4-6") == "anthropic"
+    assert LLM._infer_provider_from_model("claude-future-5") == "anthropic"
+    assert LLM._infer_provider_from_model("gemma-3-latest") == "gemini"
+
+    # No pattern match still defaults to openai.
+    assert LLM._infer_provider_from_model("unknown-model") == "openai"
+
+
 @pytest.mark.vcr(record_mode="once",decode_compressed_response=True)
 def test_usage_info_non_streaming_with_call():
     llm = LLM(model="gpt-4o-mini", is_litellm=True)

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -994,6 +994,15 @@ def test_infer_provider_from_model_falls_back_to_patterns():
     assert LLM._infer_provider_from_model("claude-future-5") == "anthropic"
     assert LLM._infer_provider_from_model("gemma-3-latest") == "gemini"
 
+    # Bedrock's namespaced ids also match the "anthropic." prefix pattern, so
+    # they are deliberately left out of the fallback and keep resolving
+    # exactly as before -- they belong on the explicit "bedrock/" path.
+    assert (
+        LLM._infer_provider_from_model("anthropic.claude-opus-4-1-20250805-v1:0")
+        == "bedrock"
+    )
+    assert LLM._infer_provider_from_model("anthropic.claude-future-v1:0") == "openai"
+
     # No pattern match still defaults to openai.
     assert LLM._infer_provider_from_model("unknown-model") == "openai"
 


### PR DESCRIPTION
## What

`LLM._infer_provider_from_model` checked only the hardcoded constants lists (`OPENAI_MODELS`, `ANTHROPIC_MODELS`, …) and then defaulted to `"openai"`. Its docstring promises a pattern-matching fallback:

> This method first checks the hardcoded constants list for known models. If not found, it uses pattern matching to infer the provider from model name patterns.

…but no pattern matching ever ran. The sibling `_validate_model_in_constants` already falls through to `_matches_provider_pattern`; this method never did.

## Impact

A bare Anthropic id that is not yet in `ANTHROPIC_MODELS` — e.g. `claude-sonnet-4-6`, offered near the top of the `crewai create` Anthropic menu — was inferred as `"openai"`, so `LLM(model="claude-sonnet-4-6")` silently constructed an `OpenAICompletion` instead of `AnthropicCompletion`, with no error.

## Fix

Fall through to `_matches_provider_pattern` for the providers whose prefixes are unambiguous (`anthropic`, `gemini`) before defaulting to `openai`. `bedrock` (`"." in name`) and `azure` (gpt-/o-series) are intentionally excluded here because their patterns overlap other providers and would reroute models that currently resolve to openai; those remain on the explicit-provider path. Models already present in the constants lists are unaffected (they return before the new fallback).

## Test

Adds `test_infer_provider_from_model_falls_back_to_patterns`, mirroring the existing `test_validate_model_in_constants`: in-constants ids keep resolving as before, `claude-sonnet-4-6` / `claude-future-5` / `gemma-3-latest` now resolve to their real provider, and a non-matching id still defaults to `openai`.

Fixes #6813

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->