### PR TITLE
feat(tools): add OutageDeck status tool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -123,6 +123,10 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outagedeck_status_tool import (
+    OutageDeckStatusInput,
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -289,6 +293,8 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusInput",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -123,6 +123,10 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outagedeck_status_tool import (
+    OutageDeckStatusInput,
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -290,6 +294,8 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusInput",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -113,6 +113,10 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outagedeck_status_tool import (
+    OutageDeckStatusInput,
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -273,6 +277,8 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusInput",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -113,6 +113,10 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outagedeck_status_tool import (
+    OutageDeckStatusInput,
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -274,6 +278,8 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusInput",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/README.md
@@ -1,0 +1,32 @@
+# OutageDeck Status Tool
+
+`OutageDeckStatusTool` lets a CrewAI agent check current infrastructure-provider status, incidents, and individual service health without an API key.
+
+```python
+from crewai_tools import OutageDeckStatusTool
+
+tool = OutageDeckStatusTool()
+
+provider = tool.run(operation="provider_status", slug="github")
+active_incidents = tool.run(
+    operation="list_incidents",
+    provider="github",
+    state="active",
+    limit=10,
+)
+service = tool.run(operation="service_status", slug="github-actions")
+```
+
+The tool returns JSON with a stable `success` flag. Successful results include normalized status or incident data and a live OutageDeck URL. Failures return `{"success":false,"error":"..."}`.
+
+Supported operations:
+
+| Operation | Required input | Optional input |
+| --- | --- | --- |
+| `provider_status` | `slug` | — |
+| `list_incidents` | — | `provider`, `state`, `severity`, `page`, `limit` |
+| `service_status` | `slug` | — |
+
+Provider and service slugs use lowercase letters, numbers, and single hyphens. Incident state is `active` or `resolved`; severity is `minor`, `major`, `critical`, or `maintenance`.
+
+The API is read-only for these operations and the tool fixes requests to OutageDeck's production HTTPS origin. See the [OutageDeck API documentation](https://outagedeck.com/docs/api?utm_source=crewai&utm_medium=integration&utm_campaign=crewai_tool) for the underlying response contract and anonymous rate limit.

--- a/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/README.md
@@ -29,4 +29,4 @@ Supported operations:
 
 Provider and service slugs use lowercase letters, numbers, and single hyphens. Incident state is `active` or `resolved`; severity is `minor`, `major`, `critical`, or `maintenance`.
 
-The API is read-only for these operations and the tool fixes requests to OutageDeck's production HTTPS origin. See the [OutageDeck API documentation](https://outagedeck.com/docs/api?utm_source=crewai&utm_medium=integration&utm_campaign=crewai_tool) for the underlying response contract and anonymous rate limit.
+The API is read-only for these operations and the tool fixes requests to OutageDeck's production HTTPS origin. See the [OutageDeck API documentation](https://outagedeck.com/developers/api?utm_source=crewai&utm_medium=integration&utm_campaign=crewai_tool) for the underlying response contract and anonymous rate limit.

--- a/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/__init__.py
@@ -1,0 +1,7 @@
+from crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool import (
+    OutageDeckStatusInput,
+    OutageDeckStatusTool,
+)
+
+
+__all__ = ["OutageDeckStatusInput", "OutageDeckStatusTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/outagedeck_status_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/outagedeck_status_tool.py
@@ -1,0 +1,391 @@
+"""CrewAI tool for current provider and service status from OutageDeck."""
+
+import asyncio
+import json
+import re
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, field_validator, model_validator
+import requests
+from typing_extensions import Self
+
+from crewai_tools.security.safe_requests import safe_get
+
+
+OutageDeckOperation = Literal["provider_status", "list_incidents", "service_status"]
+IncidentState = Literal["active", "resolved"]
+IncidentSeverity = Literal["minor", "major", "critical", "maintenance"]
+
+_API_BASE_URL = "https://outagedeck.com/api/v1"
+_SITE_BASE_URL = "https://outagedeck.com"
+_USER_AGENT = "CrewAI-OutageDeck/1.0"
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_ATTRIBUTION = {
+    "utm_source": "crewai",
+    "utm_medium": "integration",
+    "utm_campaign": "crewai_tool",
+}
+
+
+class OutageDeckStatusInput(BaseModel):
+    """Input for OutageDeckStatusTool."""
+
+    operation: OutageDeckOperation = Field(
+        description=(
+            "Operation to run: provider_status, list_incidents, or service_status."
+        )
+    )
+    slug: str | None = Field(
+        default=None,
+        description=(
+            "Provider or service slug required by provider_status and service_status, "
+            "for example github or github-actions."
+        ),
+    )
+    provider: str | None = Field(
+        default=None,
+        description="Optional provider slug filter for list_incidents.",
+    )
+    state: IncidentState | None = Field(
+        default=None,
+        description="Optional incident lifecycle filter: active or resolved.",
+    )
+    severity: IncidentSeverity | None = Field(
+        default=None,
+        description="Optional severity filter: minor, major, critical, or maintenance.",
+    )
+    page: int = Field(
+        default=1,
+        ge=1,
+        description="1-based incident result page.",
+    )
+    limit: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description="Incidents per page from 1 through 100.",
+    )
+
+    @field_validator("slug", "provider")
+    @classmethod
+    def validate_slug(cls, value: str | None) -> str | None:
+        """Normalize a slug and reject values that could alter an API path."""
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not _SLUG_PATTERN.fullmatch(normalized):
+            raise ValueError(
+                "slugs must contain only lowercase letters, numbers, and single hyphens"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def require_operation_slug(self) -> Self:
+        """Require a path slug for operations that address one resource."""
+        if (
+            self.operation in {"provider_status", "service_status"}
+            and self.slug is None
+        ):
+            raise ValueError(f"slug is required for {self.operation}")
+        return self
+
+
+class OutageDeckStatusTool(BaseTool):
+    """Check live infrastructure status and incidents through OutageDeck.
+
+    OutageDeck normalizes provider status feeds into a public, read-only API.
+    This tool requires no API key and uses a fixed production origin.
+    """
+
+    name: str = "OutageDeck Status"
+    description: str = (
+        "Check current infrastructure-provider and service status with OutageDeck. "
+        "Use provider_status with a provider slug such as github or openai; "
+        "use list_incidents for active or historical incidents with optional provider, "
+        "state, and severity filters; use service_status with a service slug such as "
+        "github-actions or openai-api. The tool is read-only and requires no API key."
+    )
+    args_schema: type[BaseModel] = OutageDeckStatusInput
+    timeout: int = Field(
+        default=20,
+        gt=0,
+        le=120,
+        description="HTTP request timeout in seconds.",
+    )
+
+    def _run(
+        self,
+        operation: OutageDeckOperation,
+        slug: str | None = None,
+        provider: str | None = None,
+        state: IncidentState | None = None,
+        severity: IncidentSeverity | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> str:
+        """Run one OutageDeck status operation and return structured JSON."""
+        request = OutageDeckStatusInput(
+            operation=operation,
+            slug=slug,
+            provider=provider,
+            state=state,
+            severity=severity,
+            page=page,
+            limit=limit,
+        )
+        return self._execute(request)
+
+    async def _arun(
+        self,
+        operation: OutageDeckOperation,
+        slug: str | None = None,
+        provider: str | None = None,
+        state: IncidentState | None = None,
+        severity: IncidentSeverity | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> str:
+        """Run one OutageDeck status operation without blocking the event loop."""
+        request = OutageDeckStatusInput(
+            operation=operation,
+            slug=slug,
+            provider=provider,
+            state=state,
+            severity=severity,
+            page=page,
+            limit=limit,
+        )
+        return await asyncio.to_thread(self._execute, request)
+
+    def _execute(self, request: OutageDeckStatusInput) -> str:
+        url, params, resource = self._request_details(request)
+        try:
+            response = safe_get(
+                url,
+                params=params,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": _USER_AGENT,
+                },
+                timeout=self.timeout,
+                max_redirects=0,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as error:
+            return self._failure(self._http_error(error, resource))
+        except requests.RequestException as error:
+            return self._failure(f"Could not reach OutageDeck: {error}")
+        except ValueError as error:
+            return self._failure(f"OutageDeck request rejected: {error}")
+
+        try:
+            parsed = self._parse_response(request.operation, response.json())
+        except ValueError as error:
+            return self._failure(f"OutageDeck returned invalid JSON: {error}")
+        if "error" in parsed:
+            return self._failure(str(parsed["error"]))
+        return self._success(parsed)
+
+    @staticmethod
+    def _request_details(
+        request: OutageDeckStatusInput,
+    ) -> tuple[str, dict[str, str | int], str]:
+        if request.operation == "provider_status":
+            return (
+                f"{_API_BASE_URL}/providers/{request.slug}",
+                {},
+                f"provider '{request.slug}'",
+            )
+        if request.operation == "service_status":
+            return (
+                f"{_API_BASE_URL}/services/{request.slug}",
+                {},
+                f"service '{request.slug}'",
+            )
+
+        params: dict[str, str | int] = {
+            "page": request.page,
+            "limit": request.limit,
+        }
+        if request.provider is not None:
+            params["provider"] = request.provider
+        if request.state is not None:
+            params["state"] = request.state
+        if request.severity is not None:
+            params["severity"] = request.severity
+        return f"{_API_BASE_URL}/incidents", params, "the requested incidents"
+
+    @classmethod
+    def _parse_response(
+        cls, operation: OutageDeckOperation, payload: Any
+    ) -> dict[str, Any]:
+        if operation == "provider_status":
+            return cls._parse_provider(payload)
+        if operation == "service_status":
+            return cls._parse_service(payload)
+        return cls._parse_incidents(payload)
+
+    @staticmethod
+    def _data(payload: Any) -> dict[str, Any] | None:
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        return data if isinstance(data, dict) else None
+
+    @classmethod
+    def _parse_provider(cls, payload: Any) -> dict[str, Any]:
+        data = cls._data(payload)
+        if data is None:
+            return {"error": "OutageDeck returned an unexpected provider response."}
+        status = data.get("currentStatus")
+        slug = data.get("slug")
+        if not isinstance(status, dict) or not isinstance(slug, str):
+            return {"error": "OutageDeck returned an unexpected provider response."}
+
+        services = data.get("services")
+        incidents = data.get("activeIncidents")
+        return {
+            "operation": "provider_status",
+            "provider": {"slug": slug, "name": data.get("name")},
+            "status": {
+                "code": status.get("code"),
+                "label": status.get("label"),
+                "headline": status.get("headline"),
+                "summary": status.get("summary"),
+                "captured_at": status.get("capturedAt"),
+            },
+            "counts": data.get("counts")
+            if isinstance(data.get("counts"), dict)
+            else {},
+            "services": [
+                {
+                    "slug": service.get("slug"),
+                    "name": service.get("name"),
+                    "category": service.get("category"),
+                    "status": service.get("status"),
+                    "summary": service.get("summary"),
+                }
+                for service in services
+                if isinstance(service, dict)
+            ]
+            if isinstance(services, list)
+            else [],
+            "active_incidents": cls._normalized_incidents(incidents, limit=10),
+            "outagedeck_url": cls._attributed_url(f"/providers/{slug}"),
+        }
+
+    @classmethod
+    def _parse_incidents(cls, payload: Any) -> dict[str, Any]:
+        data = cls._data(payload)
+        if data is None or not isinstance(data.get("incidents"), list):
+            return {"error": "OutageDeck returned an unexpected incident response."}
+        incidents = cls._normalized_incidents(data["incidents"])
+        return {
+            "operation": "list_incidents",
+            "count": data.get("count", len(incidents)),
+            "page": data.get("page"),
+            "total_pages": data.get("totalPages"),
+            "total_incidents": data.get("totalIncidents"),
+            "incidents": incidents,
+            "outagedeck_url": cls._attributed_url("/incidents"),
+        }
+
+    @classmethod
+    def _parse_service(cls, payload: Any) -> dict[str, Any]:
+        data = cls._data(payload)
+        if data is None:
+            return {"error": "OutageDeck returned an unexpected service response."}
+        slug = data.get("slug")
+        provider = data.get("provider")
+        if not isinstance(slug, str) or not isinstance(provider, dict):
+            return {"error": "OutageDeck returned an unexpected service response."}
+        return {
+            "operation": "service_status",
+            "service": {
+                "slug": slug,
+                "name": data.get("name"),
+                "category": data.get("category"),
+                "status": data.get("status"),
+                "summary": data.get("summary"),
+            },
+            "provider": {"slug": provider.get("slug"), "name": provider.get("name")},
+            "counts": data.get("counts")
+            if isinstance(data.get("counts"), dict)
+            else {},
+            "recent_incidents": cls._normalized_incidents(
+                data.get("incidents"), limit=10
+            ),
+            "outagedeck_url": cls._attributed_url(f"/services/{slug}"),
+        }
+
+    @classmethod
+    def _normalized_incidents(
+        cls, incidents: Any, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        if not isinstance(incidents, list):
+            return []
+        normalized = [
+            incident
+            for item in incidents
+            if (incident := cls._incident(item)) is not None
+        ]
+        return normalized[:limit] if limit is not None else normalized
+
+    @classmethod
+    def _incident(cls, incident: Any) -> dict[str, Any] | None:
+        if not isinstance(incident, dict):
+            return None
+        provider = incident.get("provider")
+        affected = incident.get("affectedServices")
+        slug = incident.get("slug")
+        result = {
+            "slug": slug,
+            "title": incident.get("title"),
+            "summary": incident.get("summary"),
+            "status": incident.get("status"),
+            "severity": incident.get("severity"),
+            "started_at": incident.get("startedAt"),
+            "updated_at": incident.get("updatedAt"),
+            "resolved_at": incident.get("resolvedAt"),
+            "provider": {
+                "slug": provider.get("slug"),
+                "name": provider.get("name"),
+            }
+            if isinstance(provider, dict)
+            else None,
+            "affected_services": [
+                {"slug": service.get("slug"), "name": service.get("name")}
+                for service in affected
+                if isinstance(service, dict)
+            ]
+            if isinstance(affected, list)
+            else [],
+        }
+        if isinstance(slug, str) and _SLUG_PATTERN.fullmatch(slug):
+            result["outagedeck_url"] = cls._attributed_url(f"/incidents/{slug}")
+        return result
+
+    @staticmethod
+    def _attributed_url(path: str) -> str:
+        return f"{_SITE_BASE_URL}{path}?{urlencode(_ATTRIBUTION)}"
+
+    @staticmethod
+    def _http_error(error: requests.HTTPError, resource: str) -> str:
+        status = error.response.status_code if error.response is not None else None
+        if status == 404:
+            return f"OutageDeck could not find {resource}."
+        if status == 429:
+            return "OutageDeck rate limit exceeded. Try again later."
+        if status in {401, 403}:
+            return "OutageDeck rejected the request."
+        return f"OutageDeck API error: HTTP {status or 'unknown'}."
+
+    @staticmethod
+    def _success(result: dict[str, Any]) -> str:
+        return json.dumps({"success": True, **result}, separators=(",", ":"))
+
+    @staticmethod
+    def _failure(message: str) -> str:
+        return json.dumps({"success": False, "error": message}, separators=(",", ":"))

--- a/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/outagedeck_status_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/outagedeck_status_tool/outagedeck_status_tool.py
@@ -160,6 +160,7 @@ class OutageDeckStatusTool(BaseTool):
         return await asyncio.to_thread(self._execute, request)
 
     def _execute(self, request: OutageDeckStatusInput) -> str:
+        """Execute a validated request and serialize a stable result envelope."""
         url, params, resource = self._request_details(request)
         try:
             response = safe_get(
@@ -192,6 +193,7 @@ class OutageDeckStatusTool(BaseTool):
     def _request_details(
         request: OutageDeckStatusInput,
     ) -> tuple[str, dict[str, str | int], str]:
+        """Map an operation to its fixed endpoint, query, and error context."""
         if request.operation == "provider_status":
             return (
                 f"{_API_BASE_URL}/providers/{request.slug}",
@@ -221,6 +223,7 @@ class OutageDeckStatusTool(BaseTool):
     def _parse_response(
         cls, operation: OutageDeckOperation, payload: Any
     ) -> dict[str, Any]:
+        """Dispatch an API payload to the matching response normalizer."""
         if operation == "provider_status":
             return cls._parse_provider(payload)
         if operation == "service_status":
@@ -229,6 +232,7 @@ class OutageDeckStatusTool(BaseTool):
 
     @staticmethod
     def _data(payload: Any) -> dict[str, Any] | None:
+        """Return the response data object when its shape is valid."""
         if not isinstance(payload, dict):
             return None
         data = payload.get("data")
@@ -236,6 +240,7 @@ class OutageDeckStatusTool(BaseTool):
 
     @classmethod
     def _parse_provider(cls, payload: Any) -> dict[str, Any]:
+        """Normalize one provider response for agent consumption."""
         data = cls._data(payload)
         if data is None:
             return {"error": "OutageDeck returned an unexpected provider response."}
@@ -278,6 +283,7 @@ class OutageDeckStatusTool(BaseTool):
 
     @classmethod
     def _parse_incidents(cls, payload: Any) -> dict[str, Any]:
+        """Normalize a paginated incident-list response."""
         data = cls._data(payload)
         if data is None or not isinstance(data.get("incidents"), list):
             return {"error": "OutageDeck returned an unexpected incident response."}
@@ -294,6 +300,7 @@ class OutageDeckStatusTool(BaseTool):
 
     @classmethod
     def _parse_service(cls, payload: Any) -> dict[str, Any]:
+        """Normalize one service response with bounded incident context."""
         data = cls._data(payload)
         if data is None:
             return {"error": "OutageDeck returned an unexpected service response."}
@@ -324,6 +331,7 @@ class OutageDeckStatusTool(BaseTool):
     def _normalized_incidents(
         cls, incidents: Any, limit: int | None = None
     ) -> list[dict[str, Any]]:
+        """Normalize valid incident objects and apply an optional result cap."""
         if not isinstance(incidents, list):
             return []
         normalized = [
@@ -335,6 +343,7 @@ class OutageDeckStatusTool(BaseTool):
 
     @classmethod
     def _incident(cls, incident: Any) -> dict[str, Any] | None:
+        """Normalize one incident object or reject an invalid value."""
         if not isinstance(incident, dict):
             return None
         provider = incident.get("provider")
@@ -369,10 +378,12 @@ class OutageDeckStatusTool(BaseTool):
 
     @staticmethod
     def _attributed_url(path: str) -> str:
+        """Build a campaign-attributed OutageDeck page URL."""
         return f"{_SITE_BASE_URL}{path}?{urlencode(_ATTRIBUTION)}"
 
     @staticmethod
     def _http_error(error: requests.HTTPError, resource: str) -> str:
+        """Translate an HTTP failure into a concise, non-sensitive message."""
         status = error.response.status_code if error.response is not None else None
         if status == 404:
             return f"OutageDeck could not find {resource}."
@@ -384,8 +395,10 @@ class OutageDeckStatusTool(BaseTool):
 
     @staticmethod
     def _success(result: dict[str, Any]) -> str:
+        """Serialize a successful tool result as compact JSON."""
         return json.dumps({"success": True, **result}, separators=(",", ":"))
 
     @staticmethod
     def _failure(message: str) -> str:
+        """Serialize a failed tool result as compact JSON."""
         return json.dumps({"success": False, "error": message}, separators=(",", ":"))

--- a/lib/crewai-tools/tests/tools/outagedeck_status_tool_test.py
+++ b/lib/crewai-tools/tests/tools/outagedeck_status_tool_test.py
@@ -1,0 +1,282 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from crewai_tools.tools.outagedeck_status_tool import OutageDeckStatusTool
+
+
+@pytest.fixture
+def tool() -> OutageDeckStatusTool:
+    return OutageDeckStatusTool(timeout=7)
+
+
+def response(payload: object) -> Mock:
+    result = Mock()
+    result.json.return_value = payload
+    result.raise_for_status.return_value = None
+    return result
+
+
+def incident() -> dict[str, object]:
+    return {
+        "slug": "github-actions-delays-2026-08-05",
+        "title": "Actions delays",
+        "summary": "Some workflow runs are delayed.",
+        "status": "monitoring",
+        "severity": "major",
+        "startedAt": "2026-08-05T10:00:00Z",
+        "updatedAt": "2026-08-05T11:00:00Z",
+        "resolvedAt": None,
+        "provider": {"slug": "github", "name": "GitHub"},
+        "affectedServices": [{"slug": "github-actions", "name": "GitHub Actions"}],
+    }
+
+
+def provider_payload() -> dict[str, object]:
+    return {
+        "data": {
+            "slug": "github",
+            "name": "GitHub",
+            "currentStatus": {
+                "code": "degraded",
+                "label": "Degraded Performance",
+                "headline": "Some systems are degraded",
+                "summary": "GitHub reports degraded performance.",
+                "capturedAt": "2026-08-05T12:00:00Z",
+            },
+            "counts": {"services": 3, "activeIncidents": 1, "incidents": 10},
+            "services": [
+                {
+                    "slug": "github-actions",
+                    "name": "GitHub Actions",
+                    "category": "ci-cd",
+                    "status": "degraded",
+                    "summary": "Workflow execution.",
+                }
+            ],
+            "activeIncidents": [incident()],
+        }
+    }
+
+
+def service_payload() -> dict[str, object]:
+    return {
+        "data": {
+            "slug": "github-actions",
+            "name": "GitHub Actions",
+            "category": "ci-cd",
+            "status": "degraded",
+            "summary": "Workflow execution.",
+            "provider": {"slug": "github", "name": "GitHub"},
+            "counts": {"incidents": 12, "activeIncidents": 1},
+            "incidents": [incident()] * 12,
+        }
+    }
+
+
+def parsed(result: str) -> dict[str, object]:
+    value = json.loads(result)
+    assert isinstance(value, dict)
+    return value
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_provider_status_request_and_response(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.return_value = response(provider_payload())
+
+    result = parsed(tool.run(operation="provider_status", slug=" GitHub "))
+
+    mock_get.assert_called_once_with(
+        "https://outagedeck.com/api/v1/providers/github",
+        params={},
+        headers={"Accept": "application/json", "User-Agent": "CrewAI-OutageDeck/1.0"},
+        timeout=7,
+        max_redirects=0,
+    )
+    assert result["success"] is True
+    assert result["provider"] == {"slug": "github", "name": "GitHub"}
+    assert result["status"]["code"] == "degraded"
+    assert result["active_incidents"][0]["severity"] == "major"
+    assert "utm_campaign=crewai_tool" in result["outagedeck_url"]
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_incident_filters_and_pagination(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.return_value = response(
+        {
+            "data": {
+                "count": 1,
+                "page": 2,
+                "totalPages": 4,
+                "totalIncidents": 7,
+                "incidents": [incident()],
+            }
+        }
+    )
+
+    result = parsed(
+        tool.run(
+            operation="list_incidents",
+            provider=" GitHub ",
+            state="active",
+            severity="major",
+            page=2,
+            limit=5,
+        )
+    )
+
+    mock_get.assert_called_once_with(
+        "https://outagedeck.com/api/v1/incidents",
+        params={
+            "page": 2,
+            "limit": 5,
+            "provider": "github",
+            "state": "active",
+            "severity": "major",
+        },
+        headers={"Accept": "application/json", "User-Agent": "CrewAI-OutageDeck/1.0"},
+        timeout=7,
+        max_redirects=0,
+    )
+    assert result["total_pages"] == 4
+    assert result["incidents"][0]["affected_services"][0]["slug"] == "github-actions"
+    assert "utm_source=crewai" in result["incidents"][0]["outagedeck_url"]
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_service_status_caps_incident_context(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.return_value = response(service_payload())
+
+    result = parsed(tool.run(operation="service_status", slug="github-actions"))
+
+    assert result["service"]["status"] == "degraded"
+    assert result["provider"] == {"slug": "github", "name": "GitHub"}
+    assert len(result["recent_incidents"]) == 10
+    assert "utm_medium=integration" in result["outagedeck_url"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"operation": "provider_status"}, "slug is required"),
+        ({"operation": "service_status", "slug": "../admin"}, "slugs must contain"),
+        ({"operation": "provider_status", "slug": "github/status"}, "slugs must contain"),
+        ({"operation": "list_incidents", "provider": "github?limit=100"}, "slugs must contain"),
+        ({"operation": "list_incidents", "page": 0}, "greater than or equal to 1"),
+        ({"operation": "list_incidents", "limit": 101}, "less than or equal to 100"),
+        ({"operation": "list_incidents", "state": "investigating"}, "active"),
+        ({"operation": "list_incidents", "severity": "catastrophic"}, "minor"),
+    ],
+)
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_invalid_input_never_requests(
+    mock_get: Mock,
+    kwargs: dict[str, object],
+    message: str,
+    tool: OutageDeckStatusTool,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        tool.run(**kwargs)
+
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [(404, "could not find"), (429, "rate limit"), (500, "HTTP 500")],
+)
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_http_errors_return_stable_failure(
+    mock_get: Mock,
+    status: int,
+    message: str,
+    tool: OutageDeckStatusTool,
+) -> None:
+    http_response = requests.Response()
+    http_response.status_code = status
+    http_response.url = "https://outagedeck.com/api/v1/providers/missing"
+    mock_get.return_value = http_response
+
+    result = parsed(tool.run(operation="provider_status", slug="missing"))
+
+    assert result["success"] is False
+    assert message.lower() in result["error"].lower()
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_network_error_returns_stable_failure(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.side_effect = requests.ConnectTimeout("timed out")
+
+    result = parsed(tool.run(operation="list_incidents"))
+
+    assert result == {"success": False, "error": "Could not reach OutageDeck: timed out"}
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_redirect_is_rejected(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.side_effect = ValueError("Too many redirects")
+
+    result = parsed(tool.run(operation="list_incidents"))
+
+    assert result == {
+        "success": False,
+        "error": "OutageDeck request rejected: Too many redirects",
+    }
+
+
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_invalid_json_returns_stable_failure(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_response = response({})
+    mock_response.json.side_effect = ValueError("invalid document")
+    mock_get.return_value = mock_response
+
+    result = parsed(tool.run(operation="provider_status", slug="github"))
+
+    assert result == {
+        "success": False,
+        "error": "OutageDeck returned invalid JSON: invalid document",
+    }
+
+
+@pytest.mark.parametrize(
+    ("operation", "slug"),
+    [
+        ("provider_status", "github"),
+        ("list_incidents", None),
+        ("service_status", "github-actions"),
+    ],
+)
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+def test_unexpected_response_shape_is_actionable(
+    mock_get: Mock,
+    operation: str,
+    slug: str | None,
+    tool: OutageDeckStatusTool,
+) -> None:
+    mock_get.return_value = response({"data": []})
+
+    result = parsed(tool.run(operation=operation, slug=slug))
+
+    assert result["success"] is False
+    assert "unexpected" in result["error"]
+
+
+@pytest.mark.asyncio
+@patch("crewai_tools.tools.outagedeck_status_tool.outagedeck_status_tool.safe_get")
+async def test_async_execution_matches_sync(mock_get: Mock, tool: OutageDeckStatusTool) -> None:
+    mock_get.return_value = response(provider_payload())
+
+    result = parsed(await tool.arun(operation="provider_status", slug="github"))
+
+    assert result["success"] is True
+    assert result["provider"] == {"slug": "github", "name": "GitHub"}
+
+
+def test_exported_from_package() -> None:
+    from crewai_tools import OutageDeckStatusTool as ExportedTool
+    from crewai_tools.tools import OutageDeckStatusTool as ToolsExportedTool
+
+    assert ExportedTool is OutageDeckStatusTool
+    assert ToolsExportedTool is OutageDeckStatusTool

--- a/lib/crewai-tools/tests/tools/outagedeck_status_tool_test.py
+++ b/lib/crewai-tools/tests/tools/outagedeck_status_tool_test.py
@@ -151,6 +151,13 @@ def test_service_status_caps_incident_context(mock_get: Mock, tool: OutageDeckSt
 
     result = parsed(tool.run(operation="service_status", slug="github-actions"))
 
+    mock_get.assert_called_once_with(
+        "https://outagedeck.com/api/v1/services/github-actions",
+        params={},
+        headers={"Accept": "application/json", "User-Agent": "CrewAI-OutageDeck/1.0"},
+        timeout=7,
+        max_redirects=0,
+    )
     assert result["service"]["status"] == "degraded"
     assert result["provider"] == {"slug": "github", "name": "GitHub"}
     assert len(result["recent_incidents"]) == 10

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -16892,6 +16892,173 @@
       }
     },
     {
+      "description": "Check current infrastructure-provider and service status with OutageDeck. Use provider_status with a provider slug such as github or openai; use list_incidents for active or historical incidents with optional provider, state, and severity filters; use service_status with a service slug such as github-actions or openai-api. The tool is read-only and requires no API key.",
+      "env_vars": [],
+      "humanized_name": "OutageDeck Status",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Check live infrastructure status and incidents through OutageDeck.\n\nOutageDeck normalizes provider status feeds into a public, read-only API.\nThis tool requires no API key and uses a fixed production origin.",
+        "properties": {
+          "timeout": {
+            "default": 20,
+            "description": "HTTP request timeout in seconds.",
+            "exclusiveMinimum": 0,
+            "maximum": 120,
+            "title": "Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "title": "OutageDeckStatusTool",
+        "type": "object"
+      },
+      "name": "OutageDeckStatusTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for OutageDeckStatusTool.",
+        "properties": {
+          "limit": {
+            "default": 20,
+            "description": "Incidents per page from 1 through 100.",
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "operation": {
+            "description": "Operation to run: provider_status, list_incidents, or service_status.",
+            "enum": [
+              "provider_status",
+              "list_incidents",
+              "service_status"
+            ],
+            "title": "Operation",
+            "type": "string"
+          },
+          "page": {
+            "default": 1,
+            "description": "1-based incident result page.",
+            "minimum": 1,
+            "title": "Page",
+            "type": "integer"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional provider slug filter for list_incidents.",
+            "title": "Provider"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "minor",
+                  "major",
+                  "critical",
+                  "maintenance"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional severity filter: minor, major, critical, or maintenance.",
+            "title": "Severity"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider or service slug required by provider_status and service_status, for example github or github-actions.",
+            "title": "Slug"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "enum": [
+                  "active",
+                  "resolved"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional incident lifecycle filter: active or resolved.",
+            "title": "State"
+          }
+        },
+        "required": [
+          "operation"
+        ],
+        "title": "OutageDeckStatusInput",
+        "type": "object"
+      }
+    },
+    {
       "description": "Scrape Amazon product pages with Oxylabs Amazon Product Scraper",
       "env_vars": [
         {


### PR DESCRIPTION
## Summary

- add a zero-credential `OutageDeckStatusTool` to `crewai-tools`
- expose provider status, filtered incident search, and service status through one compact input schema
- provide synchronous and asynchronous execution with strict slug/filter validation, a fixed HTTPS origin, redirect rejection, bounded response context, and stable JSON result envelopes
- export the tool from the public package surface and add it to the generated tool catalog

## Why

Infrastructure status changes faster than model knowledge. This gives crews a native, read-only way to inspect current provider and service health without setting up separate vendor parsers, credentials, or an MCP adapter.

Closes #6826

## Validation

- repository pre-commit hooks on every changed Python file: Ruff, Ruff format, and mypy passed
- focused tool and catalog suite: 32 passed
- live production smoke: provider status, filtered incidents, service status, and async provider status passed
- wheel and sdist build passed; both artifacts contain the tool module and README
- broader `crewai-tools` run reached 309 passed and 2 skipped; remaining unrelated tests require optional Oxylabs/Mongo packages or an `OPENAI_API_KEY` for existing RAG fixtures

## AI-authorship disclosure

This PR and its linked issue were authored by an AI agent. GitHub does not grant outside contributors permission to apply upstream labels, so please apply the required `llm-generated` label. The same disclosure and label request are public on #6826.

