### PR TITLE
docs: update scaffold AGENTS.md for unified create CLI

### DIFF
--- a/lib/cli/src/crewai_cli/templates/AGENTS.md
+++ b/lib/cli/src/crewai_cli/templates/AGENTS.md
@@ -40,6 +40,14 @@ This ensures generated code always matches the version actually installed, not s
 - ❌ `Agent(llm=ChatOpenAI(...))` → ✅ `Agent(llm="openai/gpt-4o")` or `Agent(llm=LLM(model="..."))`
 - ❌ Passing raw OpenAI client objects → ✅ Use `crewai.LLM` wrapper
 
+### Deprecated CLI scaffolding aliases (still supported)
+
+These commands remain supported but print a yellow deprecation warning. Prefer the canonical forms:
+
+- ⚠️ `crewai tool create <handle>` → ✅ `crewai create tool <handle>`
+- ⚠️ `crewai skill create <name>` → ✅ `crewai create skill <name>`
+- ⚠️ `crewai template add <name>` → ✅ `crewai create template <name>`
+
 ### How to verify you're using current patterns:
 1. You ran the version check and docs lookup steps above before writing code
 2. All LLM references use `crewai.LLM` or string shorthand (`"openai/gpt-4o"`)
@@ -137,8 +145,26 @@ uv sync                   # Sync dependencies
 uv lock                   # Lock dependencies
 
 # Project scaffolding
-crewai create crew <name> --skip_provider   # New crew project
-crewai create flow <name> --skip_provider  # New flow project
+crewai create crew <name> --skip_provider       # New crew project
+crewai create flow <name>                       # New flow project
+crewai create tool <handle>                     # Custom tool repository
+crewai create skill <name>                      # Agent skill (./skills/ in crew projects)
+crewai create skill <name> --no-project         # Skill in current directory
+crewai create template <name>                   # Remote project template
+crewai create template <name> -o <output_dir>   # Template with custom output directory
+
+# Deprecated scaffolding aliases (still work; print a yellow warning)
+# crewai tool create <handle>  →  crewai create tool <handle>
+# crewai skill create <name>   →  crewai create skill <name>
+# crewai template add <name>   →  crewai create template <name>
+
+# Tool, skill, and template lifecycle (unchanged)
+crewai tool install <handle>
+crewai tool publish
+crewai skill install @org/name
+crewai skill publish
+crewai skill list
+crewai template list
 
 # Running
 crewai run                  # Run crew or flow (auto-detects from pyproject.toml)
@@ -1113,7 +1139,9 @@ Python >=3.10, <3.14
 ```bash
 uv tool install crewai        # Install CrewAI CLI
 uv tool list                  # Verify installation
-crewai create crew my_crew --skip_provider   # Scaffold a new project
+crewai create crew my_crew --skip_provider   # Scaffold a crew project
+crewai create tool my_tool                   # Scaffold a tool repository
+crewai create skill my_skill                 # Scaffold an agent skill
 crewai install                # Install project dependencies
 crewai run                    # Execute
 ```


### PR DESCRIPTION
## Summary

Updates the project template `AGENTS.md` (copied into new projects by `crewai create`) to document the unified scaffolding CLI from #6821.

- Documents canonical `crewai create tool`, `create skill`, and `create template` commands
- Notes deprecated aliases (`tool create`, `skill create`, `template add`) that still work with warnings
- Adds tool/skill/template lifecycle commands to the Quick Reference
- Updates "Patterns to NEVER use" and Installation examples

## Test plan

- [x] Verified markdown edits are limited to `lib/cli/src/crewai_cli/templates/AGENTS.md`
- [ ] Spot-check Quick Reference and Installation sections read correctly in preview
- [ ] After merge, run `crewai create crew test_proj` and confirm copied `AGENTS.md` includes the new commands