### PR TITLE
feat: add app metadata to platform action tools

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
@@ -50,7 +50,6 @@ class CrewAIPlatformActionTool(BaseTool):
             args_schema=args_schema,
             app=app,
         )
-        self.app = app
         self.action_name = action_name
         self.action_schema = action_schema
 

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
@@ -17,6 +17,7 @@ from crewai_tools.tools.crewai_platform_tools.misc import (
 
 
 class CrewAIPlatformActionTool(BaseTool):
+    app: str = Field(description="The integration slug for this action")
     action_name: str = Field(default="", description="The name of the action")
     action_schema: dict[str, Any] = Field(
         default_factory=dict, description="The schema of the action"
@@ -25,6 +26,7 @@ class CrewAIPlatformActionTool(BaseTool):
     def __init__(
         self,
         description: str,
+        app: str,
         action_name: str,
         action_schema: dict[str, Any],
     ):
@@ -46,7 +48,9 @@ class CrewAIPlatformActionTool(BaseTool):
             name=action_name.lower().replace(" ", "_"),
             description=description,
             args_schema=args_schema,
+            app=app,
         )
+        self.app = app
         self.action_name = action_name
         self.action_schema = action_schema
 

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
@@ -89,6 +89,7 @@ class CrewaiPlatformToolBuilder:
 
             tool = CrewAIPlatformActionTool(
                 description=description,
+                app=function_details["app"],
                 action_name=action_name,
                 action_schema=action_schema,
             )

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_action_tool.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_action_tool.py
@@ -28,6 +28,7 @@ class TestCrewAIPlatformActionToolVerify:
     def create_test_tool(self):
         return CrewAIPlatformActionTool(
             description="Test action tool",
+            app="test_app",
             action_name="test_action",
             action_schema=self.action_schema
         )

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tool_builder.py
@@ -171,6 +171,10 @@ class TestCrewaiPlatformToolBuilder(unittest.TestCase):
         tool_names = [tool.action_name for tool in tools]
         assert "create_issue" in tool_names
         assert "send_message" in tool_names
+        assert {tool.action_name: tool.app for tool in tools} == {
+            "create_issue": "github",
+            "send_message": "slack",
+        }
 
         github_tool = next((t for t in tools if t.action_name == "create_issue"), None)
         slack_tool = next((t for t in tools if t.action_name == "send_message"), None)

--- a/lib/crewai/tests/tools/test_tool_failure.py
+++ b/lib/crewai/tests/tools/test_tool_failure.py
@@ -1698,6 +1698,7 @@ class TestPlatformActionTool:
 
         return mod.CrewAIPlatformActionTool(
             description="Send a Slack message",
+            app="slack",
             action_name="slackbot_send_message",
             action_schema={
                 "function": {


### PR DESCRIPTION
Platform action tools did not carry a stable integration identity for policy matching, so AMP catalog app IDs could not be compared at evaluation time. This adds a required app slug on CrewAIPlatformActionTool and has the platform tool builder set it from each Agent.apps key.