### PR TITLE
fix(tools): stop running a failing tool twice per attempt

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -359,14 +359,11 @@ class ToolUsage:
                                 for k, v in calling.arguments.items()
                                 if k in acceptable_args
                             }
-                            result = await tool.ainvoke(
-                                input=arguments, config=fingerprint_config
-                            )
                         except Exception:
                             arguments = calling.arguments
-                            result = await tool.ainvoke(
-                                input=arguments, config=fingerprint_config
-                            )
+                        result = await tool.ainvoke(
+                            input=arguments, config=fingerprint_config
+                        )
                     else:
                         result = await tool.ainvoke(input={}, config=fingerprint_config)
 
@@ -610,14 +607,9 @@ class ToolUsage:
                                 for k, v in calling.arguments.items()
                                 if k in acceptable_args
                             }
-                            result = tool.invoke(
-                                input=arguments, config=fingerprint_config
-                            )
                         except Exception:
                             arguments = calling.arguments
-                            result = tool.invoke(
-                                input=arguments, config=fingerprint_config
-                            )
+                        result = tool.invoke(input=arguments, config=fingerprint_config)
                     else:
                         result = tool.invoke(input={}, config=fingerprint_config)
 

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -939,25 +939,7 @@ def _call(tool_name: str = "recording_tool") -> ToolCalling:
     return ToolCalling(tool_name=tool_name, arguments={"to": "user@example.com"})
 
 
-def test_failing_tool_body_runs_once_per_attempt():
-    tool, calls = _recording_tool(should_fail=True)
-
-    _tool_usage_for(tool).use(calling=_call(), tool_string="")
-
-    assert len(calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_failing_tool_body_runs_once_per_attempt_async():
-    tool, calls = _recording_tool(should_fail=True)
-
-    await _tool_usage_for(tool).ause(calling=_call(), tool_string="")
-
-    assert len(calls) == 1
-
-
-def test_unreadable_args_schema_falls_back_to_raw_arguments():
-    tool, calls = _recording_tool(should_fail=False)
+def _strip_schema_properties(tool: Any) -> None:
     original_schema = tool.args_schema
 
     class SchemaWithoutProperties:
@@ -971,7 +953,39 @@ def test_unreadable_args_schema_falls_back_to_raw_arguments():
 
     tool.args_schema = SchemaWithoutProperties()
 
+
+def test_failing_tool_body_runs_once_per_attempt():
+    tool, calls = _recording_tool(should_fail=True)
+
+    _tool_usage_for(tool, attempts=3).use(calling=_call(), tool_string="")
+
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_body_runs_once_per_attempt_async():
+    tool, calls = _recording_tool(should_fail=True)
+
+    await _tool_usage_for(tool, attempts=3).ause(calling=_call(), tool_string="")
+
+    assert len(calls) == 3
+
+
+def test_unreadable_args_schema_falls_back_to_raw_arguments():
+    tool, calls = _recording_tool(should_fail=False)
+    _strip_schema_properties(tool)
+
     _tool_usage_for(tool).use(calling=_call(), tool_string="")
+
+    assert calls == [{"to": "user@example.com"}]
+
+
+@pytest.mark.asyncio
+async def test_unreadable_args_schema_falls_back_to_raw_arguments_async():
+    tool, calls = _recording_tool(should_fail=False)
+    _strip_schema_properties(tool)
+
+    await _tool_usage_for(tool).ause(calling=_call(), tool_string="")
 
     assert calls == [{"to": "user@example.com"}]
 

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -4,6 +4,7 @@ import json
 import random
 import threading
 import time
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from crewai import Agent, Task
@@ -903,3 +904,81 @@ def test_tool_error_does_not_emit_finished_event():
     assert len(finished_events) == 0, (
         "ToolUsageFinishedEvent should NOT be emitted after ToolUsageErrorEvent"
     )
+
+
+def _recording_tool(*, should_fail: bool) -> tuple[Any, list[dict[str, Any]]]:
+    calls: list[dict[str, Any]] = []
+
+    class RecordingTool(BaseTool):
+        name: str = "recording_tool"
+        description: str = "Records each call, optionally failing afterwards."
+
+        def _run(self, to: str) -> str:
+            calls.append({"to": to})
+            if should_fail:
+                raise RuntimeError("upstream timeout after the side effect")
+            return f"sent to {to}"
+
+    return RecordingTool().to_structured_tool(), calls
+
+
+def _tool_usage_for(tool: Any, *, attempts: int = 1) -> ToolUsage:
+    tool_usage = ToolUsage(
+        tools_handler=None,
+        tools=[tool],
+        task=None,
+        function_calling_llm=None,
+        agent=None,
+        action=None,
+    )
+    tool_usage._max_parsing_attempts = attempts
+    return tool_usage
+
+
+def _call(tool_name: str = "recording_tool") -> ToolCalling:
+    return ToolCalling(tool_name=tool_name, arguments={"to": "user@example.com"})
+
+
+def test_failing_tool_body_runs_once_per_attempt():
+    tool, calls = _recording_tool(should_fail=True)
+
+    _tool_usage_for(tool).use(calling=_call(), tool_string="")
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_body_runs_once_per_attempt_async():
+    tool, calls = _recording_tool(should_fail=True)
+
+    await _tool_usage_for(tool).ause(calling=_call(), tool_string="")
+
+    assert len(calls) == 1
+
+
+def test_unreadable_args_schema_falls_back_to_raw_arguments():
+    tool, calls = _recording_tool(should_fail=False)
+    original_schema = tool.args_schema
+
+    class SchemaWithoutProperties:
+        def model_json_schema(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            schema = dict(original_schema.model_json_schema(*args, **kwargs))
+            schema.pop("properties", None)
+            return schema
+
+        def __getattr__(self, item: str) -> Any:
+            return getattr(original_schema, item)
+
+    tool.args_schema = SchemaWithoutProperties()
+
+    _tool_usage_for(tool).use(calling=_call(), tool_string="")
+
+    assert calls == [{"to": "user@example.com"}]
+
+
+def test_successful_tool_body_runs_once():
+    tool, calls = _recording_tool(should_fail=False)
+
+    _tool_usage_for(tool).use(calling=_call(), tool_string="")
+
+    assert len(calls) == 1


### PR DESCRIPTION
## Related issue

Fixes #7449

## Summary

When a tool raises, `ToolUsage` runs it twice per attempt. The `try`/`except` that guards argument filtering in `_use` and `_ause` also wraps the tool call, so an exception from the tool body lands in the fallback, which calls the tool again with the unfiltered arguments. With the default 3 attempts a failing tool runs 6 times. The extra runs are not logged or counted as attempts, so side effects (an email sent, a row written) repeat with no trace.

This moves the call out of the `try`, so the fallback only covers the schema lookup it was written for. The retry count and the raw-argument fallback are unchanged.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

Calls to a tool that always raises, through `ToolUsage.use` / `ToolUsage.ause` with default settings:

|       | `main` | this PR |
|-------|--------|---------|
| sync  | 6      | 3       |
| async | 6      | 3       |

New tests in `tests/tools/test_tool_usage.py`:
- a failing tool runs once per attempt, sync and async (both fail on `main`, pass here)
- if `args_schema` can't be read, the tool still receives the raw arguments, sync and async
- a successful tool runs once

```
uv run pytest lib/crewai/tests/       5686 passed, 43 skipped
uv run ruff check lib/crewai/src      All checks passed
uv run mypy lib/crewai/src/crewai     no issues found in 525 source files
```

## Additional context

One behavior change: when the tool body raises, the fallback no longer retries it with unfiltered arguments. That retry can't recover a missing required parameter, since `CrewStructuredTool` rejects an `args_schema` that omits one at construction. As far as I can tell it could only matter for a custom `args_schema` that leaves out an optional parameter the function reads at runtime. Happy to add a narrower recovery for that case if you want it.
