### PR TITLE
feat: add Azure Cosmos DB for NoSQL tools and memory backend

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -272,7 +272,8 @@
                           "edge/en/tools/database-data/weaviatevectorsearchtool",
                           "edge/en/tools/database-data/mongodbvectorsearchtool",
                           "edge/en/tools/database-data/singlestoresearchtool",
-                          "edge/en/tools/database-data/db2searchtool"
+                          "edge/en/tools/database-data/db2searchtool",
+                          "edge/en/tools/database-data/azurecosmosdbtool"
                         ]
                       },
                       {

--- a/docs/edge/en/concepts/memory.mdx
+++ b/docs/edge/en/concepts/memory.mdx
@@ -762,6 +762,7 @@ memory = Memory(
 ## Storage Backend
 
 - **Default**: LanceDB, stored under `./.crewai/memory` (or `$CREWAI_STORAGE_DIR/memory` if the env var is set, or the path you pass as `storage="path/to/dir"`).
+- **Azure Cosmos DB (NoSQL)**: Pass `storage="cosmosdb"` to persist memories in Azure Cosmos DB for NoSQL with vector search. Install the extra (`pip install 'crewai[cosmosdb]'`) and configure the connection via environment variables — either `AZURE_COSMOS_CONNECTION_STRING`, or `AZURE_COSMOS_HOST` together with `AZURE_COSMOS_KEY` (falling back to `DefaultAzureCredential` when no key is set). Optional overrides: `AZURE_COSMOS_DATABASE_NAME`, `AZURE_COSMOS_CONTAINER_NAME`, `AZURE_COSMOS_VECTOR_DIM`. For full control, pass a pre-built instance: `Memory(storage=CosmosDBNoSqlStorage.from_env())`.
 - **Custom backend**: Implement the `StorageBackend` protocol (see `crewai.memory.storage.backend`) and pass an instance to `Memory(storage=your_backend)`.
 
 
@@ -868,7 +869,7 @@ All configuration is passed as keyword arguments to `Memory(...)`. Every paramet
 | Parameter | Default | Description |
 | :--- | :--- | :--- |
 | `llm` | `"gpt-4o-mini"` | LLM for analysis (model name or `BaseLLM` instance). |
-| `storage` | `"lancedb"` | Storage backend (`"lancedb"`, a path string, or a `StorageBackend` instance). |
+| `storage` | `"lancedb"` | Storage backend (`"lancedb"`, `"cosmosdb"`, a path string, or a `StorageBackend` instance). |
 | `embedder` | `None` (OpenAI `text-embedding-3-large`) | Embedder (config dict, callable, or `None` for default OpenAI). |
 | `recency_weight` | `0.3` | Weight for recency in composite score. |
 | `semantic_weight` | `0.5` | Weight for semantic similarity in composite score. |

--- a/docs/edge/en/tools/database-data/azurecosmosdbtool.mdx
+++ b/docs/edge/en/tools/database-data/azurecosmosdbtool.mdx
@@ -1,0 +1,222 @@
+---
+title: 'Azure Cosmos DB (NoSQL) Tools'
+description: 'Vector, full-text, and hybrid search plus semantic caching and agent memory on Azure Cosmos DB for NoSQL'
+icon: database
+mode: "wide"
+---
+
+## Overview
+
+The Azure Cosmos DB (NoSQL) tools let your CrewAI agents use [Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/) as a vector store, a semantic cache, and a memory store. The package ships three agent-callable tools plus a native CrewAI memory backend:
+
+| Tool | Purpose |
+| ---- | ------- |
+| `AzureCosmosDBNoSqlSearchTool` | Vector, full-text, or hybrid search over a Cosmos NoSQL container |
+| `AzureCosmosDBSemanticCacheTool` | Semantic cache for LLM responses with TTL support |
+| `AzureCosmosDBMemoryTool` | CRUD over agent memory items with hierarchical partition keys |
+| `CosmosDBNoSqlStorage` | Native `Memory` storage backend (vs. an agent-callable tool) |
+
+## Installation
+
+The tools live behind an optional extra so the base install stays small:
+
+```bash
+uv add 'crewai-tools[azure-cosmosdb]'
+```
+
+This pulls in `azure-cosmos`, `azure-identity`, and `openai`. To use the native
+memory backend from the `crewai` package, install its extra instead:
+
+```bash
+uv add 'crewai[cosmosdb]'
+```
+
+## Authentication
+
+All three tools accept an account key, a connection string, **or** an
+`azure.core.credentials.TokenCredential` (e.g. `DefaultAzureCredential`):
+
+```python
+from azure.identity import DefaultAzureCredential
+
+# Any one of these auth styles works:
+#   key="<account-key>"
+#   connection_string="AccountEndpoint=...;AccountKey=...;"
+#   token_credential=DefaultAzureCredential()
+```
+
+For embeddings, set either `azure_openai_endpoint` (Azure OpenAI) or
+`openai_api_key` (standard OpenAI). The `AZURE_OPENAI_ENDPOINT`,
+`AZURE_OPENAI_API_KEY`, and `OPENAI_API_KEY` environment variables are used as
+fallbacks. You can also plug in a custom embedder that exposes
+`embed_documents` / `embed_query`.
+
+## Vector / Full-text / Hybrid Search Tool
+
+`AzureCosmosDBNoSqlSearchTool` embeds the incoming query and retrieves the most
+relevant documents from a Cosmos NoSQL container.
+
+```python
+from crewai import Agent
+from crewai_tools import AzureCosmosDBNoSqlSearchTool
+
+indexing_policy = {
+    "indexingMode": "consistent",
+    "automatic": True,
+    "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+}
+vector_embedding_policy = {
+    "vectorEmbeddings": [
+        {
+            "path": "/embedding",
+            "dataType": "float32",
+            "dimensions": 1536,
+            "distanceFunction": "cosine",
+        }
+    ]
+}
+container_properties = {"partition_key": {"paths": ["/id"], "kind": "Hash"}}
+
+search_tool = AzureCosmosDBNoSqlSearchTool(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    database_name="crewAI_database",
+    container_name="crewAI_container",
+    indexing_policy=indexing_policy,
+    vector_embedding_policy=vector_embedding_policy,
+    cosmos_container_properties=container_properties,
+    embedding_model="text-embedding-3-large",
+    dimensions=1536,
+    search_type="vector",  # see options below
+)
+
+# Ingest documents (embeds text and writes them in batches):
+search_tool.add_texts(
+    texts=["CrewAI orchestrates role-playing autonomous agents."],
+    metadatas=[{"source": "docs"}],
+)
+
+agent = Agent(
+    role="Research Assistant",
+    goal="Find relevant information in the knowledge base",
+    tools=[search_tool],
+)
+```
+
+### Search types
+
+Set `search_type` to one of:
+
+- `vector` – pure vector similarity search.
+- `vector_score_threshold` – vector search with a minimum-similarity cutoff.
+- `full_text_search` – keyword search (no embedding required).
+- `full_text_ranking` – BM25-style full-text ranking.
+- `hybrid` – Reciprocal Rank Fusion (RRF) of vector + full-text.
+- `hybrid_score_threshold` – hybrid search with a similarity cutoff.
+
+Full-text and hybrid searches require `full_text_search_enabled=True`, a
+`fullTextIndexes` entry in the indexing policy, and a `full_text_policy`.
+
+### Query configuration
+
+Pass an `AzureCosmosDBNoSqlSearchConfig` via `query_config` to control per-query
+behaviour — `max_results`, `where`, `offset_limit`, `projection_mapping`,
+`full_text_rank_filter`, `weights` (hybrid RRF), and `threshold`.
+
+```python
+from crewai_tools import AzureCosmosDBNoSqlSearchConfig
+
+search_tool.query_config = AzureCosmosDBNoSqlSearchConfig(
+    max_results=5,
+    threshold=0.75,
+)
+```
+
+You can also build the tool from a connection string with
+`AzureCosmosDBNoSqlSearchTool.from_connection_string(...)`.
+
+## Semantic Cache Tool
+
+`AzureCosmosDBSemanticCacheTool` caches LLM responses keyed by prompt
+similarity, so semantically equivalent prompts return a cached answer. Cache
+entries are namespaced per `llm_string` and can expire via `default_ttl`.
+
+```python
+from crewai_tools import (
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheConfig,
+)
+
+config = AzureCosmosDBSemanticCacheConfig(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    indexing_policy=indexing_policy,
+    vector_embedding_policy=vector_embedding_policy,
+    full_text_policy={"fullTextPaths": [{"path": "/prompt", "language": "en-US"}]},
+    similarity_threshold=0.85,
+    default_ttl=86400,          # seconds; None disables expiry
+    enable_hybrid_search=True,
+    llm_string="gpt-4o-2024-08-06",
+)
+
+cache_tool = AzureCosmosDBSemanticCacheTool(config=config)
+```
+
+Operations (passed as the `operation` argument):
+
+- `search` – look up a cached response for a `prompt`.
+- `update` – store a `prompt` / `response` pair.
+- `clear` – delete cached entries for the current `llm_string` namespace.
+
+## Agent Memory Tool
+
+`AzureCosmosDBMemoryTool` performs CRUD over memory items and supports
+[hierarchical partition keys](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys).
+
+```python
+from crewai_tools import AzureCosmosDBMemoryTool, AzureCosmosDBMemoryConfig
+
+config = AzureCosmosDBMemoryConfig(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    database_name="memory_database",
+    container_name="memory_container",
+    cosmos_container_properties={
+        "partition_key": {"paths": ["/agent_id"], "kind": "Hash"}
+    },
+    use_optimistic_concurrency=False,
+)
+
+memory_tool = AzureCosmosDBMemoryTool(config=config)
+```
+
+Operations (passed as the `operation` argument): `store`, `read`, `retrieve`,
+`update`, `delete`, and `clear`. Set `use_optimistic_concurrency=True` to guard
+updates with the document's `_etag` (surfacing a 412 on concurrent writes).
+
+## Native Memory Backend
+
+For a native CrewAI **memory backend** (as opposed to an agent-callable tool),
+use `CosmosDBNoSqlStorage`. It implements the `StorageBackend` protocol and can
+be selected by name from `Memory`:
+
+```python
+from crewai.memory.unified_memory import Memory
+
+# Reads AZURE_COSMOS_CONNECTION_STRING, or AZURE_COSMOS_HOST (+ AZURE_COSMOS_KEY,
+# else DefaultAzureCredential). Optional: AZURE_COSMOS_DATABASE_NAME,
+# AZURE_COSMOS_CONTAINER_NAME, AZURE_COSMOS_VECTOR_DIM.
+memory = Memory(storage="cosmosdb")
+
+# ...or pass a pre-configured instance for full control:
+from crewai.memory.storage.cosmosdb_nosql_storage import CosmosDBNoSqlStorage
+
+memory = Memory(storage=CosmosDBNoSqlStorage.from_env())
+```
+
+## See also
+
+- [Azure Cosmos DB NoSQL vector search](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search)
+- [Full-text and hybrid search](https://learn.microsoft.com/azure/cosmos-db/gen-ai/hybrid-search)
+- [Hierarchical partition keys](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys)
+- [Container TTL](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)

--- a/docs/edge/en/tools/database-data/overview.mdx
+++ b/docs/edge/en/tools/database-data/overview.mdx
@@ -41,6 +41,10 @@ These tools enable your agents to interact with various database systems, from t
   <Card title="SingleStore Search" icon="database" href="/en/tools/database-data/singlestoresearchtool">
     Safe SELECT/SHOW queries on SingleStore with pooling and validation.
   </Card>
+
+  <Card title="Azure Cosmos DB (NoSQL)" icon="database" href="/en/tools/database-data/azurecosmosdbtool">
+    Vector, full-text, and hybrid search plus semantic caching and agent memory on Azure Cosmos DB for NoSQL.
+  </Card>
 </CardGroup>
 
 ## **Common Use Cases**

--- a/lib/crewai-tools/README.md
+++ b/lib/crewai-tools/README.md
@@ -26,6 +26,8 @@ CrewAI provides an extensive collection of powerful tools ready to enhance your 
 - **Web Scraping**: `ScrapeWebsiteTool`, `SeleniumScrapingTool`
 - **Database Integrations**: `MySQLSearchTool`
 - **Vector Database Integrations**: `MongoDBVectorSearchTool`, `QdrantVectorSearchTool`, `WeaviateVectorSearchTool`
+- **Vector Database Integrations**: `MongoDBVectorSearchTool`, `QdrantVectorSearchTool`, `WeaviateVectorSearchTool`
+- **Azure Cosmos DB (NoSQL)**: `AzureCosmosDBNoSqlSearchTool`, `AzureCosmosDBSemanticCacheTool`, `AzureCosmosDBMemoryTool`
 - **API Integrations**: `SerperApiTool`, `ExaSearchTool`
 - **AI-powered Tools**: `DallETool`, `VisionTool`, `StagehandTool`
 

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -92,6 +92,11 @@ qdrant-client = [
 apify = [
     "langchain-apify>=0.1.2,<1.0.0",
 ]
+azure-cosmosdb = [
+    "azure-cosmos>=4.15.0",
+    "azure-identity>=1.17.0",
+    "openai>=1.30.0",
+]
 
 databricks-sdk = [
     "databricks-sdk>=0.46.0",

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -7,6 +7,21 @@ from crewai_tools.aws.bedrock.knowledge_base.retriever_tool import (
 )
 from crewai_tools.aws.s3.reader_tool import S3ReaderTool
 from crewai_tools.aws.s3.writer_tool import S3WriterTool
+from crewai_tools.azure.cosmosdb_nosql.memory_store import (
+    AzureCosmosDBMemoryConfig,
+    AzureCosmosDBMemoryTool,
+    AzureCosmosDBMemoryToolSchema,
+)
+from crewai_tools.azure.cosmosdb_nosql.semantic_cache import (
+    AzureCosmosDBSemanticCacheConfig,
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheToolSchema,
+)
+from crewai_tools.azure.cosmosdb_nosql.vector_search import (
+    AzureCosmosDBNoSqlSearchConfig,
+    AzureCosmosDBNoSqlSearchTool,
+    AzureCosmosDBNoSqlToolSchema,
+)
 from crewai_tools.tools.ai_mind_tool.ai_mind_tool import AIMindTool
 from crewai_tools.tools.apify_actors_tool.apify_actors_tool import ApifyActorsTool
 from crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool import ArxivPaperTool
@@ -228,6 +243,15 @@ __all__ = [
     "AIMindTool",
     "ApifyActorsTool",
     "ArxivPaperTool",
+    "AzureCosmosDBMemoryConfig",
+    "AzureCosmosDBMemoryTool",
+    "AzureCosmosDBMemoryToolSchema",
+    "AzureCosmosDBNoSqlSearchConfig",
+    "AzureCosmosDBNoSqlSearchTool",
+    "AzureCosmosDBNoSqlToolSchema",
+    "AzureCosmosDBSemanticCacheConfig",
+    "AzureCosmosDBSemanticCacheTool",
+    "AzureCosmosDBSemanticCacheToolSchema",
     "BedrockInvokeAgentTool",
     "BedrockKBRetrieverTool",
     "BraveImageSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/azure/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/__init__.py
@@ -1,0 +1,24 @@
+from crewai_tools.azure.cosmosdb_nosql import (
+    AzureCosmosDBMemoryConfig,
+    AzureCosmosDBMemoryTool,
+    AzureCosmosDBMemoryToolSchema,
+    AzureCosmosDBNoSqlSearchConfig,
+    AzureCosmosDBNoSqlSearchTool,
+    AzureCosmosDBNoSqlToolSchema,
+    AzureCosmosDBSemanticCacheConfig,
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheToolSchema,
+)
+
+
+__all__ = [
+    "AzureCosmosDBMemoryConfig",
+    "AzureCosmosDBMemoryTool",
+    "AzureCosmosDBMemoryToolSchema",
+    "AzureCosmosDBNoSqlSearchConfig",
+    "AzureCosmosDBNoSqlSearchTool",
+    "AzureCosmosDBNoSqlToolSchema",
+    "AzureCosmosDBSemanticCacheConfig",
+    "AzureCosmosDBSemanticCacheTool",
+    "AzureCosmosDBSemanticCacheToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/README.md
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/README.md
@@ -1,0 +1,66 @@
+# Azure CosmosDB NoSQL Tools
+
+Three CrewAI `BaseTool` integrations backed by **Azure CosmosDB for NoSQL**:
+
+| Tool | Purpose |
+| ---- | ------- |
+| `AzureCosmosDBNoSqlSearchTool` | Vector / full-text / hybrid search over a Cosmos NoSQL container |
+| `AzureCosmosDBSemanticCacheTool` | Semantic cache for LLM responses with TTL support |
+| `AzureCosmosDBMemoryTool` | CRUD over agent memory items with hierarchical partition keys |
+
+## Installation
+
+These tools live behind an optional extra so the base `crewai-tools` install
+stays small:
+
+```bash
+pip install 'crewai-tools[azure-cosmosdb]'
+```
+
+This pulls in `azure-cosmos`, `azure-identity`, and `openai`.
+
+## Authentication
+
+All three tools accept either an account key **or** an
+`azure.core.credentials.TokenCredential` (e.g. `DefaultAzureCredential`):
+
+```python
+from azure.identity import DefaultAzureCredential
+
+tool = AzureCosmosDBNoSqlSearchTool(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    token_credential=DefaultAzureCredential(),
+    indexing_policy=...,
+    cosmos_container_properties={"partition_key": {"paths": ["/agent_id"], "kind": "Hash"}},
+)
+```
+
+For embeddings, set either `azure_openai_endpoint` (Azure OpenAI) or
+`openai_api_key` (standard OpenAI). Environment variables
+`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `OPENAI_API_KEY` are
+respected as fallbacks.
+
+## See also
+
+* [Azure CosmosDB NoSQL vector search](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search)
+* [Hierarchical partition keys](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys)
+* [Container TTL](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+
+For a native CrewAI **memory backend** (vs. an agent-callable tool), see
+`crewai.memory.storage.cosmosdb_nosql_storage.CosmosDBNoSqlStorage`.
+
+It can be selected directly from `Memory`:
+
+```python
+from crewai.memory.unified_memory import Memory
+
+# Reads AZURE_COSMOS_CONNECTION_STRING, or AZURE_COSMOS_HOST (+ AZURE_COSMOS_KEY,
+# else DefaultAzureCredential). Optional: AZURE_COSMOS_DATABASE_NAME,
+# AZURE_COSMOS_CONTAINER_NAME, AZURE_COSMOS_VECTOR_DIM.
+memory = Memory(storage="cosmosdb")
+
+# ...or pass a pre-configured instance for full control:
+from crewai.memory.storage.cosmosdb_nosql_storage import CosmosDBNoSqlStorage
+
+memory = Memory(storage=CosmosDBNoSqlStorage.from_env())
+```

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/README.md
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/README.md
@@ -38,11 +38,147 @@ tool = AzureCosmosDBNoSqlSearchTool(
 For embeddings, set either `azure_openai_endpoint` (Azure OpenAI) or
 `openai_api_key` (standard OpenAI). Environment variables
 `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `OPENAI_API_KEY` are
-respected as fallbacks.
+respected as fallbacks. You can also pass a custom `embedder` exposing
+`embed_documents` / `embed_query` to bypass OpenAI entirely.
+
+## Usage
+
+### `AzureCosmosDBNoSqlSearchTool` — vector / full-text / hybrid search
+
+```python
+from crewai import Agent
+from crewai_tools import AzureCosmosDBNoSqlSearchTool, AzureCosmosDBNoSqlSearchConfig
+
+indexing_policy = {
+    "indexingMode": "consistent",
+    "automatic": True,
+    "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+}
+vector_embedding_policy = {
+    "vectorEmbeddings": [
+        {
+            "path": "/embedding",
+            "dataType": "float32",
+            "dimensions": 1536,
+            "distanceFunction": "cosine",
+        }
+    ]
+}
+
+search_tool = AzureCosmosDBNoSqlSearchTool(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    database_name="crewAI_database",
+    container_name="crewAI_container",
+    indexing_policy=indexing_policy,
+    vector_embedding_policy=vector_embedding_policy,
+    cosmos_container_properties={"partition_key": {"paths": ["/id"], "kind": "Hash"}},
+    embedding_model="text-embedding-3-large",
+    dimensions=1536,
+    search_type="vector",  # or vector_score_threshold / full_text_search /
+                           # full_text_ranking / hybrid / hybrid_score_threshold
+    query_config=AzureCosmosDBNoSqlSearchConfig(max_results=5),
+)
+
+# Ingest documents (embeds text and writes them in batches):
+search_tool.add_texts(["CrewAI orchestrates role-playing autonomous agents."])
+
+agent = Agent(
+    role="Research Assistant",
+    goal="Find relevant information in the knowledge base",
+    tools=[search_tool],
+)
+```
+
+Full-text and hybrid searches require `full_text_search_enabled=True`, a
+`fullTextIndexes` entry in the indexing policy, and a `full_text_policy`.
+
+### `AzureCosmosDBSemanticCacheTool` — semantic cache for LLM responses
+
+```python
+from crewai_tools import (
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheConfig,
+)
+
+config = AzureCosmosDBSemanticCacheConfig(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    indexing_policy=indexing_policy,
+    vector_embedding_policy=vector_embedding_policy,
+    full_text_policy={"fullTextPaths": [{"path": "/prompt", "language": "en-US"}]},
+    similarity_threshold=0.85,
+    default_ttl=86400,          # seconds; None disables expiry
+    enable_hybrid_search=True,  # set False for vector-only (no full-text policy)
+    llm_string="gpt-4o-2024-08-06",
+)
+cache_tool = AzureCosmosDBSemanticCacheTool(config=config)
+
+# operation is one of: 'search', 'update', 'clear'
+cache_tool.run(operation="update", prompt="What is CrewAI?", response="A multi-agent framework.")
+cache_tool.run(operation="search", prompt="What's CrewAI?")   # -> cache hit
+cache_tool.run(operation="clear")                              # clears this llm_string namespace
+```
+
+### `AzureCosmosDBMemoryTool` — agent memory CRUD
+
+```python
+from crewai_tools import AzureCosmosDBMemoryTool, AzureCosmosDBMemoryConfig
+
+config = AzureCosmosDBMemoryConfig(
+    cosmos_host="https://<account>.documents.azure.com:443/",
+    key="<account-key>",
+    database_name="memory_database",
+    container_name="memory_container",
+    cosmos_container_properties={
+        "partition_key": {"paths": ["/agent_id"], "kind": "Hash"}
+    },
+    use_optimistic_concurrency=False,  # True -> guard updates with the doc _etag
+)
+memory_tool = AzureCosmosDBMemoryTool(config=config)
+
+# operation is one of: 'store', 'read', 'retrieve', 'update', 'delete', 'clear'
+memory_tool.run(
+    operation="store",
+    memory_item={"id": "m-1", "agent_id": "a-1", "content": {"text": "user likes dark mode"}},
+)
+memory_tool.run(operation="read", partition_key_value="a-1", memory_id="m-1")
+memory_tool.run(operation="retrieve", partition_key_value="a-1", max_results=10)
+memory_tool.run(operation="delete", partition_key_value="a-1", memory_id="m-1")
+```
+
+Both configs also accept `connection_string` (instead of `cosmos_host` + `key`)
+and `token_credential` for AAD auth. Hierarchical partition keys are supported
+by passing multiple `paths` and list-valued `partition_key_value`.
+
+## Testing
+
+Unit tests are fully mocked (no live account or extras required) and run in CI.
+
+A separate **live integration suite**
+(`tests/tools/azure/cosmosdb_nosql/test_integration_cosmosdb.py`) exercises the
+real service end-to-end. It is **skipped unless `AZURE_COSMOS_URI` is set**, so
+CI stays hermetic. It uses a deterministic embedder, so no OpenAI key is needed.
+
+Authenticate with an account key **or** AAD/RBAC — set `AZURE_COSMOS_KEY` for
+key auth, or leave it unset to use `DefaultAzureCredential` (managed identity,
+`az login`, service-principal env vars, ...):
+
+```bash
+export AZURE_COSMOS_URI="https://<account>.documents.azure.com:443/"
+
+# Key auth:
+export AZURE_COSMOS_KEY="<account-key>"
+# ...or AAD/RBAC: leave AZURE_COSMOS_KEY unset and run `az login` first.
+
+uv run pytest lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_integration_cosmosdb.py
+```
 
 ## See also
 
 * [Azure CosmosDB NoSQL vector search](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search)
+* [Full-text search](https://learn.microsoft.com/en-us/azure/cosmos-db/gen-ai/full-text-search)
+* [Hybrid search](https://learn.microsoft.com/en-us/azure/cosmos-db/gen-ai/hybrid-search)
 * [Hierarchical partition keys](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys)
 * [Container TTL](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
 

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/__init__.py
@@ -1,0 +1,28 @@
+from crewai_tools.azure.cosmosdb_nosql.memory_store import (
+    AzureCosmosDBMemoryConfig,
+    AzureCosmosDBMemoryTool,
+    AzureCosmosDBMemoryToolSchema,
+)
+from crewai_tools.azure.cosmosdb_nosql.semantic_cache import (
+    AzureCosmosDBSemanticCacheConfig,
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheToolSchema,
+)
+from crewai_tools.azure.cosmosdb_nosql.vector_search import (
+    AzureCosmosDBNoSqlSearchConfig,
+    AzureCosmosDBNoSqlSearchTool,
+    AzureCosmosDBNoSqlToolSchema,
+)
+
+
+__all__ = [
+    "AzureCosmosDBMemoryConfig",
+    "AzureCosmosDBMemoryTool",
+    "AzureCosmosDBMemoryToolSchema",
+    "AzureCosmosDBNoSqlSearchConfig",
+    "AzureCosmosDBNoSqlSearchTool",
+    "AzureCosmosDBNoSqlToolSchema",
+    "AzureCosmosDBSemanticCacheConfig",
+    "AzureCosmosDBSemanticCacheTool",
+    "AzureCosmosDBSemanticCacheToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_client.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_client.py
@@ -1,0 +1,135 @@
+"""Shared Azure CosmosDB NoSQL client helpers.
+
+These helpers centralise the client/database/container construction logic that
+the three CosmosDB tools (vector search, semantic cache, memory store) all
+share. They also gate the optional ``azure-cosmos`` / ``azure-identity``
+dependency behind a clean lazy import so that simply importing
+``crewai_tools`` does not require the extra to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_INSTALL_HINT = (
+    "Azure CosmosDB tools require the optional 'azure-cosmosdb' extra. "
+    "Install it with: pip install 'crewai-tools[azure-cosmosdb]'"
+)
+
+
+def require_azure_cosmos() -> Any:
+    """Import and return the ``azure.cosmos`` module, with a friendly error."""
+    try:
+        import azure.cosmos  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise ImportError(_INSTALL_HINT) from exc
+    import azure.cosmos as azure_cosmos
+
+    return azure_cosmos
+
+
+def build_cosmos_client(
+    cosmos_host: str | None = None,
+    key: str | None = None,
+    token_credential: Any | None = None,
+    user_agent: str = "Crew-AI-CDBNoSql-Python",
+    *,
+    connection_string: str | None = None,
+) -> Any:
+    """Construct a CosmosClient from a key, credential or connection string.
+
+    Exactly one auth source must be supplied. ``connection_string`` is
+    preferred when set; otherwise either ``key`` (with ``cosmos_host``) or
+    ``token_credential`` (with ``cosmos_host``) is used.
+    """
+    azure_cosmos = require_azure_cosmos()
+
+    sources = sum(
+        1 for src in (key, token_credential, connection_string) if src is not None
+    )
+    if sources == 0:
+        raise ValueError(
+            "Provide one of 'key', 'token_credential' or 'connection_string'."
+        )
+    if sources > 1:
+        raise ValueError(
+            "Provide only one of 'key', 'token_credential' or 'connection_string'."
+        )
+
+    if connection_string is not None:
+        return azure_cosmos.CosmosClient.from_connection_string(
+            connection_string, user_agent=user_agent
+        )
+    if not cosmos_host:
+        raise ValueError(
+            "'cosmos_host' is required when authenticating with a key or token "
+            "credential."
+        )
+    if key is not None:
+        return azure_cosmos.CosmosClient(cosmos_host, key, user_agent=user_agent)
+    return azure_cosmos.CosmosClient(
+        cosmos_host, token_credential, user_agent=user_agent
+    )
+
+
+def close_cosmos_client(client: Any) -> None:
+    """Best-effort close of a CosmosClient; safe to call multiple times."""
+    if client is None:
+        return
+    try:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    except Exception:  # pragma: no cover - defensive cleanup  # noqa: S110
+        pass
+
+
+def create_database_if_not_exists(
+    cosmos_client: Any,
+    database_name: str,
+    database_properties: dict[str, Any] | None = None,
+) -> Any:
+    """Create the database if it does not already exist."""
+    props = database_properties or {}
+    return cosmos_client.create_database_if_not_exists(
+        id=database_name,
+        offer_throughput=props.get("offer_throughput"),
+        session_token=props.get("session_token"),
+        initial_headers=props.get("initial_headers"),
+        etag=props.get("etag"),
+        match_condition=props.get("match_condition"),
+    )
+
+
+def create_container_if_not_exists(
+    database: Any,
+    container_name: str,
+    container_properties: dict[str, Any],
+    indexing_policy: dict[str, Any] | None = None,
+    vector_embedding_policy: dict[str, Any] | None = None,
+    full_text_policy: dict[str, Any] | None = None,
+    default_ttl: int | None = None,
+) -> Any:
+    """Create the container if it does not already exist."""
+    return database.create_container_if_not_exists(
+        id=container_name,
+        partition_key=container_properties["partition_key"],
+        indexing_policy=indexing_policy,
+        vector_embedding_policy=vector_embedding_policy,
+        full_text_policy=full_text_policy,
+        default_ttl=default_ttl
+        if default_ttl is not None
+        else container_properties.get("default_ttl"),
+        offer_throughput=container_properties.get("offer_throughput"),
+        unique_key_policy=container_properties.get("unique_key_policy"),
+        conflict_resolution_policy=container_properties.get(
+            "conflict_resolution_policy"
+        ),
+        analytical_storage_ttl=container_properties.get("analytical_storage_ttl"),
+        computed_properties=container_properties.get("computed_properties"),
+        etag=container_properties.get("etag"),
+        match_condition=container_properties.get("match_condition"),
+        session_token=container_properties.get("session_token"),
+        initial_headers=container_properties.get("initial_headers"),
+    )

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_embeddings.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_embeddings.py
@@ -1,0 +1,126 @@
+"""Shared embedding helpers for the Azure CosmosDB NoSQL tools.
+
+Wraps the OpenAI / AzureOpenAI clients so the tools can keep their
+construction code small and the optional ``openai`` dependency stays lazy.
+Also accepts any object satisfying the
+:class:`crewai_tools.azure.cosmosdb_nosql._utils.EmbedderProtocol` so callers
+can plug in their own embedder (HuggingFace, Bedrock, etc.) without taking
+``openai`` as a hard dependency.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+
+_INSTALL_HINT = (
+    "Embedding generation requires the 'openai' package. "
+    "Install it with: pip install openai"
+)
+
+
+def _require_openai() -> Any:
+    try:
+        import openai
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise ImportError(_INSTALL_HINT) from exc
+    import openai
+
+    return openai
+
+
+def build_openai_client(
+    azure_openai_endpoint: str | None = None,
+    openai_api_key: str | None = None,
+    azure_api_version: str = "2024-02-01",
+) -> Any:
+    """Build either an ``AzureOpenAI`` or ``OpenAI`` client.
+
+    Selection rules (mirrors what the three tools used independently before):
+
+    * if ``azure_openai_endpoint`` is provided, use ``AzureOpenAI`` with the
+      supplied API key (falling back to ``AZURE_OPENAI_API_KEY``).
+    * else if ``AZURE_OPENAI_ENDPOINT`` is set in the environment, use
+      ``AzureOpenAI`` with default settings (and the env-derived API key).
+    * else use the standard ``OpenAI`` client (key from ``openai_api_key`` or
+      ``OPENAI_API_KEY``).
+    """
+    openai = _require_openai()
+
+    if azure_openai_endpoint:
+        return openai.AzureOpenAI(
+            azure_endpoint=azure_openai_endpoint,
+            api_key=openai_api_key or os.environ.get("AZURE_OPENAI_API_KEY"),
+            api_version=azure_api_version,
+        )
+    if "AZURE_OPENAI_ENDPOINT" in os.environ:
+        return openai.AzureOpenAI(
+            api_key=openai_api_key or os.environ.get("AZURE_OPENAI_API_KEY"),
+            api_version=azure_api_version,
+        )
+    api_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "Either an Azure OpenAI endpoint or an OpenAI API key must be "
+            "provided (set 'azure_openai_endpoint', 'openai_api_key', or the "
+            "AZURE_OPENAI_ENDPOINT / OPENAI_API_KEY environment variables)."
+        )
+    return openai.OpenAI(api_key=api_key)
+
+
+def embed_texts(
+    client: Any,
+    texts: list[str],
+    model: str,
+    dimensions: int,
+    *,
+    max_attempts: int = 4,
+    initial_backoff: float = 0.5,
+) -> list[list[float]]:
+    """Embed a list of texts via the given client and return the vectors.
+
+    Retries on transient failures from the OpenAI / AzureOpenAI clients
+    (``RateLimitError`` and ``APIConnectionError``) with exponential backoff.
+    """
+    try:
+        from openai import APIConnectionError, RateLimitError
+
+        retryable_errors: tuple[type[BaseException], ...] = (
+            RateLimitError,
+            APIConnectionError,
+        )
+    except ImportError:  # pragma: no cover - extras not installed
+        retryable_errors = ()
+
+    backoff = initial_backoff
+    for attempt in range(max_attempts):
+        try:
+            response = client.embeddings.create(
+                input=texts,
+                model=model,
+                dimensions=dimensions,
+            )
+            return [item.embedding for item in response.data]
+        except retryable_errors:  # noqa: PERF203
+            if attempt == max_attempts - 1:
+                raise
+            time.sleep(backoff)
+            backoff = min(backoff * 2, 8.0)
+    raise RuntimeError(
+        "embed_texts retry loop exited without result"
+    )  # pragma: no cover
+
+
+def embed_texts_via_embedder(
+    embedder: Any,
+    texts: list[str],
+) -> list[list[float]]:
+    """Call a langchain-compatible embedder (``embed_documents``)."""
+    if not hasattr(embedder, "embed_documents"):
+        raise TypeError(
+            "Custom embedder must expose an 'embed_documents(texts)' method"
+        )
+    result: list[list[float]] = embedder.embed_documents(texts)
+    return result

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_utils.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/_utils.py
@@ -1,0 +1,236 @@
+"""Shared utilities for the Azure CosmosDB NoSQL tools.
+
+Contains the safety primitives (SQL identifier validation, value quoting,
+distance-aware score thresholding) and small algorithms (Max Marginal
+Relevance) that the three tools and the storage backend share. Lifted from
+the equivalent helpers in ``langchain-azure``'s
+``libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_utils.py`` and
+``_vectorstore.py`` (BSD-3-Clause), simplified for crewAI's needs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+import enum
+import functools
+import re
+import time
+from typing import Any, Protocol, TypeVar
+
+
+# ---------------------------------------------------------------------------
+# Distance strategies
+# ---------------------------------------------------------------------------
+
+
+class DistanceStrategy(str, enum.Enum):
+    """Vector distance strategies supported by Cosmos NoSQL."""
+
+    COSINE = "cosine"
+    DOT_PRODUCT = "dotproduct"
+    EUCLIDEAN = "euclidean"
+
+    @classmethod
+    def from_str(cls, value: str | None) -> DistanceStrategy:
+        if not value:
+            return cls.COSINE
+        norm = value.replace("_", "").replace("-", "").lower()
+        for member in cls:
+            if member.value.replace("_", "").lower() == norm:
+                return member
+        return cls.COSINE
+
+
+def score_threshold_passes(
+    score: float,
+    threshold: float | None,
+    distance_function: str | DistanceStrategy = DistanceStrategy.COSINE,
+) -> bool:
+    """Return True if ``score`` satisfies ``threshold`` for the distance fn.
+
+    Cosmos NoSQL ``VectorDistance`` returns:
+
+    * For ``cosine`` / ``dotproduct``: a similarity-like score where higher is
+      better (Cosmos rescales these so larger == more similar).
+    * For ``euclidean``: an actual distance where lower == more similar.
+
+    A ``threshold`` of ``None`` always passes.
+    """
+    if threshold is None:
+        return True
+    strategy = (
+        distance_function
+        if isinstance(distance_function, DistanceStrategy)
+        else DistanceStrategy.from_str(distance_function)
+    )
+    if strategy is DistanceStrategy.EUCLIDEAN:
+        return score <= threshold
+    return score >= threshold
+
+
+# ---------------------------------------------------------------------------
+# SQL identifier / literal safety
+# ---------------------------------------------------------------------------
+
+
+# Cosmos NoSQL SQL reserved words (subset that matters for identifier safety).
+# Mirrors the list maintained by the langchain-azure project; kept here so we
+# do not introduce a runtime dep on langchain.
+_SQL_RESERVED_WORDS: frozenset[str] = frozenset(
+    {
+        "select",
+        "from",
+        "where",
+        "and",
+        "or",
+        "not",
+        "in",
+        "like",
+        "between",
+        "is",
+        "null",
+        "true",
+        "false",
+        "order",
+        "by",
+        "group",
+        "having",
+        "join",
+        "inner",
+        "outer",
+        "left",
+        "right",
+        "on",
+        "as",
+        "case",
+        "when",
+        "then",
+        "else",
+        "end",
+        "exists",
+        "value",
+        "distinct",
+        "top",
+        "offset",
+        "limit",
+        "asc",
+        "desc",
+        "rank",
+    }
+)
+
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def validate_sql_identifier(value: str, *, name: str = "identifier") -> str:
+    """Validate that ``value`` is safe to splice into a Cosmos SQL query.
+
+    Rejects empty strings, reserved keywords and anything containing characters
+    other than ``[A-Za-z0-9_]``. Returns the value unchanged on success.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string, got {value!r}")
+    if not _IDENT_RE.match(value):
+        raise ValueError(
+            f"{name} {value!r} is not a valid SQL identifier "
+            "(must start with a letter or underscore and contain only "
+            "letters, digits or underscores)"
+        )
+    if value.lower() in _SQL_RESERVED_WORDS:
+        raise ValueError(f"{name} {value!r} is a reserved Cosmos SQL keyword")
+    return value
+
+
+def quote_sql_string(value: Any) -> str:
+    """Return ``value`` as a single-quoted SQL string literal, escaped.
+
+    Single quotes inside the value are doubled, matching ANSI SQL escaping
+    semantics (which Cosmos NoSQL also accepts).
+    """
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+# ---------------------------------------------------------------------------
+# Embedder protocol
+# ---------------------------------------------------------------------------
+
+
+class EmbedderProtocol(Protocol):
+    """Minimal embedder interface accepted by the CosmosDB tools.
+
+    Any object exposing ``embed_documents`` (batch) and ``embed_query`` (single)
+    methods returning ``List[float]`` vectors satisfies this protocol. This is
+    intentionally compatible with langchain-style ``Embeddings`` instances
+    without requiring a langchain dependency.
+    """
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]: ...
+
+    def embed_query(self, text: str) -> list[float]: ...
+
+
+# ---------------------------------------------------------------------------
+# Retry helper for transient Cosmos errors
+# ---------------------------------------------------------------------------
+
+
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({408, 429, 449, 503})
+
+T = TypeVar("T")
+
+
+def retry_on_cosmos_throttle(
+    max_attempts: int = 5,
+    initial_backoff: float = 0.5,
+    max_backoff: float = 8.0,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator that retries on Cosmos transient HTTP errors (429/503/408).
+
+    The Cosmos SDK exposes a per-error ``retry_after_in_ms`` for 429s; we
+    honour it when present, falling back to exponential backoff otherwise.
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                from azure.cosmos.exceptions import CosmosHttpResponseError
+            except ImportError:  # pragma: no cover - extras not installed
+                return fn(*args, **kwargs)
+
+            backoff = initial_backoff
+            last_exc: BaseException | None = None
+            for attempt in range(max_attempts):
+                try:
+                    return fn(*args, **kwargs)
+                except CosmosHttpResponseError as exc:  # noqa: PERF203
+                    if exc.status_code not in _RETRYABLE_STATUS_CODES:
+                        raise
+                    last_exc = exc
+                    if attempt == max_attempts - 1:
+                        break
+                    sleep_for = backoff
+                    retry_after_ms = getattr(exc, "retry_after_in_ms", None)
+                    if retry_after_ms:
+                        sleep_for = max(sleep_for, retry_after_ms / 1000.0)
+                    time.sleep(min(sleep_for, max_backoff))
+                    backoff = min(backoff * 2, max_backoff)
+            assert last_exc is not None  # pragma: no cover - defensive  # noqa: S101
+            raise last_exc
+
+        return wrapper
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def chunked(seq: Sequence[T], size: int) -> Iterable[list[T]]:
+    """Yield successive ``size``-sized chunks from ``seq``."""
+    if size <= 0:
+        raise ValueError("size must be positive")
+    for i in range(0, len(seq), size):
+        yield list(seq[i : i + size])

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/__init__.py
@@ -1,0 +1,12 @@
+from crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool import (
+    AzureCosmosDBMemoryConfig,
+    AzureCosmosDBMemoryTool,
+    AzureCosmosDBMemoryToolSchema,
+)
+
+
+__all__ = [
+    "AzureCosmosDBMemoryConfig",
+    "AzureCosmosDBMemoryTool",
+    "AzureCosmosDBMemoryToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
@@ -80,6 +80,30 @@ class AzureCosmosDBMemoryToolSchema(BaseModel):
             "Operation: 'store', 'read', 'retrieve', 'update', 'delete', or 'clear'."
         ),
     )
+    memory_item: dict[str, Any] | None = Field(
+        default=None,
+        description="Memory document for 'store' and 'update' operations.",
+    )
+    partition_key_value: str | list[str] | None = Field(
+        default=None,
+        description=(
+            "Partition key value. Provide a list for hierarchical partition keys."
+        ),
+    )
+    memory_id: str | None = Field(
+        default=None,
+        description="Document id for 'read', 'update' and 'delete' operations.",
+    )
+    query_filter: dict[str, Any] | None = Field(
+        default=None,
+        description="Equality filters applied to 'c.content' fields on 'retrieve'.",
+    )
+    max_results: int | None = Field(
+        default=10, description="Maximum number of items returned by 'retrieve'."
+    )
+    ttl: int | None = Field(
+        default=None, description="Time-to-live in seconds for the stored document."
+    )
 
 
 class AzureCosmosDBMemoryTool(BaseTool):
@@ -230,6 +254,7 @@ class AzureCosmosDBMemoryTool(BaseTool):
     def _store_memory(self, memory_item: dict[str, Any], ttl: int | None = None) -> str:
         if ttl is not None:
             memory_item["ttl"] = ttl
+        memory_item.setdefault("created_at", datetime.now(timezone.utc).isoformat())
         try:
             response = self._container.create_item(body=memory_item)
             return json.dumps(response)
@@ -272,7 +297,13 @@ class AzureCosmosDBMemoryTool(BaseTool):
             partition_filter = self._build_partition_key_filter(
                 partition_key_value, field_names
             )
-            top_clause = f"TOP {int(max_results)} " if max_results else ""
+            # Only emit TOP for a positive limit; a negative/zero value would
+            # produce "TOP -1" which Cosmos rejects.
+            top_clause = (
+                f"TOP {int(max_results)} "
+                if max_results is not None and int(max_results) > 0
+                else ""
+            )
             query_sql = f"SELECT {top_clause}* FROM c WHERE {partition_filter}"  # noqa: S608
 
             if query_filter:
@@ -313,8 +344,13 @@ class AzureCosmosDBMemoryTool(BaseTool):
             existing = self._container.read_item(
                 item=memory_id, partition_key=partition_key_value
             )
+            # Merge onto the existing document so fields the caller did not
+            # resend (e.g. created_at, a prior ttl) are preserved rather than
+            # dropped by replace_item's whole-document semantics.
+            merged = {**existing, **upsert_item}
+            merged["id"] = memory_id
             if ttl is not None:
-                upsert_item["ttl"] = ttl
+                merged["ttl"] = ttl
 
             if self.config.use_optimistic_concurrency:
                 # Use ETag from the just-read document so a concurrent writer
@@ -324,14 +360,12 @@ class AzureCosmosDBMemoryTool(BaseTool):
                 etag = existing.get("_etag")
                 response = self._container.replace_item(
                     item=memory_id,
-                    body=upsert_item,
+                    body=merged,
                     etag=etag,
                     match_condition=MatchConditions.IfNotModified,
                 )
             else:
-                response = self._container.replace_item(
-                    item=memory_id, body=upsert_item
-                )
+                response = self._container.replace_item(item=memory_id, body=merged)
             return json.dumps(response)
         except Exception as exc:
             logger.exception("Failed to update memory: %s", exc)
@@ -364,31 +398,38 @@ class AzureCosmosDBMemoryTool(BaseTool):
             return json.dumps(
                 {"error": "partition_key_value is required for clear operation"}
             )
+        field_names, _ = self._get_partition_key_fields()
+        partition_filter = self._build_partition_key_filter(
+            partition_key_value, field_names
+        )
+        query_sql = f"SELECT c.id FROM c WHERE {partition_filter}"  # noqa: S608
+        # Track the count outside the try so a mid-loop batch failure still
+        # reports how many documents were already (transactionally) deleted.
+        deleted_count = 0
+        batch_size = 100
         try:
-            field_names, _ = self._get_partition_key_fields()
-            partition_filter = self._build_partition_key_filter(
-                partition_key_value, field_names
-            )
-            query_sql = f"SELECT c.id FROM c WHERE {partition_filter}"  # noqa: S608
-            items = list(
-                self._container.query_items(
-                    query=query_sql,
-                    partition_key=partition_key_value,
-                    enable_cross_partition_query=False,
-                )
-            )
-
-            deleted_count = 0
-            batch_size = 100
-            for i in range(0, len(items), batch_size):
-                batch = items[i : i + batch_size]
-                batch_ops = [("delete", (item["id"],)) for item in batch]
-                if batch_ops:
+            # Stream ids and delete in fixed-size batches instead of loading the
+            # whole (up to 20 GB) logical partition into memory at once.
+            pending: list[str] = []
+            for item in self._container.query_items(
+                query=query_sql,
+                partition_key=partition_key_value,
+                enable_cross_partition_query=False,
+            ):
+                pending.append(item["id"])
+                if len(pending) >= batch_size:
                     self._container.execute_item_batch(
-                        batch_operations=batch_ops,
+                        batch_operations=[("delete", (doc_id,)) for doc_id in pending],
                         partition_key=partition_key_value,
                     )
-                    deleted_count += len(batch_ops)
+                    deleted_count += len(pending)
+                    pending = []
+            if pending:
+                self._container.execute_item_batch(
+                    batch_operations=[("delete", (doc_id,)) for doc_id in pending],
+                    partition_key=partition_key_value,
+                )
+                deleted_count += len(pending)
 
             return json.dumps(
                 {
@@ -401,7 +442,12 @@ class AzureCosmosDBMemoryTool(BaseTool):
             )
         except Exception as exc:
             logger.exception("Failed to clear memory: %s", exc)
-            return json.dumps({"error": f"Failed to clear memory: {exc}"})
+            return json.dumps(
+                {
+                    "error": f"Failed to clear memory: {exc}",
+                    "deleted_count": deleted_count,
+                }
+            )
 
     def close(self) -> None:
         """Release the underlying CosmosClient (idempotent)."""

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
@@ -1,0 +1,416 @@
+"""Azure CosmosDB NoSQL agent-memory CRUD tool."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from logging import getLogger
+from typing import Any, ClassVar
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
+
+from crewai_tools.azure.cosmosdb_nosql._client import (
+    build_cosmos_client,
+    close_cosmos_client,
+    create_container_if_not_exists,
+    create_database_if_not_exists,
+)
+from crewai_tools.azure.cosmosdb_nosql._utils import (
+    quote_sql_string,
+    validate_sql_identifier,
+)
+
+
+logger = getLogger(__name__)
+
+
+class AzureCosmosDBMemoryConfig(BaseModel):
+    """Configuration for :class:`AzureCosmosDBMemoryTool`."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    cosmos_host: str | None = Field(
+        default=None, description="The CosmosDB account endpoint URL."
+    )
+    connection_string: str | None = Field(
+        default=None,
+        description="CosmosDB account connection string (alternative to host+key).",
+    )
+    key: str | None = Field(default=None, description="The Azure account key.")
+    token_credential: Any | None = Field(
+        default=None,
+        description="An Azure azure.core.credentials.TokenCredential instance.",
+    )
+    database_name: str = Field(
+        default="memory_database", description="CosmosDB database name."
+    )
+    container_name: str = Field(
+        default="memory_container", description="CosmosDB container name."
+    )
+    cosmos_container_properties: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "partition_key": {"paths": ["/agent_id"], "kind": "Hash"}
+        },
+        description="Container properties (partition key, etc.).",
+    )
+    cosmos_database_properties: dict[str, Any] = Field(
+        default_factory=dict, description="Database properties."
+    )
+    create_container: bool = Field(
+        default=True,
+        description="Create the container at init if it does not exist.",
+    )
+    use_optimistic_concurrency: bool = Field(
+        default=False,
+        description=(
+            "If True, ``update`` uses the document's _etag with "
+            "MatchConditions.IfNotModified to detect concurrent modifications "
+            "and surface a 412 PreconditionFailed error."
+        ),
+    )
+
+
+class AzureCosmosDBMemoryToolSchema(BaseModel):
+    """Input schema for :class:`AzureCosmosDBMemoryTool`."""
+
+    operation: str = Field(
+        ...,
+        description=(
+            "Operation: 'store', 'read', 'retrieve', 'update', 'delete', or 'clear'."
+        ),
+    )
+
+
+class AzureCosmosDBMemoryTool(BaseTool):
+    """CRUD operations on agent memory items stored in Azure CosmosDB NoSQL."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    USER_AGENT: ClassVar[str] = "CrewAI-CosmosDB-Memory-Tool-Python"
+
+    name: str = "AzureCosmosDBMemoryTool"
+    description: str = (
+        "Store, retrieve, update, and delete memory items in Azure CosmosDB."
+    )
+    args_schema: type[BaseModel] = AzureCosmosDBMemoryToolSchema
+
+    config: AzureCosmosDBMemoryConfig = Field(
+        ..., description="Configuration for the memory tool."
+    )
+    package_dependencies: list[str] = Field(
+        default_factory=lambda: ["azure-cosmos", "azure-core"]
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._cosmos_client = build_cosmos_client(
+            cosmos_host=self.config.cosmos_host,
+            key=self.config.key,
+            token_credential=self.config.token_credential,
+            user_agent=self.USER_AGENT,
+            connection_string=self.config.connection_string,
+        )
+        self._owns_cosmos_client = True
+        self._database = create_database_if_not_exists(
+            self._cosmos_client,
+            self.config.database_name,
+            self.config.cosmos_database_properties,
+        )
+        if self.config.create_container:
+            self._container = create_container_if_not_exists(
+                self._database,
+                self.config.container_name,
+                self.config.cosmos_container_properties,
+            )
+        else:
+            self._container = self._database.get_container_client(
+                self.config.container_name
+            )
+
+    @staticmethod
+    def _format_partition_value(value: Any) -> str:
+        """Quote a partition value for safe SQL interpolation."""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        return quote_sql_string(value)
+
+    def _get_partition_key_fields(self) -> tuple[list[str], Any]:
+        partition_key_config = self.config.cosmos_container_properties.get(
+            "partition_key", {}
+        )
+        if isinstance(partition_key_config, dict):
+            paths = partition_key_config.get("paths", ["/agent_id"])
+        elif isinstance(partition_key_config, str):
+            paths = [partition_key_config]
+        else:
+            paths = ["/agent_id"]
+        field_names = [path.lstrip("/") for path in paths]
+        return field_names, partition_key_config
+
+    @classmethod
+    def _build_partition_key_filter(
+        cls,
+        partition_key_value: str | list[str],
+        field_names: list[str],
+    ) -> str:
+        for field in field_names:
+            validate_sql_identifier(field, name="partition_key field")
+        if isinstance(partition_key_value, str):
+            if len(field_names) > 1:
+                raise ValueError(
+                    f"Container has hierarchical partition key with "
+                    f"{len(field_names)} levels, but only one value provided"
+                )
+            return f"c.{field_names[0]} = {cls._format_partition_value(partition_key_value)}"
+        if len(partition_key_value) != len(field_names):
+            raise ValueError(
+                f"Container has {len(field_names)} partition key levels, but "
+                f"{len(partition_key_value)} values provided"
+            )
+        return " AND ".join(
+            f"c.{field} = {cls._format_partition_value(value)}"
+            for field, value in zip(field_names, partition_key_value, strict=False)
+        )
+
+    def _run(
+        self,
+        operation: str,
+        memory_item: dict[str, Any] | None = None,
+        partition_key_value: str | list[str] | None = None,
+        memory_id: str | None = None,
+        query_filter: dict[str, Any] | None = None,
+        max_results: int | None = 10,
+        ttl: int | None = None,
+    ) -> str:
+        try:
+            if operation == "store":
+                if memory_item is None:
+                    return json.dumps(
+                        {"error": "memory_item is required for store operation"}
+                    )
+                return self._store_memory(memory_item, ttl)
+            if operation == "read":
+                return self._read_memory(partition_key_value, memory_id)
+            if operation == "retrieve":
+                return self._retrieve_memory(
+                    partition_key_value, query_filter, max_results
+                )
+            if operation == "update":
+                if memory_item is None:
+                    return json.dumps(
+                        {"error": "memory_item is required for update operation"}
+                    )
+                return self._update_memory(
+                    partition_key_value, memory_id, memory_item, ttl
+                )
+            if operation == "delete":
+                return self._delete_memory(partition_key_value, memory_id)
+            if operation == "clear":
+                return self._clear_memory(partition_key_value)
+            return json.dumps(
+                {
+                    "error": f"Unknown operation: {operation}",
+                    "valid_operations": [
+                        "store",
+                        "read",
+                        "retrieve",
+                        "update",
+                        "delete",
+                        "clear",
+                    ],
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Memory operation failed: %s", exc)
+            return json.dumps({"error": str(exc)})
+
+    def _store_memory(self, memory_item: dict[str, Any], ttl: int | None = None) -> str:
+        if ttl is not None:
+            memory_item["ttl"] = ttl
+        try:
+            response = self._container.create_item(body=memory_item)
+            return json.dumps(response)
+        except Exception as exc:
+            logger.exception("Failed to store memory: %s", exc)
+            return json.dumps({"error": f"Failed to store memory: {exc}"})
+
+    def _read_memory(
+        self,
+        partition_key_value: str | list[str] | None,
+        memory_id: str | None,
+    ) -> str:
+        if not partition_key_value:
+            return json.dumps(
+                {"error": "partition_key_value is required for read operation"}
+            )
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required for read operation"})
+        try:
+            response = self._container.read_item(
+                item=memory_id, partition_key=partition_key_value
+            )
+            return json.dumps(response)
+        except Exception as exc:
+            logger.exception("Failed to read memory: %s", exc)
+            return json.dumps({"error": f"Failed to read memory: {exc}"})
+
+    def _retrieve_memory(
+        self,
+        partition_key_value: str | list[str] | None,
+        query_filter: dict[str, Any] | None = None,
+        max_results: int | None = 10,
+    ) -> str:
+        if not partition_key_value:
+            return json.dumps(
+                {"error": "partition_key_value is required for retrieve operation"}
+            )
+        try:
+            field_names, _ = self._get_partition_key_fields()
+            partition_filter = self._build_partition_key_filter(
+                partition_key_value, field_names
+            )
+            top_clause = f"TOP {int(max_results)} " if max_results else ""
+            query_sql = f"SELECT {top_clause}* FROM c WHERE {partition_filter}"  # noqa: S608
+
+            if query_filter:
+                for key, value in query_filter.items():
+                    validate_sql_identifier(key, name="query_filter key")
+                    query_sql += (
+                        f" AND c.content.{key} = {self._format_partition_value(value)}"
+                    )
+
+            query_sql += " ORDER BY c.created_at DESC"
+
+            items = list(
+                self._container.query_items(
+                    query=query_sql,
+                    partition_key=partition_key_value,
+                    enable_cross_partition_query=False,
+                )
+            )
+            return json.dumps(items)
+        except Exception as exc:
+            logger.exception("Failed to retrieve memory: %s", exc)
+            return json.dumps({"error": f"Failed to retrieve memory: {exc}"})
+
+    def _update_memory(
+        self,
+        partition_key_value: str | list[str] | None,
+        memory_id: str | None,
+        upsert_item: dict[str, Any],
+        ttl: int | None = None,
+    ) -> str:
+        if not partition_key_value:
+            return json.dumps(
+                {"error": "partition_key_value is required for update operation"}
+            )
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required for update operation"})
+        try:
+            existing = self._container.read_item(
+                item=memory_id, partition_key=partition_key_value
+            )
+            if ttl is not None:
+                upsert_item["ttl"] = ttl
+
+            if self.config.use_optimistic_concurrency:
+                # Use ETag from the just-read document so a concurrent writer
+                # who has modified the row in between will be detected.
+                from azure.core import MatchConditions  # local import; optional dep
+
+                etag = existing.get("_etag")
+                response = self._container.replace_item(
+                    item=memory_id,
+                    body=upsert_item,
+                    etag=etag,
+                    match_condition=MatchConditions.IfNotModified,
+                )
+            else:
+                response = self._container.replace_item(
+                    item=memory_id, body=upsert_item
+                )
+            return json.dumps(response)
+        except Exception as exc:
+            logger.exception("Failed to update memory: %s", exc)
+            return json.dumps({"error": f"Failed to update memory: {exc}"})
+
+    def _delete_memory(
+        self,
+        partition_key_value: str | list[str] | None,
+        memory_id: str | None,
+    ) -> str:
+        if not partition_key_value:
+            return json.dumps(
+                {"error": "partition_key_value is required for delete operation"}
+            )
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required for delete operation"})
+        try:
+            self._container.delete_item(
+                item=memory_id, partition_key=partition_key_value
+            )
+            return json.dumps(
+                {"success": True, "message": f"Item {memory_id} has been deleted"}
+            )
+        except Exception as exc:
+            logger.exception("Failed to delete memory: %s", exc)
+            return json.dumps({"error": f"Failed to delete memory: {exc}"})
+
+    def _clear_memory(self, partition_key_value: str | list[str] | None) -> str:
+        if not partition_key_value:
+            return json.dumps(
+                {"error": "partition_key_value is required for clear operation"}
+            )
+        try:
+            field_names, _ = self._get_partition_key_fields()
+            partition_filter = self._build_partition_key_filter(
+                partition_key_value, field_names
+            )
+            query_sql = f"SELECT c.id FROM c WHERE {partition_filter}"  # noqa: S608
+            items = list(
+                self._container.query_items(
+                    query=query_sql,
+                    partition_key=partition_key_value,
+                    enable_cross_partition_query=False,
+                )
+            )
+
+            deleted_count = 0
+            batch_size = 100
+            for i in range(0, len(items), batch_size):
+                batch = items[i : i + batch_size]
+                batch_ops = [("delete", (item["id"],)) for item in batch]
+                if batch_ops:
+                    self._container.execute_item_batch(
+                        batch_operations=batch_ops,
+                        partition_key=partition_key_value,
+                    )
+                    deleted_count += len(batch_ops)
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "partition_key_value": partition_key_value,
+                    "operation": "clear",
+                    "deleted_count": deleted_count,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        except Exception as exc:
+            logger.exception("Failed to clear memory: %s", exc)
+            return json.dumps({"error": f"Failed to clear memory: {exc}"})
+
+    def close(self) -> None:
+        """Release the underlying CosmosClient (idempotent)."""
+        if getattr(self, "_owns_cosmos_client", False):
+            close_cosmos_client(getattr(self, "_cosmos_client", None))
+            self._owns_cosmos_client = False
+
+    def __enter__(self) -> AzureCosmosDBMemoryTool:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/memory_store/memory_store_tool.py
@@ -174,29 +174,44 @@ class AzureCosmosDBMemoryTool(BaseTool):
         field_names = [path.lstrip("/") for path in paths]
         return field_names, partition_key_config
 
+    @staticmethod
+    def _field_ref(field: str) -> str:
+        """Return a validated SQL reference for a partition-key field path.
+
+        Cosmos declares hierarchical/nested partition paths with ``/`` (e.g.
+        ``/address/zip`` -> field ``address/zip``) but accesses those
+        properties in SQL with dot notation (``c.address.zip``). Each path
+        segment is validated as a SQL identifier.
+        """
+        segments = [seg for seg in field.split("/") if seg]
+        if not segments:
+            raise ValueError("partition_key field must be a non-empty path")
+        for seg in segments:
+            validate_sql_identifier(seg, name="partition_key field")
+        return ".".join(segments)
+
     @classmethod
     def _build_partition_key_filter(
         cls,
         partition_key_value: str | list[str],
         field_names: list[str],
     ) -> str:
-        for field in field_names:
-            validate_sql_identifier(field, name="partition_key field")
+        refs = [cls._field_ref(field) for field in field_names]
         if isinstance(partition_key_value, str):
-            if len(field_names) > 1:
+            if len(refs) > 1:
                 raise ValueError(
                     f"Container has hierarchical partition key with "
-                    f"{len(field_names)} levels, but only one value provided"
+                    f"{len(refs)} levels, but only one value provided"
                 )
-            return f"c.{field_names[0]} = {cls._format_partition_value(partition_key_value)}"
-        if len(partition_key_value) != len(field_names):
+            return f"c.{refs[0]} = {cls._format_partition_value(partition_key_value)}"
+        if len(partition_key_value) != len(refs):
             raise ValueError(
-                f"Container has {len(field_names)} partition key levels, but "
+                f"Container has {len(refs)} partition key levels, but "
                 f"{len(partition_key_value)} values provided"
             )
         return " AND ".join(
-            f"c.{field} = {cls._format_partition_value(value)}"
-            for field, value in zip(field_names, partition_key_value, strict=False)
+            f"c.{ref} = {cls._format_partition_value(value)}"
+            for ref, value in zip(refs, partition_key_value, strict=False)
         )
 
     def _run(
@@ -297,13 +312,16 @@ class AzureCosmosDBMemoryTool(BaseTool):
             partition_filter = self._build_partition_key_filter(
                 partition_key_value, field_names
             )
-            # Only emit TOP for a positive limit; a negative/zero value would
-            # produce "TOP -1" which Cosmos rejects.
-            top_clause = (
-                f"TOP {int(max_results)} "
-                if max_results is not None and int(max_results) > 0
-                else ""
-            )
+            # Reject non-positive limits: omitting TOP would load the entire
+            # logical partition into memory. None means "no explicit limit".
+            top_clause = ""
+            if max_results is not None:
+                limit = int(max_results)
+                if limit <= 0:
+                    return json.dumps(
+                        {"error": "max_results must be a positive integer"}
+                    )
+                top_clause = f"TOP {limit} "
             query_sql = f"SELECT {top_clause}* FROM c WHERE {partition_filter}"  # noqa: S608
 
             if query_filter:

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/__init__.py
@@ -1,0 +1,12 @@
+from crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool import (
+    AzureCosmosDBSemanticCacheConfig,
+    AzureCosmosDBSemanticCacheTool,
+    AzureCosmosDBSemanticCacheToolSchema,
+)
+
+
+__all__ = [
+    "AzureCosmosDBSemanticCacheConfig",
+    "AzureCosmosDBSemanticCacheTool",
+    "AzureCosmosDBSemanticCacheToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
@@ -1,0 +1,471 @@
+"""Azure CosmosDB NoSQL semantic cache tool for LLM responses."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from logging import getLogger
+from typing import Any, ClassVar
+import uuid
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
+
+from crewai_tools.azure.cosmosdb_nosql._client import (
+    build_cosmos_client,
+    close_cosmos_client,
+    create_container_if_not_exists,
+    create_database_if_not_exists,
+)
+from crewai_tools.azure.cosmosdb_nosql._embeddings import (
+    build_openai_client,
+    embed_texts,
+    embed_texts_via_embedder,
+)
+from crewai_tools.azure.cosmosdb_nosql._utils import (
+    DistanceStrategy,
+    quote_sql_string,
+    score_threshold_passes,
+)
+
+
+logger = getLogger(__name__)
+
+
+def _quote_terms(text: str) -> str:
+    """Return a SQL-safe comma-separated list of single-quoted FTS terms."""
+    return ", ".join(quote_sql_string(t) for t in text.split() if t)
+
+
+def _llm_namespace(llm_string: str | None) -> str:
+    """Return a stable, short hash of an LLM identifier for cache namespacing."""
+    if not llm_string:
+        return "default"
+    return hashlib.sha256(llm_string.encode("utf-8")).hexdigest()[:32]
+
+
+class AzureCosmosDBSemanticCacheConfig(BaseModel):
+    """Configuration for :class:`AzureCosmosDBSemanticCacheTool`."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    cosmos_host: str | None = Field(
+        default=None, description="The CosmosDB account endpoint URL."
+    )
+    connection_string: str | None = Field(
+        default=None,
+        description="CosmosDB account connection string (alternative to host+key).",
+    )
+    key: str | None = Field(default=None, description="The Azure account key.")
+    token_credential: Any | None = Field(
+        default=None,
+        description="An Azure azure.core.credentials.TokenCredential instance.",
+    )
+    embedder: Any | None = Field(
+        default=None,
+        description=(
+            "Optional custom embedder (``embed_documents`` / ``embed_query``). "
+            "Overrides OpenAI/Azure OpenAI when provided."
+        ),
+    )
+    database_name: str = Field(
+        default="memory_database", description="CosmosDB database name."
+    )
+    container_name: str = Field(
+        default="memory_container", description="CosmosDB container name."
+    )
+    cosmos_container_properties: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "partition_key": {"paths": ["/agent_id"], "kind": "Hash"}
+        },
+        description="Container properties (partition key, etc.).",
+    )
+    cosmos_database_properties: dict[str, Any] = Field(
+        default_factory=dict, description="Database properties."
+    )
+    create_container: bool = Field(
+        default=True,
+        description="Create the container at init if it does not exist.",
+    )
+    vector_embedding_policy: dict[str, Any] | None = Field(
+        default=None, description="Vector embedding policy for container creation."
+    )
+    indexing_policy: dict[str, Any] = Field(
+        ..., description="Indexing policy for container creation."
+    )
+    full_text_policy: dict[str, Any] | None = Field(
+        default=None, description="Full-text policy for container creation."
+    )
+    dimensions: int = Field(
+        default=1536, description="Embedding vector dimensionality."
+    )
+    table_alias: str = Field(
+        default="c", description="SQL alias for the container in queries."
+    )
+
+    embedding_model: str = Field(
+        default="text-embedding-3-large",
+        description="OpenAI / Azure OpenAI embedding model identifier.",
+    )
+    embedding_dimensions: int = Field(
+        default=1536,
+        description="Dimensionality requested from the embedding model.",
+    )
+    azure_openai_endpoint: str | None = Field(
+        default=None, description="Azure OpenAI endpoint URL."
+    )
+    openai_api_key: str | None = Field(
+        default=None, description="OpenAI / Azure OpenAI API key."
+    )
+
+    similarity_threshold: float = Field(
+        default=0.85,
+        description=(
+            "Minimum similarity for a cache hit (cosine/dot-product) or maximum "
+            "distance (euclidean)."
+        ),
+    )
+    default_ttl: int | None = Field(
+        default=86400,
+        description="Default TTL in seconds (set to None to disable expiry).",
+    )
+    enable_hybrid_search: bool = Field(
+        default=True,
+        description="Combine vector + full-text RRF search when enabled.",
+    )
+    llm_string: str | None = Field(
+        default=None,
+        description=(
+            "Identifier for the LLM whose responses are being cached "
+            "(e.g. 'gpt-4o-2024-08-06'). Used to namespace cache entries so "
+            "responses from different models do not collide."
+        ),
+    )
+
+
+class AzureCosmosDBSemanticCacheToolSchema(BaseModel):
+    """Input schema for :class:`AzureCosmosDBSemanticCacheTool`."""
+
+    operation: str = Field(
+        ..., description="Operation: 'search', 'update', or 'clear'."
+    )
+    prompt: str | None = Field(
+        default=None,
+        description="Prompt to look up (search) or store (update).",
+    )
+    response: str | None = Field(
+        default=None,
+        description="LLM response to associate with the prompt (update only).",
+    )
+
+
+class AzureCosmosDBSemanticCacheTool(BaseTool):
+    """Semantic cache for LLM responses backed by Azure CosmosDB NoSQL."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    USER_AGENT: ClassVar[str] = "CrewAI-CosmosDB-SemanticCache-Tool-Python"
+
+    name: str = "AzureCosmosDBSemanticCacheTool"
+    description: str = (
+        "Semantic cache for LLM responses backed by Azure CosmosDB NoSQL vector search."
+    )
+    args_schema: type[BaseModel] = AzureCosmosDBSemanticCacheToolSchema
+
+    config: AzureCosmosDBSemanticCacheConfig = Field(
+        ..., description="Configuration for the semantic cache tool."
+    )
+    package_dependencies: list[str] = Field(
+        default_factory=lambda: ["azure-cosmos", "azure-core", "openai"]
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._validate_params()
+        if self.config.embedder is None:
+            self._openai_client = build_openai_client(
+                azure_openai_endpoint=self.config.azure_openai_endpoint,
+                openai_api_key=self.config.openai_api_key,
+            )
+        else:
+            self._openai_client = None
+        self._cosmos_client = build_cosmos_client(
+            cosmos_host=self.config.cosmos_host,
+            key=self.config.key,
+            token_credential=self.config.token_credential,
+            user_agent=self.USER_AGENT,
+            connection_string=self.config.connection_string,
+        )
+        self._owns_cosmos_client = True
+        self._database = create_database_if_not_exists(
+            self._cosmos_client,
+            self.config.database_name,
+            self.config.cosmos_database_properties,
+        )
+        if self.config.create_container:
+            self._container = create_container_if_not_exists(
+                self._database,
+                self.config.container_name,
+                self.config.cosmos_container_properties,
+                indexing_policy=self.config.indexing_policy,
+                vector_embedding_policy=self.config.vector_embedding_policy,
+                full_text_policy=self.config.full_text_policy,
+                default_ttl=self.config.default_ttl,
+            )
+        else:
+            self._container = self._database.get_container_client(
+                self.config.container_name
+            )
+        self._distance_strategy = self._infer_distance_strategy()
+        self._llm_namespace = _llm_namespace(self.config.llm_string)
+
+    def _infer_distance_strategy(self) -> DistanceStrategy:
+        embeddings = (self.config.vector_embedding_policy or {}).get(
+            "vectorEmbeddings"
+        ) or []
+        if embeddings:
+            return DistanceStrategy.from_str(
+                embeddings[0].get("distanceFunction", "cosine")
+            )
+        return DistanceStrategy.COSINE
+
+    def _validate_params(self) -> None:
+        if not self.config.create_container:
+            return
+        vector_indexes = (self.config.indexing_policy or {}).get("vectorIndexes")
+        if not vector_indexes:
+            raise ValueError(
+                "vectorIndexes cannot be null or empty in the indexing_policy."
+            )
+        vector_embeddings = (self.config.vector_embedding_policy or {}).get(
+            "vectorEmbeddings"
+        )
+        if not vector_embeddings:
+            raise ValueError(
+                "vectorEmbeddings cannot be null or empty in the "
+                "vector_embedding_policy."
+            )
+        if self.config.cosmos_container_properties.get("partition_key") is None:
+            raise ValueError("partition_key cannot be null or empty for a container.")
+        if self.config.enable_hybrid_search:
+            full_text_indexes = (self.config.indexing_policy or {}).get(
+                "fullTextIndexes"
+            )
+            if not full_text_indexes:
+                raise ValueError(
+                    "fullTextIndexes cannot be null or empty in the indexing_policy "
+                    "if hybrid search is enabled."
+                )
+            full_text_paths = (self.config.full_text_policy or {}).get("fullTextPaths")
+            if not full_text_paths:
+                raise ValueError(
+                    "fullTextPaths cannot be null or empty in the full_text_policy "
+                    "if hybrid search is enabled."
+                )
+
+    def _generate_embedding(self, text: str) -> list[float]:
+        if self.config.embedder is not None:
+            return embed_texts_via_embedder(self.config.embedder, [text])[0]
+        return embed_texts(
+            self._openai_client,
+            [text],
+            model=self.config.embedding_model,
+            dimensions=self.config.embedding_dimensions,
+        )[0]
+
+    def _run(
+        self,
+        operation: str,
+        prompt: str | None = None,
+        response: str | None = None,
+    ) -> str:
+        try:
+            if operation == "search":
+                return self._search_cache(prompt)
+            if operation == "update":
+                return self._update_cache(prompt, response)
+            if operation == "clear":
+                return self._clear_cache()
+            return json.dumps(
+                {
+                    "error": f"Unknown operation: {operation}",
+                    "valid_operations": ["search", "update", "clear"],
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Semantic cache operation failed: %s", exc)
+            return json.dumps({"error": str(exc)})
+
+    def _search_cache(self, prompt: str | None) -> str:
+        if not prompt:
+            return json.dumps({"error": "prompt is required for search operation"})
+        try:
+            query_embedding = self._generate_embedding(prompt)
+            namespace_literal = quote_sql_string(self._llm_namespace)
+
+            if self.config.enable_hybrid_search:
+                # NOTE: FullTextScore / VectorDistance do not currently accept
+                # parameter placeholders, so the embedding and search terms are
+                # interpolated directly. FTS terms are SQL-quoted via
+                # quote_sql_string to neutralise injection.
+                terms = _quote_terms(prompt)
+                query_sql = f"""
+                SELECT TOP 1 c.id, c.prompt, c.response, c.metadata, c.llm_namespace,
+                       VectorDistance(c.prompt_embedding, {query_embedding}) AS similarity_score
+                FROM c
+                WHERE c.llm_namespace = {namespace_literal}
+                ORDER BY RANK RRF(
+                    FullTextScore(c.prompt, {terms}),
+                    VectorDistance(c.prompt_embedding, {query_embedding})
+                )
+                """  # noqa: S608
+                parameters: list[dict[str, Any]] = []
+            else:
+                query_sql = f"""
+                SELECT TOP 1 c.id, c.prompt, c.response, c.metadata, c.llm_namespace,
+                       VectorDistance(c.prompt_embedding, @query_embedding) AS similarity_score
+                FROM c
+                WHERE c.llm_namespace = {namespace_literal}
+                ORDER BY VectorDistance(c.prompt_embedding, @query_embedding)
+                """  # noqa: S608
+                parameters = [{"name": "@query_embedding", "value": query_embedding}]
+
+            items = list(
+                self._container.query_items(
+                    query=query_sql,
+                    parameters=parameters,
+                    enable_cross_partition_query=True,
+                )
+            )
+
+            for item in items:
+                raw_score = item.get("similarity_score", 1.0)
+                # Cosmos VectorDistance semantics are distance-function-aware:
+                # cosine/dotproduct return higher == better; euclidean returns
+                # lower == better. score_threshold_passes encapsulates that.
+                if score_threshold_passes(
+                    raw_score,
+                    self.config.similarity_threshold,
+                    self._distance_strategy,
+                ):
+                    return json.dumps(
+                        {
+                            "cache_hit": True,
+                            "similarity_score": raw_score,
+                            "cached_response": item.get("response"),
+                            "cache_id": item.get("id"),
+                            "timestamp": item.get("metadata", {}).get("timestamp"),
+                            "prompt": item.get("prompt"),
+                        }
+                    )
+
+            return json.dumps(
+                {
+                    "cache_hit": False,
+                    "similarity_score": 0.0,
+                    "message": (
+                        f"No cached response found above similarity threshold "
+                        f"{self.config.similarity_threshold}"
+                    ),
+                }
+            )
+        except Exception as exc:
+            logger.exception("Failed to search cache: %s", exc)
+            return json.dumps({"error": f"Failed to search cache: {exc}"})
+
+    def _update_cache(self, prompt: str | None, response: str | None) -> str:
+        if not prompt:
+            return json.dumps({"error": "prompt is required for update operation"})
+        if not response:
+            return json.dumps({"error": "response is required for update operation"})
+        try:
+            prompt_embedding = self._generate_embedding(prompt)
+            partition_paths = self.config.cosmos_container_properties[
+                "partition_key"
+            ].get("paths", ["/agent_id"])
+            document: dict[str, Any] = {
+                "id": str(uuid.uuid4()),
+                "prompt": prompt,
+                "prompt_embedding": prompt_embedding,
+                "response": response,
+                "llm_namespace": self._llm_namespace,
+                "metadata": {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "llm_string": self.config.llm_string,
+                },
+            }
+            # Ensure each partition-key field has a default so upsert succeeds
+            # when the caller has not pre-populated them on the document.
+            for path in partition_paths:
+                field = path.lstrip("/")
+                document.setdefault(field, "default")
+
+            if self.config.default_ttl is not None:
+                document["ttl"] = self.config.default_ttl
+
+            stored = self._container.upsert_item(body=document)
+            return json.dumps(stored)
+        except Exception as exc:
+            logger.exception("Failed to update cache: %s", exc)
+            return json.dumps({"error": f"Failed to update cache: {exc}"})
+
+    def _clear_cache(self) -> str:
+        """Delete cache entries for the current LLM namespace.
+
+        Earlier versions of this method called ``delete_database`` which
+        destroyed every container in the database — including unrelated
+        memory/vector containers. We now query the matching cache rows and
+        delete them individually, mirroring langchain-azure's behaviour
+        (``_cache.py:CosmosDBNoSqlSemanticCache.clear``).
+        """
+        try:
+            namespace_literal = quote_sql_string(self._llm_namespace)
+            partition_paths = self.config.cosmos_container_properties[
+                "partition_key"
+            ].get("paths", ["/agent_id"])
+            partition_field = partition_paths[0].lstrip("/")
+            sql = (
+                f"SELECT c.id, c.{partition_field} AS _pk FROM c "  # noqa: S608
+                f"WHERE c.llm_namespace = {namespace_literal}"
+            )
+            items = list(
+                self._container.query_items(
+                    query=sql, enable_cross_partition_query=True
+                )
+            )
+            deleted = 0
+            for item in items:
+                try:
+                    self._container.delete_item(
+                        item=item["id"], partition_key=item.get("_pk")
+                    )
+                    deleted += 1
+                except Exception:  # noqa: PERF203
+                    logger.debug(
+                        "Failed to delete cache item %s",
+                        item.get("id"),
+                        exc_info=True,
+                    )
+            return json.dumps(
+                {
+                    "success": True,
+                    "deleted_count": deleted,
+                    "llm_namespace": self._llm_namespace,
+                }
+            )
+        except Exception as exc:
+            logger.exception("Failed to clear cache: %s", exc)
+            return json.dumps({"error": f"Failed to clear cache: {exc}"})
+
+    def close(self) -> None:
+        """Release the underlying CosmosClient (idempotent)."""
+        if getattr(self, "_owns_cosmos_client", False):
+            close_cosmos_client(getattr(self, "_cosmos_client", None))
+            self._owns_cosmos_client = False
+
+    def __enter__(self) -> AzureCosmosDBSemanticCacheTool:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
@@ -230,6 +230,15 @@ class AzureCosmosDBSemanticCacheTool(BaseTool):
         return DistanceStrategy.COSINE
 
     def _validate_params(self) -> None:
+        partition_key = self.config.cosmos_container_properties.get("partition_key")
+        if isinstance(partition_key, dict):
+            for path in partition_key.get("paths", []):
+                if len([seg for seg in str(path).split("/") if seg]) > 1:
+                    raise ValueError(
+                        f"Nested partition key paths are not supported by the "
+                        f"semantic cache tool: {path!r}. Use a single-level path "
+                        f"such as '/agent_id'."
+                    )
         if not self.config.create_container:
             return
         vector_indexes = (self.config.indexing_policy or {}).get("vectorIndexes")
@@ -440,6 +449,7 @@ class AzureCosmosDBSemanticCacheTool(BaseTool):
                 )
             )
             deleted = 0
+            failed = 0
             for item in items:
                 try:
                     self._container.delete_item(
@@ -447,6 +457,7 @@ class AzureCosmosDBSemanticCacheTool(BaseTool):
                     )
                     deleted += 1
                 except Exception:  # noqa: PERF203
+                    failed += 1
                     logger.debug(
                         "Failed to delete cache item %s",
                         item.get("id"),
@@ -454,8 +465,9 @@ class AzureCosmosDBSemanticCacheTool(BaseTool):
                     )
             return json.dumps(
                 {
-                    "success": True,
+                    "success": failed == 0,
                     "deleted_count": deleted,
+                    "failed_count": failed,
                     "llm_namespace": self._llm_namespace,
                 }
             )

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/semantic_cache/semantic_cache_tool.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 from logging import getLogger
 from typing import Any, ClassVar
-import uuid
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field
@@ -384,8 +383,14 @@ class AzureCosmosDBSemanticCacheTool(BaseTool):
             partition_paths = self.config.cosmos_container_properties[
                 "partition_key"
             ].get("paths", ["/agent_id"])
+            # Derive a deterministic id from the namespace + prompt so that
+            # re-caching the same prompt upserts the existing row instead of
+            # inserting an unbounded stream of duplicate documents.
+            cache_key = hashlib.sha256(
+                f"{self._llm_namespace}:{prompt}".encode("utf-8")
+            ).hexdigest()
             document: dict[str, Any] = {
-                "id": str(uuid.uuid4()),
+                "id": cache_key,
                 "prompt": prompt,
                 "prompt_embedding": prompt_embedding,
                 "response": response,

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/__init__.py
@@ -1,0 +1,12 @@
+from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+    AzureCosmosDBNoSqlSearchConfig,
+    AzureCosmosDBNoSqlSearchTool,
+    AzureCosmosDBNoSqlToolSchema,
+)
+
+
+__all__ = [
+    "AzureCosmosDBNoSqlSearchConfig",
+    "AzureCosmosDBNoSqlSearchTool",
+    "AzureCosmosDBNoSqlToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
@@ -294,18 +294,28 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
             )
         if self.cosmos_container_properties.get("partition_key") is None:
             raise ValueError("partition_key cannot be null or empty for a container.")
-        if self.full_text_search_enabled:
+        # Full-text / hybrid queries build FullTextScore / FullTextContains SQL
+        # that needs a full-text index + policy. search_type is independent of
+        # full_text_search_enabled, so require the policy whenever either the
+        # flag is set or the search_type implies full-text.
+        needs_full_text = self.full_text_search_enabled or self.search_type in (
+            "full_text_search",
+            "full_text_ranking",
+            "hybrid",
+            "hybrid_score_threshold",
+        )
+        if needs_full_text:
             full_text_indexes = (self.indexing_policy or {}).get("fullTextIndexes")
             if not full_text_indexes:
                 raise ValueError(
                     "fullTextIndexes cannot be null or empty in the indexing_policy "
-                    "if full text search is enabled."
+                    "for full-text or hybrid search."
                 )
             full_text_paths = (self.full_text_policy or {}).get("fullTextPaths")
             if not full_text_paths:
                 raise ValueError(
                     "fullTextPaths cannot be null or empty in the full_text_policy "
-                    "if full text search is enabled."
+                    "for full-text or hybrid search."
                 )
 
     def _infer_distance_strategy(self) -> DistanceStrategy:
@@ -403,10 +413,14 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
 
     @retry_on_cosmos_throttle()
     def _batch_create(self, batch: list[dict[str, Any]], pk_value: Any) -> None:
-        # execute_item_batch expects each operation as (type, args_tuple[, kwargs]);
-        # the create body must be wrapped in a 1-tuple, i.e. ("create", (doc,)).
+        # Use "upsert" rather than "create" so this operation is idempotent
+        # under the retry decorator: a transient error (429/503) can occur
+        # *after* the batch already committed server-side, and a "create"
+        # retry would then fail the whole batch with a 409 Conflict.
+        # execute_item_batch expects each op as (type, args_tuple[, kwargs]);
+        # the body is wrapped in a 1-tuple, i.e. ("upsert", (doc,)).
         self._container.execute_item_batch(
-            batch_operations=[("create", (doc,)) for doc in batch],
+            batch_operations=[("upsert", (doc,)) for doc in batch],
             partition_key=pk_value,
         )
 

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
@@ -1,0 +1,658 @@
+"""Azure CosmosDB NoSQL vector / hybrid / full-text search tool."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import json
+from logging import getLogger
+from typing import Any, ClassVar
+import uuid
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
+
+from crewai_tools.azure.cosmosdb_nosql._client import (
+    build_cosmos_client,
+    close_cosmos_client,
+    create_container_if_not_exists,
+    create_database_if_not_exists,
+)
+from crewai_tools.azure.cosmosdb_nosql._embeddings import (
+    build_openai_client,
+    embed_texts,
+    embed_texts_via_embedder,
+)
+from crewai_tools.azure.cosmosdb_nosql._utils import (
+    DistanceStrategy,
+    chunked,
+    quote_sql_string,
+    retry_on_cosmos_throttle,
+    score_threshold_passes,
+    validate_sql_identifier,
+)
+
+
+logger = getLogger(__name__)
+
+
+def _quote_terms(text: str) -> str:
+    """Return a SQL-safe comma-separated list of single-quoted FTS terms."""
+    return ", ".join(quote_sql_string(t) for t in text.split() if t)
+
+
+class AzureCosmosDBNoSqlSearchConfig(BaseModel):
+    """Per-query configuration for :class:`AzureCosmosDBNoSqlSearchTool`."""
+
+    max_results: int | None = Field(
+        default=5, description="The maximum number of items to return."
+    )
+    with_embedding: bool = Field(
+        default=False, description="Include embedding vectors in the projection."
+    )
+    where: str | None = Field(
+        default=None, description="Optional SQL WHERE clause appended to the query."
+    )
+    offset_limit: str | None = Field(
+        default=None, description="Optional SQL OFFSET / LIMIT clause."
+    )
+    projection_mapping: dict[str, Any] | None = Field(
+        default=None, description="Custom projection mapping (field -> alias)."
+    )
+    full_text_rank_filter: list[dict[str, str]] | None = Field(
+        default=None,
+        description=(
+            "Full text rank filters. Each item is a dict with 'search_field' and "
+            "'search_text' keys, used by full_text_ranking and hybrid searches."
+        ),
+    )
+    weights: list[float] | None = Field(
+        default=None, description="Weights for hybrid RRF scoring."
+    )
+    threshold: float | None = Field(
+        default=None,
+        description=(
+            "Minimum SimilarityScore for cosine/dot-product results, or maximum "
+            "distance for euclidean. None disables thresholding."
+        ),
+    )
+
+
+class AzureCosmosDBNoSqlToolSchema(BaseModel):
+    """Input schema for :class:`AzureCosmosDBNoSqlSearchTool`."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "The search query. Pass only the query text (not a question) - it "
+            "will be embedded and used to retrieve relevant documents."
+        ),
+    )
+
+
+class AzureCosmosDBNoSqlSearchTool(BaseTool):
+    """Vector / full-text / hybrid search over an Azure CosmosDB NoSQL container."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    VALID_SEARCH_TYPES: ClassVar[set[str]] = {
+        "vector",
+        "vector_score_threshold",
+        "full_text_search",
+        "full_text_ranking",
+        "hybrid",
+        "hybrid_score_threshold",
+    }
+    USER_AGENT: ClassVar[str] = "Crew-AI-CDBNoSql-VectorSearchTool-Python"
+
+    name: str = "AzureCosmosDBNoSqlVectorSearchTool"
+    description: str = (
+        "Perform vector, full-text, or hybrid search over an Azure CosmosDB "
+        "NoSQL container."
+    )
+    args_schema: type[BaseModel] = AzureCosmosDBNoSqlToolSchema
+
+    query_config: AzureCosmosDBNoSqlSearchConfig | None = Field(
+        default=None,
+        description="Query-time configuration; defaults are used when omitted.",
+    )
+    search_type: str = Field(
+        default="vector",
+        description=(
+            "Type of search to perform. One of: vector, vector_score_threshold, "
+            "full_text_search, full_text_ranking, hybrid, hybrid_score_threshold."
+        ),
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-large",
+        description="OpenAI / Azure OpenAI embedding model identifier.",
+    )
+    cosmos_host: str | None = Field(
+        default=None, description="The CosmosDB account endpoint URL."
+    )
+    connection_string: str | None = Field(
+        default=None,
+        description="CosmosDB account connection string (alternative to host+key).",
+    )
+    key: str | None = Field(default=None, description="The Azure account key.")
+    token_credential: Any | None = Field(
+        default=None,
+        description="An Azure azure.core.credentials.TokenCredential instance.",
+    )
+    embedder: Any | None = Field(
+        default=None,
+        description=(
+            "Optional custom embedder satisfying the EmbedderProtocol "
+            "(``embed_documents`` / ``embed_query``). Overrides OpenAI/Azure "
+            "OpenAI when provided."
+        ),
+    )
+    azure_openai_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "Azure OpenAI endpoint. If not set, the AZURE_OPENAI_ENDPOINT env "
+            "var or the standard OpenAI client is used."
+        ),
+    )
+    openai_api_key: str | None = Field(
+        default=None,
+        description="OpenAI / Azure OpenAI API key (overrides env vars).",
+    )
+    database_name: str = Field(
+        default="crewAI_database", description="CosmosDB database name."
+    )
+    container_name: str = Field(
+        default="crewAI_container", description="CosmosDB container name."
+    )
+    vector_embedding_policy: dict[str, Any] | None = Field(
+        default=None, description="Vector embedding policy for container creation."
+    )
+    indexing_policy: dict[str, Any] = Field(
+        ..., description="Indexing policy for container creation."
+    )
+    cosmos_container_properties: dict[str, Any] = Field(
+        ..., description="Properties used when creating the container."
+    )
+    cosmos_database_properties: dict[str, Any] = Field(
+        default_factory=dict, description="Properties used when creating the database."
+    )
+    full_text_policy: dict[str, Any] | None = Field(
+        default=None, description="Full-text policy for container creation."
+    )
+    text_key: str = Field(
+        default="text", description="Document field that stores the source text."
+    )
+    embedding_key: str = Field(
+        default="embedding", description="Document field that stores the embedding."
+    )
+    metadata_key: str = Field(
+        default="metadata", description="Document field that stores metadata."
+    )
+    dimensions: int = Field(
+        default=1536, description="Embedding vector dimensionality."
+    )
+    create_container: bool = Field(
+        default=True,
+        description="If True, create the container at init if it does not exist.",
+    )
+    full_text_search_enabled: bool = Field(
+        default=False,
+        description="Whether the container is configured for full-text search.",
+    )
+    table_alias: str = Field(
+        default="c", description="SQL alias used for the container in queries."
+    )
+    package_dependencies: list[str] = Field(
+        default_factory=lambda: ["azure-cosmos", "azure-core", "openai"]
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._validate_params()
+        # Identifiers spliced into SQL must be validated up front to defend
+        # against accidental injection / reserved-keyword collisions.
+        validate_sql_identifier(self.text_key, name="text_key")
+        validate_sql_identifier(self.embedding_key, name="embedding_key")
+        validate_sql_identifier(self.metadata_key, name="metadata_key")
+        validate_sql_identifier(self.table_alias, name="table_alias")
+
+        if self.embedder is None:
+            self._openai_client = build_openai_client(
+                azure_openai_endpoint=self.azure_openai_endpoint,
+                openai_api_key=self.openai_api_key,
+            )
+        else:
+            self._openai_client = None
+        self._cosmos_client = build_cosmos_client(
+            cosmos_host=self.cosmos_host,
+            key=self.key,
+            token_credential=self.token_credential,
+            user_agent=self.USER_AGENT,
+            connection_string=self.connection_string,
+        )
+        self._owns_cosmos_client = True
+        self._database = create_database_if_not_exists(
+            self._cosmos_client,
+            self.database_name,
+            self.cosmos_database_properties,
+        )
+        if self.create_container:
+            self._container = create_container_if_not_exists(
+                self._database,
+                self.container_name,
+                self.cosmos_container_properties,
+                indexing_policy=self.indexing_policy,
+                vector_embedding_policy=self.vector_embedding_policy,
+                full_text_policy=self.full_text_policy,
+            )
+        else:
+            self._container = self._database.get_container_client(self.container_name)
+        self._distance_strategy = self._infer_distance_strategy()
+
+    # ------------------------------------------------------------------
+    # alternative constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_connection_string(
+        cls,
+        connection_string: str,
+        *,
+        indexing_policy: dict[str, Any],
+        cosmos_container_properties: dict[str, Any],
+        **kwargs: Any,
+    ) -> AzureCosmosDBNoSqlSearchTool:
+        """Construct the tool from a CosmosDB connection string."""
+        return cls(
+            connection_string=connection_string,
+            indexing_policy=indexing_policy,
+            cosmos_container_properties=cosmos_container_properties,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # validation
+    # ------------------------------------------------------------------
+
+    def _validate_params(self) -> None:
+        if self.search_type not in self.VALID_SEARCH_TYPES:
+            raise ValueError(
+                f"Invalid search_type '{self.search_type}'. "
+                f"Valid options are: {sorted(self.VALID_SEARCH_TYPES)}"
+            )
+        if not self.create_container:
+            return
+        vector_indexes = (self.indexing_policy or {}).get("vectorIndexes")
+        if not vector_indexes:
+            raise ValueError(
+                "vectorIndexes cannot be null or empty in the indexing_policy."
+            )
+        vector_embeddings = (self.vector_embedding_policy or {}).get("vectorEmbeddings")
+        if not vector_embeddings:
+            raise ValueError(
+                "vectorEmbeddings cannot be null or empty in the "
+                "vector_embedding_policy."
+            )
+        if self.cosmos_container_properties.get("partition_key") is None:
+            raise ValueError("partition_key cannot be null or empty for a container.")
+        if self.full_text_search_enabled:
+            full_text_indexes = (self.indexing_policy or {}).get("fullTextIndexes")
+            if not full_text_indexes:
+                raise ValueError(
+                    "fullTextIndexes cannot be null or empty in the indexing_policy "
+                    "if full text search is enabled."
+                )
+            full_text_paths = (self.full_text_policy or {}).get("fullTextPaths")
+            if not full_text_paths:
+                raise ValueError(
+                    "fullTextPaths cannot be null or empty in the full_text_policy "
+                    "if full text search is enabled."
+                )
+
+    def _infer_distance_strategy(self) -> DistanceStrategy:
+        embeddings = (self.vector_embedding_policy or {}).get("vectorEmbeddings") or []
+        if embeddings:
+            return DistanceStrategy.from_str(
+                embeddings[0].get("distanceFunction", "cosine")
+            )
+        return DistanceStrategy.COSINE
+
+    # ------------------------------------------------------------------
+    # writes
+    # ------------------------------------------------------------------
+
+    def add_texts(
+        self,
+        texts: list[str],
+        metadatas: list[dict[str, Any]] | None = None,
+        ids: list[str] | None = None,
+        **_: Any,
+    ) -> list[str]:
+        """Embed ``texts`` and insert them into the container in batches."""
+        if not texts:
+            raise ValueError("texts cannot be null or empty")
+
+        embeddings = self._embed_texts(texts)
+        partition_key_config = self.cosmos_container_properties["partition_key"]
+        if isinstance(partition_key_config, dict):
+            partition_paths = partition_key_config.get("paths", ["/id"])
+        elif isinstance(partition_key_config, str):
+            partition_paths = [partition_key_config]
+        else:
+            partition_paths = ["/id"]
+        # Hierarchical partition keys are resolved via the first level for
+        # add_texts; callers needing finer control can pre-shape the document.
+        partition_field = partition_paths[0].lstrip("/")
+
+        meta_list = list(metadatas) if metadatas is not None else [{} for _ in texts]
+        id_list = list(ids) if ids is not None else [str(uuid.uuid4()) for _ in texts]
+
+        partition_values: list[Any] = []
+        for idx, meta in enumerate(meta_list):
+            if partition_field == "id":
+                partition_values.append(id_list[idx])
+            else:
+                value = meta.get(partition_field) if isinstance(meta, dict) else None
+                if value is None:
+                    raise ValueError(
+                        f"Partition key '{partition_field}' not found in metadata "
+                        f"at index {idx}"
+                    )
+                partition_values.append(value)
+
+        items = [
+            {
+                "id": item_id,
+                "pk": pk,
+                self.text_key: text,
+                self.embedding_key: embedding,
+                self.metadata_key: meta,
+            }
+            for item_id, pk, text, meta, embedding in zip(
+                id_list, partition_values, texts, meta_list, embeddings, strict=False
+            )
+        ]
+
+        grouped: dict[Any, list[dict[str, Any]]] = defaultdict(list)
+        for item in items:
+            grouped[item["pk"]].append(item)
+
+        batch_size = 25
+        doc_ids: list[str] = []
+        for pk_value, group in grouped.items():
+            for batch in chunked(group, batch_size):
+                self._batch_create(batch, pk_value)
+                doc_ids.extend(doc["id"] for doc in batch)
+        return doc_ids
+
+    @retry_on_cosmos_throttle()
+    def _batch_create(self, batch: list[dict[str, Any]], pk_value: Any) -> None:
+        # execute_item_batch expects each operation as (type, args_tuple[, kwargs]);
+        # the create body must be wrapped in a 1-tuple, i.e. ("create", (doc,)).
+        self._container.execute_item_batch(
+            batch_operations=[("create", (doc,)) for doc in batch],
+            partition_key=pk_value,
+        )
+
+    def delete_by_id(self, document_id: str, partition_key_value: Any) -> bool:
+        """Delete a single document; returns True on success, False on miss."""
+        try:
+            self._container.delete_item(
+                item=document_id, partition_key=partition_key_value
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - depends on SDK
+            logger.warning(
+                "delete_by_id failed for %s/%s: %s",
+                document_id,
+                partition_key_value,
+                exc,
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # embedding
+    # ------------------------------------------------------------------
+
+    def _embed_texts(self, texts: list[str]) -> list[list[float]]:
+        if self.embedder is not None:
+            return embed_texts_via_embedder(self.embedder, texts)
+        return embed_texts(
+            self._openai_client,
+            texts,
+            model=self.embedding_model,
+            dimensions=self.dimensions,
+        )
+
+    # ------------------------------------------------------------------
+    # tool entry point
+    # ------------------------------------------------------------------
+
+    def _run(self, query: str) -> str:
+        try:
+            search_query, parameters = self._construct_query(query=query)
+            results = self._execute_query(search_query, parameters)
+            return json.dumps(results)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Vector search failed: %s", exc)
+            return json.dumps({"error": str(exc)})
+
+    def _normalised_search_type(self) -> str:
+        """Strip _score_threshold suffix; keeps SQL generation simple."""
+        if self.search_type == "vector_score_threshold":
+            return "vector"
+        if self.search_type == "hybrid_score_threshold":
+            return "hybrid"
+        return self.search_type
+
+    def _construct_query(self, query: str) -> tuple[str, list[dict[str, Any]]]:
+        config = self.query_config or AzureCosmosDBNoSqlSearchConfig()
+        effective_type = self._normalised_search_type()
+        # Only vector / hybrid searches need an embedding; pure full-text
+        # searches must not force an embedder (or an OpenAI key) to be present.
+        embeddings = (
+            self._embed_texts([query])[0]
+            if effective_type in ("vector", "hybrid")
+            else None
+        )
+
+        if effective_type in ("full_text_ranking", "hybrid"):
+            sql = f"SELECT {'TOP ' + str(config.max_results) + ' ' if not config.offset_limit else ''}"
+        else:
+            sql = f"""SELECT {"TOP @top " if not config.offset_limit else ""}"""
+
+        sql += self._generate_projection_fields(embeddings, effective_type)
+        table = self.table_alias
+        sql += f" FROM {table}"
+
+        if config.where:
+            sql += f" WHERE {config.where}"
+
+        # NOTE: Cosmos NoSQL VectorDistance/FullTextScore do not currently
+        # accept @param placeholders, so embedding values and FTS terms must
+        # be interpolated. Embedding values come from the embedder; FTS terms
+        # are SQL-quoted via quote_sql_string to defend against injection.
+        if effective_type == "full_text_ranking":
+            if config.full_text_rank_filter is None:
+                raise ValueError(
+                    "full_text_rank_filter cannot be None for full_text_ranking queries."
+                )
+            if len(config.full_text_rank_filter) == 1:
+                f = config.full_text_rank_filter[0]
+                field = validate_sql_identifier(f["search_field"], name="search_field")
+                terms = _quote_terms(f["search_text"])
+                sql += f" ORDER BY RANK FullTextScore({table}.{field}, {terms})"
+            else:
+                rank_components = [
+                    f"FullTextScore({table}."
+                    f"{validate_sql_identifier(item['search_field'], name='search_field')}, "
+                    f"{_quote_terms(item['search_text'])})"
+                    for item in config.full_text_rank_filter
+                ]
+                sql += f" ORDER BY RANK RRF({', '.join(rank_components)})"
+        elif effective_type == "vector":
+            sql += f" ORDER BY VectorDistance({table}[@embeddingKey], @embeddings)"
+        elif effective_type == "hybrid":
+            if config.full_text_rank_filter is None:
+                raise ValueError(
+                    "full_text_rank_filter cannot be None for hybrid queries."
+                )
+            rank_components = [
+                f"FullTextScore({table}."
+                f"{validate_sql_identifier(item['search_field'], name='search_field')}, "
+                f"{_quote_terms(item['search_text'])})"
+                for item in config.full_text_rank_filter
+            ]
+            sql += (
+                f" ORDER BY RANK RRF({', '.join(rank_components)}, "
+                f"VectorDistance({table}.{self.embedding_key}, {embeddings})"
+            )
+            if config.weights:
+                sql += f", {config.weights})"
+            else:
+                sql += ")"
+
+        if config.offset_limit is not None:
+            sql += f" {config.offset_limit}"
+
+        parameters: list[dict[str, Any]] = []
+        if effective_type in ("full_text_search", "vector"):
+            parameters = self._build_parameters(embeddings)
+        return sql, parameters
+
+    def _generate_projection_fields(
+        self,
+        embeddings: list[float] | None = None,
+        effective_type: str | None = None,
+    ) -> str:
+        config = self.query_config or AzureCosmosDBNoSqlSearchConfig()
+        table = self.table_alias
+        effective_type = effective_type or self._normalised_search_type()
+
+        if effective_type in ("full_text_ranking", "hybrid"):
+            if config.projection_mapping:
+                projection = ", ".join(
+                    f"{table}.{validate_sql_identifier(key, name='projection key')} "
+                    f"as {validate_sql_identifier(alias, name='projection alias')}"
+                    for key, alias in config.projection_mapping.items()
+                )
+            elif config.full_text_rank_filter:
+                projection = f"{table}.id, " + ", ".join(
+                    f"{table}.{validate_sql_identifier(item['search_field'], name='search_field')} "
+                    f"as {validate_sql_identifier(item['search_field'], name='search_field')}"
+                    for item in config.full_text_rank_filter
+                )
+            else:
+                projection = (
+                    f"{table}.id, {table}.{self.text_key} as description, "
+                    f"{table}.{self.metadata_key} as metadata"
+                )
+            if effective_type == "hybrid":
+                if config.with_embedding:
+                    projection += f", {table}.{self.embedding_key} as embedding"
+                projection += (
+                    f", VectorDistance({table}.{self.embedding_key}, "
+                    f"{embeddings}) as SimilarityScore"
+                )
+            return projection
+
+        if config.projection_mapping:
+            projection = ", ".join(
+                f"{table}[@{validate_sql_identifier(key, name='projection key')}] "
+                f"as {validate_sql_identifier(alias, name='projection alias')}"
+                for key, alias in config.projection_mapping.items()
+            )
+        elif config.full_text_rank_filter:
+            projection = f"{table}.id, " + ", ".join(
+                f"{table}.{validate_sql_identifier(item['search_field'], name='search_field')} "
+                f"as {validate_sql_identifier(item['search_field'], name='search_field')}"
+                for item in config.full_text_rank_filter
+            )
+        else:
+            projection = (
+                f"{table}.id, {table}[@textKey] as description, "
+                f"{table}[@metadataKey] as metadata"
+            )
+
+        if effective_type == "vector":
+            if config.with_embedding:
+                projection += f", {table}[@embeddingKey] as embedding"
+            projection += (
+                f", VectorDistance({table}[@embeddingKey], "
+                "@embeddings) as SimilarityScore"
+            )
+        return projection
+
+    def _build_parameters(self, embeddings: list[float] | None) -> list[dict[str, Any]]:
+        config = self.query_config or AzureCosmosDBNoSqlSearchConfig()
+        parameters: list[dict[str, Any]] = [
+            {"name": "@top", "value": config.max_results},
+        ]
+
+        if config.projection_mapping:
+            for key in config.projection_mapping:
+                parameters.append({"name": f"@{key}", "value": key})  # noqa: PERF401
+        else:
+            parameters.append({"name": "@textKey", "value": self.text_key})
+            parameters.append({"name": "@metadataKey", "value": self.metadata_key})
+
+        if self._normalised_search_type() == "vector":
+            parameters.append({"name": "@embeddingKey", "value": self.embedding_key})
+            parameters.append({"name": "@embeddings", "value": embeddings})
+        return parameters
+
+    @retry_on_cosmos_throttle()
+    def _query_items(
+        self, query: str, parameters: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return list(
+            self._container.query_items(
+                query=query, parameters=parameters, enable_cross_partition_query=True
+            )
+        )
+
+    def _execute_query(
+        self, query: str, parameters: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        config = self.query_config or AzureCosmosDBNoSqlSearchConfig()
+        items = self._query_items(query, parameters)
+        results: list[dict[str, Any]] = []
+        threshold_search = self.search_type in (
+            "vector_score_threshold",
+            "hybrid_score_threshold",
+        )
+        for item in items:
+            if self._normalised_search_type() in ("vector", "hybrid"):
+                score = item.get("SimilarityScore", 0.0)
+                # For the *_score_threshold types, always apply the configured
+                # threshold (None => keep all). For the plain "vector"/"hybrid"
+                # types, only filter when the caller explicitly set a threshold;
+                # applying a 0.0 default here would wrongly drop every result
+                # for euclidean distance (where lower == more similar).
+                if threshold_search:
+                    if not score_threshold_passes(
+                        score, config.threshold, self._distance_strategy
+                    ):
+                        continue
+                elif config.threshold is not None:
+                    if not score_threshold_passes(
+                        score, config.threshold, self._distance_strategy
+                    ):
+                        continue
+            results.append(item)
+        return results
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying CosmosClient (idempotent)."""
+        if getattr(self, "_owns_cosmos_client", False):
+            close_cosmos_client(getattr(self, "_cosmos_client", None))
+            self._owns_cosmos_client = False
+
+    def __enter__(self) -> AzureCosmosDBNoSqlSearchTool:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/azure/cosmosdb_nosql/vector_search/vector_search_tool.py
@@ -330,8 +330,16 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
         """Embed ``texts`` and insert them into the container in batches."""
         if not texts:
             raise ValueError("texts cannot be null or empty")
+        if metadatas is not None and len(metadatas) != len(texts):
+            raise ValueError(
+                f"metadatas length ({len(metadatas)}) must match texts length "
+                f"({len(texts)})"
+            )
+        if ids is not None and len(ids) != len(texts):
+            raise ValueError(
+                f"ids length ({len(ids)}) must match texts length ({len(texts)})"
+            )
 
-        embeddings = self._embed_texts(texts)
         partition_key_config = self.cosmos_container_properties["partition_key"]
         if isinstance(partition_key_config, dict):
             partition_paths = partition_key_config.get("paths", ["/id"])
@@ -339,10 +347,15 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
             partition_paths = [partition_key_config]
         else:
             partition_paths = ["/id"]
-        # Hierarchical partition keys are resolved via the first level for
-        # add_texts; callers needing finer control can pre-shape the document.
+        if len(partition_paths) > 1:
+            raise ValueError(
+                "add_texts does not support hierarchical (multi-path) partition "
+                "keys. Pre-shape the documents and insert them directly via the "
+                "container, or configure a single-level partition key."
+            )
         partition_field = partition_paths[0].lstrip("/")
 
+        embeddings = self._embed_texts(texts)
         meta_list = list(metadatas) if metadatas is not None else [{} for _ in texts]
         id_list = list(ids) if ids is not None else [str(uuid.uuid4()) for _ in texts]
 
@@ -359,22 +372,26 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
                     )
                 partition_values.append(value)
 
-        items = [
-            {
+        items: list[dict[str, Any]] = []
+        for item_id, pk, text, meta, embedding in zip(
+            id_list, partition_values, texts, meta_list, embeddings, strict=False
+        ):
+            doc: dict[str, Any] = {
                 "id": item_id,
-                "pk": pk,
                 self.text_key: text,
                 self.embedding_key: embedding,
                 self.metadata_key: meta,
             }
-            for item_id, pk, text, meta, embedding in zip(
-                id_list, partition_values, texts, meta_list, embeddings, strict=False
-            )
-        ]
+            # Write the partition value at the container's actual partition-key
+            # path so Cosmos can locate it (a hardcoded "pk" field would be
+            # rejected whenever the path is not "/pk"). "/id" needs nothing extra.
+            if partition_field != "id":
+                doc[partition_field] = pk
+            items.append(doc)
 
         grouped: dict[Any, list[dict[str, Any]]] = defaultdict(list)
-        for item in items:
-            grouped[item["pk"]].append(item)
+        for item, pk in zip(items, partition_values, strict=False):
+            grouped[pk].append(item)
 
         batch_size = 25
         doc_ids: list[str] = []
@@ -455,22 +472,43 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
             else None
         )
 
+        # Guard against ``max_results=None`` (typed Optional) producing invalid
+        # SQL like "TOP None" / a null ``@top`` parameter. When there is no
+        # ``max_results`` and no ``offset_limit`` clause, omit TOP entirely.
+        max_results = config.max_results
+        use_top = max_results is not None and not config.offset_limit
         if effective_type in ("full_text_ranking", "hybrid"):
-            sql = f"SELECT {'TOP ' + str(config.max_results) + ' ' if not config.offset_limit else ''}"
+            top_clause = (
+                f"TOP {int(max_results)} "
+                if (max_results is not None and not config.offset_limit)
+                else ""
+            )
         else:
-            sql = f"""SELECT {"TOP @top " if not config.offset_limit else ""}"""
+            top_clause = "TOP @top " if use_top else ""
+        sql = f"SELECT {top_clause}"
 
         sql += self._generate_projection_fields(embeddings, effective_type)
         table = self.table_alias
         sql += f" FROM {table}"
 
-        if config.where:
-            sql += f" WHERE {config.where}"
-
         # NOTE: Cosmos NoSQL VectorDistance/FullTextScore do not currently
         # accept @param placeholders, so embedding values and FTS terms must
         # be interpolated. Embedding values come from the embedder; FTS terms
         # are SQL-quoted via quote_sql_string to defend against injection.
+        where_clauses: list[str] = []
+        if config.where:
+            where_clauses.append(config.where)
+        if effective_type == "full_text_search":
+            # Use the query text as a full-text predicate; without this the
+            # tool would return arbitrary documents that ignore the query.
+            terms = _quote_terms(query)
+            if terms:
+                where_clauses.append(
+                    f"FullTextContainsAll({table}.{self.text_key}, {terms})"
+                )
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+
         if effective_type == "full_text_ranking":
             if config.full_text_rank_filter is None:
                 raise ValueError(
@@ -584,9 +622,12 @@ class AzureCosmosDBNoSqlSearchTool(BaseTool):
 
     def _build_parameters(self, embeddings: list[float] | None) -> list[dict[str, Any]]:
         config = self.query_config or AzureCosmosDBNoSqlSearchConfig()
-        parameters: list[dict[str, Any]] = [
-            {"name": "@top", "value": config.max_results},
-        ]
+        parameters: list[dict[str, Any]] = []
+        # Only bind @top when it is actually referenced in the SQL (i.e. there
+        # is a max_results and no offset_limit); otherwise Cosmos would receive
+        # a null-valued parameter.
+        if config.max_results is not None and not config.offset_limit:
+            parameters.append({"name": "@top", "value": config.max_results})
 
         if config.projection_mapping:
             for key in config.projection_mapping:

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/conftest.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/conftest.py
@@ -1,0 +1,43 @@
+"""Shared mocks for the Azure CosmosDB NoSQL tool tests.
+
+The tests do not require live ``azure-cosmos`` / ``azure-identity`` /
+``openai`` installations. We register lightweight ``MagicMock`` stand-ins for
+the modules in :mod:`sys.modules` so importing the tools succeeds and we can
+assert against the recorded calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+
+def _install_stub(module_path: str) -> MagicMock:
+    """Register a MagicMock at ``module_path`` if no real module is present."""
+    if module_path in sys.modules and not isinstance(
+        sys.modules[module_path], MagicMock
+    ):
+        return sys.modules[module_path]  # real module present, leave it
+    stub = sys.modules.get(module_path)
+    if stub is None:
+        stub = MagicMock(name=module_path)
+        sys.modules[module_path] = stub
+    return stub
+
+
+# azure.cosmos / azure.core.credentials — only stub if azure-cosmos is missing.
+try:  # pragma: no cover - presence depends on extras
+    import azure.cosmos  # noqa: F401
+except ImportError:  # pragma: no cover
+    azure_pkg = _install_stub("azure")
+    azure_cosmos = _install_stub("azure.cosmos")
+    azure_pkg.cosmos = azure_cosmos
+    azure_core = _install_stub("azure.core")
+    azure_core_creds = _install_stub("azure.core.credentials")
+    azure_pkg.core = azure_core
+    azure_core.credentials = azure_core_creds
+
+try:  # pragma: no cover
+    import openai  # noqa: F401
+except ImportError:  # pragma: no cover
+    _install_stub("openai")

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
@@ -264,3 +264,29 @@ def test_clear_streams_and_counts(patched_helpers):
     assert payload["success"] is True
     assert payload["deleted_count"] == 150
     assert patched_helpers["container"].execute_item_batch.call_count == 2
+
+
+def test_retrieve_supports_nested_partition_path(patched_helpers):
+    """Nested partition paths ('/address/zip') must map to SQL dot notation."""
+    tool = _build_tool(
+        cosmos_container_properties={
+            "partition_key": {"paths": ["/address/zip"], "kind": "Hash"}
+        }
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+    tool._run(operation="retrieve", partition_key_value="98052")
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "c.address.zip = '98052'" in sql
+
+
+def test_retrieve_rejects_non_positive_max_results(patched_helpers):
+    """max_results <= 0 must error out instead of loading the whole partition."""
+    tool = _build_tool()
+    for bad in (0, -5):
+        payload = json.loads(
+            tool._run(
+                operation="retrieve", partition_key_value="a-1", max_results=bad
+            )
+        )
+        assert payload == {"error": "max_results must be a positive integer"}
+    patched_helpers["container"].query_items.assert_not_called()

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
@@ -178,3 +178,89 @@ def test_partition_key_value_with_quote_is_escaped(patched_helpers):
     tool._run(operation="retrieve", partition_key_value="agent's-1")
     sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
     assert "c.agent_id = 'agent''s-1'" in sql
+
+
+# ---------------------------------------------------------------------------
+# Review-fix regressions
+# ---------------------------------------------------------------------------
+
+
+def test_args_schema_declares_all_operands():
+    """args_schema must expose every field _run needs, or the agent path drops them."""
+    from crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool import (
+        AzureCosmosDBMemoryToolSchema,
+    )
+
+    fields = set(AzureCosmosDBMemoryToolSchema.model_fields)
+    assert {
+        "operation",
+        "memory_item",
+        "partition_key_value",
+        "memory_id",
+        "query_filter",
+        "max_results",
+        "ttl",
+    } <= fields
+
+
+def test_store_stamps_created_at(patched_helpers):
+    """Stored items must get a created_at so retrieve's ORDER BY includes them."""
+    tool = _build_tool()
+    patched_helpers["container"].create_item.return_value = {"id": "m-1"}
+    tool._run(
+        operation="store",
+        memory_item={"id": "m-1", "agent_id": "a-1", "content": {"text": "hi"}},
+    )
+    body = patched_helpers["container"].create_item.call_args.kwargs["body"]
+    assert "created_at" in body
+
+
+def test_update_merges_into_existing(patched_helpers):
+    """update must preserve fields the caller did not resend."""
+    tool = _build_tool()
+    patched_helpers["container"].read_item.return_value = {
+        "id": "m-1",
+        "agent_id": "a-1",
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "content": {"text": "old"},
+        "keep": "me",
+    }
+    patched_helpers["container"].replace_item.return_value = {"id": "m-1"}
+
+    tool._run(
+        operation="update",
+        partition_key_value="a-1",
+        memory_id="m-1",
+        memory_item={"content": {"text": "new"}},
+    )
+
+    body = patched_helpers["container"].replace_item.call_args.kwargs["body"]
+    assert body["content"] == {"text": "new"}      # updated
+    assert body["created_at"] == "2024-01-01T00:00:00+00:00"  # preserved
+    assert body["keep"] == "me"                    # preserved
+    assert body["id"] == "m-1"
+
+
+def test_clear_reports_partial_count_on_failure(patched_helpers):
+    """A mid-loop batch failure must still report how many were deleted."""
+    tool = _build_tool()
+    # 150 ids -> two batches (100 + 50); make the first batch delete fail.
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": f"m-{i}"} for i in range(150)]
+    )
+    patched_helpers["container"].execute_item_batch.side_effect = RuntimeError("boom")
+
+    payload = json.loads(tool._run(operation="clear", partition_key_value="a-1"))
+    assert "error" in payload
+    assert payload["deleted_count"] == 0
+
+
+def test_clear_streams_and_counts(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": f"m-{i}"} for i in range(150)]
+    )
+    payload = json.loads(tool._run(operation="clear", partition_key_value="a-1"))
+    assert payload["success"] is True
+    assert payload["deleted_count"] == 150
+    assert patched_helpers["container"].execute_item_batch.call_count == 2

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_memory_store_tool.py
@@ -1,0 +1,180 @@
+"""Tests for AzureCosmosDBMemoryTool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+CONTAINER_PROPS = {"partition_key": {"paths": ["/agent_id"], "kind": "Hash"}}
+
+
+@pytest.fixture
+def patched_helpers():
+    with (
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool.build_cosmos_client"
+        ),
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool.create_database_if_not_exists"
+        ) as make_db,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool.create_container_if_not_exists"
+        ) as make_container,
+    ):
+        container = MagicMock()
+        make_container.return_value = container
+        make_db.return_value.get_container_client.return_value = container
+        yield {"container": container}
+
+
+def _build_tool(**config_overrides):
+    from crewai_tools.azure.cosmosdb_nosql.memory_store.memory_store_tool import (
+        AzureCosmosDBMemoryConfig,
+        AzureCosmosDBMemoryTool,
+    )
+
+    cfg = dict(
+        cosmos_host="https://example.documents.azure.com:443/",
+        key="dummy-key",
+        cosmos_container_properties=CONTAINER_PROPS,
+    )
+    cfg.update(config_overrides)
+    return AzureCosmosDBMemoryTool(config=AzureCosmosDBMemoryConfig(**cfg))
+
+
+def test_unknown_operation_returns_valid_operations(patched_helpers):
+    tool = _build_tool()
+    payload = json.loads(tool._run(operation="bogus"))
+    assert payload["error"].startswith("Unknown operation")
+    assert set(payload["valid_operations"]) == {
+        "store",
+        "read",
+        "retrieve",
+        "update",
+        "delete",
+        "clear",
+    }
+
+
+def test_store_requires_memory_item(patched_helpers):
+    tool = _build_tool()
+    payload = json.loads(tool._run(operation="store"))
+    assert payload == {"error": "memory_item is required for store operation"}
+
+
+def test_store_persists_item_with_ttl(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["container"].create_item.return_value = {
+        "id": "m-1",
+        "agent_id": "a-1",
+    }
+    payload = json.loads(
+        tool._run(
+            operation="store",
+            memory_item={"id": "m-1", "agent_id": "a-1", "content": {"text": "hi"}},
+            ttl=60,
+        )
+    )
+    body = patched_helpers["container"].create_item.call_args.kwargs["body"]
+    assert body["ttl"] == 60
+    assert payload["id"] == "m-1"
+
+
+def test_read_requires_partition_key_and_id(patched_helpers):
+    tool = _build_tool()
+    assert json.loads(tool._run(operation="read")) == {
+        "error": "partition_key_value is required for read operation"
+    }
+    assert json.loads(tool._run(operation="read", partition_key_value="a-1")) == {
+        "error": "memory_id is required for read operation"
+    }
+
+
+def test_retrieve_builds_partition_filter_with_query_filter(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": "m-1", "agent_id": "a-1"}]
+    )
+
+    payload = json.loads(
+        tool._run(
+            operation="retrieve",
+            partition_key_value="a-1",
+            query_filter={"category": "facts"},
+            max_results=3,
+        )
+    )
+
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "TOP 3" in sql
+    assert "c.agent_id = 'a-1'" in sql
+    assert "c.content.category = 'facts'" in sql
+    assert payload == [{"id": "m-1", "agent_id": "a-1"}]
+
+
+def test_retrieve_hierarchical_partition_value_count_mismatch(patched_helpers):
+    tool = _build_tool(
+        cosmos_container_properties={
+            "partition_key": {
+                "paths": ["/tenant_id", "/agent_id"],
+                "kind": "MultiHash",
+            }
+        }
+    )
+    payload = json.loads(
+        tool._run(operation="retrieve", partition_key_value=["a-1"])
+    )
+    assert "partition key levels" in payload["error"]
+
+
+def test_clear_uses_batch_delete_tuple_format(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": "m-1"}, {"id": "m-2"}]
+    )
+
+    json.loads(tool._run(operation="clear", partition_key_value="a-1"))
+
+    batch_kwargs = patched_helpers["container"].execute_item_batch.call_args.kwargs
+    assert batch_kwargs["partition_key"] == "a-1"
+    assert batch_kwargs["batch_operations"] == [
+        ("delete", ("m-1",)),
+        ("delete", ("m-2",)),
+    ]
+
+
+def test_retrieve_query_filter_escapes_single_quotes(patched_helpers):
+    """Single quotes in filter values must be SQL-escaped."""
+    tool = _build_tool()
+    patched_helpers["container"].query_items.return_value = iter([])
+
+    tool._run(
+        operation="retrieve",
+        partition_key_value="a-1",
+        query_filter={"author": "O'Brien"},
+    )
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "c.content.author = 'O''Brien'" in sql
+
+
+def test_retrieve_query_filter_rejects_bad_key(patched_helpers):
+    tool = _build_tool()
+    payload = json.loads(
+        tool._run(
+            operation="retrieve",
+            partition_key_value="a-1",
+            query_filter={"bad key; DROP TABLE c": "x"},
+        )
+    )
+    assert "error" in payload
+
+
+def test_partition_key_value_with_quote_is_escaped(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["container"].query_items.return_value = iter([])
+    tool._run(operation="retrieve", partition_key_value="agent's-1")
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "c.agent_id = 'agent''s-1'" in sql

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
@@ -205,3 +205,23 @@ def test_clear_cache_deletes_items_not_database(patched_helpers):
     assert payload["success"] is True
     assert payload["deleted_count"] == 2
     assert patched_helpers["container"].delete_item.call_count == 2
+
+
+def test_update_uses_deterministic_id(patched_helpers):
+    """Re-caching the same prompt+namespace must reuse the same document id."""
+    tool = _build_tool(llm_string="gpt-4o")
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].upsert_item.return_value = {"id": "x"}
+
+    tool._run(operation="update", prompt="hello", response="a")
+    id_1 = patched_helpers["container"].upsert_item.call_args.kwargs["body"]["id"]
+    tool._run(operation="update", prompt="hello", response="b")
+    id_2 = patched_helpers["container"].upsert_item.call_args.kwargs["body"]["id"]
+
+    assert id_1 == id_2  # same prompt -> same id -> upsert replaces
+
+    tool._run(operation="update", prompt="different", response="c")
+    id_3 = patched_helpers["container"].upsert_item.call_args.kwargs["body"]["id"]
+    assert id_3 != id_1  # different prompt -> different id

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
@@ -225,3 +225,29 @@ def test_update_uses_deterministic_id(patched_helpers):
     tool._run(operation="update", prompt="different", response="c")
     id_3 = patched_helpers["container"].upsert_item.call_args.kwargs["body"]["id"]
     assert id_3 != id_1  # different prompt -> different id
+
+
+def test_nested_partition_path_rejected_at_init(patched_helpers):
+    """Nested partition paths would be written as a flat 'metadata/agent_id'
+    field; the cache must reject them at construction time."""
+    with pytest.raises(ValueError, match="Nested partition key"):
+        _build_tool(
+            cosmos_container_properties={
+                "partition_key": {"paths": ["/metadata/agent_id"], "kind": "Hash"}
+            }
+        )
+
+
+def test_clear_reports_failed_deletions(patched_helpers):
+    """_clear_cache must surface failed deletions instead of always success."""
+    tool = _build_tool(llm_string="gpt-4o")
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": "a", "_pk": "p"}, {"id": "b", "_pk": None}]
+    )
+    # Second delete (missing _pk) raises; first succeeds.
+    patched_helpers["container"].delete_item.side_effect = [None, RuntimeError("boom")]
+
+    payload = json.loads(tool._run(operation="clear"))
+    assert payload["deleted_count"] == 1
+    assert payload["failed_count"] == 1
+    assert payload["success"] is False

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_semantic_cache_tool.py
@@ -1,0 +1,207 @@
+"""Tests for AzureCosmosDBSemanticCacheTool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+INDEXING_POLICY = {
+    "indexingMode": "consistent",
+    "automatic": True,
+    "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+    "fullTextIndexes": [{"path": "/prompt"}],
+}
+EMBEDDING_POLICY = {
+    "vectorEmbeddings": [
+        {
+            "path": "/embedding",
+            "dataType": "float32",
+            "dimensions": 4,
+            "distanceFunction": "cosine",
+        }
+    ]
+}
+FULL_TEXT_POLICY = {"fullTextPaths": [{"path": "/prompt", "language": "en-US"}]}
+CONTAINER_PROPS = {"partition_key": {"paths": ["/agent_id"], "kind": "Hash"}}
+
+
+def _embed_response(vec):
+    item = MagicMock()
+    item.embedding = vec
+    response = MagicMock()
+    response.data = [item]
+    return response
+
+
+@pytest.fixture
+def patched_helpers():
+    with (
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool.build_cosmos_client"
+        ),
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool.create_database_if_not_exists"
+        ) as make_db,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool.create_container_if_not_exists"
+        ) as make_container,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool.build_openai_client"
+        ) as openai_client,
+    ):
+        container = MagicMock()
+        make_container.return_value = container
+        make_db.return_value.get_container_client.return_value = container
+        yield {"openai": openai_client.return_value, "container": container}
+
+
+def _build_tool(**overrides):
+    from crewai_tools.azure.cosmosdb_nosql.semantic_cache.semantic_cache_tool import (
+        AzureCosmosDBSemanticCacheConfig,
+        AzureCosmosDBSemanticCacheTool,
+    )
+
+    cfg_kwargs = dict(
+        cosmos_host="https://example.documents.azure.com:443/",
+        key="dummy-key",
+        openai_api_key="dummy-openai-key",
+        cosmos_container_properties=CONTAINER_PROPS,
+        indexing_policy=INDEXING_POLICY,
+        vector_embedding_policy=EMBEDDING_POLICY,
+        full_text_policy=FULL_TEXT_POLICY,
+        embedding_dimensions=4,
+        dimensions=4,
+    )
+    cfg_kwargs.update(overrides)
+    config = AzureCosmosDBSemanticCacheConfig(**cfg_kwargs)
+    return AzureCosmosDBSemanticCacheTool(config=config)
+
+
+def test_init_validates_vector_indexes(patched_helpers):
+    with pytest.raises(ValueError, match="vectorIndexes"):
+        _build_tool(indexing_policy={"vectorIndexes": []})
+
+
+def test_hybrid_requires_full_text_policy(patched_helpers):
+    with pytest.raises(ValueError, match="fullTextIndexes|fullTextPaths"):
+        _build_tool(
+            indexing_policy={
+                "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}]
+            }
+        )
+
+
+def test_unknown_operation_returns_error_payload(patched_helpers):
+    tool = _build_tool()
+    payload = json.loads(tool._run(operation="bogus"))
+    assert payload["error"].startswith("Unknown operation")
+    assert "search" in payload["valid_operations"]
+
+
+def test_search_requires_prompt(patched_helpers):
+    tool = _build_tool()
+    payload = json.loads(tool._run(operation="search"))
+    assert payload == {"error": "prompt is required for search operation"}
+
+
+def test_search_returns_cached_response_above_threshold(patched_helpers):
+    tool = _build_tool(similarity_threshold=0.5)
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    # Cosmos VectorDistance for cosine returns a similarity-like score
+    # (higher = better). 0.95 is comfortably above threshold 0.5.
+    patched_helpers["container"].query_items.return_value = iter(
+        [
+            {
+                "id": "cache-1",
+                "prompt": "what is crewAI",
+                "response": "a multi-agent framework",
+                "similarity_score": 0.95,
+            }
+        ]
+    )
+
+    payload = json.loads(tool._run(operation="search", prompt="what is crewAI?"))
+
+    assert payload["cache_hit"] is True
+    assert payload["cached_response"] == "a multi-agent framework"
+
+
+def test_update_persists_document_with_partition_key_field(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].upsert_item.return_value = {"id": "cache-x"}
+
+    json.loads(tool._run(operation="update", prompt="hi", response="hello"))
+
+    upsert_call = patched_helpers["container"].upsert_item.call_args
+    body = upsert_call.kwargs["body"]
+    assert body["prompt"] == "hi"
+    assert body["response"] == "hello"
+    # partition key field should be filled in by setdefault
+    assert "agent_id" in body
+
+
+def test_search_filters_by_llm_namespace(patched_helpers):
+    """Different llm_string values must produce different cache namespaces."""
+    tool_a = _build_tool(llm_string="gpt-4o")
+    tool_b = _build_tool(llm_string="claude-opus-4")
+    assert tool_a._llm_namespace != tool_b._llm_namespace
+
+
+def test_search_quote_escapes_fts_terms(patched_helpers):
+    """Single quotes inside the prompt must not break out of the FTS literal."""
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+
+    tool._run(operation="search", prompt="O'Brien")
+
+    call = patched_helpers["container"].query_items.call_args
+    sql = call.kwargs.get("query") or call.args[0]
+    # Apostrophe must be doubled; raw single quote must NOT appear unescaped
+    # adjacent to the token.
+    assert "'O''Brien'" in sql
+
+
+def test_search_uses_explicit_projection_not_star(patched_helpers):
+    """Cosmos rejects 'SELECT *, <expr>'; the cache must project explicit fields.
+
+    Covers both the hybrid (RRF) and vector-only query paths.
+    """
+    for enable_hybrid in (True, False):
+        tool = _build_tool(enable_hybrid_search=enable_hybrid)
+        patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+            [0.1, 0.2, 0.3, 0.4]
+        )
+        patched_helpers["container"].query_items.return_value = iter([])
+
+        tool._run(operation="search", prompt="hello world")
+
+        call = patched_helpers["container"].query_items.call_args
+        sql = call.kwargs.get("query") or call.args[0]
+        assert "*" not in sql, f"SELECT * leaked into SQL (hybrid={enable_hybrid})"
+        assert "c.response" in sql
+        assert "similarity_score" in sql
+
+
+def test_clear_cache_deletes_items_not_database(patched_helpers):
+    """_clear_cache must delete matching rows, not the whole database."""
+    tool = _build_tool(llm_string="gpt-4o")
+    patched_helpers["container"].query_items.return_value = iter(
+        [{"id": "a", "_pk": "agent1"}, {"id": "b", "_pk": "agent1"}]
+    )
+
+    payload = json.loads(tool._run(operation="clear"))
+
+    assert payload["success"] is True
+    assert payload["deleted_count"] == 2
+    assert patched_helpers["container"].delete_item.call_count == 2

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
@@ -1,0 +1,282 @@
+"""Tests for AzureCosmosDBNoSqlSearchTool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Reasonable defaults reused across tests --------------------------------------
+
+INDEXING_POLICY = {
+    "indexingMode": "consistent",
+    "automatic": True,
+    "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+}
+EMBEDDING_POLICY = {
+    "vectorEmbeddings": [
+        {
+            "path": "/embedding",
+            "dataType": "float32",
+            "dimensions": 4,
+            "distanceFunction": "cosine",
+        }
+    ]
+}
+CONTAINER_PROPS = {"partition_key": {"paths": ["/pk"], "kind": "Hash"}}
+
+
+def _embed_response(vec):
+    item = MagicMock()
+    item.embedding = vec
+    response = MagicMock()
+    response.data = [item]
+    return response
+
+
+@pytest.fixture
+def patched_helpers():
+    """Patch the shared client/embedding helpers and yield references."""
+    with (
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool.build_cosmos_client"
+        ) as cosmos,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool.create_database_if_not_exists"
+        ) as make_db,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool.create_container_if_not_exists"
+        ) as make_container,
+        patch(
+            "crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool.build_openai_client"
+        ) as openai_client,
+    ):
+        container = MagicMock()
+        make_container.return_value = container
+        make_db.return_value.get_container_client.return_value = container
+        yield {
+            "cosmos": cosmos,
+            "openai": openai_client.return_value,
+            "container": container,
+        }
+
+
+def _build_tool(**overrides):
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchTool,
+    )
+
+    defaults = dict(
+        cosmos_host="https://example.documents.azure.com:443/",
+        key="dummy-key",
+        openai_api_key="dummy-openai-key",
+        indexing_policy=INDEXING_POLICY,
+        vector_embedding_policy=EMBEDDING_POLICY,
+        cosmos_container_properties=CONTAINER_PROPS,
+        dimensions=4,
+    )
+    defaults.update(overrides)
+    return AzureCosmosDBNoSqlSearchTool(**defaults)
+
+
+def test_init_creates_database_and_container(patched_helpers):
+    tool = _build_tool()
+    assert tool._container is patched_helpers["container"]
+
+
+def test_invalid_search_type_rejected(patched_helpers):
+    with pytest.raises(ValueError, match="Invalid search_type"):
+        _build_tool(search_type="not-a-real-type")
+
+
+def test_missing_partition_key_rejected(patched_helpers):
+    with pytest.raises(ValueError, match="partition_key"):
+        _build_tool(cosmos_container_properties={})
+
+
+def test_full_text_requires_indexes_when_enabled(patched_helpers):
+    with pytest.raises(ValueError, match="fullTextIndexes"):
+        _build_tool(full_text_search_enabled=True)
+
+
+def test_run_vector_search_returns_filtered_results(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter(
+        [
+            {"id": "doc-1", "description": "high", "SimilarityScore": 0.9},
+            {"id": "doc-2", "description": "low", "SimilarityScore": 0.0},
+        ]
+    )
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchConfig,
+    )
+
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(threshold=0.1, max_results=5)
+
+    output = json.loads(tool._run("hello"))
+
+    assert [item["id"] for item in output] == ["doc-1"]
+    call_kwargs = patched_helpers["container"].query_items.call_args.kwargs
+    assert "VectorDistance" in call_kwargs["query"]
+
+
+def test_add_texts_without_metadata_partition_key_raises(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    with pytest.raises(ValueError, match="Partition key 'pk'"):
+        tool.add_texts(["hello"])
+
+
+def test_add_texts_wraps_batch_create_body_in_tuple(patched_helpers):
+    """execute_item_batch requires ('create', (doc,)); a bare dict body is rejected
+    by the SDK's _format_batch_operations. Guard the tuple shape here."""
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+
+    ids = tool.add_texts(["hello"], metadatas=[{"pk": "tenant-1"}])
+
+    assert len(ids) == 1
+    ops = patched_helpers["container"].execute_item_batch.call_args.kwargs[
+        "batch_operations"
+    ]
+    assert ops, "expected at least one batch operation"
+    for op in ops:
+        assert op[0] == "create"
+        assert isinstance(op[1], tuple) and len(op[1]) == 1
+        assert isinstance(op[1][0], dict)
+
+
+def test_plain_vector_euclidean_keeps_results_without_threshold(patched_helpers):
+    """Plain 'vector' + euclidean must not drop every result when no threshold set."""
+    euclidean_policy = {
+        "vectorEmbeddings": [
+            {
+                "path": "/embedding",
+                "dataType": "float32",
+                "dimensions": 4,
+                "distanceFunction": "euclidean",
+            }
+        ]
+    }
+    tool = _build_tool(vector_embedding_policy=euclidean_policy)
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter(
+        [
+            {"id": "near", "description": "x", "SimilarityScore": 0.05},
+            {"id": "far", "description": "y", "SimilarityScore": 5.00},
+        ]
+    )
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchConfig,
+    )
+
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(max_results=10)
+    output = json.loads(tool._run("hi"))
+    assert [item["id"] for item in output] == ["near", "far"]
+
+
+def test_run_swallows_exceptions_into_error_payload(patched_helpers):
+    tool = _build_tool()
+    patched_helpers["openai"].embeddings.create.side_effect = RuntimeError("boom")
+    output = json.loads(tool._run("hi"))
+    assert output == {"error": "boom"}
+
+
+def test_init_validates_text_key_against_injection(patched_helpers):
+    """Identifier fields must reject characters that could break out of SQL."""
+    with pytest.raises(ValueError):
+        _build_tool(text_key="text; DROP TABLE c")
+
+
+def test_full_text_terms_are_quote_escaped(patched_helpers):
+    """Single quotes in FTS search terms must be doubled in the SQL emitted."""
+    fts_indexing = {
+        **INDEXING_POLICY,
+        "fullTextIndexes": [{"path": "/text"}],
+    }
+    tool = _build_tool(
+        full_text_search_enabled=True,
+        search_type="full_text_ranking",
+        indexing_policy=fts_indexing,
+        full_text_policy={"fullTextPaths": [{"path": "/text", "language": "en-US"}]},
+    )
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchConfig,
+    )
+
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(
+        full_text_rank_filter=[{"search_field": "text", "search_text": "O'Brien"}],
+        max_results=5,
+        threshold=0.0,
+    )
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+    tool._run("anything")
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "'O''Brien'" in sql
+
+
+def test_full_text_search_does_not_require_embedder(patched_helpers):
+    """Pure full-text search must not call the embedder / require an OpenAI key."""
+    fts_indexing = {
+        **INDEXING_POLICY,
+        "fullTextIndexes": [{"path": "/text"}],
+    }
+    tool = _build_tool(
+        full_text_search_enabled=True,
+        search_type="full_text_search",
+        indexing_policy=fts_indexing,
+        full_text_policy={"fullTextPaths": [{"path": "/text", "language": "en-US"}]},
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+
+    tool._run("some free text query")
+
+    patched_helpers["openai"].embeddings.create.assert_not_called()
+
+
+def test_distance_aware_threshold_for_euclidean(patched_helpers):
+    """Euclidean: lower distance is better; threshold filters by distance."""
+    euclidean_policy = {
+        "vectorEmbeddings": [
+            {
+                "path": "/embedding",
+                "dataType": "float32",
+                "dimensions": 4,
+                "distanceFunction": "euclidean",
+            }
+        ]
+    }
+    tool = _build_tool(vector_embedding_policy=euclidean_policy)
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter(
+        [
+            {"id": "near", "description": "x", "SimilarityScore": 0.05},
+            {"id": "far",  "description": "y", "SimilarityScore": 5.00},
+        ]
+    )
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchConfig,
+    )
+
+    # For euclidean, threshold means MAX allowed distance.
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(
+        search_type="vector_score_threshold", threshold=1.0, max_results=10
+    )
+    output = json.loads(tool._run("hi"))
+    assert [item["id"] for item in output] == ["near"]

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
@@ -134,9 +134,9 @@ def test_add_texts_without_metadata_partition_key_raises(patched_helpers):
         tool.add_texts(["hello"])
 
 
-def test_add_texts_wraps_batch_create_body_in_tuple(patched_helpers):
-    """execute_item_batch requires ('create', (doc,)); a bare dict body is rejected
-    by the SDK's _format_batch_operations. Guard the tuple shape here."""
+def test_add_texts_wraps_batch_body_in_tuple(patched_helpers):
+    """execute_item_batch requires (op, (doc,)); a bare dict body is rejected by
+    the SDK's _format_batch_operations. Use 'upsert' so retries are idempotent."""
     tool = _build_tool()
     patched_helpers["openai"].embeddings.create.return_value = _embed_response(
         [0.1, 0.2, 0.3, 0.4]
@@ -150,7 +150,7 @@ def test_add_texts_wraps_batch_create_body_in_tuple(patched_helpers):
     ]
     assert ops, "expected at least one batch operation"
     for op in ops:
-        assert op[0] == "create"
+        assert op[0] == "upsert"
         assert isinstance(op[1], tuple) and len(op[1]) == 1
         assert isinstance(op[1][0], dict)
 
@@ -361,3 +361,10 @@ def test_distance_aware_threshold_for_euclidean(patched_helpers):
     tool.query_config = AzureCosmosDBNoSqlSearchConfig(threshold=1.0, max_results=10)
     output = json.loads(tool._run("hi"))
     assert [item["id"] for item in output] == ["near"]
+
+
+def test_hybrid_search_type_requires_full_text_policy(patched_helpers):
+    """search_type='hybrid' must require a full-text policy even when the
+    full_text_search_enabled flag is left at its default (False)."""
+    with pytest.raises(ValueError, match="fullTextIndexes|fullTextPaths"):
+        _build_tool(search_type="hybrid")  # no fullTextIndexes/paths provided

--- a/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
+++ b/lib/crewai-tools/tests/tools/azure/cosmosdb_nosql/test_vector_search_tool.py
@@ -155,6 +155,86 @@ def test_add_texts_wraps_batch_create_body_in_tuple(patched_helpers):
         assert isinstance(op[1][0], dict)
 
 
+def test_add_texts_writes_partition_value_at_configured_field(patched_helpers):
+    """The partition value must land on the container's partition path, not 'pk'."""
+    tool = _build_tool(
+        cosmos_container_properties={
+            "partition_key": {"paths": ["/agent_id"], "kind": "Hash"}
+        }
+    )
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+
+    tool.add_texts(["hello"], metadatas=[{"agent_id": "a-1"}])
+
+    call = patched_helpers["container"].execute_item_batch.call_args
+    doc = call.kwargs["batch_operations"][0][1][0]
+    assert doc["agent_id"] == "a-1"
+    assert "pk" not in doc
+    assert call.kwargs["partition_key"] == "a-1"
+
+
+def test_add_texts_rejects_hierarchical_partition_key(patched_helpers):
+    tool = _build_tool(
+        cosmos_container_properties={
+            "partition_key": {"paths": ["/tenant", "/agent_id"], "kind": "MultiHash"}
+        }
+    )
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    with pytest.raises(ValueError, match="hierarchical"):
+        tool.add_texts(["hello"], metadatas=[{"tenant": "t", "agent_id": "a"}])
+
+
+def test_add_texts_rejects_length_mismatch(patched_helpers):
+    tool = _build_tool()
+    with pytest.raises(ValueError, match="metadatas length"):
+        tool.add_texts(["a", "b"], metadatas=[{"pk": "x"}])
+
+
+def test_full_text_search_uses_query_as_predicate(patched_helpers):
+    """full_text_search must turn the query into a FullTextContains predicate."""
+    fts_indexing = {**INDEXING_POLICY, "fullTextIndexes": [{"path": "/text"}]}
+    tool = _build_tool(
+        full_text_search_enabled=True,
+        search_type="full_text_search",
+        indexing_policy=fts_indexing,
+        full_text_policy={"fullTextPaths": [{"path": "/text", "language": "en-US"}]},
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+
+    tool._run("quick brown fox")
+
+    sql = patched_helpers["container"].query_items.call_args.kwargs["query"]
+    assert "FullTextContainsAll(c.text, 'quick', 'brown', 'fox')" in sql
+    patched_helpers["openai"].embeddings.create.assert_not_called()
+
+
+def test_max_results_none_omits_top_clause(patched_helpers):
+    """max_results=None must not emit 'TOP None' or a null @top parameter."""
+    from crewai_tools.azure.cosmosdb_nosql.vector_search.vector_search_tool import (
+        AzureCosmosDBNoSqlSearchConfig,
+    )
+
+    tool = _build_tool()
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(max_results=None)
+    patched_helpers["openai"].embeddings.create.return_value = _embed_response(
+        [0.1, 0.2, 0.3, 0.4]
+    )
+    patched_helpers["container"].query_items.return_value = iter([])
+
+    tool._run("hi")
+
+    call = patched_helpers["container"].query_items.call_args
+    sql = call.kwargs["query"]
+    assert "TOP None" not in sql
+    assert "TOP " not in sql
+    names = [p["name"] for p in call.kwargs["parameters"]]
+    assert "@top" not in names
+
+
 def test_plain_vector_euclidean_keeps_results_without_threshold(patched_helpers):
     """Plain 'vector' + euclidean must not drop every result when no threshold set."""
     euclidean_policy = {
@@ -260,7 +340,10 @@ def test_distance_aware_threshold_for_euclidean(patched_helpers):
             }
         ]
     }
-    tool = _build_tool(vector_embedding_policy=euclidean_policy)
+    tool = _build_tool(
+        vector_embedding_policy=euclidean_policy,
+        search_type="vector_score_threshold",
+    )
     patched_helpers["openai"].embeddings.create.return_value = _embed_response(
         [0.1, 0.2, 0.3, 0.4]
     )
@@ -275,8 +358,6 @@ def test_distance_aware_threshold_for_euclidean(patched_helpers):
     )
 
     # For euclidean, threshold means MAX allowed distance.
-    tool.query_config = AzureCosmosDBNoSqlSearchConfig(
-        search_type="vector_score_threshold", threshold=1.0, max_results=10
-    )
+    tool.query_config = AzureCosmosDBNoSqlSearchConfig(threshold=1.0, max_results=10)
     output = json.loads(tool._run("hi"))
     assert [item["id"] for item in output] == ["near"]

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -116,6 +116,10 @@ file-processing = [
 qdrant-edge = [
     "qdrant-edge-py>=0.6.0",
 ]
+cosmosdb = [
+    "azure-cosmos>=4.7.0",
+    "azure-identity>=1.17.0",
+]
 
 
 [tool.uv]

--- a/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
@@ -1,0 +1,667 @@
+"""Azure CosmosDB NoSQL storage backend for the unified memory system.
+
+Stores :class:`crewai.memory.types.MemoryRecord` instances in an Azure
+CosmosDB for NoSQL container with vector search enabled.
+
+Container layout (created automatically on first use):
+
+* Partition key:  ``/scope`` (hash) — most queries filter by scope prefix.
+* Vector index:   ``/embedding`` (diskANN, cosine distance).
+* Document fields::
+
+    {
+        "id": "<record id>",            # also used as Cosmos doc id
+        "scope": "/...",                # partition key
+        "content": "...",
+        "categories": ["..."],
+        "metadata": {...},
+        "importance": 0.5,
+        "created_at": "ISO-8601",
+        "last_accessed": "ISO-8601",
+        "source": "...",
+        "private": false,
+        "embedding": [..]               # vector
+    }
+
+The optional ``azure-cosmos`` / ``azure-identity`` dependencies are imported
+lazily so simply ``import crewai`` does not require the extra to be
+installed; instantiating :class:`CosmosDBNoSqlStorage` does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+import logging
+from typing import Any
+
+from crewai.memory.types import MemoryRecord, ScopeInfo
+
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_VECTOR_DIM = 1536
+DEFAULT_DATABASE_NAME = "crewai_memory"
+DEFAULT_CONTAINER_NAME = "memories"
+
+_INSTALL_HINT = (
+    "CosmosDBNoSqlStorage requires the optional 'cosmosdb' extra. "
+    "Install it with: pip install 'crewai[cosmosdb]'"
+)
+
+
+def _require_azure_cosmos() -> Any:
+    """Lazy-import :mod:`azure.cosmos` with a clear error message."""
+    try:
+        import azure.cosmos  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    import azure.cosmos as azure_cosmos
+
+    return azure_cosmos
+
+
+def _default_indexing_policy() -> dict[str, Any]:
+    return {
+        "indexingMode": "consistent",
+        "automatic": True,
+        "includedPaths": [{"path": "/*"}],
+        "excludedPaths": [
+            {"path": "/embedding/*"},
+            {"path": '/"_etag"/?'},
+        ],
+        "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+    }
+
+
+def _default_vector_embedding_policy(dimensions: int) -> dict[str, Any]:
+    return {
+        "vectorEmbeddings": [
+            {
+                "path": "/embedding",
+                "dataType": "float32",
+                "distanceFunction": "cosine",
+                "dimensions": dimensions,
+            }
+        ]
+    }
+
+
+def _parse_dt(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if value is None:
+        return datetime.utcnow()
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def _quote(value: str) -> str:
+    """SQL-quote a string literal for safe interpolation in Cosmos SQL."""
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+# Cosmos VectorDistance() returns higher == better for cosine/dot-product
+# (it is rescaled to behave like a similarity), and lower == better for
+# euclidean. We inspect the configured distance function to score correctly.
+_HIGHER_BETTER = {"cosine", "dotproduct", "dot_product"}
+_LOWER_BETTER = {"euclidean"}
+
+
+def _score_from_distance(raw: float, distance_function: str) -> float:
+    """Map Cosmos' raw score to a 0..1 'higher is better' score."""
+    fn = (distance_function or "cosine").lower().replace("_", "")
+    if fn in _HIGHER_BETTER:
+        # Cosmos cosine/dot-product: already similarity-like (~0..1, higher better).
+        return float(raw)
+    # Euclidean: monotonic transform so higher = better.
+    return 1.0 / (1.0 + float(raw))
+
+
+class CosmosDBNoSqlStorage:
+    """CosmosDB NoSQL backend for crewAI's unified memory system."""
+
+    def __init__(
+        self,
+        cosmos_host: str | None = None,
+        key: str | None = None,
+        token_credential: Any | None = None,
+        database_name: str = DEFAULT_DATABASE_NAME,
+        container_name: str = DEFAULT_CONTAINER_NAME,
+        vector_dim: int = DEFAULT_VECTOR_DIM,
+        indexing_policy: dict[str, Any] | None = None,
+        vector_embedding_policy: dict[str, Any] | None = None,
+        offer_throughput: int | None = None,
+        create_container: bool = True,
+        user_agent: str = "CrewAI-CosmosDB-Memory-Python",
+        *,
+        connection_string: str | None = None,
+    ) -> None:
+        """Initialize the CosmosDB storage backend.
+
+        Args:
+            cosmos_host: Cosmos account endpoint (``https://<acct>.documents.azure.com:443/``).
+                Required unless ``connection_string`` is given.
+            key: Account primary/secondary key. Mutually exclusive with ``token_credential``.
+            token_credential: ``azure.core.credentials.TokenCredential`` (e.g.
+                ``DefaultAzureCredential``). Mutually exclusive with ``key``.
+            database_name: Database to use; created if missing.
+            container_name: Container to use; created if missing.
+            vector_dim: Embedding dimensionality used at container creation.
+            indexing_policy: Override indexing policy (default enables vector index).
+            vector_embedding_policy: Override vector embedding policy.
+            offer_throughput: Provisioned RU/s for new containers (None = serverless).
+            create_container: If False, expect the container to already exist.
+            user_agent: Suffix appended to the Cosmos SDK user agent.
+            connection_string: Cosmos account connection string (host + key). When
+                provided it is used instead of ``cosmos_host`` + ``key`` /
+                ``token_credential``.
+        """
+        azure_cosmos = _require_azure_cosmos()
+
+        if connection_string is not None:
+            if key is not None or token_credential is not None:
+                raise ValueError(
+                    "Provide 'connection_string' on its own, not together with "
+                    "'key' or 'token_credential'."
+                )
+            self._client = azure_cosmos.CosmosClient.from_connection_string(
+                connection_string, user_agent=user_agent
+            )
+        else:
+            if key is not None and token_credential is not None:
+                raise ValueError(
+                    "Provide either 'key' or 'token_credential', not both."
+                )
+            if key is None and token_credential is None:
+                raise ValueError(
+                    "Provide one of 'key', 'token_credential' or 'connection_string'."
+                )
+            if not cosmos_host:
+                raise ValueError(
+                    "'cosmos_host' is required when authenticating with a key or "
+                    "token credential."
+                )
+            credential: Any = key if key is not None else token_credential
+            self._client = azure_cosmos.CosmosClient(
+                cosmos_host, credential, user_agent=user_agent
+            )
+
+        self._cosmos_host = cosmos_host
+        self._database_name = database_name
+        self._container_name = container_name
+        self._vector_dim = vector_dim
+
+        self._database = self._client.create_database_if_not_exists(
+            id=database_name,
+            offer_throughput=offer_throughput,
+        )
+        partition_key = azure_cosmos.PartitionKey(path="/scope", kind="Hash")
+        effective_vector_policy = (
+            vector_embedding_policy or _default_vector_embedding_policy(vector_dim)
+        )
+        embeddings_def = (effective_vector_policy.get("vectorEmbeddings") or [{}])[0]
+        self._distance_function = embeddings_def.get("distanceFunction", "cosine")
+        if create_container:
+            self._container = self._database.create_container_if_not_exists(
+                id=container_name,
+                partition_key=partition_key,
+                indexing_policy=indexing_policy or _default_indexing_policy(),
+                vector_embedding_policy=effective_vector_policy,
+                offer_throughput=offer_throughput,
+            )
+        else:
+            self._container = self._database.get_container_client(container_name)
+
+    # ------------------------------------------------------------------
+    # constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_env(cls, **overrides: Any) -> CosmosDBNoSqlStorage:
+        """Build a storage backend from environment variables.
+
+        Recognised variables (first matching auth source wins):
+
+        * ``AZURE_COSMOS_CONNECTION_STRING`` -- full account connection string.
+        * ``AZURE_COSMOS_HOST`` + ``AZURE_COSMOS_KEY`` -- endpoint + account key.
+        * ``AZURE_COSMOS_HOST`` alone -- endpoint authenticated with
+          ``azure.identity.DefaultAzureCredential`` (requires the ``azure-identity``
+          package from the ``cosmosdb`` extra).
+
+        Optional overrides via env: ``AZURE_COSMOS_DATABASE_NAME``,
+        ``AZURE_COSMOS_CONTAINER_NAME``, ``AZURE_COSMOS_VECTOR_DIM``. Any keyword
+        ``overrides`` take precedence over the environment.
+
+        Raises:
+            ValueError: If no usable authentication variables are set.
+        """
+        import os
+
+        kwargs: dict[str, Any] = {
+            "database_name": os.environ.get(
+                "AZURE_COSMOS_DATABASE_NAME", DEFAULT_DATABASE_NAME
+            ),
+            "container_name": os.environ.get(
+                "AZURE_COSMOS_CONTAINER_NAME", DEFAULT_CONTAINER_NAME
+            ),
+        }
+        vector_dim = os.environ.get("AZURE_COSMOS_VECTOR_DIM")
+        if vector_dim:
+            kwargs["vector_dim"] = int(vector_dim)
+        kwargs.update(overrides)
+
+        connection_string = os.environ.get("AZURE_COSMOS_CONNECTION_STRING")
+        host = os.environ.get("AZURE_COSMOS_HOST")
+        key = os.environ.get("AZURE_COSMOS_KEY")
+
+        if connection_string:
+            return cls(connection_string=connection_string, **kwargs)
+        if host and key:
+            return cls(cosmos_host=host, key=key, **kwargs)
+        if host:
+            try:
+                from azure.identity import DefaultAzureCredential
+            except ImportError as exc:
+                raise ImportError(_INSTALL_HINT) from exc
+            return cls(
+                cosmos_host=host,
+                token_credential=DefaultAzureCredential(),
+                **kwargs,
+            )
+        raise ValueError(
+            "CosmosDBNoSqlStorage.from_env() requires "
+            "'AZURE_COSMOS_CONNECTION_STRING', or 'AZURE_COSMOS_HOST' with "
+            "'AZURE_COSMOS_KEY' (or DefaultAzureCredential) to be set."
+        )
+
+    # ------------------------------------------------------------------
+    # (de)serialisation
+    # ------------------------------------------------------------------
+
+    def _record_to_doc(self, record: MemoryRecord) -> dict[str, Any]:
+        return {
+            "id": record.id,
+            "scope": record.scope or "/",
+            "content": record.content,
+            "categories": list(record.categories),
+            "metadata": dict(record.metadata),
+            "importance": float(record.importance),
+            "created_at": record.created_at.isoformat(),
+            "last_accessed": record.last_accessed.isoformat(),
+            "source": record.source,
+            "private": bool(record.private),
+            "embedding": list(record.embedding)
+            if record.embedding is not None
+            else [0.0] * self._vector_dim,
+        }
+
+    def _doc_to_record(self, doc: dict[str, Any]) -> MemoryRecord:
+        return MemoryRecord(
+            id=str(doc["id"]),
+            content=str(doc.get("content", "")),
+            scope=str(doc.get("scope", "/")),
+            categories=list(doc.get("categories") or []),
+            metadata=dict(doc.get("metadata") or {}),
+            importance=float(doc.get("importance", 0.5)),
+            created_at=_parse_dt(doc.get("created_at")),
+            last_accessed=_parse_dt(doc.get("last_accessed")),
+            embedding=doc.get("embedding"),
+            source=doc.get("source") or None,
+            private=bool(doc.get("private", False)),
+        )
+
+    # ------------------------------------------------------------------
+    # filter helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _scope_prefix_filter(scope_prefix: str | None) -> str | None:
+        """Return a SQL fragment selecting docs whose scope is under ``scope_prefix``."""
+        if scope_prefix is None:
+            return None
+        prefix = scope_prefix.rstrip("/")
+        if not prefix or prefix == "":
+            return None
+        if not prefix.startswith("/"):
+            prefix = "/" + prefix
+        return f"(c.scope = {_quote(prefix)} OR STARTSWITH(c.scope, {_quote(prefix + '/')}))"
+
+    @staticmethod
+    def _categories_filter(categories: list[str] | None) -> str | None:
+        if not categories:
+            return None
+        clauses = [f"ARRAY_CONTAINS(c.categories, {_quote(cat)})" for cat in categories]
+        return "(" + " OR ".join(clauses) + ")"
+
+    @staticmethod
+    def _metadata_filter(metadata_filter: dict[str, Any] | None) -> str | None:
+        if not metadata_filter:
+            return None
+        clauses: list[str] = []
+        for key, value in metadata_filter.items():
+            if not key.replace("_", "").isalnum():
+                raise ValueError(
+                    f"metadata_filter key {key!r} must be alphanumeric/underscore"
+                )
+            if isinstance(value, str):
+                clauses.append(f"c.metadata.{key} = {_quote(value)}")
+            elif isinstance(value, bool):
+                clauses.append(f"c.metadata.{key} = {'true' if value else 'false'}")
+            elif isinstance(value, (int, float)):
+                clauses.append(f"c.metadata.{key} = {value}")
+            else:
+                clauses.append(f"c.metadata.{key} = {_quote(str(value))}")
+        return "(" + " AND ".join(clauses) + ")"
+
+    # ------------------------------------------------------------------
+    # write API
+    # ------------------------------------------------------------------
+
+    def save(self, records: list[MemoryRecord]) -> None:
+        for record in records:
+            self._container.upsert_item(body=self._record_to_doc(record))
+
+    def update(self, record: MemoryRecord) -> None:
+        self._container.upsert_item(body=self._record_to_doc(record))
+
+    # ------------------------------------------------------------------
+    # read API
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query_embedding: list[float],
+        scope_prefix: str | None = None,
+        categories: list[str] | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        min_score: float = 0.0,
+    ) -> list[tuple[MemoryRecord, float]]:
+        if not query_embedding:
+            return []
+
+        where_parts = [
+            part
+            for part in (
+                self._scope_prefix_filter(scope_prefix),
+                self._categories_filter(categories),
+                self._metadata_filter(metadata_filter),
+            )
+            if part
+        ]
+        where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+
+        # Cosmos NoSQL VectorDistance does not currently accept parameter
+        # placeholders, so the embedding is interpolated. Values come from
+        # the embedder, not user-supplied text, so injection risk is bounded.
+        sql = (
+            f"SELECT TOP @top c.id, c.scope, c.content, c.categories, c.metadata, "  # noqa: S608
+            f"c.importance, c.created_at, c.last_accessed, c.source, c.private, "
+            f"c.embedding, "
+            f"VectorDistance(c.embedding, {list(query_embedding)}) AS _distance "
+            f"FROM c{where_clause} "
+            f"ORDER BY VectorDistance(c.embedding, {list(query_embedding)})"
+        )
+        parameters = [{"name": "@top", "value": limit}]
+        items = list(
+            self._container.query_items(
+                query=sql,
+                parameters=parameters,
+                enable_cross_partition_query=True,
+            )
+        )
+        out: list[tuple[MemoryRecord, float]] = []
+        for doc in items:
+            distance = float(doc.pop("_distance", 1.0))
+            score = _score_from_distance(distance, self._distance_function)
+            if score < min_score:
+                continue
+            out.append((self._doc_to_record(doc), score))
+        return out
+
+    def get_record(self, record_id: str) -> MemoryRecord | None:
+        sql = "SELECT TOP 1 * FROM c WHERE c.id = @id"
+        items = list(
+            self._container.query_items(
+                query=sql,
+                parameters=[{"name": "@id", "value": record_id}],
+                enable_cross_partition_query=True,
+            )
+        )
+        if not items:
+            return None
+        return self._doc_to_record(items[0])
+
+    def list_records(
+        self,
+        scope_prefix: str | None = None,
+        limit: int = 200,
+        offset: int = 0,
+    ) -> list[MemoryRecord]:
+        scope_clause = self._scope_prefix_filter(scope_prefix)
+        where = (" WHERE " + scope_clause) if scope_clause else ""
+        sql = (
+            f"SELECT * FROM c{where} ORDER BY c.created_at DESC "  # noqa: S608
+            f"OFFSET {int(offset)} LIMIT {int(limit)}"
+        )
+        items = list(
+            self._container.query_items(
+                query=sql,
+                enable_cross_partition_query=True,
+            )
+        )
+        return [self._doc_to_record(doc) for doc in items]
+
+    def get_scope_info(self, scope: str) -> ScopeInfo:
+        scope = scope.rstrip("/") or "/"
+        clause = self._scope_prefix_filter(scope) or "true"
+        sql = f"SELECT c.scope, c.categories, c.created_at FROM c WHERE {clause}"  # noqa: S608
+        rows = list(
+            self._container.query_items(
+                query=sql,
+                enable_cross_partition_query=True,
+            )
+        )
+        if not rows:
+            return ScopeInfo(
+                path=scope,
+                record_count=0,
+                categories=[],
+                oldest_record=None,
+                newest_record=None,
+                child_scopes=[],
+            )
+        categories: set[str] = set()
+        oldest: datetime | None = None
+        newest: datetime | None = None
+        child_prefix = (scope.rstrip("/") + "/") if scope != "/" else "/"
+        children: set[str] = set()
+        for row in rows:
+            for cat in row.get("categories") or []:
+                categories.add(str(cat))
+            created = row.get("created_at")
+            if created:
+                dt = _parse_dt(created)
+                if oldest is None or dt < oldest:
+                    oldest = dt
+                if newest is None or dt > newest:
+                    newest = dt
+            sc = str(row.get("scope", ""))
+            if child_prefix and sc.startswith(child_prefix):
+                rest = sc[len(child_prefix) :]
+                first = rest.split("/", 1)[0]
+                if first:
+                    children.add(child_prefix + first)
+        return ScopeInfo(
+            path=scope,
+            record_count=len(rows),
+            categories=sorted(categories),
+            oldest_record=oldest,
+            newest_record=newest,
+            child_scopes=sorted(children),
+        )
+
+    def list_scopes(self, parent: str = "/") -> list[str]:
+        parent = parent.rstrip("/") or ""
+        prefix = (parent + "/") if parent else "/"
+        clause = self._scope_prefix_filter(parent or None)
+        sql_where = (" WHERE " + clause) if clause else ""
+        sql = f"SELECT DISTINCT VALUE c.scope FROM c{sql_where}"  # noqa: S608
+        scopes = list(
+            self._container.query_items(query=sql, enable_cross_partition_query=True)
+        )
+        children: set[str] = set()
+        for raw in scopes:
+            sc = str(raw)
+            if not sc.startswith(prefix):
+                continue
+            if sc == prefix.rstrip("/") or sc == "/":
+                continue
+            rest = sc[len(prefix) :]
+            first = rest.split("/", 1)[0]
+            if first:
+                children.add(prefix + first)
+        return sorted(children)
+
+    def list_categories(self, scope_prefix: str | None = None) -> dict[str, int]:
+        clause = self._scope_prefix_filter(scope_prefix)
+        where = (" WHERE " + clause) if clause else ""
+        sql = f"SELECT VALUE c.categories FROM c{where}"  # noqa: S608
+        rows = list(
+            self._container.query_items(query=sql, enable_cross_partition_query=True)
+        )
+        counts: dict[str, int] = {}
+        for cats in rows:
+            for cat in cats or []:
+                counts[str(cat)] = counts.get(str(cat), 0) + 1
+        return counts
+
+    def count(self, scope_prefix: str | None = None) -> int:
+        clause = self._scope_prefix_filter(scope_prefix)
+        where = (" WHERE " + clause) if clause else ""
+        sql = f"SELECT VALUE COUNT(1) FROM c{where}"  # noqa: S608
+        rows = list(
+            self._container.query_items(query=sql, enable_cross_partition_query=True)
+        )
+        return int(rows[0]) if rows else 0
+
+    # ------------------------------------------------------------------
+    # delete API
+    # ------------------------------------------------------------------
+
+    def delete(
+        self,
+        scope_prefix: str | None = None,
+        categories: list[str] | None = None,
+        record_ids: list[str] | None = None,
+        older_than: datetime | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> int:
+        # Cosmos NoSQL has no native bulk-delete-by-query in GA today, so we
+        # query the matching set first and delete document-by-document.
+        where_parts: list[str] = []
+        if (clause := self._scope_prefix_filter(scope_prefix)) is not None:
+            where_parts.append(clause)
+        if (clause := self._categories_filter(categories)) is not None:
+            where_parts.append(clause)
+        if (clause := self._metadata_filter(metadata_filter)) is not None:
+            where_parts.append(clause)
+        if record_ids:
+            id_list = ", ".join(_quote(rid) for rid in record_ids)
+            where_parts.append(f"c.id IN ({id_list})")
+        if older_than is not None:
+            where_parts.append(f"c.created_at < {_quote(older_than.isoformat())}")
+        if not where_parts:
+            # Refuse to wipe the whole container via delete() — use reset() for that.
+            raise ValueError(
+                "delete() requires at least one filter (scope_prefix, categories, "
+                "record_ids, older_than, or metadata_filter). Use reset() to wipe "
+                "the entire container."
+            )
+        where_clause = " AND ".join(where_parts)
+        sql = f"SELECT c.id, c.scope FROM c WHERE {where_clause}"  # noqa: S608
+        targets = list(
+            self._container.query_items(query=sql, enable_cross_partition_query=True)
+        )
+        deleted = 0
+        for target in targets:
+            try:
+                self._container.delete_item(
+                    item=target["id"], partition_key=target["scope"]
+                )
+                deleted += 1
+            except Exception:  # noqa: PERF203
+                _logger.debug(
+                    "Failed to delete item %s in scope %s",
+                    target.get("id"),
+                    target.get("scope"),
+                    exc_info=True,
+                )
+        return deleted
+
+    def reset(self, scope_prefix: str | None = None) -> None:
+        if scope_prefix is None or scope_prefix.strip("/") == "":
+            try:
+                self._database.delete_container(self._container_name)
+            except Exception:
+                _logger.debug(
+                    "Container %s could not be dropped on reset",
+                    self._container_name,
+                    exc_info=True,
+                )
+            azure_cosmos = _require_azure_cosmos()
+            partition_key = azure_cosmos.PartitionKey(path="/scope", kind="Hash")
+            self._container = self._database.create_container_if_not_exists(
+                id=self._container_name,
+                partition_key=partition_key,
+                indexing_policy=_default_indexing_policy(),
+                vector_embedding_policy=_default_vector_embedding_policy(
+                    self._vector_dim
+                ),
+            )
+            return
+        # Per-scope reset = delete with scope_prefix.
+        self.delete(scope_prefix=scope_prefix)
+
+    # ------------------------------------------------------------------
+    # async API (delegates to sync via threadpool)
+    # ------------------------------------------------------------------
+
+    async def asave(self, records: list[MemoryRecord]) -> None:
+        await asyncio.to_thread(self.save, records)
+
+    async def asearch(
+        self,
+        query_embedding: list[float],
+        scope_prefix: str | None = None,
+        categories: list[str] | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        min_score: float = 0.0,
+    ) -> list[tuple[MemoryRecord, float]]:
+        return await asyncio.to_thread(
+            self.search,
+            query_embedding,
+            scope_prefix,
+            categories,
+            metadata_filter,
+            limit,
+            min_score,
+        )
+
+    async def adelete(
+        self,
+        scope_prefix: str | None = None,
+        categories: list[str] | None = None,
+        record_ids: list[str] | None = None,
+        older_than: datetime | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> int:
+        return await asyncio.to_thread(
+            self.delete,
+            scope_prefix,
+            categories,
+            record_ids,
+            older_than,
+            metadata_filter,
+        )

--- a/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
@@ -31,7 +31,7 @@ installed; instantiating :class:`CosmosDBNoSqlStorage` does.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any
 
@@ -87,12 +87,19 @@ def _default_vector_embedding_policy(dimensions: int) -> dict[str, Any]:
     }
 
 
+def _to_naive_utc(dt: datetime) -> datetime:
+    """Convert an aware datetime to naive UTC; leave naive datetimes as-is."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
 def _parse_dt(value: Any) -> datetime:
     if isinstance(value, datetime):
-        return value
+        return _to_naive_utc(value)
     if value is None:
         return datetime.utcnow()
-    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return _to_naive_utc(datetime.fromisoformat(str(value).replace("Z", "+00:00")))
 
 
 def _quote(value: str) -> str:
@@ -286,8 +293,8 @@ class CosmosDBNoSqlStorage:
             "categories": list(record.categories),
             "metadata": dict(record.metadata),
             "importance": float(record.importance),
-            "created_at": record.created_at.isoformat(),
-            "last_accessed": record.last_accessed.isoformat(),
+            "created_at": _to_naive_utc(record.created_at).isoformat(),
+            "last_accessed": _to_naive_utc(record.last_accessed).isoformat(),
             "source": record.source,
             "private": bool(record.private),
             "embedding": list(record.embedding)
@@ -455,14 +462,19 @@ class CosmosDBNoSqlStorage:
     def get_scope_info(self, scope: str) -> ScopeInfo:
         scope = scope.rstrip("/") or "/"
         clause = self._scope_prefix_filter(scope) or "true"
-        sql = f"SELECT c.scope, c.categories, c.created_at FROM c WHERE {clause}"  # noqa: S608
-        rows = list(
+        where = f" WHERE {clause}"
+        agg_sql = (
+            f"SELECT COUNT(1) AS n, MIN(c.created_at) AS oldest, "  # noqa: S608
+            f"MAX(c.created_at) AS newest FROM c{where}"
+        )
+        agg_rows = list(
             self._container.query_items(
-                query=sql,
-                enable_cross_partition_query=True,
+                query=agg_sql, enable_cross_partition_query=True
             )
         )
-        if not rows:
+        agg = agg_rows[0] if agg_rows else {}
+        record_count = int(agg.get("n", 0) or 0)
+        if record_count == 0:
             return ScopeInfo(
                 path=scope,
                 record_count=0,
@@ -471,31 +483,36 @@ class CosmosDBNoSqlStorage:
                 newest_record=None,
                 child_scopes=[],
             )
-        categories: set[str] = set()
-        oldest: datetime | None = None
-        newest: datetime | None = None
+        oldest = _parse_dt(agg["oldest"]) if agg.get("oldest") else None
+        newest = _parse_dt(agg["newest"]) if agg.get("newest") else None
+
+        # Distinct categories, flattened and de-duplicated server-side.
+        cat_sql = f"SELECT DISTINCT VALUE cat FROM c JOIN cat IN c.categories{where}"  # noqa: S608
+        categories = sorted(
+            str(cat)
+            for cat in self._container.query_items(
+                query=cat_sql, enable_cross_partition_query=True
+            )
+        )
+
+        # Distinct scopes -> immediate child scopes.
+        scope_sql = f"SELECT DISTINCT VALUE c.scope FROM c{where}"  # noqa: S608
         child_prefix = (scope.rstrip("/") + "/") if scope != "/" else "/"
         children: set[str] = set()
-        for row in rows:
-            for cat in row.get("categories") or []:
-                categories.add(str(cat))
-            created = row.get("created_at")
-            if created:
-                dt = _parse_dt(created)
-                if oldest is None or dt < oldest:
-                    oldest = dt
-                if newest is None or dt > newest:
-                    newest = dt
-            sc = str(row.get("scope", ""))
+        for raw in self._container.query_items(
+            query=scope_sql, enable_cross_partition_query=True
+        ):
+            sc = str(raw)
             if child_prefix and sc.startswith(child_prefix):
                 rest = sc[len(child_prefix) :]
                 first = rest.split("/", 1)[0]
                 if first:
                     children.add(child_prefix + first)
+
         return ScopeInfo(
             path=scope,
-            record_count=len(rows),
-            categories=sorted(categories),
+            record_count=record_count,
+            categories=categories,
             oldest_record=oldest,
             newest_record=newest,
             child_scopes=sorted(children),
@@ -526,14 +543,18 @@ class CosmosDBNoSqlStorage:
     def list_categories(self, scope_prefix: str | None = None) -> dict[str, int]:
         clause = self._scope_prefix_filter(scope_prefix)
         where = (" WHERE " + clause) if clause else ""
-        sql = f"SELECT VALUE c.categories FROM c{where}"  # noqa: S608
+        sql = (
+            f"SELECT cat AS category, COUNT(1) AS n "  # noqa: S608
+            f"FROM c JOIN cat IN c.categories{where} GROUP BY cat"
+        )
         rows = list(
             self._container.query_items(query=sql, enable_cross_partition_query=True)
         )
         counts: dict[str, int] = {}
-        for cats in rows:
-            for cat in cats or []:
-                counts[str(cat)] = counts.get(str(cat), 0) + 1
+        for row in rows:
+            cat = row.get("category")
+            if cat is not None:
+                counts[str(cat)] = int(row.get("n", 0) or 0)
         return counts
 
     def count(self, scope_prefix: str | None = None) -> int:
@@ -570,7 +591,9 @@ class CosmosDBNoSqlStorage:
             id_list = ", ".join(_quote(rid) for rid in record_ids)
             where_parts.append(f"c.id IN ({id_list})")
         if older_than is not None:
-            where_parts.append(f"c.created_at < {_quote(older_than.isoformat())}")
+            where_parts.append(
+                f"c.created_at < {_quote(_to_naive_utc(older_than).isoformat())}"
+            )
         if not where_parts:
             # Refuse to wipe the whole container via delete() — use reset() for that.
             raise ValueError(
@@ -601,15 +624,15 @@ class CosmosDBNoSqlStorage:
 
     def reset(self, scope_prefix: str | None = None) -> None:
         if scope_prefix is None or scope_prefix.strip("/") == "":
+            azure_cosmos = _require_azure_cosmos()
             try:
                 self._database.delete_container(self._container_name)
-            except Exception:
-                _logger.debug(
-                    "Container %s could not be dropped on reset",
-                    self._container_name,
-                    exc_info=True,
-                )
-            azure_cosmos = _require_azure_cosmos()
+            except azure_cosmos.exceptions.CosmosResourceNotFoundError:
+                # Container already absent — nothing to drop, safe to recreate.
+                pass
+            # Any other error (throttling, auth, etc.) must propagate: silently
+            # continuing would recreate/return a container that still holds
+            # every record while reporting a successful reset.
             partition_key = azure_cosmos.PartitionKey(path="/scope", kind="Hash")
             self._container = self._database.create_container_if_not_exists(
                 id=self._container_name,
@@ -622,6 +645,34 @@ class CosmosDBNoSqlStorage:
             return
         # Per-scope reset = delete with scope_prefix.
         self.delete(scope_prefix=scope_prefix)
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying ``CosmosClient`` (idempotent).
+
+        ``Memory.close()`` calls this when the backend defines it; without it the
+        client's HTTP connection pool would leak for the process lifetime.
+        """
+        client = getattr(self, "_client", None)
+        if client is None:
+            return
+        try:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+        except Exception:  # pragma: no cover - defensive cleanup
+            _logger.debug("Failed to close Cosmos client", exc_info=True)
+        finally:
+            self._client = None
+
+    def __enter__(self) -> CosmosDBNoSqlStorage:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
 
     # ------------------------------------------------------------------
     # async API (delegates to sync via threadpool)

--- a/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/cosmosdb_nosql_storage.py
@@ -459,21 +459,28 @@ class CosmosDBNoSqlStorage:
         )
         return [self._doc_to_record(doc) for doc in items]
 
+    def _scalar_query(self, sql: str) -> Any:
+        """Run a single-value query (e.g. ``SELECT VALUE COUNT(1)``) and return it.
+
+        The Cosmos NoSQL Python SDK only supports one VALUE aggregate per
+        cross-partition query (it rejects multiple/non-VALUE aggregates), so
+        aggregates are issued one at a time through this helper.
+        """
+        rows = list(
+            self._container.query_items(query=sql, enable_cross_partition_query=True)
+        )
+        return rows[0] if rows else None
+
     def get_scope_info(self, scope: str) -> ScopeInfo:
         scope = scope.rstrip("/") or "/"
         clause = self._scope_prefix_filter(scope) or "true"
         where = f" WHERE {clause}"
-        agg_sql = (
-            f"SELECT COUNT(1) AS n, MIN(c.created_at) AS oldest, "  # noqa: S608
-            f"MAX(c.created_at) AS newest FROM c{where}"
+
+        # One VALUE aggregate per query — the SDK cannot serve multiple/aliased
+        # aggregates in a single cross-partition query.
+        record_count = int(
+            self._scalar_query(f"SELECT VALUE COUNT(1) FROM c{where}") or 0  # noqa: S608
         )
-        agg_rows = list(
-            self._container.query_items(
-                query=agg_sql, enable_cross_partition_query=True
-            )
-        )
-        agg = agg_rows[0] if agg_rows else {}
-        record_count = int(agg.get("n", 0) or 0)
         if record_count == 0:
             return ScopeInfo(
                 path=scope,
@@ -483,8 +490,14 @@ class CosmosDBNoSqlStorage:
                 newest_record=None,
                 child_scopes=[],
             )
-        oldest = _parse_dt(agg["oldest"]) if agg.get("oldest") else None
-        newest = _parse_dt(agg["newest"]) if agg.get("newest") else None
+        oldest_raw = self._scalar_query(
+            f"SELECT VALUE MIN(c.created_at) FROM c{where}"  # noqa: S608
+        )
+        newest_raw = self._scalar_query(
+            f"SELECT VALUE MAX(c.created_at) FROM c{where}"  # noqa: S608
+        )
+        oldest = _parse_dt(oldest_raw) if oldest_raw else None
+        newest = _parse_dt(newest_raw) if newest_raw else None
 
         # Distinct categories, flattened and de-duplicated server-side.
         cat_sql = f"SELECT DISTINCT VALUE cat FROM c JOIN cat IN c.categories{where}"  # noqa: S608
@@ -543,18 +556,18 @@ class CosmosDBNoSqlStorage:
     def list_categories(self, scope_prefix: str | None = None) -> dict[str, int]:
         clause = self._scope_prefix_filter(scope_prefix)
         where = (" WHERE " + clause) if clause else ""
-        sql = (
-            f"SELECT cat AS category, COUNT(1) AS n "  # noqa: S608
-            f"FROM c JOIN cat IN c.categories{where} GROUP BY cat"
-        )
-        rows = list(
-            self._container.query_items(query=sql, enable_cross_partition_query=True)
-        )
+        # The Cosmos NoSQL Python SDK cannot serve a cross-partition GROUP BY,
+        # so instead of aggregating server-side we UNWIND the categories array
+        # (JOIN) and stream just the category values (not whole documents),
+        # counting them client-side. This still avoids transferring full docs.
+        sql = f"SELECT VALUE cat FROM c JOIN cat IN c.categories{where}"  # noqa: S608
         counts: dict[str, int] = {}
-        for row in rows:
-            cat = row.get("category")
+        for cat in self._container.query_items(
+            query=sql, enable_cross_partition_query=True
+        ):
             if cat is not None:
-                counts[str(cat)] = int(row.get("n", 0) or 0)
+                key = str(cat)
+                counts[key] = counts.get(key, 0) + 1
         return counts
 
     def count(self, scope_prefix: str | None = None) -> int:

--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -91,7 +91,12 @@ class Memory(BaseModel):
     )
     storage: Annotated[StorageBackend | str, PlainValidator(_passthrough)] = Field(
         default="lancedb",
-        description="Storage backend instance or path string.",
+        description=(
+            "Storage backend: a StorageBackend instance, a recognised selector "
+            "string ('lancedb', 'qdrant-edge', 'cosmosdb'), or a filesystem path "
+            "(treated as a LanceDB location). 'cosmosdb' is configured from "
+            "AZURE_COSMOS_* environment variables."
+        ),
     )
     embedder: Any = Field(
         default=None,
@@ -239,6 +244,12 @@ class Memory(BaseModel):
                 from crewai.memory.storage.qdrant_edge_storage import QdrantEdgeStorage
 
                 self._storage = QdrantEdgeStorage()
+            elif self.storage == "cosmosdb":
+                from crewai.memory.storage.cosmosdb_nosql_storage import (
+                    CosmosDBNoSqlStorage,
+                )
+
+                self._storage = CosmosDBNoSqlStorage.from_env()
             elif self.storage == "lancedb":
                 from crewai.memory.storage.lancedb_storage import LanceDBStorage
 

--- a/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
+++ b/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
@@ -385,3 +385,74 @@ def test_memory_selector_cosmosdb_uses_from_env(monkeypatch: pytest.MonkeyPatch)
         mem = Memory(storage="cosmosdb", llm=MagicMock(), embedder=MagicMock())
     from_env.assert_called_once()
     assert mem._storage is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Review-fix regressions
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dt_normalizes_aware_to_naive_utc() -> None:
+    from crewai.memory.storage.cosmosdb_nosql_storage import _parse_dt
+
+    dt = _parse_dt("2024-01-01T12:00:00+02:00")
+    assert dt.tzinfo is None
+    assert (dt.hour, dt.minute) == (10, 0)  # converted to UTC
+
+
+def test_record_to_doc_stores_naive_utc_iso(storage: CosmosDBNoSqlStorage) -> None:
+    rec = _record()
+    rec.created_at = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    doc = storage._record_to_doc(rec)
+    assert "+" not in doc["created_at"] and "Z" not in doc["created_at"]
+
+
+def test_close_releases_client(storage: CosmosDBNoSqlStorage) -> None:
+    client = storage._client
+    storage.close()
+    client.close.assert_called_once()
+    assert storage._client is None
+    storage.close()  # idempotent, no raise
+
+
+def test_reset_propagates_non_notfound_error(storage: CosmosDBNoSqlStorage) -> None:
+    storage._database.delete_container.side_effect = RuntimeError("throttled")
+    with pytest.raises(RuntimeError, match="throttled"):
+        storage.reset()
+
+
+def test_reset_ignores_container_not_found(storage: CosmosDBNoSqlStorage) -> None:
+    import azure.cosmos as ac
+
+    storage._database.delete_container.side_effect = (
+        ac.exceptions.CosmosResourceNotFoundError()
+    )
+    storage.reset()  # must not raise; recreates the container
+    storage._database.create_container_if_not_exists.assert_called()
+
+
+def test_get_scope_info_uses_server_side_aggregates(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    mock_container.query_items.side_effect = [
+        iter([{"n": 2, "oldest": "2024-01-01T00:00:00", "newest": "2024-02-01T00:00:00"}]),
+        iter(["k1", "k2"]),
+        iter(["/a", "/a/b"]),
+    ]
+    info = storage.get_scope_info("/a")
+    assert info.record_count == 2
+    assert info.categories == ["k1", "k2"]
+    agg_sql = mock_container.query_items.call_args_list[0].kwargs["query"]
+    assert "COUNT(1)" in agg_sql and "MIN(c.created_at)" in agg_sql
+
+
+def test_list_categories_uses_group_by(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    mock_container.query_items.return_value = iter(
+        [{"category": "k1", "n": 3}, {"category": "k2", "n": 1}]
+    )
+    counts = storage.list_categories()
+    assert counts == {"k1": 3, "k2": 1}
+    sql = mock_container.query_items.call_args.kwargs["query"]
+    assert "GROUP BY cat" in sql

--- a/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
+++ b/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
@@ -1,0 +1,387 @@
+"""Tests for the CosmosDB NoSQL memory storage backend.
+
+The Azure SDK is mocked end-to-end so these tests run with no live Cosmos
+account and without requiring the ``cosmosdb`` extra to be installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# azure.cosmos stub (installed before the module under test is imported)
+# ---------------------------------------------------------------------------
+
+
+def _install_azure_cosmos_stub() -> None:
+    if "azure.cosmos" in sys.modules:
+        return
+
+    azure_pkg = sys.modules.setdefault("azure", types.ModuleType("azure"))
+    cosmos_module = types.ModuleType("azure.cosmos")
+
+    class _PartitionKey:
+        def __init__(self, path: str, kind: str = "Hash") -> None:
+            self.path = path
+            self.kind = kind
+
+    class _CosmosClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def create_database_if_not_exists(self, **_: Any) -> Any:
+            return MagicMock(name="database")
+
+    cosmos_module.CosmosClient = _CosmosClient
+    cosmos_module.PartitionKey = _PartitionKey
+    cosmos_module.exceptions = types.SimpleNamespace(
+        CosmosResourceNotFoundError=type("CosmosResourceNotFoundError", (Exception,), {})
+    )
+    sys.modules["azure.cosmos"] = cosmos_module
+    setattr(azure_pkg, "cosmos", cosmos_module)
+
+
+_install_azure_cosmos_stub()
+
+from crewai.memory.storage.cosmosdb_nosql_storage import (  # noqa: E402
+    CosmosDBNoSqlStorage,
+    _score_from_distance,
+)
+from crewai.memory.types import MemoryRecord  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_container() -> MagicMock:
+    return MagicMock(name="container")
+
+
+@pytest.fixture
+def storage(mock_container: MagicMock) -> CosmosDBNoSqlStorage:
+    """Build a storage backend whose Cosmos plumbing is fully mocked."""
+    db = MagicMock(name="database")
+    db.create_container_if_not_exists.return_value = mock_container
+    db.get_container_client.return_value = mock_container
+
+    client = MagicMock(name="client")
+    client.create_database_if_not_exists.return_value = db
+
+    with patch(
+        "crewai.memory.storage.cosmosdb_nosql_storage._require_azure_cosmos"
+    ) as require:
+        azure_cosmos = MagicMock()
+        azure_cosmos.CosmosClient.return_value = client
+        azure_cosmos.PartitionKey.side_effect = lambda **kw: kw
+        require.return_value = azure_cosmos
+
+        store = CosmosDBNoSqlStorage(
+            cosmos_host="https://example.documents.azure.com:443/",
+            key="fake-key",
+            vector_dim=4,
+        )
+    store._container = mock_container  # ensure tests target the right mock
+    return store
+
+
+def _record(content: str = "hello", scope: str = "/", **overrides: Any) -> MemoryRecord:
+    payload: dict[str, Any] = dict(
+        content=content,
+        scope=scope,
+        categories=[],
+        importance=0.5,
+        embedding=[0.1, 0.2, 0.3, 0.4],
+        metadata={},
+    )
+    payload.update(overrides)
+    return MemoryRecord(**payload)
+
+
+# ---------------------------------------------------------------------------
+# Lazy-import / install hint
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_import_raises_with_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If azure-cosmos is missing, the error must mention the extras name."""
+    from crewai.memory.storage import cosmosdb_nosql_storage as mod
+
+    # Force the import inside _require_azure_cosmos to fail by hiding the
+    # already-loaded stub from sys.modules and short-circuiting the loader.
+    monkeypatch.delitem(sys.modules, "azure.cosmos", raising=False)
+    monkeypatch.delitem(sys.modules, "azure", raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "azure.cosmos" or name.startswith("azure.cosmos."):
+            raise ImportError("simulated missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _fake_import)
+    with pytest.raises(ImportError) as exc:
+        mod._require_azure_cosmos()
+    assert "cosmosdb" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Distance scoring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,fn,expected_high_better",
+    [
+        (0.95, "cosine", True),
+        (0.95, "dotProduct", True),
+        (0.05, "euclidean", True),  # transformed: 1/(1+0.05) ~= 0.952
+    ],
+)
+def test_score_from_distance_orientation(
+    raw: float, fn: str, expected_high_better: bool
+) -> None:
+    """Score must be 'higher = better' regardless of distance function."""
+    s = _score_from_distance(raw, fn)
+    assert 0.0 <= s <= 1.0
+    if expected_high_better:
+        assert s > 0.5
+
+
+def test_score_from_distance_euclidean_smaller_distance_higher_score() -> None:
+    near = _score_from_distance(0.01, "euclidean")
+    far = _score_from_distance(2.0, "euclidean")
+    assert near > far
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_save_upserts_each_record(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    storage.save([_record(content="a"), _record(content="b")])
+    assert mock_container.upsert_item.call_count == 2
+
+
+def test_get_record_returns_none_when_missing(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    mock_container.query_items.return_value = iter([])
+    assert storage.get_record("missing-id") is None
+
+
+def test_get_record_round_trip(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    mock_container.query_items.return_value = iter(
+        [
+            {
+                "id": "rec-1",
+                "scope": "/agents/a1",
+                "content": "remembered",
+                "categories": ["k"],
+                "metadata": {"source": "test"},
+                "importance": 0.7,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_accessed": None,
+                "source": None,
+                "private": False,
+                "embedding": [0.1, 0.2, 0.3, 0.4],
+            }
+        ]
+    )
+    rec = storage.get_record("rec-1")
+    assert rec is not None
+    assert rec.content == "remembered"
+    assert rec.scope == "/agents/a1"
+
+
+def test_search_uses_distance_aware_score_for_cosine(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    """For cosine, Cosmos VectorDistance is similarity-like (higher = better)."""
+    mock_container.query_items.return_value = iter(
+        [
+            {
+                "id": "doc-good",
+                "scope": "/",
+                "content": "good",
+                "categories": [],
+                "metadata": {},
+                "importance": 0.5,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_accessed": None,
+                "source": None,
+                "private": False,
+                "embedding": [0.1, 0.2, 0.3, 0.4],
+                "_distance": 0.92,  # similarity-like (cosine)
+            },
+            {
+                "id": "doc-bad",
+                "scope": "/",
+                "content": "bad",
+                "categories": [],
+                "metadata": {},
+                "importance": 0.5,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_accessed": None,
+                "source": None,
+                "private": False,
+                "embedding": [0.1, 0.2, 0.3, 0.4],
+                "_distance": 0.10,
+            },
+        ]
+    )
+    results = storage.search([0.1, 0.2, 0.3, 0.4], min_score=0.5)
+    assert [r.content for r, _ in results] == ["good"]
+    # The kept score is the raw similarity for cosine.
+    assert results[0][1] == pytest.approx(0.92)
+
+
+def test_search_empty_query_returns_empty(storage: CosmosDBNoSqlStorage) -> None:
+    assert storage.search([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Filter SQL safety
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_filter_rejects_non_alphanumeric_key() -> None:
+    with pytest.raises(ValueError):
+        CosmosDBNoSqlStorage._metadata_filter({"bad key": "x"})
+
+
+def test_metadata_filter_quotes_string_values_safely() -> None:
+    sql = CosmosDBNoSqlStorage._metadata_filter({"author": "O'Reilly"})
+    assert sql is not None
+    # Single quotes inside the value must be doubled per SQL escape rules.
+    assert "O''Reilly" in sql
+
+
+def test_scope_prefix_filter_quotes_value() -> None:
+    sql = CosmosDBNoSqlStorage._scope_prefix_filter("/agents/a'1")
+    assert sql is not None
+    assert "a''1" in sql
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_asave_dispatches_to_save(
+    storage: CosmosDBNoSqlStorage, mock_container: MagicMock
+) -> None:
+    asyncio.run(storage.asave([_record()]))
+    assert mock_container.upsert_item.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth: connection string + from_env()
+# ---------------------------------------------------------------------------
+
+
+def _mock_azure_cosmos() -> MagicMock:
+    db = MagicMock(name="database")
+    container = MagicMock(name="container")
+    db.create_container_if_not_exists.return_value = container
+    db.get_container_client.return_value = container
+    client = MagicMock(name="client")
+    client.create_database_if_not_exists.return_value = db
+
+    azure_cosmos = MagicMock()
+    azure_cosmos.CosmosClient.return_value = client
+    azure_cosmos.CosmosClient.from_connection_string.return_value = client
+    azure_cosmos.PartitionKey.side_effect = lambda **kw: kw
+    return azure_cosmos
+
+
+def test_init_connection_string_conflicts_with_key() -> None:
+    azure_cosmos = _mock_azure_cosmos()
+    with patch(
+        "crewai.memory.storage.cosmosdb_nosql_storage._require_azure_cosmos",
+        return_value=azure_cosmos,
+    ):
+        with pytest.raises(ValueError, match="connection_string"):
+            CosmosDBNoSqlStorage(connection_string="conn", key="k", vector_dim=4)
+
+
+def test_init_connection_string_builds_client_from_connection_string() -> None:
+    azure_cosmos = _mock_azure_cosmos()
+    with patch(
+        "crewai.memory.storage.cosmosdb_nosql_storage._require_azure_cosmos",
+        return_value=azure_cosmos,
+    ):
+        CosmosDBNoSqlStorage(connection_string="AccountEndpoint=x;AccountKey=y;", vector_dim=4)
+    azure_cosmos.CosmosClient.from_connection_string.assert_called_once()
+    azure_cosmos.CosmosClient.assert_not_called()
+
+
+def test_from_env_prefers_connection_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_COSMOS_CONNECTION_STRING", "AccountEndpoint=x;AccountKey=y;")
+    monkeypatch.delenv("AZURE_COSMOS_HOST", raising=False)
+    monkeypatch.delenv("AZURE_COSMOS_KEY", raising=False)
+    azure_cosmos = _mock_azure_cosmos()
+    with patch(
+        "crewai.memory.storage.cosmosdb_nosql_storage._require_azure_cosmos",
+        return_value=azure_cosmos,
+    ):
+        store = CosmosDBNoSqlStorage.from_env(vector_dim=4)
+    assert store is not None
+    azure_cosmos.CosmosClient.from_connection_string.assert_called_once()
+
+
+def test_from_env_host_and_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AZURE_COSMOS_CONNECTION_STRING", raising=False)
+    monkeypatch.setenv("AZURE_COSMOS_HOST", "https://acct.documents.azure.com:443/")
+    monkeypatch.setenv("AZURE_COSMOS_KEY", "fake-key")
+    monkeypatch.setenv("AZURE_COSMOS_DATABASE_NAME", "envdb")
+    azure_cosmos = _mock_azure_cosmos()
+    with patch(
+        "crewai.memory.storage.cosmosdb_nosql_storage._require_azure_cosmos",
+        return_value=azure_cosmos,
+    ):
+        store = CosmosDBNoSqlStorage.from_env(vector_dim=4)
+    call = azure_cosmos.CosmosClient.call_args
+    assert call.args[0] == "https://acct.documents.azure.com:443/"
+    assert call.args[1] == "fake-key"
+    assert store._database_name == "envdb"
+
+
+def test_from_env_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AZURE_COSMOS_CONNECTION_STRING",
+        "AZURE_COSMOS_HOST",
+        "AZURE_COSMOS_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ValueError, match="from_env"):
+        CosmosDBNoSqlStorage.from_env()
+
+
+def test_memory_selector_cosmosdb_uses_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Memory(storage='cosmosdb') must route to CosmosDBNoSqlStorage.from_env()."""
+    from crewai.memory.unified_memory import Memory
+
+    sentinel = MagicMock(name="cosmos-storage")
+    with patch.object(
+        CosmosDBNoSqlStorage, "from_env", return_value=sentinel
+    ) as from_env:
+        mem = Memory(storage="cosmosdb", llm=MagicMock(), embedder=MagicMock())
+    from_env.assert_called_once()
+    assert mem._storage is sentinel

--- a/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
+++ b/lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py
@@ -434,25 +434,36 @@ def test_reset_ignores_container_not_found(storage: CosmosDBNoSqlStorage) -> Non
 def test_get_scope_info_uses_server_side_aggregates(
     storage: CosmosDBNoSqlStorage, mock_container: MagicMock
 ) -> None:
+    # get_scope_info issues one VALUE aggregate per query (COUNT, then MIN, then
+    # MAX), followed by DISTINCT category and scope queries — the SDK cannot
+    # serve multiple/aliased aggregates in a single cross-partition query.
     mock_container.query_items.side_effect = [
-        iter([{"n": 2, "oldest": "2024-01-01T00:00:00", "newest": "2024-02-01T00:00:00"}]),
-        iter(["k1", "k2"]),
-        iter(["/a", "/a/b"]),
+        iter([2]),  # SELECT VALUE COUNT(1)
+        iter(["2024-01-01T00:00:00"]),  # SELECT VALUE MIN(c.created_at)
+        iter(["2024-02-01T00:00:00"]),  # SELECT VALUE MAX(c.created_at)
+        iter(["k1", "k2"]),  # DISTINCT categories
+        iter(["/a", "/a/b"]),  # DISTINCT scopes
     ]
     info = storage.get_scope_info("/a")
     assert info.record_count == 2
     assert info.categories == ["k1", "k2"]
-    agg_sql = mock_container.query_items.call_args_list[0].kwargs["query"]
-    assert "COUNT(1)" in agg_sql and "MIN(c.created_at)" in agg_sql
+    assert info.oldest_record is not None and info.newest_record is not None
+    queries = [c.kwargs["query"] for c in mock_container.query_items.call_args_list]
+    assert "VALUE COUNT(1)" in queries[0]
+    assert "MIN(c.created_at)" in queries[1]
+    assert "MAX(c.created_at)" in queries[2]
+    # No multi-aggregate / aliased-aggregate query (rejected by the SDK).
+    assert not any(" AS n" in q for q in queries)
 
 
-def test_list_categories_uses_group_by(
+def test_list_categories_counts_without_group_by(
     storage: CosmosDBNoSqlStorage, mock_container: MagicMock
 ) -> None:
-    mock_container.query_items.return_value = iter(
-        [{"category": "k1", "n": 3}, {"category": "k2", "n": 1}]
-    )
+    # Cross-partition GROUP BY is unsupported by the SDK: categories are
+    # unwound with JOIN and counted client-side over the streamed values.
+    mock_container.query_items.return_value = iter(["k1", "k1", "k1", "k2"])
     counts = storage.list_categories()
     assert counts == {"k1": 3, "k2": 1}
     sql = mock_container.query_items.call_args.kwargs["query"]
-    assert "GROUP BY cat" in sql
+    assert "SELECT VALUE cat" in sql
+    assert "GROUP BY" not in sql

--- a/uv.lock
+++ b/uv.lock
@@ -545,6 +545,19 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-cosmos"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/a3/0474e622bf9676e3206d61269461ed16a05958363c254ea3b15af16219b2/azure_cosmos-4.15.0.tar.gz", hash = "sha256:be1cf49837c197d9da880ec47fe020a24d679075b89e0e1e2aca8d376b3a5a24", size = 2100744, upload-time = "2026-02-23T16:01:52.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/5f/b6e3d3ae16fa121fdc17e62447800d378b7e716cd6103c3650977a6c4618/azure_cosmos-4.15.0-py3-none-any.whl", hash = "sha256:83c1da7386bcd0df9a15c52116cc35012225d8a72d4f1379938b83ea5eb19fff", size = 424870, upload-time = "2026-02-23T16:01:54.514Z" },
+]
+
+[[package]]
 name = "azure-identity"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1391,10 @@ bedrock = [
     { name = "aiobotocore" },
     { name = "boto3" },
 ]
+cosmosdb = [
+    { name = "azure-cosmos" },
+    { name = "azure-identity" },
+]
 docling = [
     { name = "docling" },
     { name = "docling-core", extra = ["chunking"] },
@@ -1430,7 +1447,9 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "~=0.73.0" },
     { name = "appdirs", specifier = "~=1.4.4" },
     { name = "azure-ai-inference", marker = "extra == 'azure-ai-inference'", specifier = "~=1.0.0b9" },
+    { name = "azure-cosmos", marker = "extra == 'cosmosdb'", specifier = ">=4.7.0" },
     { name = "azure-identity", marker = "extra == 'azure-ai-inference'", specifier = ">=1.17.0,<2" },
+    { name = "azure-identity", marker = "extra == 'cosmosdb'", specifier = ">=1.17.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = "~=1.43.46" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "~=1.43.46" },
     { name = "cel-python", specifier = ">=0.5.0,<0.6" },
@@ -1478,7 +1497,7 @@ requires-dist = [
     { name = "tomli-w", specifier = "~=1.1.0" },
     { name = "voyageai", marker = "extra == 'voyageai'", specifier = "~=0.3.5" },
 ]
-provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
+provides-extras = ["a2a", "anthropic", "aws", "azure-ai-inference", "bedrock", "cosmosdb", "docling", "embeddings", "file-processing", "google-genai", "litellm", "mem0", "openpyxl", "pandas", "qdrant", "qdrant-edge", "tools", "voyageai", "watson"]
 
 [[package]]
 name = "crewai-cli"
@@ -1622,6 +1641,11 @@ dependencies = [
 apify = [
     { name = "langchain-apify" },
 ]
+azure-cosmosdb = [
+    { name = "azure-cosmos" },
+    { name = "azure-identity" },
+    { name = "openai" },
+]
 beautifulsoup4 = [
     { name = "beautifulsoup4" },
 ]
@@ -1744,6 +1768,8 @@ xml = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-cosmos", marker = "extra == 'azure-cosmosdb'", specifier = ">=4.15.0" },
+    { name = "azure-identity", marker = "extra == 'azure-cosmosdb'", specifier = ">=1.17.0" },
     { name = "beautifulsoup4", specifier = "~=4.13.4" },
     { name = "beautifulsoup4", marker = "extra == 'beautifulsoup4'", specifier = ">=4.12.3" },
     { name = "beautifulsoup4", marker = "extra == 'bedrock'", specifier = ">=4.13.4" },
@@ -1771,6 +1797,7 @@ requires-dist = [
     { name = "nest-asyncio", marker = "extra == 'bedrock'", specifier = ">=1.6.0" },
     { name = "nest-asyncio", marker = "extra == 'contextual'", specifier = ">=1.6.0" },
     { name = "nltk", marker = "extra == 'xml'", specifier = ">=3.10.0" },
+    { name = "openai", marker = "extra == 'azure-cosmosdb'", specifier = ">=1.30.0" },
     { name = "oxylabs", marker = "extra == 'oxylabs'", specifier = "==2.0.0" },
     { name = "patronus", marker = "extra == 'patronus'", specifier = ">=0.0.16" },
     { name = "playwright", marker = "extra == 'bedrock'", specifier = ">=1.52.0" },
@@ -1801,7 +1828,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate-client'", specifier = ">=4.10.2" },
     { name = "youtube-transcript-api", specifier = "~=1.2.2" },
 ]
-provides-extras = ["apify", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
+provides-extras = ["apify", "azure-cosmosdb", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
 
 [[package]]
 name = "cryptography"


### PR DESCRIPTION
## Summary

Adds first-class Azure Cosmos DB for NoSQL support to CrewAI across both  crewai-tools  and  crewai  core memory. This ships three agent-callable tools and a native  Memory  storage backend, all behind optional extras so the base install is unaffected.

## What's added

### crewai-tools  - three agent tools ( crewai_tools.azure.cosmosdb_nosql )

-  AzureCosmosDBNoSqlSearchTool  — vector, full-text, and hybrid (RRF) search over a Cosmos NoSQL container, with configurable distance function, score thresholds, projections, and batch ingestion via  add_texts() .
-  AzureCosmosDBSemanticCacheTool  — semantic cache for LLM responses ( search  /  update  /  clear ), with TTL expiry and per-model namespacing via  llm_string .
-  AzureCosmosDBMemoryTool  — CRUD over agent memory items ( store  /  read  /  retrieve  /  update  /  delete  /  clear ) with hierarchical partition keys and optional optimistic concurrency (ETag).

### crewai  - native memory backend

-  CosmosDBNoSqlStorage  — implements the  StorageBackend  protocol (save/search/delete/update/list/scopes/categories/count/reset + async variants) using  VectorDistance  for similarity and  /scope  partitioning.
-  Memory(storage="cosmosdb")  selector wired into  unified_memory , configured from environment via  CosmosDBNoSqlStorage.from_env() .

### Authentication & configuration

- Auth via account key, connection string, or  TokenCredential  (e.g.  DefaultAzureCredential ).
- Embeddings via OpenAI, Azure OpenAI, or a custom embedder ( embed_documents / embed_query ).
-  Memory(storage="cosmosdb")  reads  AZURE_COSMOS_CONNECTION_STRING , or  AZURE_COSMOS_HOST  +  AZURE_COSMOS_KEY  (falling back to  DefaultAzureCredential ); optional  AZURE_COSMOS_DATABASE_NAME ,  AZURE_COSMOS_CONTAINER_NAME ,  AZURE_COSMOS_VECTOR_DIM .

### Dependencies (optional extras, lazily imported)

-  crewai-tools[azure-cosmosdb]  →  azure-cosmos ,  azure-identity ,  openai 
-  crewai[cosmosdb]  →  azure-cosmos ,  azure-identity 

Importing  crewai_tools  /  crewai  does not require these packages; the extra is only needed when a tool/backend is instantiated.

### Notable implementation details

- SQL safety: Cosmos  VectorDistance  /  FullTextScore  can't bind parameters, so embeddings/terms are interpolated — all spliced identifiers are validated and string literals are escaped ( # noqa: S608  where interpolation is intentional).
- Distance-aware scoring: cosine/dot-product (higher = better) vs euclidean (lower = better) handled consistently across search and thresholds.
- Resilience: retry-on-throttle for 429/503/408 honoring  retry_after_in_ms ; batched writes grouped by partition key.

### Documentation

- New tool page  docs/en/tools/database-data/azurecosmosdbtool.mdx  + overview card +  docs.json  nav (English).
-  docs/en/concepts/memory.mdx  documents the  cosmosdb  storage selector.
- Package READMEs updated.

### Testing

- 53 unit tests across the four suites, with the Azure SDK fully mocked — no live Cosmos account or extras required to run them.
-  ruff check ,  ruff format --check , and strict  mypy  all pass on the changed files.

uv sync --all-extras
uv run pytest lib/crewai-tools/tests/tools/azure/
uv run pytest lib/crewai/tests/memory/storage/test_cosmosdb_nosql_storage.py

<!-- crewai-require-issue-check -->