### PR TITLE
fix(anthropic): count cached input tokens in the reported totals

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1971,10 +1971,19 @@ class AnthropicCompletion(BaseLLM):
             cache_creation_tokens = (
                 getattr(usage, "cache_creation_input_tokens", 0) or 0
             )
+            # Anthropic reports input_tokens NET of the prompt cache and bills
+            # cache_read_input_tokens and cache_creation_input_tokens on top of
+            # it, so input_tokens alone is not what the request was charged for.
+            # OpenAI and Gemini report a prompt count that already contains its
+            # cached portion, so normalise to that shape here: prompt_tokens is
+            # the full billed input and cached_prompt_tokens is the subset of it
+            # that was served from cache. Without this, total_tokens is short by
+            # the cached amount on Anthropic alone and nothing raises.
+            prompt_tokens = input_tokens + cache_read_tokens + cache_creation_tokens
             result: dict[str, Any] = {
-                "input_tokens": input_tokens,
+                "input_tokens": prompt_tokens,
                 "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": prompt_tokens + output_tokens,
                 "cached_prompt_tokens": cache_read_tokens,
                 "cache_creation_tokens": cache_creation_tokens,
             }

--- a/lib/crewai/tests/llms/anthropic/test_anthropic_cached_token_totals.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic_cached_token_totals.py
@@ -1,0 +1,142 @@
+"""Anthropic cached input tokens must be counted in the reported totals.
+
+Anthropic reports ``input_tokens`` NET of the prompt cache and bills
+``cache_read_input_tokens`` and ``cache_creation_input_tokens`` separately, and
+it never sends a total. Every other provider CrewAI supports reports a prompt
+count that already contains its cached portion: OpenAI nests ``cached_tokens``
+inside ``prompt_tokens``, and Gemini and Bedrock send an authoritative total.
+
+So mapping Anthropic's raw ``input_tokens`` onto ``prompt_tokens`` makes the
+same field mean two different things depending on the provider, and
+``total_tokens`` comes out low on Anthropic alone. Nothing raises: the number
+is simply smaller than what was billed. ``UsageMetrics.from_provider_dict``
+states the invariant these tests defend, that per-LLM totals, flow-level
+aggregation and OTel spans "agree on every provider".
+"""
+
+from types import SimpleNamespace
+
+from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+from crewai.types.usage_metrics import UsageMetrics
+
+
+def _usage(**kwargs):
+    """Build an Anthropic-shaped usage object."""
+    return SimpleNamespace(**kwargs)
+
+
+def _extract(usage):
+    return AnthropicCompletion._extract_anthropic_token_usage(
+        SimpleNamespace(usage=usage)
+    )
+
+
+class TestAnthropicCachedTokensInTotals:
+    def test_cache_read_tokens_are_counted_in_the_total(self):
+        """200 cached + 50 fresh input + 100 output is 350 billed tokens."""
+        result = _extract(
+            _usage(
+                input_tokens=50,
+                output_tokens=100,
+                cache_read_input_tokens=200,
+                cache_creation_input_tokens=0,
+            )
+        )
+        assert result["total_tokens"] == 350
+
+    def test_cache_creation_tokens_are_counted_in_the_total(self):
+        """Cache writes are billed too, at a premium, so they belong in the total."""
+        result = _extract(
+            _usage(
+                input_tokens=50,
+                output_tokens=100,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=200,
+            )
+        )
+        assert result["total_tokens"] == 350
+
+    def test_cached_prompt_tokens_stay_a_subset_of_the_prompt_count(self):
+        """Matches OpenAI, where cached_tokens is contained by prompt_tokens.
+
+        If the cached count were additive rather than a subset, any consumer
+        adding them together would double count.
+        """
+        result = _extract(
+            _usage(
+                input_tokens=50,
+                output_tokens=100,
+                cache_read_input_tokens=200,
+                cache_creation_input_tokens=25,
+            )
+        )
+        assert result["input_tokens"] == 275
+        assert result["cached_prompt_tokens"] == 200
+        assert result["cache_creation_tokens"] == 25
+        assert result["cached_prompt_tokens"] <= result["input_tokens"]
+
+    def test_totals_agree_across_providers_for_the_same_billed_work(self):
+        """The invariant from_provider_dict's own docstring promises.
+
+        The same 250 input tokens, 200 of them cached, and 100 output tokens,
+        reported in Anthropic's shape and in OpenAI's shape, must produce the
+        same UsageMetrics total.
+        """
+        anthropic = UsageMetrics.from_provider_dict(
+            _extract(
+                _usage(
+                    input_tokens=50,
+                    output_tokens=100,
+                    cache_read_input_tokens=200,
+                    cache_creation_input_tokens=0,
+                )
+            )
+        )
+        openai = UsageMetrics.from_provider_dict(
+            {
+                "prompt_tokens": 250,
+                "completion_tokens": 100,
+                "total_tokens": 350,
+                "prompt_tokens_details": {"cached_tokens": 200},
+            }
+        )
+        assert anthropic.total_tokens == openai.total_tokens
+        assert anthropic.prompt_tokens == openai.prompt_tokens
+        assert anthropic.cached_prompt_tokens == openai.cached_prompt_tokens
+
+    def test_uncached_call_is_unchanged(self):
+        """The common path must not move."""
+        result = _extract(
+            _usage(
+                input_tokens=250,
+                output_tokens=100,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            )
+        )
+        assert result["input_tokens"] == 250
+        assert result["total_tokens"] == 350
+
+    def test_absent_cache_fields_are_treated_as_zero(self):
+        """Older SDK responses omit the cache counters entirely."""
+        result = _extract(_usage(input_tokens=250, output_tokens=100))
+        assert result["total_tokens"] == 350
+        assert result["cached_prompt_tokens"] == 0
+
+    def test_none_cache_fields_are_treated_as_zero(self):
+        """The SDK sends null rather than 0 when caching is not in play."""
+        result = _extract(
+            _usage(
+                input_tokens=250,
+                output_tokens=100,
+                cache_read_input_tokens=None,
+                cache_creation_input_tokens=None,
+            )
+        )
+        assert result["total_tokens"] == 350
+
+    def test_response_without_usage_reports_zero(self):
+        """Guard the existing early return rather than assuming it."""
+        assert AnthropicCompletion._extract_anthropic_token_usage(
+            SimpleNamespace(usage=None)
+        ) == {"total_tokens": 0}


### PR DESCRIPTION
## The problem

Anthropic reports `input_tokens` **net of the prompt cache** and bills `cache_read_input_tokens` and `cache_creation_input_tokens` on top of it. It never sends a total.

`_extract_anthropic_token_usage` read both cache counters, surfaced them as their own keys, and then built `total_tokens` from `input_tokens + output_tokens` only. So the total is short by the cached amount, and nothing raises. The number is simply smaller than what was charged for.

On a call with 200 cached, 50 fresh input and 100 output tokens:

| | reported | billed |
|---|---|---|
| `total_tokens` | 150 | 350 |

A second symptom makes it self-evident: on that same call `cached_prompt_tokens` comes back as **200** while `prompt_tokens` is **50**, so the cached subset is larger than the set it belongs to.

## Why this is a cross-provider inconsistency, not just a missing addition

Every other provider here reports a prompt count that already contains its cached portion. OpenAI nests `cached_tokens` inside `prompt_tokens`; Gemini uses `total_token_count` and Bedrock uses the API's own total. Anthropic is the only one where the cached tokens sit outside the number that gets mapped onto `prompt_tokens`.

`UsageMetrics.from_provider_dict` states the invariant this breaks in its own docstring:

> Mirrors `BaseLLM._track_token_usage_internal` so per-LLM totals, flow-level aggregation, and OTel spans agree on every provider.

They do not agree. The same billed work reported through the Anthropic path and the OpenAI path produces 150 and 350.

## The fix

Normalise Anthropic to the OpenAI-compatible shape at the point of extraction: `prompt_tokens` becomes the full billed input, and `cached_prompt_tokens` stays a **subset** of it rather than a disjoint number a consumer might add on top. That keeps `cache_creation_tokens` available separately for anyone pricing cache writes at their own rate.

It flows through `UsageMetrics`, `BaseLLM._track_token_usage_internal`, `CrewOutput.token_usage` and the OTel span without further change.

## Tests

Eight, in `tests/llms/anthropic/test_anthropic_cached_token_totals.py`. **Four fail before this change**, including a direct parity assertion that the Anthropic and OpenAI shapes of identical work produce identical `UsageMetrics`.

The other four pin the edges so the fix cannot regress them: an uncached call is unchanged, absent cache fields are treated as zero, `None` cache fields are treated as zero, and a response with no usage still returns `{"total_tokens": 0}`.

Verified against `develop` at `18c52c4`. The three failures in `tests/test_flow_usage_metrics.py` are present on a clean checkout without this change and are unrelated.

## Context

This is the sixth framework I have found with the same defect. The equivalent fixes are merged in [Pipecat](https://github.com/pipecat-ai/pipecat/pull/5163), [LiveKit](https://github.com/livekit/agents/pull/6663) and [Haystack](https://github.com/deepset-ai/haystack-core-integrations/pull/3717), the last of which took exactly this OpenAI-compatible approach.
