### PR TITLE
fix(llm): strip cache_breakpoint for litellm fallback providers

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2320,11 +2320,19 @@ class LLM(BaseLLM):
         if messages is None:
             raise TypeError("Messages cannot be None")
 
+        from crewai.llms.cache import CACHE_BREAKPOINT_KEY
+
+        clean_messages = []
         for msg in messages:
             if not isinstance(msg, dict) or "role" not in msg or "content" not in msg:
                 raise TypeError(
                     "Invalid message format. Each message must be a dict with 'role' and 'content' keys"
                 )
+            clean_msg = dict(msg)
+            clean_msg.pop(CACHE_BREAKPOINT_KEY, None)
+            clean_messages.append(clean_msg)
+            
+        messages = clean_messages  # type: ignore[assignment]
 
         if "o1" in self.model.lower():
             formatted_messages = []


### PR DESCRIPTION
Fixes #6789
    
    **Description**
    Mistral's native API strictly validates schema payloads and throws an `extra_forbidden` error when it encounters the `cache_breakpoint` flag injected by the Agent execution path. 
    
    This fix explicitly pops the `cache_breakpoint` flag inside `_format_messages_for_provider`. This ensures that LiteLLM (and by extension Mistral) receives a clean payload. Native Anthropic caching remains unaffected because Anthropic models are routed to `AnthropicCompletion`, which bypasses `_format_messages_for_provider`.



Note: I am a first-time contributor and do not have permission to attach labels in GitHub yet, but please consider this PR as having the `llm-generated` label as per CONTRIBUTING.md!