### PR TITLE
fix(crewai-tools): let DirectoryReadTool use a fixed directory outside cwd

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/directory_read_tool/directory_read_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/directory_read_tool/directory_read_tool.py
@@ -2,9 +2,13 @@ import os
 from typing import Any
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
-from crewai_tools.security.safe_path import validate_directory_path
+from crewai_tools.security.safe_path import (
+    format_error_for_display,
+    format_sandbox_error,
+    validate_directory_path,
+)
 
 
 class FixedDirectoryReadToolSchema(BaseModel):
@@ -18,20 +22,58 @@ class DirectoryReadToolSchema(FixedDirectoryReadToolSchema):
 
 
 class DirectoryReadTool(BaseTool):
+    """A tool for recursively listing a directory's content.
+
+    A directory given at construction time is intent declared by the
+    developer, so it is always allowed past the containment check, even when
+    it lives outside base_dir (the tool's operation can still fail if the
+    path does not exist). It is pinned at construction, so a later chdir
+    cannot repoint it. A directory supplied at runtime, typically chosen by
+    an LLM, must resolve inside base_dir (the current working directory by
+    default).
+
+    Args:
+        directory (Optional[str]): Directory to list. If provided, this
+            becomes the fixed directory for the tool and the LLM can no
+            longer choose a different one.
+        base_dir (Optional[str]): Directory that runtime supplied paths
+            must stay inside. Defaults to the current working directory.
+        **kwargs: Additional keyword arguments passed to BaseTool.
+    """
+
     name: str = "List files in directory"
     description: str = (
         "A tool that can be used to recursively list a directory's content."
     )
     args_schema: type[BaseModel] = DirectoryReadToolSchema
     directory: str | None = None
+    base_dir: str | None = None
 
-    def __init__(self, directory: str | None = None, **kwargs: Any) -> None:
+    _declared_realpath: str | None = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        directory: str | None = None,
+        base_dir: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
+        if base_dir is not None:
+            base_dir = os.path.realpath(base_dir)
+        self.base_dir = base_dir
+
         if directory is not None:
             self.directory = directory
             self.description = f"A tool that can be used to list {directory}'s content."
             self.args_schema = FixedDirectoryReadToolSchema
             self._generate_description()
+            # Resolve now so a later chdir can't move the declared directory
+            # and so it always passes the containment check below.
+            self._declared_realpath = (
+                os.path.realpath(directory)
+                if os.path.isabs(directory)
+                else os.path.realpath(os.path.join(base_dir or os.getcwd(), directory))
+            )
 
     def _run(
         self,
@@ -41,13 +83,31 @@ class DirectoryReadTool(BaseTool):
         if directory is None:
             raise ValueError("Directory must be provided.")
 
-        directory = validate_directory_path(directory)
-        if directory[-1] == "/":
-            directory = directory[:-1]
+        if self._declared_realpath is not None and directory == self.directory:
+            directory = self._declared_realpath
+            if not os.path.isdir(directory):
+                return f"Error: '{directory}' is not a directory."
+        else:
+            try:
+                directory = validate_directory_path(directory, self.base_dir)
+            except ValueError as e:
+                return "Error: Invalid directory: " + format_sandbox_error(
+                    e,
+                    "Pass base_dir to DirectoryReadTool to allow listing another "
+                    "directory tree.",
+                )
+
+        directory = directory.rstrip("/") or "/"
+        walk_errors: list[OSError] = []
         files_list = [
-            f"{directory}/{(os.path.join(root, filename).replace(directory, '').lstrip(os.path.sep))}"
-            for root, dirs, files in os.walk(directory)
+            os.path.join(directory, os.path.relpath(os.path.join(root, filename), directory))
+            for root, dirs, files in os.walk(directory, onerror=walk_errors.append)
             for filename in files
         ]
+        if walk_errors and not files_list:
+            # os.walk() does not raise on its own. It only calls onerror if
+            # given one, then moves on. Without this check a missing or
+            # unreadable directory would silently return an empty listing.
+            return f"Error: Could not list '{directory}'. {format_error_for_display(walk_errors[0])}"
         files = "\n- ".join(files_list)
         return f"File paths: \n-{files}"

--- a/lib/crewai-tools/tests/directory_read_tool_test.py
+++ b/lib/crewai-tools/tests/directory_read_tool_test.py
@@ -1,0 +1,133 @@
+"""Regression tests for DirectoryReadTool.
+
+Covers a bug where a fixed directory configured by the developer, outside
+the process's current working directory, was always rejected as outside the
+allowed directory, because _run validated it against validate_directory_path
+with its default base_dir (os.getcwd()) and no way to widen or pin it,
+unlike the sibling FileReadTool/FileWriterTool, which pin a declared path at
+construction time.
+
+This made the tool's most basic documented use case,
+DirectoryReadTool(directory="/some/other/dir"), unusable whenever that
+directory was not the current working directory, and raised an unhandled
+ValueError instead of returning a graceful error string.
+"""
+
+import os
+
+import pytest
+
+from crewai_tools.tools.directory_read_tool.directory_read_tool import (
+    DirectoryReadTool,
+)
+
+
+@pytest.fixture
+def outside_dir(tmp_path_factory):
+    """A directory that is not nested under the cwd tests chdir into.
+
+    Built from its own top level tmp path, a sibling of the cwd fixture
+    below, not a descendant of it. A directory nested inside the cwd would
+    already be reachable under the old, broken containment check, which
+    allowed anything under os.getcwd(). A test using a nested path would
+    pass on the old code too and prove nothing about the fix.
+    """
+    target = tmp_path_factory.mktemp("outside")
+    (target / "a.txt").write_text("hello")
+    (target / "nested").mkdir()
+    (target / "nested" / "b.txt").write_text("world")
+    return target
+
+
+@pytest.fixture
+def cwd(tmp_path_factory):
+    """A cwd directory that does not contain outside_dir (see above)."""
+    return tmp_path_factory.mktemp("cwd")
+
+
+def test_fixed_directory_outside_cwd_is_listed(outside_dir, cwd, monkeypatch):
+    """A directory declared at construction time must work even when it is
+    not the current working directory (the primary documented use case)."""
+    monkeypatch.chdir(cwd)
+    tool = DirectoryReadTool(directory=str(outside_dir))
+
+    result = tool._run()
+
+    assert "Error" not in result
+    assert "a.txt" in result
+    assert "b.txt" in result
+
+
+def test_fixed_directory_survives_chdir(outside_dir, cwd, tmp_path_factory, monkeypatch):
+    """The declared directory is pinned at construction time, like
+    FileReadTool's declared file_path, so a later chdir cannot break it."""
+    monkeypatch.chdir(cwd)
+    tool = DirectoryReadTool(directory=str(outside_dir))
+
+    other_cwd = tmp_path_factory.mktemp("elsewhere")
+    monkeypatch.chdir(other_cwd)
+
+    result = tool._run()
+
+    assert "Error" not in result
+    assert "a.txt" in result
+
+
+def test_runtime_directory_outside_base_dir_is_rejected(outside_dir, tmp_path, monkeypatch):
+    """Sandboxing must be preserved for LLM supplied paths at runtime: only
+    the declared, construction time directory bypasses containment."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    tool = DirectoryReadTool()
+
+    result = tool._run(directory=str(outside_dir))
+
+    assert "Error" in result
+    assert "outside the allowed directory" in result
+
+
+def test_runtime_directory_inside_cwd_is_listed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("hi")
+    tool = DirectoryReadTool()
+
+    result = tool._run(directory=".")
+
+    assert "Error" not in result
+    assert "f.txt" in result
+
+
+def test_base_dir_widens_runtime_sandbox(outside_dir, tmp_path, monkeypatch):
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    tool = DirectoryReadTool(base_dir=str(outside_dir.parent))
+
+    result = tool._run(directory=str(outside_dir))
+
+    assert "Error" not in result
+    assert "a.txt" in result
+
+
+def test_missing_directory_returns_error_not_exception(tmp_path, monkeypatch):
+    """A nonexistent fixed directory must return a graceful error, not raise."""
+    monkeypatch.chdir(tmp_path)
+    missing = tmp_path / "missing_dir"
+    tool = DirectoryReadTool(directory=str(missing))
+
+    result = tool._run()
+
+    assert "Error" in result
+
+
+def test_root_directory_paths_have_single_leading_slash():
+    """Listing '/' must not produce a doubled leading slash.
+
+    directory + "/" + relpath string concatenation turns "/" into "//" once
+    joined with a relative path. os.path.join avoids this.
+    """
+    directory = "/"
+    joined = os.path.join(directory, os.path.relpath("/etc/hosts", directory))
+    assert joined == "/etc/hosts"
+    assert not joined.startswith("//")


### PR DESCRIPTION
## Summary

#6248 confined file tools to an allow listed root to block path traversal. `FileReadTool` and `FileWriterTool` pin a declared path from construction time as always allowed developer intent (resolved once so a later `chdir` can't move it), while runtime or LLM supplied paths still go through the containment check.

`DirectoryReadTool` was not updated to match this pattern. Its `_run` validates the directory via `validate_directory_path(directory)` with no `base_dir` argument, which defaults to `os.getcwd()`. Any fixed `directory` passed at construction time that isn't the current working directory was rejected, with an unhandled `ValueError`, unlike its sibling tools, which catch this and return a graceful error string.

This broke the tool's own documented use case, `DirectoryReadTool(directory="/some/dir")`, whenever that directory wasn't the process's cwd:

```
ValueError: Path 'otherdir' is outside the allowed directory. Set CREWAI_TOOLS_ALLOW_UNSAFE_PATHS=true to bypass this check.
```

## Fix

* Adds a `base_dir` parameter mirroring `FileReadTool`, for widening the sandbox for runtime supplied directories.
* Pins the construction time `directory` as `_declared_realpath`, resolved once at `__init__` time, which always bypasses the containment check, since this is intent declared by the developer, exactly like `FileReadTool`'s declared `file_path`, so a later `chdir` can't move it.
* Runtime or LLM supplied directories (passed to `_run(directory=...)` when no fixed directory was configured) still go through `validate_directory_path` and remain fully sandboxed. No change to the actual security boundary #6248 introduced.
* `os.walk()` does not raise on its own, it only calls `onerror` if given one, then moves on. A missing or unreadable directory previously returned an empty, misleadingly successful listing instead of an error. Now passes `onerror` to actually capture and report top level walk failures.
* Also fixed while touching this code (both predate this PR): a trailing slash of exactly `/` collapsed to an empty string and made `os.walk` list the cwd instead of the filesystem root, and file paths were built with a string replace on the directory prefix, which corrupts paths through any subdirectory whose name repeats the parent directory's name (for example `.../data/data/file.txt`). Both are replaced with `os.path.relpath`.
* Verified not a bug (per review, see thread below): a relative directory anchors to `base_dir` rather than the construction time cwd. This matches `FileReadTool`'s own tested behavior (`test_relative_declared_path_anchors_to_base_dir`), since anchoring to cwd instead would let the same relative name mean two different files depending on when it runs.

## Test plan

New tests in `lib/crewai-tools/tests/directory_read_tool_test.py` (no tests existed for this tool before). `outside_dir` and `cwd` fixtures are built from independent `tmp_path_factory` roots so a fixed directory can never accidentally be nested under the test's cwd, since that would let the test pass on the old, broken code too.

Covers: fixed directory outside cwd is listed, fixed directory survives a later `chdir`, runtime directory outside `base_dir` is still rejected, runtime directory inside cwd still works, `base_dir` widens the runtime sandbox, missing fixed directory returns a graceful error instead of raising, and a permission denied directory is now reported as an error instead of an empty listing.

```
tests/directory_read_tool_test.py tests/file_read_tool_test.py tests/tools/test_file_writer_tool.py tests/utilities/test_safe_path.py
102 passed
```

<!-- crewai-require-issue-check -->