### PR TITLE
fix(crewai-files): replace bare raises with PermanentUploadError in get_uploader

### DIFF
--- a/lib/crewai-files/src/crewai_files/uploaders/factory.py
+++ b/lib/crewai-files/src/crewai_files/uploaders/factory.py
@@ -189,9 +189,8 @@ def get_uploader(
     if "bedrock" in provider_lower or "aws" in provider_lower:
         import os
 
-        if (
-            not os.environ.get("CREWAI_BEDROCK_S3_BUCKET")
-            and "bucket_name" not in kwargs
+        if not os.environ.get("CREWAI_BEDROCK_S3_BUCKET") and not kwargs.get(
+            "bucket_name"
         ):
             logger.debug(
                 "Bedrock S3 uploader not configured. "

--- a/lib/crewai-files/src/crewai_files/uploaders/factory.py
+++ b/lib/crewai-files/src/crewai_files/uploaders/factory.py
@@ -7,6 +7,7 @@ from typing import Any as AnyType, Literal, TypeAlias, TypedDict, overload
 
 from typing_extensions import NotRequired, Unpack
 
+from crewai_files.processing.exceptions import PermanentUploadError
 from crewai_files.uploaders.anthropic import AnthropicFileUploader
 from crewai_files.uploaders.bedrock import BedrockFileUploader
 from crewai_files.uploaders.gemini import GeminiFileUploader
@@ -196,7 +197,11 @@ def get_uploader(
                 "Bedrock S3 uploader not configured. "
                 "Set CREWAI_BEDROCK_S3_BUCKET environment variable to enable."
             )
-            raise
+            raise PermanentUploadError(
+                "Bedrock S3 uploader not configured. "
+                "Set CREWAI_BEDROCK_S3_BUCKET environment variable or pass "
+                "bucket_name to enable Bedrock file uploads."
+            )
         try:
             from crewai_files.uploaders.bedrock import BedrockFileUploader
 
@@ -213,4 +218,7 @@ def get_uploader(
             raise
 
     logger.debug(f"No file uploader available for provider: {provider}")
-    raise
+    raise PermanentUploadError(
+      f"No file uploader available for provider: {provider}. "
+      f"Supported providers: gemini, anthropic, openai, bedrock."
+    )

--- a/lib/crewai-files/tests/test_uploader_factory.py
+++ b/lib/crewai-files/tests/test_uploader_factory.py
@@ -65,3 +65,10 @@ class TestGetUploader:
 
         uploader = get_uploader("bedrock", bucket_name="my-kwarg-bucket")
         assert isinstance(uploader, BedrockFileUploader)
+
+    def test_get_uploader_bedrock_with_none_bucket_raises(self, monkeypatch):
+        """Test that bedrock provider with bucket_name=None raises PermanentUploadError."""
+        monkeypatch.delenv("CREWAI_BEDROCK_S3_BUCKET", raising=False)
+
+        with pytest.raises(PermanentUploadError, match="Bedrock S3 uploader not configured"):
+            get_uploader("bedrock", bucket_name=None)

--- a/lib/crewai-files/tests/test_uploader_factory.py
+++ b/lib/crewai-files/tests/test_uploader_factory.py
@@ -1,0 +1,67 @@
+"""Tests for the uploader factory function get_uploader."""
+
+
+from crewai_files.processing.exceptions import PermanentUploadError
+from crewai_files.uploaders.anthropic import AnthropicFileUploader
+from crewai_files.uploaders.factory import get_uploader
+from crewai_files.uploaders.gemini import GeminiFileUploader
+from crewai_files.uploaders.openai import OpenAIFileUploader
+import pytest
+
+
+class TestGetUploader:
+    """Tests for get_uploader factory function."""
+
+    def test_get_uploader_anthropic(self):
+        """Test get_uploader returns AnthropicFileUploader for 'anthropic'."""
+        uploader = get_uploader("anthropic")
+        assert isinstance(uploader, AnthropicFileUploader)
+
+    def test_get_uploader_gemini(self):
+        """Test get_uploader returns GeminiFileUploader for 'gemini'."""
+        uploader = get_uploader("gemini")
+        assert isinstance(uploader, GeminiFileUploader)
+
+    def test_get_uploader_openai(self):
+        """Test get_uploader returns OpenAIFileUploader for 'openai'."""
+        uploader = get_uploader("openai")
+        assert isinstance(uploader, OpenAIFileUploader)
+
+    def test_get_uploader_unsupported_provider_raises(self):
+        """Test that an unsupported provider raises PermanentUploadError, not RuntimeError."""
+        with pytest.raises(PermanentUploadError, match="No file uploader available"):
+            get_uploader("invalid_provider")
+
+    def test_get_uploader_bedrock_without_config_raises(self, monkeypatch):
+        """Test that bedrock provider without S3 bucket config raises PermanentUploadError."""
+        # Ensure the env var is not set
+        monkeypatch.delenv("CREWAI_BEDROCK_S3_BUCKET", raising=False)
+
+        with pytest.raises(PermanentUploadError, match="Bedrock S3 uploader not configured"):
+            get_uploader("bedrock")
+
+    def test_get_uploader_bedrock_with_bucket_env(self, monkeypatch):
+        """Test that bedrock provider works when CREWAI_BEDROCK_S3_BUCKET is set."""
+        monkeypatch.setenv("CREWAI_BEDROCK_S3_BUCKET", "my-test-bucket")
+
+        # Lazy import so the test doesn't fail if boto3 isn't installed
+        try:
+            from crewai_files.uploaders.bedrock import BedrockFileUploader
+        except ImportError:
+            pytest.skip("boto3 not installed, skipping bedrock uploader test")
+
+        uploader = get_uploader("bedrock")
+        assert isinstance(uploader, BedrockFileUploader)
+
+    def test_get_uploader_bedrock_with_bucket_kwarg(self, monkeypatch):
+        """Test that bedrock provider works when bucket_name is passed as kwarg."""
+        # Ensure env var is NOT set, so we only rely on the kwarg
+        monkeypatch.delenv("CREWAI_BEDROCK_S3_BUCKET", raising=False)
+
+        try:
+            from crewai_files.uploaders.bedrock import BedrockFileUploader
+        except ImportError:
+            pytest.skip("boto3 not installed, skipping bedrock uploader test")
+
+        uploader = get_uploader("bedrock", bucket_name="my-kwarg-bucket")
+        assert isinstance(uploader, BedrockFileUploader)


### PR DESCRIPTION
## Problem

Bare `raise` statements in `get_uploader()` are used outside of `except` blocks, which causes a confusing `RuntimeError: No active exception to re-raise` instead of a meaningful error message.

Two affected locations:
1. When an unsupported provider is passed (line 216)
2. When bedrock provider is used without S3 bucket config (line 199)

## Solution

Replace both bare `raise` statements with `PermanentUploadError` so users get a clear, actionable error message.

## Changes

- `lib/crewai-files/src/crewai_files/uploaders/factory.py`:
  - Import `PermanentUploadError` from `crewai_files.processing.exceptions`
  - Replace bare raise for unsupported provider with `PermanentUploadError` listing supported providers
  - Replace bare raise for unconfigured bedrock with `PermanentUploadError` explaining how to configure
- `lib/crewai-files/tests/test_uploader_factory.py`:
  - Add unit tests for `get_uploader()` covering all supported providers and error paths

## Testing

All 7 new tests pass: