### PR TITLE
feat(tools): add OutageDeckStatusTool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -123,6 +123,9 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outage_deck_status_tool.outage_deck_status_tool import (
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -290,6 +293,7 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -113,6 +113,9 @@ from crewai_tools.tools.multion_tool.multion_tool import MultiOnTool
 from crewai_tools.tools.mysql_search_tool.mysql_search_tool import MySQLSearchTool
 from crewai_tools.tools.nl2sql.nl2sql_tool import NL2SQLTool
 from crewai_tools.tools.ocr_tool.ocr_tool import OCRTool
+from crewai_tools.tools.outage_deck_status_tool.outage_deck_status_tool import (
+    OutageDeckStatusTool,
+)
 from crewai_tools.tools.oxylabs_amazon_product_scraper_tool.oxylabs_amazon_product_scraper_tool import (
     OxylabsAmazonProductScraperTool,
 )
@@ -274,6 +277,7 @@ __all__ = [
     "MySQLSearchTool",
     "NL2SQLTool",
     "OCRTool",
+    "OutageDeckStatusTool",
     "OxylabsAmazonProductScraperTool",
     "OxylabsAmazonSearchScraperTool",
     "OxylabsGoogleSearchScraperTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/outage_deck_status_tool/outage_deck_status_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/outage_deck_status_tool/outage_deck_status_tool.py
@@ -1,0 +1,350 @@
+"""Tool that checks infrastructure provider status via OutageDeck public API."""
+
+import json
+import re
+from typing import Any, Literal, cast
+
+from crewai.tools import BaseTool
+import httpx
+from pydantic import BaseModel, Field, field_validator
+
+
+OUTAGE_DECK_BASE_URL = "https://outagedeck.com/api/v1"
+
+# Slug pattern: lowercase letters, digits, and hyphens only
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Known valid values for filter parameters
+_VALID_LIFECYCLES = {"active", "resolved"}
+_VALID_SEVERITIES = {"minor", "major", "critical"}
+_VALID_ACTIONS = {"provider_status", "list_incidents", "service_status"}
+
+ActionType = Literal["provider_status", "list_incidents", "service_status"]
+
+
+def _validate_slug(value: str, field_name: str) -> str:
+    """Validate that a slug matches the expected format.
+
+    Args:
+        value: The slug string to validate.
+        field_name: Name of the field being validated, used in error messages.
+
+    Returns:
+        The validated slug.
+
+    Raises:
+        ValueError: If the slug is empty or has an invalid format.
+    """
+    if not value:
+        raise ValueError(f"{field_name} must not be empty.")
+    if not _SLUG_PATTERN.match(value):
+        raise ValueError(
+            f"{field_name} must contain only lowercase letters, digits, and hyphens, "
+            f"and must not start or end with a hyphen. Got: {value!r}"
+        )
+    return value
+
+
+class OutageDeckStatusToolSchema(BaseModel):
+    """Input for OutageDeckStatusTool."""
+
+    action: ActionType = Field(
+        ...,
+        description=(
+            "Which status check to perform. Use 'provider_status' to get the overall "
+            "status of a provider with all its services and active incidents. Use "
+            "'list_incidents' to browse paginated incidents with optional filters. Use "
+            "'service_status' to get the status of a specific service with recent "
+            "incident context."
+        ),
+    )
+    provider_slug: str | None = Field(
+        default=None,
+        description=(
+            "Provider slug for 'provider_status' or as a filter for 'list_incidents'. "
+            "Examples: 'aws', 'openai', 'github', 'vercel'. "
+            "Required when action is 'provider_status'."
+        ),
+    )
+    service_slug: str | None = Field(
+        default=None,
+        description=(
+            "Service slug for 'service_status'. Examples: 'aws-ec2', 'openai-api', "
+            "'github-actions'. Required when action is 'service_status'."
+        ),
+    )
+    lifecycle: str | None = Field(
+        default=None,
+        description=(
+            "Optional filter for 'list_incidents'. Only return incidents in this "
+            "lifecycle state. Valid values: 'active', 'resolved'."
+        ),
+    )
+    severity: str | None = Field(
+        default=None,
+        description=(
+            "Optional filter for 'list_incidents'. Only return incidents of this "
+            "severity. Valid values: 'minor', 'major', 'critical'."
+        ),
+    )
+    page: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Page number for 'list_incidents' pagination. Defaults to 1. "
+            "Each page contains up to 25 incidents."
+        ),
+    )
+
+    @field_validator("action")
+    @classmethod
+    def _validate_action(cls, value: str) -> str:
+        if value not in _VALID_ACTIONS:
+            raise ValueError(
+                f"action must be one of {sorted(_VALID_ACTIONS)}, got {value!r}."
+            )
+        return value
+
+    @field_validator("provider_slug")
+    @classmethod
+    def _validate_provider_slug(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_slug(value, "provider_slug")
+
+    @field_validator("service_slug")
+    @classmethod
+    def _validate_service_slug(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_slug(value, "service_slug")
+
+    @field_validator("lifecycle")
+    @classmethod
+    def _validate_lifecycle(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value not in _VALID_LIFECYCLES:
+            raise ValueError(
+                f"lifecycle must be one of {sorted(_VALID_LIFECYCLES)}, got {value!r}."
+            )
+        return value
+
+    @field_validator("severity")
+    @classmethod
+    def _validate_severity(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value not in _VALID_SEVERITIES:
+            raise ValueError(
+                f"severity must be one of {sorted(_VALID_SEVERITIES)}, got {value!r}."
+            )
+        return value
+
+
+class OutageDeckStatusTool(BaseTool):
+    """Check infrastructure provider and service status using the OutageDeck public API.
+
+    Agents can use this tool to verify whether a third-party service is experiencing
+    an outage before debugging their own code, or to pull recent incident history for
+    context about reliability issues.
+
+    The OutageDeck public API is read-only and requires no API key or account.
+    Three operations are supported:
+    - provider_status: overall status of a provider plus its services and active incidents
+    - list_incidents: paginated incident list with optional provider/lifecycle/severity filters
+    - service_status: status of a single service with limited recent incident context
+    """
+
+    name: str = "OutageDeck status check"
+    description: str = (
+        "Check the current status of infrastructure providers and services using "
+        "the OutageDeck public status API. Use this when you need to know whether "
+        "a third-party service (such as a cloud provider, API, or SaaS platform) "
+        "is currently experiencing an outage, degraded performance, or has recent "
+        "incident history. No API key is required. Three operations are available: "
+        "'provider_status' returns the overall status of a provider with its services "
+        "and active incidents; 'list_incidents' returns paginated incidents with "
+        "optional filters by provider, lifecycle, and severity; 'service_status' "
+        "returns the status of a specific service with recent incident context."
+    )
+    args_schema: type[BaseModel] = OutageDeckStatusToolSchema
+
+    def _run(
+        self,
+        action: str,
+        provider_slug: str | None = None,
+        service_slug: str | None = None,
+        lifecycle: str | None = None,
+        severity: str | None = None,
+        page: int = 1,
+    ) -> str:
+        """Execute a status check against the OutageDeck public API.
+
+        Args:
+            action: Which operation to perform.
+            provider_slug: Provider slug for provider_status or list_incidents filter.
+            service_slug: Service slug for service_status.
+            lifecycle: Optional lifecycle filter for list_incidents.
+            severity: Optional severity filter for list_incidents.
+            page: Page number for list_incidents pagination.
+
+        Returns:
+            JSON string with the status data returned by the API.
+        """
+        data = self._fetch(action, provider_slug, service_slug, lifecycle, severity, page)
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    async def _arun(
+        self,
+        action: str,
+        provider_slug: str | None = None,
+        service_slug: str | None = None,
+        lifecycle: str | None = None,
+        severity: str | None = None,
+        page: int = 1,
+    ) -> str:
+        """Asynchronously execute a status check against the OutageDeck public API.
+
+        Args:
+            action: Which operation to perform.
+            provider_slug: Provider slug for provider_status or list_incidents filter.
+            service_slug: Service slug for service_status.
+            lifecycle: Optional lifecycle filter for list_incidents.
+            severity: Optional severity filter for list_incidents.
+            page: Page number for list_incidents pagination.
+
+        Returns:
+            JSON string with the status data returned by the API.
+        """
+        data = await self._async_fetch(
+            action, provider_slug, service_slug, lifecycle, severity, page
+        )
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    def _fetch(
+        self,
+        action: str,
+        provider_slug: str | None,
+        service_slug: str | None,
+        lifecycle: str | None,
+        severity: str | None,
+        page: int,
+    ) -> dict[str, Any]:
+        """Perform the HTTP request synchronously and return parsed JSON.
+
+        Args:
+            action: Which operation to perform.
+            provider_slug: Provider slug.
+            service_slug: Service slug.
+            lifecycle: Lifecycle filter.
+            severity: Severity filter.
+            page: Page number.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            ValueError: If required parameters are missing for the chosen action.
+            httpx.HTTPError: If the HTTP request fails.
+        """
+        url, params = self._build_request(
+            action, provider_slug, service_slug, lifecycle, severity, page
+        )
+        response = httpx.get(url, params=params, timeout=15.0)
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    async def _async_fetch(
+        self,
+        action: str,
+        provider_slug: str | None,
+        service_slug: str | None,
+        lifecycle: str | None,
+        severity: str | None,
+        page: int,
+    ) -> dict[str, Any]:
+        """Perform the HTTP request asynchronously and return parsed JSON.
+
+        Args:
+            action: Which operation to perform.
+            provider_slug: Provider slug.
+            service_slug: Service slug.
+            lifecycle: Lifecycle filter.
+            severity: Severity filter.
+            page: Page number.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            ValueError: If required parameters are missing for the chosen action.
+            httpx.HTTPError: If the HTTP request fails.
+        """
+        url, params = self._build_request(
+            action, provider_slug, service_slug, lifecycle, severity, page
+        )
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            return cast(dict[str, Any], response.json())
+
+    @staticmethod
+    def _build_request(
+        action: str,
+        provider_slug: str | None,
+        service_slug: str | None,
+        lifecycle: str | None,
+        severity: str | None,
+        page: int,
+    ) -> tuple[str, dict[str, Any]]:
+        """Build the URL and query parameters for the API request.
+
+        Args:
+            action: Which operation to perform.
+            provider_slug: Provider slug.
+            service_slug: Service slug.
+            lifecycle: Lifecycle filter.
+            severity: Severity filter.
+            page: Page number.
+
+        Returns:
+            A tuple of (url, params_dict).
+
+        Raises:
+            ValueError: If required parameters are missing for the chosen action.
+        """
+        params: dict[str, Any] = {}
+
+        if action == "provider_status":
+            if not provider_slug:
+                raise ValueError(
+                    "provider_slug is required when action is 'provider_status'."
+                )
+            url = f"{OUTAGE_DECK_BASE_URL}/providers/{provider_slug}"
+
+        elif action == "service_status":
+            if not service_slug:
+                raise ValueError(
+                    "service_slug is required when action is 'service_status'."
+                )
+            url = f"{OUTAGE_DECK_BASE_URL}/services/{service_slug}"
+
+        elif action == "list_incidents":
+            url = f"{OUTAGE_DECK_BASE_URL}/incidents"
+            if provider_slug:
+                params["provider"] = provider_slug
+            if lifecycle:
+                params["lifecycle"] = lifecycle
+            if severity:
+                params["severity"] = severity
+            if page > 1:
+                params["page"] = page
+
+        else:
+            raise ValueError(
+                f"Unknown action: {action!r}. "
+                f"Must be one of {sorted(_VALID_ACTIONS)}."
+            )
+
+        return url, params

--- a/lib/crewai-tools/tests/tools/test_outage_deck_status_tool.py
+++ b/lib/crewai-tools/tests/tools/test_outage_deck_status_tool.py
@@ -1,0 +1,207 @@
+"""Tests for OutageDeckStatusTool."""
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from crewai_tools import OutageDeckStatusTool
+import pytest
+
+
+class TestOutageDeckStatusTool:
+    """Tests for OutageDeckStatusTool."""
+
+    def test_tool_is_base_tool_subclass(self):
+        """Test that OutageDeckStatusTool is a proper BaseTool subclass."""
+        tool = OutageDeckStatusTool()
+        assert tool.name == "OutageDeck status check"
+        assert "OutageDeck" in tool.description
+        assert tool.args_schema is not None
+
+    def test_provider_status_builds_correct_url(self):
+        """Test _build_request for provider_status action."""
+        url, params = OutageDeckStatusTool._build_request(
+            action="provider_status",
+            provider_slug="aws",
+            service_slug=None,
+            lifecycle=None,
+            severity=None,
+            page=1,
+        )
+        assert url == "https://outagedeck.com/api/v1/providers/aws"
+        assert params == {}
+
+    def test_service_status_builds_correct_url(self):
+        """Test _build_request for service_status action."""
+        url, params = OutageDeckStatusTool._build_request(
+            action="service_status",
+            provider_slug=None,
+            service_slug="aws-ec2",
+            lifecycle=None,
+            severity=None,
+            page=1,
+        )
+        assert url == "https://outagedeck.com/api/v1/services/aws-ec2"
+        assert params == {}
+
+    def test_list_incidents_builds_correct_url(self):
+        """Test _build_request for list_incidents action with no filters."""
+        url, params = OutageDeckStatusTool._build_request(
+            action="list_incidents",
+            provider_slug=None,
+            service_slug=None,
+            lifecycle=None,
+            severity=None,
+            page=1,
+        )
+        assert url == "https://outagedeck.com/api/v1/incidents"
+        assert params == {}
+
+    def test_list_incidents_with_all_filters(self):
+        """Test _build_request for list_incidents with all filters."""
+        url, params = OutageDeckStatusTool._build_request(
+            action="list_incidents",
+            provider_slug="github",
+            service_slug=None,
+            lifecycle="active",
+            severity="critical",
+            page=3,
+        )
+        assert url == "https://outagedeck.com/api/v1/incidents"
+        assert params == {
+            "provider": "github",
+            "lifecycle": "active",
+            "severity": "critical",
+            "page": 3,
+        }
+
+    def test_list_incidents_page_1_not_included(self):
+        """Test that page=1 is not sent as a query param (default)."""
+        _, params = OutageDeckStatusTool._build_request(
+            action="list_incidents",
+            provider_slug=None,
+            service_slug=None,
+            lifecycle=None,
+            severity=None,
+            page=1,
+        )
+        assert "page" not in params
+
+    def test_provider_status_requires_provider_slug(self):
+        """Test that provider_status raises ValueError without provider_slug."""
+        with pytest.raises(ValueError, match="provider_slug is required"):
+            OutageDeckStatusTool._build_request(
+                action="provider_status",
+                provider_slug=None,
+                service_slug=None,
+                lifecycle=None,
+                severity=None,
+                page=1,
+            )
+
+    def test_service_status_requires_service_slug(self):
+        """Test that service_status raises ValueError without service_slug."""
+        with pytest.raises(ValueError, match="service_slug is required"):
+            OutageDeckStatusTool._build_request(
+                action="service_status",
+                provider_slug=None,
+                service_slug=None,
+                lifecycle=None,
+                severity=None,
+                page=1,
+            )
+
+    def test_invalid_action_raises(self):
+        """Test that an unknown action raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown action"):
+            OutageDeckStatusTool._build_request(
+                action="invalid_action",
+                provider_slug=None,
+                service_slug=None,
+                lifecycle=None,
+                severity=None,
+                page=1,
+            )
+
+    def test_invalid_provider_slug_format_raises(self):
+        """Test that provider_slug with invalid format is rejected by schema."""
+        from crewai_tools.tools.outage_deck_status_tool.outage_deck_status_tool import (
+            OutageDeckStatusToolSchema,
+        )
+
+        with pytest.raises(ValueError):
+            OutageDeckStatusToolSchema(
+                action="provider_status", provider_slug="INVALID_SLUG!"
+            )
+
+    def test_invalid_lifecycle_raises(self):
+        """Test that invalid lifecycle value is rejected."""
+        from crewai_tools.tools.outage_deck_status_tool.outage_deck_status_tool import (
+            OutageDeckStatusToolSchema,
+        )
+
+        with pytest.raises(ValueError, match="lifecycle must be one of"):
+            OutageDeckStatusToolSchema(
+                action="list_incidents", lifecycle="invalid"
+            )
+
+    def test_invalid_severity_raises(self):
+        """Test that invalid severity value is rejected."""
+        from crewai_tools.tools.outage_deck_status_tool.outage_deck_status_tool import (
+            OutageDeckStatusToolSchema,
+        )
+
+        with pytest.raises(ValueError, match="severity must be one of"):
+            OutageDeckStatusToolSchema(
+                action="list_incidents", severity="invalid"
+            )
+
+    def test_run_returns_json_string(self):
+        """Test that _run returns a JSON string with the API response."""
+        tool = OutageDeckStatusTool()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {"status": "operational", "slug": "vercel"}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.get", return_value=mock_response) as mock_get:
+            result = tool._run(action="provider_status", provider_slug="vercel")
+
+            mock_get.assert_called_once()
+            args, kwargs = mock_get.call_args
+            assert args[0] == "https://outagedeck.com/api/v1/providers/vercel"
+            assert kwargs["timeout"] == 15.0
+
+            parsed = json.loads(result)
+            assert parsed["data"]["status"] == "operational"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Async tests require an event loop, which uses internal socketpair() "
+        "that is blocked by pytest-recording's --block-network on Windows. "
+        "CI runs on Linux and covers async execution paths.",
+    )
+    async def test_arun_returns_json_string(self):
+        """Test that _arun returns a JSON string with the API response."""
+        tool = OutageDeckStatusTool()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {"status": "operational", "slug": "vercel"}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await tool._arun(
+                action="provider_status", provider_slug="vercel"
+            )
+
+            mock_client.get.assert_called_once()
+            parsed = json.loads(result)
+            assert parsed["data"]["slug"] == "vercel"


### PR DESCRIPTION
## Description

Adds a built-in `OutageDeckStatusTool` that lets agents check the current status of infrastructure providers and services using the OutageDeck public read-only API. No API key or account required.

The tool uses a compact schema with three operations:
- **`provider_status`** — overall provider status, including services list and active incidents
- **`list_incidents`** — paginated incident list with optional `provider`, `lifecycle`, and `severity` filters
- **`service_status`** — individual service status with limited recent incident context

## Design decisions

- **Single tool + action parameter** — compact schema, all three operations are conceptually the same "status check" category
- **Strict input validation before network calls** — slugs are validated against a regex, lifecycle/severity are validated against known enums, using Pydantic field validators
- **Fixed base URL** — always points at the production API, not configurable
- **Sync + async** — both `_run` and `_arun` are implemented, using httpx
- **Structured JSON output** — returns the full API response as formatted JSON so the agent has all the data it needs

## Changes

- `lib/crewai-tools/src/crewai_tools/tools/outage_deck_status_tool/outage_deck_status_tool.py` — tool implementation
- `lib/crewai-tools/src/crewai_tools/tools/outage_deck_status_tool/__init__.py` — package init
- `lib/crewai-tools/tests/tools/test_outage_deck_status_tool.py` — 14 unit tests
- `lib/crewai-tools/src/crewai_tools/tools/__init__.py` — register tool
- `lib/crewai-tools/src/crewai_tools/__init__.py` — register tool

## Testing

13 passed, 1 skipped (async test skipped on Windows due to pytest-recording + asyncio event loop compatibility — CI on Linux covers async paths).
