### PR TITLE
fix(bedrock): track Bedrock cache-write tokens in usage metrics

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -2075,12 +2075,21 @@ class BedrockCompletion(BaseLLM):
             or 0
         )
         cached_tokens = raw_cached if isinstance(raw_cached, int) else 0
+        raw_cache_write = (
+            usage.get("cacheWriteInputTokenCount")
+            or usage.get("cacheWriteInputTokens")
+            or 0
+        )
+        cache_creation_tokens = (
+            raw_cache_write if isinstance(raw_cache_write, int) else 0
+        )
 
         self._token_usage["prompt_tokens"] += input_tokens
         self._token_usage["completion_tokens"] += output_tokens
         self._token_usage["total_tokens"] += total_tokens
         self._token_usage["successful_requests"] += 1
         self._token_usage["cached_prompt_tokens"] += cached_tokens
+        self._token_usage["cache_creation_tokens"] += cache_creation_tokens
 
     def supports_function_calling(self) -> bool:
         """Check if the model supports function calling."""

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -1164,6 +1164,60 @@ def test_bedrock_cached_token_alternate_key():
         assert llm._token_usage['cached_prompt_tokens'] == 25
 
 
+def test_bedrock_cache_write_token_tracking():
+    """Test that cache writes (cacheWriteInputTokenCount) are tracked for Bedrock."""
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    with patch.object(llm._client, 'converse') as mock_converse:
+        mock_response = {
+            'output': {
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'text': 'test response'}]
+                }
+            },
+            'usage': {
+                'inputTokens': 100,
+                'outputTokens': 50,
+                'totalTokens': 150,
+                'cacheReadInputTokenCount': 0,
+                'cacheWriteInputTokenCount': 1024,
+            }
+        }
+        mock_converse.return_value = mock_response
+
+        llm.call("Hello")
+        assert llm._token_usage['cache_creation_tokens'] == 1024
+        assert llm._token_usage['cached_prompt_tokens'] == 0
+
+
+def test_bedrock_cache_write_token_alternate_key():
+    """Test that the alternate key cacheWriteInputTokens also works."""
+    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    with patch.object(llm._client, 'converse') as mock_converse:
+        mock_response = {
+            'output': {
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'text': 'test response'}]
+                }
+            },
+            'usage': {
+                'inputTokens': 80,
+                'outputTokens': 40,
+                'totalTokens': 120,
+                'cacheReadInputTokens': 25,
+                'cacheWriteInputTokens': 512,
+            }
+        }
+        mock_converse.return_value = mock_response
+
+        llm.call("Hello")
+        assert llm._token_usage['cached_prompt_tokens'] == 25
+        assert llm._token_usage['cache_creation_tokens'] == 512
+
+
 def test_bedrock_no_cache_tokens_defaults_to_zero():
     """Test that missing cache token keys default to zero."""
     llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
@@ -1186,3 +1240,4 @@ def test_bedrock_no_cache_tokens_defaults_to_zero():
 
         llm.call("Hello")
         assert llm._token_usage['cached_prompt_tokens'] == 0
+        assert llm._token_usage['cache_creation_tokens'] == 0


### PR DESCRIPTION
## Problem

`BedrockCompletion._track_token_usage_internal` reads Bedrock's cache **read** counter under both of the names the Converse API uses, but never looks at the matching **write** counters:

```python
raw_cached = (
    usage.get("cacheReadInputTokenCount")
    or usage.get("cacheReadInputTokens")
    or 0
)
cached_tokens = raw_cached if isinstance(raw_cached, int) else 0
# ... no cacheWrite* equivalent
self._token_usage["cached_prompt_tokens"] += cached_tokens
```

So `UsageMetrics.cache_creation_tokens` — a field this repo documents as "Number of cache creation tokens (e.g. Anthropic cache writes)" and which the native Anthropic provider *does* populate — is permanently `0` on Bedrock, however much of the prompt was written to cache.

Real Converse responses carry all four counters side by side. From this repo's own recorded cassette, `lib/crewai/tests/cassettes/llms/bedrock/test_bedrock_async_basic_call.yaml`:

```json
"usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,
         "cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,
         "inputTokens":9,"outputTokens":24,"serverToolUsage":{},"totalTokens":33}
```

Cache writes are billed at a premium on the Anthropic models Bedrock hosts, so anyone computing cost from CrewAI's usage metrics silently loses that component on Bedrock while getting it on the native Anthropic provider.

## Fix

Read the write counters exactly the way the read counters are already read (both key spellings, same `isinstance` guard) and add them to `cache_creation_tokens`.

`total_tokens` is deliberately left alone: it still comes from the provider's own `totalTokens`, so the existing assertions in `test_bedrock_cached_token_tracking` (`total_tokens == 150` with `cacheReadInputTokenCount == 30`) keep holding. This PR only fills a counter that was always zero.

## Verification

Ran against `crewai==1.15.9`, whose `llms/providers/bedrock/completion.py` is byte-identical to `main`, hot-swapping the patched file for a real old-vs-new run:

| `usage` payload | `cache_creation_tokens` before | after |
|---|---|---|
| cassette shape with `cacheWriteInputTokenCount: 1024` | `0` | `1024` |
| Converse-style `cacheWriteInputTokens: 512` | `0` | `512` |
| no cache keys at all | `0` | `0` |

Tests, run with the real `lib/crewai/tests/llms/bedrock/test_bedrock.py`:

- The two new tests **fail on `main`** (`assert 0 == 1024`, `assert 0 == 512`) and **pass with the fix**.
- The three pre-existing cache tests plus `test_bedrock_token_usage_tracking` pass unchanged before and after (`4 passed`).

`ruff check` on the patched file reports exactly what `main` reports on the same file (one pre-existing import-sorting finding) — nothing new introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- crewai-require-issue-check -->