### PR TITLE
fix(mcp): do not call asyncio.run on an already-running event loop

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -347,31 +347,20 @@ class MCPToolResolver:
                 return tools_list
             except Exception as e:
                 if discovery_client.connected:
-                    await discovery_client.disconnect()
-                    await asyncio.sleep(0.1)
+                    try:
+                        await discovery_client.disconnect()
+                        await asyncio.sleep(0.1)
+                    except Exception as disconnect_error:
+                        self._logger.log(
+                            "error", f"Error during disconnect: {disconnect_error}"
+                        )
                 raise RuntimeError(
                     f"Error during setup client and list tools: {e}"
                 ) from e
 
         try:
-            # Flows already run inside asyncio.run(...). Never fall back to
-            # asyncio.run() on this thread when a loop is active — a broad
-            # RuntimeError catch around the worker-thread path used to do that
-            # and re-raised "asyncio.run() cannot be called from a running
-            # event loop" (#6843). Mirror agent_utils' worker-thread pattern.
             try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-
-            coro = _setup_client_and_list_tools()
-            try:
-                if loop is not None and loop.is_running():
-                    ctx = contextvars.copy_context()
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                        tools_list = executor.submit(ctx.run, asyncio.run, coro).result()
-                else:
-                    tools_list = asyncio.run(coro)
+                tools_list = self._run_coro_sync(_setup_client_and_list_tools())
             except RuntimeError as e:
                 error_msg = str(e).lower()
                 if "cancel scope" in error_msg or "task" in error_msg:
@@ -464,9 +453,28 @@ class MCPToolResolver:
             return cast(list[BaseTool], tools), []
         except Exception as e:
             if discovery_client.connected:
-                asyncio.run(discovery_client.disconnect())
+                try:
+                    self._run_coro_sync(discovery_client.disconnect())
+                except Exception as disconnect_error:
+                    self._logger.log(
+                        "error", f"Error during MCP client cleanup: {disconnect_error}"
+                    )
 
             raise RuntimeError(f"Failed to get native MCP tools: {e}") from e
+
+    @staticmethod
+    def _run_coro_sync(coro: Any) -> Any:
+        """Run ``coro`` synchronously without nesting ``asyncio.run`` on an active loop."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None and loop.is_running():
+            ctx = contextvars.copy_context()
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(ctx.run, asyncio.run, coro).result()
+        return asyncio.run(coro)
 
     @staticmethod
     def _build_mcp_config_from_dict(

--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -11,6 +11,7 @@ into a standalone MCPToolResolver. It handles three flavours of MCP reference:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import contextvars
 import time
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -353,32 +354,37 @@ class MCPToolResolver:
                 ) from e
 
         try:
+            # Flows already run inside asyncio.run(...). Never fall back to
+            # asyncio.run() on this thread when a loop is active — a broad
+            # RuntimeError catch around the worker-thread path used to do that
+            # and re-raised "asyncio.run() cannot be called from a running
+            # event loop" (#6843). Mirror agent_utils' worker-thread pattern.
             try:
-                asyncio.get_running_loop()
-                import concurrent.futures
-
-                ctx = contextvars.copy_context()
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(
-                        ctx.run, asyncio.run, _setup_client_and_list_tools()
-                    )
-                    tools_list = future.result()
+                loop = asyncio.get_running_loop()
             except RuntimeError:
-                try:
-                    tools_list = asyncio.run(_setup_client_and_list_tools())
-                except RuntimeError as e:
-                    error_msg = str(e).lower()
-                    if "cancel scope" in error_msg or "task" in error_msg:
-                        raise ConnectionError(
-                            "MCP connection failed due to event loop cleanup issues. "
-                            "This may be due to authentication errors or server unavailability."
-                        ) from e
-                    raise
-                except asyncio.CancelledError as e:
+                loop = None
+
+            coro = _setup_client_and_list_tools()
+            try:
+                if loop is not None and loop.is_running():
+                    ctx = contextvars.copy_context()
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                        tools_list = executor.submit(ctx.run, asyncio.run, coro).result()
+                else:
+                    tools_list = asyncio.run(coro)
+            except RuntimeError as e:
+                error_msg = str(e).lower()
+                if "cancel scope" in error_msg or "task" in error_msg:
                     raise ConnectionError(
-                        "MCP connection was cancelled. This may indicate an authentication "
-                        "error or server unavailability."
+                        "MCP connection failed due to event loop cleanup issues. "
+                        "This may be due to authentication errors or server unavailability."
                     ) from e
+                raise
+            except asyncio.CancelledError as e:
+                raise ConnectionError(
+                    "MCP connection was cancelled. This may indicate an authentication "
+                    "error or server unavailability."
+                ) from e
 
             if mcp_config.tool_filter:
                 filtered_tools = []

--- a/lib/crewai/tests/mcp/test_tool_resolver_native.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_native.py
@@ -138,3 +138,28 @@ class TestResolveNativeRuntimeError:
         mock_executor.submit.assert_called_once()
         # asyncio.run must not be invoked on this thread when a loop is running
         mock_asyncio_run.assert_not_called()
+
+    @patch("crewai.mcp.tool_resolver.MCPToolResolver._run_coro_sync")
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    def test_cleanup_uses_loop_safe_runner_when_discovery_fails(
+        self, mock_client_class, mock_run_coro_sync, resolver, http_config
+    ):
+        mock_client = AsyncMock()
+        mock_client.connected = True
+        mock_client_class.return_value = mock_client
+
+        mock_run_coro_sync.side_effect = [
+            RuntimeError("discovery blew up"),
+            None,
+        ]
+
+        with pytest.raises(RuntimeError, match="Failed to get native MCP tools"):
+            resolver._resolve_native(http_config)
+
+        assert mock_run_coro_sync.call_count == 2
+        cleanup_coro = mock_run_coro_sync.call_args_list[1].args[0]
+        assert asyncio.iscoroutine(cleanup_coro)
+        cleanup_coro.close()
+        first_coro = mock_run_coro_sync.call_args_list[0].args[0]
+        if asyncio.iscoroutine(first_coro):
+            first_coro.close()

--- a/lib/crewai/tests/mcp/test_tool_resolver_native.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_native.py
@@ -1,5 +1,6 @@
 """Tests for MCPToolResolver native (non-AMP) resolution paths."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,16 +29,15 @@ def http_config():
 
 
 class TestResolveNativeEmptyTools:
+    @patch("crewai.mcp.tool_resolver.asyncio.run")
     @patch("crewai.mcp.tool_resolver.MCPClient")
     def test_logs_warning_and_returns_empty_when_server_has_no_tools(
-        self, mock_client_class, resolver, http_config
+        self, mock_client_class, mock_asyncio_run, resolver, http_config
     ):
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[])
         mock_client.connected = False
-        mock_client.connect = AsyncMock()
-        mock_client.disconnect = AsyncMock()
         mock_client_class.return_value = mock_client
+        mock_asyncio_run.return_value = []
 
         mock_log = MagicMock()
         resolver._logger = MagicMock(log=mock_log)
@@ -54,18 +54,15 @@ class TestResolveNativeEmptyTools:
             for call in warning_calls
         )
 
+    @patch("crewai.mcp.tool_resolver.asyncio.run")
     @patch("crewai.mcp.tool_resolver.MCPClient")
     def test_logs_warning_when_tool_filter_removes_all_tools(
-        self, mock_client_class, resolver
+        self, mock_client_class, mock_asyncio_run, resolver
     ):
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(
-            return_value=[{"name": "search", "description": "Search"}]
-        )
         mock_client.connected = False
-        mock_client.connect = AsyncMock()
-        mock_client.disconnect = AsyncMock()
         mock_client_class.return_value = mock_client
+        mock_asyncio_run.return_value = [{"name": "search", "description": "Search"}]
 
         config = MCPServerHTTP(
             url="https://mcp.example.com/api",
@@ -97,3 +94,47 @@ class TestResolveNativeRuntimeError:
 
         with pytest.raises(RuntimeError, match="Failed to get native MCP tools"):
             resolver._resolve_native(http_config)
+
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    @patch("crewai.mcp.tool_resolver.concurrent.futures.ThreadPoolExecutor")
+    @patch("crewai.mcp.tool_resolver.asyncio.get_running_loop")
+    @patch("crewai.mcp.tool_resolver.asyncio.run")
+    def test_uses_worker_thread_when_event_loop_already_running(
+        self,
+        mock_asyncio_run,
+        mock_get_running_loop,
+        mock_executor_cls,
+        mock_client_class,
+        resolver,
+        http_config,
+    ):
+        """Flow runtime already owns an event loop; discovery must run
+        asyncio.run in a worker thread, not on the caller's loop (#6843)."""
+        mock_get_running_loop.return_value = MagicMock(is_running=MagicMock(return_value=True))
+        mock_asyncio_run.return_value = [
+            {
+                "name": "search",
+                "description": "Search",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ]
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = mock_asyncio_run.return_value
+        mock_executor = MagicMock()
+        mock_executor.__enter__.return_value = mock_executor
+        mock_executor.__exit__.return_value = False
+        mock_executor.submit.return_value = mock_future
+        mock_executor_cls.return_value = mock_executor
+
+        mock_client = AsyncMock()
+        mock_client.connected = False
+        mock_client_class.return_value = mock_client
+
+        tools, clients = resolver._resolve_native(http_config)
+
+        assert clients == []
+        assert len(tools) == 1
+        mock_executor.submit.assert_called_once()
+        # asyncio.run must not be invoked on this thread when a loop is running
+        mock_asyncio_run.assert_not_called()

--- a/lib/crewai/tests/mcp/test_tool_resolver_native.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_native.py
@@ -5,8 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from crewai.agent.core import Agent
-from crewai.mcp.config import MCPServerHTTP
+from crewai.mcp.config import MCPServerHTTP, MCPServerSSE
 from crewai.mcp.tool_resolver import MCPToolResolver
+
+# asyncio.run() in a worker thread needs localhost socketpair for the event loop.
+pytestmark = pytest.mark.block_network(
+    allowed_hosts=["127.0.0.1", "::1", "localhost"]
+)
 
 
 @pytest.fixture
@@ -28,6 +33,39 @@ def http_config():
     return MCPServerHTTP(url="https://mcp.example.com/api")
 
 
+@pytest.fixture
+def sse_config():
+    return MCPServerSSE(url="https://mcp.example.com/sse")
+
+
+def _mock_discovery_client(mock_client_class, tools):
+    mock_client = AsyncMock()
+    mock_client.list_tools = AsyncMock(return_value=tools)
+    mock_client.connected = False
+    mock_client.connect = AsyncMock()
+    mock_client.disconnect = AsyncMock()
+    mock_client_class.return_value = mock_client
+    return mock_client
+
+
+def _close_coro_and_return(value):
+    def _runner(coro):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return value
+
+    return _runner
+
+
+def _close_coro_and_raise(exc):
+    def _runner(coro):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise exc
+
+    return _runner
+
+
 class TestResolveNativeEmptyTools:
     @patch("crewai.mcp.tool_resolver.asyncio.run")
     @patch("crewai.mcp.tool_resolver.MCPClient")
@@ -37,7 +75,7 @@ class TestResolveNativeEmptyTools:
         mock_client = AsyncMock()
         mock_client.connected = False
         mock_client_class.return_value = mock_client
-        mock_asyncio_run.return_value = []
+        mock_asyncio_run.side_effect = _close_coro_and_return([])
 
         mock_log = MagicMock()
         resolver._logger = MagicMock(log=mock_log)
@@ -62,7 +100,9 @@ class TestResolveNativeEmptyTools:
         mock_client = AsyncMock()
         mock_client.connected = False
         mock_client_class.return_value = mock_client
-        mock_asyncio_run.return_value = [{"name": "search", "description": "Search"}]
+        mock_asyncio_run.side_effect = _close_coro_and_return(
+            [{"name": "search", "description": "Search"}]
+        )
 
         config = MCPServerHTTP(
             url="https://mcp.example.com/api",
@@ -90,54 +130,46 @@ class TestResolveNativeRuntimeError:
     def test_unmatched_runtime_error_is_wrapped_not_swallowed(
         self, mock_asyncio_run, resolver, http_config
     ):
-        mock_asyncio_run.side_effect = RuntimeError("some other failure")
+        mock_asyncio_run.side_effect = _close_coro_and_raise(
+            RuntimeError("some other failure")
+        )
 
         with pytest.raises(RuntimeError, match="Failed to get native MCP tools"):
             resolver._resolve_native(http_config)
 
+    @pytest.mark.parametrize(
+        "config_fixture",
+        ["http_config", "sse_config"],
+    )
     @patch("crewai.mcp.tool_resolver.MCPClient")
-    @patch("crewai.mcp.tool_resolver.concurrent.futures.ThreadPoolExecutor")
-    @patch("crewai.mcp.tool_resolver.asyncio.get_running_loop")
-    @patch("crewai.mcp.tool_resolver.asyncio.run")
-    def test_uses_worker_thread_when_event_loop_already_running(
-        self,
-        mock_asyncio_run,
-        mock_get_running_loop,
-        mock_executor_cls,
-        mock_client_class,
-        resolver,
-        http_config,
+    def test_resolves_tools_from_running_event_loop(
+        self, mock_client_class, resolver, config_fixture, request
     ):
-        """Flow runtime already owns an event loop; discovery must run
-        asyncio.run in a worker thread, not on the caller's loop (#6843)."""
-        mock_get_running_loop.return_value = MagicMock(is_running=MagicMock(return_value=True))
-        mock_asyncio_run.return_value = [
-            {
-                "name": "search",
-                "description": "Search",
-                "inputSchema": {"type": "object", "properties": {}},
-            }
-        ]
+        """Flow runtime already owns an event loop; discovery must complete via
+        a real worker thread without calling asyncio.run on the caller (#6843)."""
+        config = request.getfixturevalue(config_fixture)
+        mock_client = _mock_discovery_client(
+            mock_client_class,
+            [
+                {
+                    "name": "search",
+                    "description": "Search",
+                    "inputSchema": {"type": "object", "properties": {}},
+                }
+            ],
+        )
 
-        mock_future = MagicMock()
-        mock_future.result.return_value = mock_asyncio_run.return_value
-        mock_executor = MagicMock()
-        mock_executor.__enter__.return_value = mock_executor
-        mock_executor.__exit__.return_value = False
-        mock_executor.submit.return_value = mock_future
-        mock_executor_cls.return_value = mock_executor
+        async def _call_from_running_loop():
+            return resolver._resolve_native(config)
 
-        mock_client = AsyncMock()
-        mock_client.connected = False
-        mock_client_class.return_value = mock_client
-
-        tools, clients = resolver._resolve_native(http_config)
+        tools, clients = asyncio.run(_call_from_running_loop())
 
         assert clients == []
         assert len(tools) == 1
-        mock_executor.submit.assert_called_once()
-        # asyncio.run must not be invoked on this thread when a loop is running
-        mock_asyncio_run.assert_not_called()
+        assert "search" in tools[0].name
+        mock_client.connect.assert_awaited()
+        mock_client.list_tools.assert_awaited()
+        mock_client.disconnect.assert_awaited()
 
     @patch("crewai.mcp.tool_resolver.MCPToolResolver._run_coro_sync")
     @patch("crewai.mcp.tool_resolver.MCPClient")


### PR DESCRIPTION
## Summary
- Stop treating every RuntimeError from MCP tool discovery as "no running loop".
- When a flow already owns an event loop, run discovery via ^Gsyncio.run in a worker thread (same pattern as ^Ggent_utils), and never fall back to ^Gsyncio.run on the caller thread.
- Add a unit test that asserts the worker-thread path is used when a loop is running.

## Test plan
- [x] pytest lib/crewai/tests/mcp/test_tool_resolver_native.py
- [ ] Manual: Flow with streamable: true MCP HTTP server discovers tools without the nested-loop crash

Fixes #6843


<!-- crewai-require-issue-check -->