### PR TITLE
fix(cli): preserve compatibility with older project environments

### DIFF
--- a/lib/cli/src/crewai_cli/utils.py
+++ b/lib/cli/src/crewai_cli/utils.py
@@ -8,19 +8,6 @@ import shutil
 from typing import Any
 
 import click
-from crewai_core.project import (
-    get_or_create_project_id as get_or_create_project_id,
-    get_project_description as get_project_description,
-    get_project_id as get_project_id,
-    get_project_name as get_project_name,
-    get_project_version as get_project_version,
-    parse_toml as parse_toml,
-    read_toml as read_toml,
-)
-from crewai_core.tool_credentials import (
-    build_env_with_all_tool_credentials as build_env_with_all_tool_credentials,
-    build_env_with_tool_repository_credentials as build_env_with_tool_repository_credentials,
-)
 from rich.console import Console
 
 from crewai_cli.version import get_crewai_tools_dependency
@@ -59,6 +46,64 @@ def warn_deprecated_command(*, old: str, new: str) -> None:
 
 console = Console()
 _TEMPLATE_TOKEN_RE = re.compile(r"{{([a-zA-Z_][a-zA-Z0-9_]*)}}")
+
+
+def get_or_create_project_id(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import get_or_create_project_id as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def get_project_description(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import get_project_description as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def get_project_id(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import get_project_id as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def get_project_name(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import get_project_name as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def get_project_version(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import get_project_version as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def parse_toml(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import parse_toml as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def read_toml(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.project import read_toml as implementation
+
+    return implementation(*args, **kwargs)
+
+
+def build_env_with_all_tool_credentials(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.tool_credentials import (
+        build_env_with_all_tool_credentials as implementation,
+    )
+
+    return implementation(*args, **kwargs)
+
+
+def build_env_with_tool_repository_credentials(*args: Any, **kwargs: Any) -> Any:
+    from crewai_core.tool_credentials import (
+        build_env_with_tool_repository_credentials as implementation,
+    )
+
+    return implementation(*args, **kwargs)
 
 
 def is_dmn_mode_enabled() -> bool:

--- a/lib/cli/tests/test_create_crew.py
+++ b/lib/cli/tests/test_create_crew.py
@@ -11,6 +11,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 import crewai_cli.create_json_crew as json_crew
 import crewai_cli.tui_picker as tui_picker
+from crewai_cli import __version__ as crewai_cli_version
 from crewai_cli.cli import crewai
 from crewai_cli.create_crew import create_crew, create_folder_structure
 from crewai_cli.utils import render_template
@@ -762,15 +763,15 @@ def test_json_create_provider_preselects_default_model(tmp_path, monkeypatch):
     pyproject = tomli.loads((tmp_path / "json_crew" / "pyproject.toml").read_text())
     dependency = pyproject["project"]["dependencies"][0]
     assert dependency == get_crewai_tools_dependency()
-    assert Version("1.15.0") in Requirement(dependency).specifier
+    assert Version(crewai_cli_version) in Requirement(dependency).specifier
     assert Version("2.0.0") not in Requirement(dependency).specifier
     assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"][
         "only-include"
     ] == ["agents", "crew.jsonc", "tools", "knowledge", "skills"]
-    assert pyproject["tool"]["crewai"] == {
-        "type": "crew",
-        "definition": "crew.jsonc",
-    }
+    crewai_config = pyproject["tool"]["crewai"]
+    assert crewai_config["type"] == "crew"
+    assert crewai_config["definition"] == "crew.jsonc"
+    assert crewai_config["project_id"]
 
     crew_template = (tmp_path / "json_crew" / "crew.jsonc").read_text()
     assert (
@@ -933,4 +934,4 @@ def test_json_create_dmn_mode_uses_non_interactive_defaults(tmp_path, monkeypatc
     assert '"description": "Research current AI trends and write a concise summary."' in (
         crew_template
     )
-    assert '"llm": "anthropic/claude-opus-4-6"' in agent_template
+    assert '"llm": "anthropic/claude-fable-5"' in agent_template

--- a/lib/cli/tests/test_run_crew.py
+++ b/lib/cli/tests/test_run_crew.py
@@ -11,6 +11,7 @@ from crewai_core.constants import CREWAI_TRAINED_AGENTS_FILE_ENV
 
 import crewai_cli.input_prompt as input_prompt_module
 import crewai_cli.run_crew as run_crew_module
+from crewai_cli.version import get_crewai_tools_dependency
 
 
 def test_missing_crewai_package_shows_full_install_hint(monkeypatch):
@@ -31,7 +32,8 @@ def test_missing_crewai_package_shows_full_install_hint(monkeypatch):
 
     message = exc_info.value.message
     assert "CrewAI CLI is installed without the `crewai` package" in message
-    assert "uv tool install --force 'crewai[tools]>=1.15.0,<2.0.0'" in message
+    dependency = get_crewai_tools_dependency()
+    assert f"uv tool install --force '{dependency}'" in message
     assert "quotes are required in zsh" in message
 
 

--- a/lib/cli/tests/tools/test_main.py
+++ b/lib/cli/tests/tools/test_main.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from crewai_cli.shared.token_manager import TokenManager
 from crewai_cli.tools.main import ToolCommand
+from crewai_cli.version import get_crewai_tools_dependency
 from pytest import raises
 
 
@@ -56,7 +57,7 @@ def test_create_success(mock_subprocess, capsys, tool_command):
 
         with open(os.path.join("test_tool", "pyproject.toml"), "r") as f:
             content = f.read()
-            assert '"crewai[tools]>=1.15.0,<2.0.0"' in content
+            assert f'"{get_crewai_tools_dependency()}"' in content
 
         with open(os.path.join("test_tool", "src", "test_tool", "tool.py"), "r") as f:
             content = f.read()
@@ -312,7 +313,9 @@ def test_publish_success(
     new_callable=unittest.mock.mock_open,
     read_data=b"sample tarball content",
 )
+@patch("crewai_cli.tools.main.git.Repository.fetch")
 @patch("crewai_cli.plus_api.PlusAPI.publish_tool")
+@patch("crewai_cli.tools.main.git.Repository.is_synced", return_value=True)
 @patch(
     "crewai.utilities.project_utils.extract_available_exports",
     return_value=[{"name": "SampleTool"}],
@@ -324,7 +327,9 @@ def test_publish_success(
 def test_publish_failure(
     mock_tools_metadata,
     mock_available_exports,
+    mock_is_synced,
     mock_publish,
+    mock_fetch,
     mock_open,
     mock_listdir,
     mock_subprocess_run,
@@ -358,7 +363,9 @@ def test_publish_failure(
     new_callable=unittest.mock.mock_open,
     read_data=b"sample tarball content",
 )
+@patch("crewai_cli.tools.main.git.Repository.fetch")
 @patch("crewai_cli.plus_api.PlusAPI.publish_tool")
+@patch("crewai_cli.tools.main.git.Repository.is_synced", return_value=True)
 @patch(
     "crewai.utilities.project_utils.extract_available_exports",
     return_value=[{"name": "SampleTool"}],
@@ -370,7 +377,9 @@ def test_publish_failure(
 def test_publish_api_error(
     mock_tools_metadata,
     mock_available_exports,
+    mock_is_synced,
     mock_publish,
+    mock_fetch,
     mock_open,
     mock_listdir,
     mock_subprocess_run,
@@ -404,6 +413,7 @@ def test_publish_api_error(
     new_callable=unittest.mock.mock_open,
     read_data=b"sample tarball content",
 )
+@patch("crewai_cli.tools.main.git.Repository.fetch")
 @patch("crewai_cli.plus_api.PlusAPI.publish_tool")
 @patch("crewai_cli.tools.main.git.Repository.is_synced", return_value=True)
 @patch(
@@ -419,6 +429,7 @@ def test_publish_metadata_extraction_failure_continues_with_warning(
     mock_available_exports,
     mock_is_synced,
     mock_publish,
+    mock_fetch,
     mock_open,
     mock_listdir,
     mock_subprocess_run,


### PR DESCRIPTION
## Summary

- defer `crewai-core` project and credential helper imports until each CLI utility is called
- keep the JSON runner importable inside projects that use an older compatible `crewai-core`
- align generated-project tests with the current CrewAI dependency range, DMN model default, project ID metadata, and repository initialization behavior

## Root cause

`crewai_cli.utils` imported every project helper at module import time. A JSON crew launched inside a project environment with an older `crewai-core` could fail while importing the CLI, before the requested command started.

Several generated-project tests also embedded an earlier CrewAI minimum version and defaults even though the implementation derives them from the current CLI version and templates.

## Behavior

The public utility functions retain their existing names and call signatures. Each wrapper now imports its implementation when invoked, allowing commands that do not use newer project helpers to run with older compatible project environments.

Version-sensitive assertions now use the CLI dependency helper and installed CLI version.

## Test plan

- `uv run --frozen --package crewai-cli pytest lib/cli/tests -q` — `711 passed`
- Ruff checks on changed files
- `git diff --check`
