### PR TITLE
test: stabilize environment-sensitive fixtures

### DIFF
--- a/lib/crewai-tools/tests/utilities/test_safe_path.py
+++ b/lib/crewai-tools/tests/utilities/test_safe_path.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import socket
 
 import pytest
 
@@ -182,7 +183,12 @@ class TestValidateUrl:
         with pytest.raises(ValueError, match="no hostname"):
             validate_url("http:///path")
 
-    def test_blocks_unresolvable_host(self):
+    def test_blocks_unresolvable_host(self, monkeypatch):
+        def fail_resolution(*_args, **_kwargs):
+            raise socket.gaierror("host not found")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fail_resolution)
+
         with pytest.raises(ValueError, match="Could not resolve"):
             validate_url("http://this-host-definitely-does-not-exist-abc123.com/")
 

--- a/lib/crewai/tests/events/test_llm_usage_event.py
+++ b/lib/crewai/tests/events/test_llm_usage_event.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import BaseModel
 
-from crewai.events.event_bus import CrewAIEventsBus
+import crewai.llms.base_llm as base_llm_module
 from crewai.events.types.llm_events import LLMCallCompletedEvent, LLMCallType
 from crewai.llm import LLM
 from crewai.llms.base_llm import BaseLLM
@@ -203,7 +203,7 @@ class _StubLLM(BaseLLM):
 class TestEmitCallCompletedEventPassesUsage:
     @pytest.fixture
     def mock_emit(self):
-        with patch.object(CrewAIEventsBus, "emit") as mock:
+        with patch.object(base_llm_module.crewai_event_bus, "emit") as mock:
             yield mock
 
     @pytest.fixture

--- a/lib/crewai/tests/knowledge/test_knowledge.py
+++ b/lib/crewai/tests/knowledge/test_knowledge.py
@@ -509,12 +509,14 @@ def test_excel_knowledge_source(mock_vector_db, tmpdir):
     mock_vector_db.query.assert_called_once()
 
 
-@pytest.mark.vcr
-def test_docling_source(mock_vector_db):
+def test_docling_source(mock_vector_db, tmp_path):
+    document = tmp_path / "reward-hacking.html"
+    document.write_text(
+        "<html><body><h1>Reward hacking</h1><p>Reward hacking changes agent behavior.</p></body></html>",
+        encoding="utf-8",
+    )
     docling_source = CrewDoclingSource(
-        file_paths=[
-            "https://lilianweng.github.io/posts/2024-11-28-reward-hacking/",
-        ],
+        file_paths=[document],
     )
     mock_vector_db.sources = [docling_source]
     mock_vector_db.query.return_value = [
@@ -530,16 +532,21 @@ def test_docling_source(mock_vector_db):
     mock_vector_db.query.assert_called_once()
 
 
-@pytest.mark.vcr
 @pytest.mark.timeout(180)
-def test_multiple_docling_sources() -> None:
-    urls: list[Path | str] = [
-        "https://lilianweng.github.io/posts/2024-11-28-reward-hacking/",
-        "https://lilianweng.github.io/posts/2024-07-07-hallucination/",
+def test_multiple_docling_sources(tmp_path) -> None:
+    documents = [
+        tmp_path / "reward-hacking.html",
+        tmp_path / "hallucination.html",
     ]
-    docling_source = CrewDoclingSource(file_paths=urls)
+    documents[0].write_text(
+        "<html><body><h1>Reward hacking</h1></body></html>", encoding="utf-8"
+    )
+    documents[1].write_text(
+        "<html><body><h1>Hallucination</h1></body></html>", encoding="utf-8"
+    )
+    docling_source = CrewDoclingSource(file_paths=documents)
 
-    assert docling_source.file_paths == urls
+    assert docling_source.file_paths == documents
     assert docling_source.content is not None
 
 

--- a/lib/crewai/tests/tracing/test_trace_enable_disable.py
+++ b/lib/crewai/tests/tracing/test_trace_enable_disable.py
@@ -67,6 +67,7 @@ class TestTraceEnableDisable:
             mp.setenv("CREWAI_TRACING_ENABLED", "true")
             mp.setenv("CREWAI_DISABLE_TELEMETRY", "false")
             mp.setenv("OTEL_SDK_DISABLED", "false")
+            mp.setenv("CREWAI_PLUS_URL", "https://app.crewai.com")
 
             agent = Agent(
                 role="Test Agent",
@@ -92,6 +93,7 @@ class TestTraceEnableDisable:
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv("CREWAI_DISABLE_TELEMETRY", "false")
             mp.setenv("OTEL_SDK_DISABLED", "false")
+            mp.setenv("CREWAI_PLUS_URL", "https://app.crewai.com")
 
             agent = Agent(
                 role="Test Agent",


### PR DESCRIPTION
## Summary

- make the unresolvable-host test deterministic by stubbing DNS resolution
- replace live Docling URLs with local HTML fixtures
- pin the tracing cassette service URL inside tests
- patch the event-bus instance used by `BaseLLM`

## Root cause

These tests depended on environment-specific state:

- wildcard or corporate DNS could resolve the synthetic hostname
- network policy could reject public Docling URLs
- `.env.test` could override the service URL recorded in tracing cassettes
- class-level event-bus patching could target a different reference after test-module initialization order changed

## Behavior

The tests continue to cover URL validation, Docling conversion, tracing requests, and LLM usage-event emission. All external inputs now come from deterministic local fixtures or the exact runtime object used by the implementation.

This PR changes test code only.

## Test plan

- CrewAI Tools fixture tests: `32 passed`
- CrewAI knowledge, tracing, and event tests: `46 passed`
- full workspace integration verification on Python 3.13: `5970 passed, 70 skipped`
- Ruff checks on changed files
- `git diff --check`
