### PR TITLE
fix(state): persist json checkpoints as utf-8

### DIFF
--- a/lib/crewai/src/crewai/state/provider/json_provider.py
+++ b/lib/crewai/src/crewai/state/provider/json_provider.py
@@ -63,7 +63,7 @@ class JsonProvider(BaseProvider):
         file_path = _build_path(location, branch, parent_id)
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(data)
         return str(file_path)
 
@@ -91,7 +91,7 @@ class JsonProvider(BaseProvider):
         file_path = _build_path(location, branch, parent_id)
         await aiofiles.os.makedirs(str(file_path.parent), exist_ok=True)
 
-        async with aiofiles.open(file_path, "w") as f:
+        async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
             await f.write(data)
         return str(file_path)
 
@@ -129,7 +129,7 @@ class JsonProvider(BaseProvider):
         Returns:
             The raw JSON string.
         """
-        return Path(location).read_text()
+        return Path(location).read_text(encoding="utf-8")
 
     async def afrom_checkpoint(self, location: str) -> str:
         """Read a JSON checkpoint file asynchronously.
@@ -140,7 +140,7 @@ class JsonProvider(BaseProvider):
         Returns:
             The raw JSON string.
         """
-        async with aiofiles.open(location) as f:
+        async with aiofiles.open(location, encoding="utf-8") as f:
             return await f.read()
 
 

--- a/lib/crewai/tests/test_checkpoint.py
+++ b/lib/crewai/tests/test_checkpoint.py
@@ -378,6 +378,23 @@ class TestJsonProviderFork:
             assert path.endswith(".json")
             assert os.path.isfile(path)
 
+    def test_checkpoint_round_trips_utf8_text(self) -> None:
+        provider = JsonProvider()
+        payload = json.dumps({"message": "resume cafe 東京"}, ensure_ascii=False)
+        with tempfile.TemporaryDirectory() as d:
+            path = provider.checkpoint(payload, d, branch="main")
+
+            assert provider.from_checkpoint(path) == payload
+
+    @pytest.mark.asyncio
+    async def test_acheckpoint_round_trips_utf8_text(self) -> None:
+        provider = JsonProvider()
+        payload = json.dumps({"message": "resume cafe 東京"}, ensure_ascii=False)
+        with tempfile.TemporaryDirectory() as d:
+            path = await provider.acheckpoint(payload, d, branch="main")
+
+            assert await provider.afrom_checkpoint(path) == payload
+
     def test_checkpoint_fork_branch_subdir(self) -> None:
         provider = JsonProvider()
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## Problem

`JsonProvider` writes and reads checkpoint JSON using the platform default text encoding. On systems where the default encoding is not UTF-8, checkpoint payloads containing non-ASCII state can fail to persist or restore consistently.

## Before / after

Before, sync and async checkpoint reads/writes relied on the process/platform default encoding.

After, both paths use `encoding="utf-8"` explicitly for checkpoint files, matching the JSON/state portability expectation.

## Verification

- `uv run pytest lib/crewai/tests/test_checkpoint.py::TestJsonProviderFork::test_checkpoint_round_trips_utf8_text lib/crewai/tests/test_checkpoint.py::TestJsonProviderFork::test_acheckpoint_round_trips_utf8_text -n 0 --allowed-hosts=127.0.0.1,localhost`
- `git diff --check`

I also tried the broader `TestJsonProviderFork` slice locally on Windows. The new UTF-8 tests passed, but the broader slice still hits existing Windows-local assumptions unrelated to this change: two tests assert POSIX-style `/main/` and `/fork/exp1/` separators, and one teardown encountered a locked temporary SQLite file.