### PR TITLE
fix(mcp): narrow RuntimeError handling in native resolver

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -355,6 +355,11 @@ class MCPToolResolver:
         try:
             try:
                 asyncio.get_running_loop()
+                loop_exists = True
+            except RuntimeError:
+                loop_exists = False
+
+            if loop_exists:
                 import concurrent.futures
 
                 ctx = contextvars.copy_context()
@@ -362,8 +367,14 @@ class MCPToolResolver:
                     future = executor.submit(
                         ctx.run, asyncio.run, _setup_client_and_list_tools()
                     )
-                    tools_list = future.result()
-            except RuntimeError:
+                    try:
+                        tools_list = future.result()
+                    except asyncio.CancelledError as e:
+                        raise ConnectionError(
+                            "MCP connection was cancelled. This may indicate an authentication "
+                            "error or server unavailability."
+                        ) from e
+            else:
                 try:
                     tools_list = asyncio.run(_setup_client_and_list_tools())
                 except RuntimeError as e:
@@ -460,6 +471,8 @@ class MCPToolResolver:
             if discovery_client.connected:
                 asyncio.run(discovery_client.disconnect())
 
+            if isinstance(e, ConnectionError):
+                raise
             raise RuntimeError(f"Failed to get native MCP tools: {e}") from e
 
     @staticmethod

--- a/lib/crewai/tests/mcp/test_tool_resolver_native.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_native.py
@@ -1,5 +1,6 @@
 """Tests for MCPToolResolver native (non-AMP) resolution paths."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -97,3 +98,53 @@ class TestResolveNativeRuntimeError:
 
         with pytest.raises(RuntimeError, match="Failed to get native MCP tools"):
             resolver._resolve_native(http_config)
+
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    @patch("crewai.mcp.tool_resolver.asyncio.run")
+    @patch.object(asyncio, "get_running_loop", return_value=MagicMock())
+    def test_thread_pool_runtimeerror_not_mistaken_for_no_event_loop(
+        self, mock_get_loop, mock_asyncio_run, mock_executor, resolver, http_config
+    ):
+        mock_future = MagicMock()
+        mock_future.result.side_effect = RuntimeError(
+            "Error during setup client and list tools: connection refused"
+        )
+
+        def _submit_side_effect(fn, *args, **kwargs):
+            coro = args[1] if len(args) > 1 else kwargs.get("coro")
+            if coro is not None:
+                coro.close()
+            return mock_future
+
+        mock_executor.return_value.__enter__.return_value.submit.side_effect = (
+            _submit_side_effect
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to get native MCP tools"):
+            resolver._resolve_native(http_config)
+
+        mock_asyncio_run.assert_not_called()
+
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    @patch("crewai.mcp.tool_resolver.asyncio.run")
+    @patch.object(asyncio, "get_running_loop", return_value=MagicMock())
+    def test_thread_pool_cancellederror_handled(
+        self, mock_get_loop, mock_asyncio_run, mock_executor, resolver, http_config
+    ):
+        mock_future = MagicMock()
+        mock_future.result.side_effect = asyncio.CancelledError("task cancelled")
+
+        def _submit_side_effect(fn, *args, **kwargs):
+            coro = args[1] if len(args) > 1 else kwargs.get("coro")
+            if coro is not None:
+                coro.close()
+            return mock_future
+
+        mock_executor.return_value.__enter__.return_value.submit.side_effect = (
+            _submit_side_effect
+        )
+
+        with pytest.raises(ConnectionError, match="MCP connection was cancelled"):
+            resolver._resolve_native(http_config)
+
+        mock_asyncio_run.assert_not_called()


### PR DESCRIPTION
## Summary

This PR fixes an issue in the native MCP resolver where a broad `except RuntimeError` unintentionally caught errors originating from the `ThreadPoolExecutor` execution path.

When `_setup_client_and_list_tools()` failed inside the worker thread, the propagated `RuntimeError` was treated as if it came from `asyncio.get_running_loop()`. As a result, the code incorrectly fell back to calling `asyncio.run()` on a thread that already had a running event loop, producing the misleading error:

```text
RuntimeError: asyncio.run() cannot be called from a running event loop
```

## Changes

- Narrow the `RuntimeError` handling so it only covers `asyncio.get_running_loop()`.
- Preserve the existing execution paths for both:
  - environments with a running event loop
  - environments without a running event loop
- Allow `RuntimeError`s raised from the `ThreadPoolExecutor` path to propagate naturally instead of being mistaken for a missing event loop.

## Testing

Added a regression test covering the thread-pool execution path to ensure that:

- a `RuntimeError` originating from `future.result()` is not interpreted as a missing event loop
- the fallback `asyncio.run()` path is **not** executed when a running event loop already exists

This prevents the regression from reappearing while preserving the existing behavior for the no-event-loop path.

<!-- crewai-require-issue-check -->