### PR TITLE
fix: remove hardcoded Unix venv activation from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: bash -c 'source .venv/bin/activate && uv run ruff check --config pyproject.toml "$@"' --
+        entry: bash -c 'uv run ruff check --config pyproject.toml "$@"' --
         language: system
         pass_filenames: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: bash -c 'source .venv/bin/activate && uv run ruff format --config pyproject.toml "$@"' --
+        entry: bash -c 'uv run ruff format --config pyproject.toml "$@"' --
         language: system
         pass_filenames: true
         types: [python]
       - id: mypy
         name: mypy
-        entry: bash -c 'source .venv/bin/activate && uv run mypy --config-file pyproject.toml "$@"' --
+        entry: bash -c 'uv run mypy --config-file pyproject.toml "$@"' --
         language: system
         pass_filenames: true
         types: [python]
@@ -30,7 +30,7 @@ repos:
         name: pip-audit
         # Keep this ignore list in sync with .github/workflows/vulnerability-scan.yml.
         entry: >-
-          bash -c 'source .venv/bin/activate && uv run pip-audit --skip-editable
+          bash -c 'uv run pip-audit --skip-editable
           --ignore-vuln PYSEC-2024-277
           --ignore-vuln PYSEC-2026-89
           --ignore-vuln PYSEC-2026-97


### PR DESCRIPTION
## Summary
- The local `pre-commit` hooks (`ruff`, `ruff-format`, `mypy`, `pip-audit`) sourced `.venv/bin/activate` directly, which doesn't exist on Windows (activation script lives under `.venv\Scripts\` there), so all hooks failed before running.
- `uv run` already resolves the project's virtual environment on its own, so the explicit `source .venv/bin/activate &&` step is unnecessary and platform-specific. Removed it from all four hook entries.

Fixes #6863

## Test plan
- [x] Ran `uv run --with pre-commit pre-commit run ruff --all-files` locally — hook executes and reports lint results instead of failing with `.venv/bin/activate: No such file or directory`
- [x] Validated `.pre-commit-config.yaml` still parses as valid YAML