### PR TITLE
fix(deps): bump gitpython to 3.1.58 in crewai-tools[github]

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -107,9 +107,12 @@ stagehand = [
     "stagehand>=0.4.1",
 ]
 github = [
-    # <3.1.57 has GHSA-p538-c434-8v24 (arbitrary file truncation) and
-    # GHSA-3f7w-8rr8-f37f (unguarded git option forwarding).
-    "gitpython>=3.1.57,<4",
+    # <3.1.58 has GHSA-p538-c434-8v24 (arbitrary file truncation),
+    # GHSA-3f7w-8rr8-f37f (unguarded git option forwarding),
+    # GHSA-9rj7-rf2p-w77r, GHSA-4gmw-gg2m-w46p, GHSA-hh9p-6wh2-4mfc,
+    # GHSA-wvpp-8hx9-p66j and GHSA-jm78-9fvv-mhgr (further unguarded git
+    # option forwarding / arbitrary file read); force 3.1.58+.
+    "gitpython>=3.1.58,<4",
     "PyGithub==1.59.1",
 ]
 rag = [

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = "~=2.6.0" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
-    { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.57,<4" },
+    { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.58,<4" },
     { name = "hyperbrowser", marker = "extra == 'hyperbrowser'", specifier = ">=0.18.0" },
     { name = "langchain-apify", marker = "extra == 'apify'", specifier = ">=0.1.2,<1.0.0" },
     { name = "linkup-sdk", marker = "extra == 'linkup-sdk'", specifier = ">=0.2.2" },


### PR DESCRIPTION
## Summary

Fixes the failing **pip-audit** job in the **Vulnerability Scan** workflow
([run 31196777645](https://github.com/crewAIInc/crewAI/actions/runs/31196777645), job 92926858095).

## Root cause

The scan resolved `gitpython==3.1.57` and reported 5 known vulnerabilities:

- GHSA-9rj7-rf2p-w77r
- GHSA-4gmw-gg2m-w46p
- GHSA-hh9p-6wh2-4mfc
- GHSA-wvpp-8hx9-p66j
- GHSA-jm78-9fvv-mhgr

These are further unguarded git option forwarding / arbitrary file read
issues (via `--pathspec-from-file`), all fixed in **gitpython 3.1.58**.

The root workspace `override-dependencies` already forces
`gitpython>=3.1.58,<4`, but the `crewai-tools[github]` extra still
allowed `>=3.1.57`, which is how the vulnerable version could resolve for
consumers installing that extra directly.

## Change

- `lib/crewai-tools/pyproject.toml`: bump the `github` extra to
  `gitpython>=3.1.58,<4` and update the comment documenting the fixed CVEs.
- `uv.lock`: regenerate so the `extra == 'github'` requirement is
  `>=3.1.58,<4` (gitpython already resolves to 3.1.58).

## Verification

`uv lock --all-groups --all-extras` resolves cleanly. The lockfile now
requires `gitpython>=3.1.58,<4` in both the root and the `github` extra, and
resolves to gitpython 3.1.58, which carries the fixes for all 5 flagged
advisories.