### PR TITLE
fix: raise PermanentUploadError instead of bare raise in get_uploader

### DIFF
--- a/lib/crewai-files/src/crewai_files/uploaders/factory.py
+++ b/lib/crewai-files/src/crewai_files/uploaders/factory.py
@@ -7,6 +7,7 @@ from typing import Any as AnyType, Literal, TypeAlias, TypedDict, overload
 
 from typing_extensions import NotRequired, Unpack
 
+from crewai_files.processing.exceptions import PermanentUploadError
 from crewai_files.uploaders.anthropic import AnthropicFileUploader
 from crewai_files.uploaders.bedrock import BedrockFileUploader
 from crewai_files.uploaders.gemini import GeminiFileUploader
@@ -196,7 +197,11 @@ def get_uploader(
                 "Bedrock S3 uploader not configured. "
                 "Set CREWAI_BEDROCK_S3_BUCKET environment variable to enable."
             )
-            raise
+            raise PermanentUploadError(
+                "Bedrock S3 uploader not configured. Set the "
+                "CREWAI_BEDROCK_S3_BUCKET environment variable or pass "
+                "bucket_name to enable it."
+            )
         try:
             from crewai_files.uploaders.bedrock import BedrockFileUploader
 
@@ -213,4 +218,4 @@ def get_uploader(
             raise
 
     logger.debug(f"No file uploader available for provider: {provider}")
-    raise
+    raise PermanentUploadError(f"No file uploader available for provider: {provider}")

--- a/lib/crewai-files/tests/uploaders/test_factory.py
+++ b/lib/crewai-files/tests/uploaders/test_factory.py
@@ -1,0 +1,30 @@
+"""Tests for get_uploader error handling."""
+
+import pytest
+
+from crewai_files.processing.exceptions import PermanentUploadError
+from crewai_files.uploaders.factory import get_uploader
+
+
+def test_get_uploader_unsupported_provider_raises_permanent_upload_error() -> None:
+    """
+    An unsupported provider must raise PermanentUploadError, not a bare
+    ``RuntimeError: No active exception to re-raise``.
+
+    The final ``raise`` in get_uploader was a bare re-raise outside any
+    except block, so Python raised RuntimeError instead of a meaningful error.
+    """
+    with pytest.raises(PermanentUploadError, match="not-a-real-provider"):
+        get_uploader("not-a-real-provider")
+
+
+def test_get_uploader_bedrock_without_bucket_raises_permanent_upload_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Requesting the Bedrock uploader without a configured bucket must raise
+    PermanentUploadError (a config error), not a bare RuntimeError.
+    """
+    monkeypatch.delenv("CREWAI_BEDROCK_S3_BUCKET", raising=False)
+    with pytest.raises(PermanentUploadError, match="CREWAI_BEDROCK_S3_BUCKET"):
+        get_uploader("bedrock")


### PR DESCRIPTION
## Fixes #6568

### Bug

`get_uploader()` (`lib/crewai-files/src/crewai_files/uploaders/factory.py`) has two bare `raise` statements outside any exception handler:

1. When Bedrock is requested without `CREWAI_BEDROCK_S3_BUCKET` configured
2. When an unsupported provider string is passed

A bare `raise` re-raises the exception currently being handled, but neither path is inside an `except` block, so instead of a meaningful error Python raises:

```
RuntimeError: No active exception to re-raise
```

```python
get_uploader("bedrock")               # without CREWAI_BEDROCK_S3_BUCKET set
get_uploader("not-a-real-provider")
# both -> RuntimeError: No active exception to re-raise
```

### Fix

Raise `PermanentUploadError` (already used across this package for non-retryable config/input errors, and defined in `crewai_files/processing/exceptions.py`) with a descriptive message in both cases.

### Tests

Added `tests/uploaders/test_factory.py` covering the unsupported-provider and missing-bucket paths (both now assert `PermanentUploadError`). `ruff check --select PLE0704` also flagged these bare raises.