### PR TITLE
feat(knowledge): add metadata_filter config and metadata save support

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -2059,22 +2059,36 @@ class Crew(FlowTrackable, BaseModel):
         return self._execute_tasks(self.tasks, start_index, True)
 
     def query_knowledge(
-        self, query: list[str], results_limit: int = 3, score_threshold: float = 0.35
+        self,
+        query: list[str],
+        results_limit: int = 3,
+        score_threshold: float = 0.35,
+        metadata_filter: dict[str, Any] | None = None,
     ) -> list[SearchResult] | None:
         """Query the crew's knowledge base for relevant information."""
         if self.knowledge:
             return self.knowledge.query(
-                query, results_limit=results_limit, score_threshold=score_threshold
+                query,
+                results_limit=results_limit,
+                score_threshold=score_threshold,
+                metadata_filter=metadata_filter,
             )
         return None
 
     async def aquery_knowledge(
-        self, query: list[str], results_limit: int = 3, score_threshold: float = 0.35
+        self,
+        query: list[str],
+        results_limit: int = 3,
+        score_threshold: float = 0.35,
+        metadata_filter: dict[str, Any] | None = None,
     ) -> list[SearchResult] | None:
         """Query the crew's knowledge base for relevant information asynchronously."""
         if self.knowledge:
             return await self.knowledge.aquery(
-                query, results_limit=results_limit, score_threshold=score_threshold
+                query,
+                results_limit=results_limit,
+                score_threshold=score_threshold,
+                metadata_filter=metadata_filter,
             )
         return None
 

--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -133,11 +133,21 @@ class Knowledge(BaseModel):
         self.sources = sources
 
     def query(
-        self, query: list[str], results_limit: int = 5, score_threshold: float = 0.6
+        self,
+        query: list[str],
+        results_limit: int = 5,
+        score_threshold: float = 0.6,
+        metadata_filter: dict[str, Any] | None = None,
     ) -> list[SearchResult]:
         """
         Query across all knowledge sources to find the most relevant information.
         Returns the top_k most relevant chunks.
+
+        Args:
+            query: List of query strings.
+            results_limit: Maximum number of results to return.
+            score_threshold: Minimum similarity score for results.
+            metadata_filter: Optional metadata filter for the search.
 
         Raises:
             ValueError: If storage is not initialized.
@@ -149,6 +159,7 @@ class Knowledge(BaseModel):
             query,
             limit=results_limit,
             score_threshold=score_threshold,
+            metadata_filter=metadata_filter,
         )
 
     def add_sources(self) -> None:
@@ -165,7 +176,11 @@ class Knowledge(BaseModel):
         self.storage.reset()
 
     async def aquery(
-        self, query: list[str], results_limit: int = 5, score_threshold: float = 0.6
+        self,
+        query: list[str],
+        results_limit: int = 5,
+        score_threshold: float = 0.6,
+        metadata_filter: dict[str, Any] | None = None,
     ) -> list[SearchResult]:
         """Query across all knowledge sources asynchronously.
 
@@ -173,6 +188,7 @@ class Knowledge(BaseModel):
             query: List of query strings.
             results_limit: Maximum number of results to return.
             score_threshold: Minimum similarity score for results.
+            metadata_filter: Optional metadata filter for the search.
 
         Returns:
             The top results matching the query.
@@ -187,6 +203,7 @@ class Knowledge(BaseModel):
             query,
             limit=results_limit,
             score_threshold=score_threshold,
+            metadata_filter=metadata_filter,
         )
 
     async def aadd_sources(self) -> None:

--- a/lib/crewai/src/crewai/knowledge/knowledge_config.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge_config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -7,10 +9,15 @@ class KnowledgeConfig(BaseModel):
     Args:
         results_limit (int): The number of relevant documents to return.
         score_threshold (float): The minimum score for a document to be considered relevant.
+        metadata_filter (dict[str, Any] | None): Optional metadata filter for knowledge search.
     """
 
     results_limit: int = Field(default=5, description="The number of results to return")
     score_threshold: float = Field(
         default=0.6,
         description="The minimum score for a result to be considered relevant",
+    )
+    metadata_filter: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional metadata filter to apply when searching the knowledge base",
     )

--- a/lib/crewai/src/crewai/knowledge/source/base_file_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/base_file_knowledge_source.py
@@ -71,14 +71,20 @@ class BaseFileKnowledgeSource(BaseKnowledgeSource, ABC):
     def _save_documents(self) -> None:
         """Save the documents to the storage."""
         if self.storage is not None:
-            self.storage.save(self.chunks)
+            self.storage.save(
+                self.chunks,
+                metadata=self.metadata if self.metadata else None,
+            )
         else:
             raise ValueError("No storage found to save documents.")
 
     async def _asave_documents(self) -> None:
         """Save the documents to the storage asynchronously."""
         if self.storage is not None:
-            await self.storage.asave(self.chunks)
+            await self.storage.asave(
+                self.chunks,
+                metadata=self.metadata if self.metadata else None,
+            )
         else:
             raise ValueError("No storage found to save documents.")
 

--- a/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
+++ b/lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py
@@ -25,7 +25,10 @@ class BaseKnowledgeSource(BaseModel, ABC):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     storage: BaseKnowledgeStorage | None = Field(default=None)
-    metadata: dict[str, Any] = Field(default_factory=dict)  # Currently unused
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Metadata to attach to all chunks from this source",
+    )
     collection_name: str | None = Field(default=None)
 
     @abstractmethod
@@ -56,7 +59,10 @@ class BaseKnowledgeSource(BaseModel, ABC):
             ValueError: If no storage is configured.
         """
         if self.storage is not None:
-            self.storage.save(self.chunks)
+            self.storage.save(
+                self.chunks,
+                metadata=self.metadata if self.metadata else None,
+            )
         else:
             raise ValueError("No storage found to save documents.")
 
@@ -73,6 +79,9 @@ class BaseKnowledgeSource(BaseModel, ABC):
             ValueError: If no storage is configured.
         """
         if self.storage is not None:
-            await self.storage.asave(self.chunks)
+            await self.storage.asave(
+                self.chunks,
+                metadata=self.metadata if self.metadata else None,
+            )
         else:
             raise ValueError("No storage found to save documents.")

--- a/lib/crewai/src/crewai/knowledge/storage/base_knowledge_storage.py
+++ b/lib/crewai/src/crewai/knowledge/storage/base_knowledge_storage.py
@@ -35,11 +35,19 @@ class BaseKnowledgeStorage(BaseModel, ABC):
         """Search for documents in the knowledge base asynchronously."""
 
     @abstractmethod
-    def save(self, documents: list[str]) -> None:
+    def save(
+        self,
+        documents: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Save documents to the knowledge base."""
 
     @abstractmethod
-    async def asave(self, documents: list[str]) -> None:
+    async def asave(
+        self,
+        documents: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Save documents to the knowledge base asynchronously."""
 
     @abstractmethod

--- a/lib/crewai/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/lib/crewai/src/crewai/knowledge/storage/knowledge_storage.py
@@ -102,7 +102,11 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                 f"Error during knowledge reset: {e!s}\n{traceback.format_exc()}"
             )
 
-    def save(self, documents: list[str]) -> None:
+    def save(
+        self,
+        documents: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         if not documents:
             return
 
@@ -115,7 +119,10 @@ class KnowledgeStorage(BaseKnowledgeStorage):
             )
             client.get_or_create_collection(collection_name=collection_name)
 
-            rag_documents: list[BaseRecord] = [{"content": doc} for doc in documents]
+            rag_documents: list[BaseRecord] = [
+                {"content": doc, "metadata": metadata} if metadata else {"content": doc}
+                for doc in documents
+            ]
 
             client.add_documents(
                 collection_name=collection_name, documents=rag_documents
@@ -178,11 +185,16 @@ class KnowledgeStorage(BaseKnowledgeStorage):
             )
             return []
 
-    async def asave(self, documents: list[str]) -> None:
+    async def asave(
+        self,
+        documents: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Save documents to the knowledge base asynchronously.
 
         Args:
             documents: List of document strings to save.
+            metadata: Optional metadata to attach to each document.
         """
         if not documents:
             return
@@ -196,7 +208,10 @@ class KnowledgeStorage(BaseKnowledgeStorage):
             )
             await client.aget_or_create_collection(collection_name=collection_name)
 
-            rag_documents: list[BaseRecord] = [{"content": doc} for doc in documents]
+            rag_documents: list[BaseRecord] = [
+                {"content": doc, "metadata": metadata} if metadata else {"content": doc}
+                for doc in documents
+            ]
 
             await client.aadd_documents(
                 collection_name=collection_name, documents=rag_documents

--- a/lib/crewai/tests/knowledge/test_knowledge_metadata.py
+++ b/lib/crewai/tests/knowledge/test_knowledge_metadata.py
@@ -1,0 +1,258 @@
+"""Tests for knowledge metadata support across config, query, and save paths."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from crewai.knowledge.knowledge import Knowledge
+from crewai.knowledge.knowledge_config import KnowledgeConfig
+from crewai.knowledge.source.string_knowledge_source import StringKnowledgeSource
+from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
+from crewai.rag.types import BaseRecord, SearchResult
+
+
+class TestKnowledgeConfigMetadata:
+    """Tests for KnowledgeConfig metadata_filter field."""
+
+    def test_knowledge_config_has_metadata_filter(self):
+        """KnowledgeConfig should have a metadata_filter field defaulting to None."""
+        config = KnowledgeConfig()
+        assert hasattr(config, "metadata_filter")
+        assert config.metadata_filter is None
+
+    def test_knowledge_config_metadata_filter_can_be_set(self):
+        """KnowledgeConfig should accept a metadata_filter dict."""
+        filter_dict = {"category": "research", "source": "internal"}
+        config = KnowledgeConfig(metadata_filter=filter_dict)
+        assert config.metadata_filter == filter_dict
+
+    def test_knowledge_config_model_dump_includes_metadata_filter(self):
+        """model_dump() should include metadata_filter so ** unpacking works with query()."""
+        config = KnowledgeConfig(
+            results_limit=10,
+            score_threshold=0.8,
+            metadata_filter={"env": "prod"},
+        )
+        dumped = config.model_dump()
+        assert "metadata_filter" in dumped
+        assert dumped["metadata_filter"] == {"env": "prod"}
+        assert dumped["results_limit"] == 10
+        assert dumped["score_threshold"] == 0.8
+
+
+class TestKnowledgeQueryMetadata:
+    """Tests for Knowledge.query() / aquery() forwarding metadata_filter."""
+
+    def test_query_forwards_metadata_filter_to_storage(self):
+        """Knowledge.query() should pass metadata_filter to storage.search()."""
+        mock_storage = MagicMock()
+        mock_storage.search.return_value = [
+            SearchResult(
+                id="1", content="test content", metadata={"env": "prod"}, score=0.9
+            )
+        ]
+
+        knowledge = Knowledge(
+            collection_name="test",
+            sources=[],
+        )
+        knowledge.storage = mock_storage
+
+        metadata_filter = {"env": "prod", "category": "tech"}
+        knowledge.query(
+            ["test query"],
+            results_limit=5,
+            score_threshold=0.5,
+            metadata_filter=metadata_filter,
+        )
+
+        mock_storage.search.assert_called_once()
+        call_kwargs = mock_storage.search.call_args
+        assert call_kwargs.kwargs.get("metadata_filter") == metadata_filter
+        assert call_kwargs.kwargs.get("limit") == 5
+        assert call_kwargs.kwargs.get("score_threshold") == 0.5
+
+    def test_query_without_metadata_filter_passes_none(self):
+        """Knowledge.query() without metadata_filter should pass None."""
+        mock_storage = MagicMock()
+        mock_storage.search.return_value = []
+
+        knowledge = Knowledge(collection_name="test", sources=[])
+        knowledge.storage = mock_storage
+
+        knowledge.query(["test query"])
+
+        mock_storage.search.assert_called_once()
+        call_kwargs = mock_storage.search.call_args
+        assert call_kwargs.kwargs.get("metadata_filter") is None
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Async tests fail on Windows due to pytest-recording + asyncio event loop compatibility",
+    )
+    @pytest.mark.asyncio
+    async def test_aquery_forwards_metadata_filter_to_storage(self):
+        """Knowledge.aquery() should pass metadata_filter to storage.asearch()."""
+        mock_storage = MagicMock()
+        mock_storage.asearch.return_value = [
+            SearchResult(
+                id="1", content="test content", metadata={"env": "prod"}, score=0.9
+            )
+        ]
+
+        knowledge = Knowledge(collection_name="test", sources=[])
+        knowledge.storage = mock_storage
+
+        metadata_filter = {"status": "active"}
+        await knowledge.aquery(
+            ["test query"],
+            results_limit=3,
+            score_threshold=0.7,
+            metadata_filter=metadata_filter,
+        )
+
+        mock_storage.asearch.assert_called_once()
+        call_kwargs = mock_storage.asearch.call_args
+        assert call_kwargs.kwargs.get("metadata_filter") == metadata_filter
+
+
+class TestKnowledgeStorageSaveMetadata:
+    """Tests for KnowledgeStorage.save() / asave() attaching metadata."""
+
+    @patch.object(KnowledgeStorage, "_get_client")
+    def test_save_with_metadata_attaches_to_all_documents(self, mock_get_client):
+        """KnowledgeStorage.save() should attach metadata dict to every document."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+
+        documents = ["doc one", "doc two", "doc three"]
+        metadata = {"source": "wiki", "category": "tech"}
+
+        storage.save(documents, metadata=metadata)
+
+        mock_client.add_documents.assert_called_once()
+        call_args = mock_client.add_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        assert len(saved_docs) == 3
+        for doc in saved_docs:
+            assert isinstance(doc, dict)
+            assert doc["content"] is not None
+            assert doc.get("metadata") == metadata
+
+    @patch.object(KnowledgeStorage, "_get_client")
+    def test_save_without_metadata_no_metadata_field(self, mock_get_client):
+        """KnowledgeStorage.save() without metadata should produce records without metadata."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+
+        documents = ["just content"]
+        storage.save(documents)
+
+        mock_client.add_documents.assert_called_once()
+        call_args = mock_client.add_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        assert len(saved_docs) == 1
+        # When no metadata is passed, the record should have just content
+        assert "metadata" not in saved_docs[0] or saved_docs[0].get("metadata") is None
+
+    @patch.object(KnowledgeStorage, "_get_client")
+    def test_save_with_empty_metadata_dict_treated_as_none(self, mock_get_client):
+        """KnowledgeStorage.save() with empty metadata dict should not attach metadata."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+        storage.save(["content"], metadata={})
+
+        mock_client.add_documents.assert_called_once()
+        call_args = mock_client.add_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        # Empty metadata dict should be treated as no metadata
+        assert saved_docs[0].get("metadata") in (None, {})
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Async tests fail on Windows due to pytest-recording + asyncio event loop compatibility",
+    )
+    @pytest.mark.asyncio
+    @patch.object(KnowledgeStorage, "_get_client")
+    async def test_asave_with_metadata_attaches_to_all_documents(self, mock_get_client):
+        """KnowledgeStorage.asave() should attach metadata dict to every document."""
+        mock_client = MagicMock()
+        mock_client.aget_or_create_collection.return_value = None
+        mock_client.aadd_documents.return_value = None
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+
+        documents = ["async doc 1", "async doc 2"]
+        metadata = {"priority": "high"}
+
+        await storage.asave(documents, metadata=metadata)
+
+        mock_client.aadd_documents.assert_called_once()
+        call_args = mock_client.aadd_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        assert len(saved_docs) == 2
+        for doc in saved_docs:
+            assert doc.get("metadata") == metadata
+
+
+class TestKnowledgeSourceSaveMetadata:
+    """Tests that BaseKnowledgeSource passes its metadata to storage.save()."""
+
+    @patch.object(KnowledgeStorage, "_get_client")
+    def test_string_source_metadata_passed_to_storage(self, mock_get_client):
+        """StringKnowledgeSource should pass its metadata to storage when saving."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+
+        source = StringKnowledgeSource(
+            content="Hello world",
+            metadata={"source_type": "manual", "author": "test"},
+        )
+        source.storage = storage
+        source.chunks = ["Hello world"]
+
+        source._save_documents()
+
+        mock_client.add_documents.assert_called_once()
+        call_args = mock_client.add_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        assert len(saved_docs) == 1
+        assert saved_docs[0].get("metadata") == {
+            "source_type": "manual",
+            "author": "test",
+        }
+
+    @patch.object(KnowledgeStorage, "_get_client")
+    def test_string_source_without_metadata_passes_none(self, mock_get_client):
+        """Knowledge source without metadata should not attach metadata."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        storage = KnowledgeStorage(collection_name="test")
+
+        source = StringKnowledgeSource(content="Hello world")
+        source.storage = storage
+        source.chunks = ["Hello world"]
+
+        source._save_documents()
+
+        mock_client.add_documents.assert_called_once()
+        call_args = mock_client.add_documents.call_args
+        saved_docs = call_args.kwargs.get("documents")
+
+        # Default metadata is empty dict, should be treated as None
+        assert saved_docs[0].get("metadata") in (None, {})


### PR DESCRIPTION
The lower layers of the knowledge system already support metadata — `KnowledgeStorage.search()` accepts `metadata_filter`, `BaseRecord` has a `metadata` field, and `BaseKnowledgeSource` has a `metadata` field. However, 4 gaps prevent users from actually using metadata from user-land:

1. **`KnowledgeConfig`** — no `metadata_filter` field, so metadata-based retrieval cannot be configured at the config/agent level
2. **`Knowledge.query()` / `Knowledge.aquery()`** — don't forward `metadata_filter` to storage
3. **`Crew.query_knowledge()` / `Crew.aquery_knowledge()`** — don't forward `metadata_filter`
4. **`BaseKnowledgeSource._save_documents()` / save path** — source metadata is never passed to storage when saving chunks

Closes #5805

## Solution

Close all 4 gaps so metadata flows end-to-end: config → query → search results, and source metadata → saved documents.

### Changes

**Config layer**
- `lib/crewai/src/crewai/knowledge/knowledge_config.py` — add `metadata_filter: dict[str, Any] | None` field to `KnowledgeConfig`

**Query layer**
- `lib/crewai/src/crewai/knowledge/knowledge.py` — add `metadata_filter` param to `query()` and `aquery()`, forward to storage
- `lib/crewai/src/crewai/crew.py` — add `metadata_filter` param to `query_knowledge()` and `aquery_knowledge()`, forward to knowledge

**Storage layer**
- `lib/crewai/src/crewai/knowledge/storage/base_knowledge_storage.py` — add `metadata` param to abstract `save()` and `asave()`
- `lib/crewai/src/crewai/knowledge/storage/knowledge_storage.py` — implement metadata attachment in `save()` and `asave()`; attach metadata dict to every `BaseRecord` when provided

**Source layer**
- `lib/crewai/src/crewai/knowledge/source/base_knowledge_source.py` — pass `self.metadata` to `storage.save()` / `storage.asave()`
- `lib/crewai/src/crewai/knowledge/source/base_file_knowledge_source.py` — same for file-based sources

**Tests**
- `lib/crewai/tests/knowledge/test_knowledge_metadata.py` — 12 unit tests covering all 4 gaps
  - KnowledgeConfig metadata_filter field + model_dump
  - Knowledge.query() / aquery() forwarding
  - KnowledgeStorage.save() / asave() metadata attachment
  - KnowledgeSource metadata propagation to storage

## Design decisions

- **Backward compatible** — all new params default to `None`, existing code works unchanged
- **Empty dict = no metadata** — when `metadata` is `{}` (the default on `BaseKnowledgeSource`), it's treated as `None` and not attached, keeping records clean
- **`metadata_filter` in KnowledgeConfig** — follows the same pattern as `results_limit` and `score_threshold`, so `**knowledge_config.model_dump()` works seamlessly with `query()`
- **Per-source metadata, applied to all chunks** — each knowledge source's metadata is attached to every chunk from that source, which is the common use case (filtering by source, category, etc.)

## Testing

10 passed, 2 skipped on Windows (async tests skipped due to pytest-recording + asyncio event loop compatibility — CI on Linux covers async paths).

```
lib/crewai/tests/knowledge/test_knowledge_metadata.py
  TestKnowledgeConfigMetadata
    ✓ test_knowledge_config_has_metadata_filter
    ✓ test_knowledge_config_metadata_filter_can_be_set
    ✓ test_knowledge_config_model_dump_includes_metadata_filter
  TestKnowledgeQueryMetadata
    ✓ test_query_forwards_metadata_filter_to_storage
    ✓ test_query_without_metadata_filter_passes_none
    • test_aquery_forwards_metadata_filter_to_storage (skipped on Windows)
  TestKnowledgeStorageSaveMetadata
    ✓ test_save_with_metadata_attaches_to_all_documents
    ✓ test_save_without_metadata_no_metadata_field
    ✓ test_save_with_empty_metadata_dict_treated_as_none
    • test_asave_with_metadata_attaches_to_all_documents (skipped on Windows)
  TestKnowledgeSourceSaveMetadata
    ✓ test_string_source_metadata_passed_to_storage
    ✓ test_string_source_without_metadata_passes_none
```

ruff: ✅ all checks passed  
mypy: ✅ no issues found in 7 source files

<!-- crewai-require-issue-check -->