### PR TITLE
fix(llm): isolate caller file messages

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -763,6 +763,8 @@ class LLM(BaseLLM):
         """
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
+        else:
+            messages = [message.copy() for message in messages]
         if not skip_file_processing:
             messages = self._process_message_files(messages)
         formatted_messages = self._format_messages_for_provider(messages)
@@ -2006,6 +2008,8 @@ class LLM(BaseLLM):
 
             if isinstance(messages, str):
                 messages = [{"role": "user", "content": messages}]
+            else:
+                messages = [message.copy() for message in messages]
 
             messages = await self._aprocess_message_files(messages)
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from time import sleep
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from crewai.agents.agent_builder.utilities.base_token_process import TokenProcess
 from crewai.events.event_types import (
@@ -198,6 +198,55 @@ def test_llm_passes_additional_params():
         assert kwargs["messages"] == messages
 
         assert result == "Test response"
+
+
+def test_call_does_not_mutate_file_messages():
+    llm = LLM(model="openai/gpt-4o", is_litellm=True)
+    messages = [{"role": "user", "content": "describe it", "files": ["image"]}]
+
+    with patch.object(llm, "supports_multimodal", return_value=True), patch(
+        "crewai.llm.format_multimodal_content",
+        return_value=[{"type": "image_url"}],
+    ), patch.object(llm, "_handle_non_streaming_response", return_value="done") as handle:
+        assert llm.call(messages) == "done"
+
+    params = handle.call_args.kwargs["params"]
+    assert params["messages"][0]["content"] == [
+        {"type": "text", "text": "describe it"},
+        {"type": "image_url"},
+    ]
+    assert messages == [
+        {"role": "user", "content": "describe it", "files": ["image"]}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_acall_does_not_mutate_file_messages():
+    llm = LLM(model="openai/gpt-4o", is_litellm=True)
+    messages = [{"role": "user", "content": "describe it", "files": ["image"]}]
+
+    async def format_files(*args, **kwargs):
+        return [{"type": "image_url"}]
+
+    with patch.object(llm, "supports_multimodal", return_value=True), patch(
+        "crewai.llm.aformat_multimodal_content",
+        new=format_files,
+    ), patch.object(
+        llm,
+        "_ahandle_non_streaming_response",
+        new_callable=AsyncMock,
+        return_value="done",
+    ) as handle:
+        assert await llm.acall(messages) == "done"
+
+    params = handle.await_args.kwargs["params"]
+    assert params["messages"][0]["content"] == [
+        {"type": "text", "text": "describe it"},
+        {"type": "image_url"},
+    ]
+    assert messages == [
+        {"role": "user", "content": "describe it", "files": ["image"]}
+    ]
 
 
 def test_get_custom_llm_provider_openrouter():


### PR DESCRIPTION
## Summary

Copy caller-supplied message dictionaries before LiteLLM file formatting can replace content or remove the `files` field.

## Root cause

The LiteLLM sync and async paths passed the caller's message dictionaries directly to their file-processing helpers, which mutate those dictionaries. Reusing the same message list therefore dropped attachments after the first call.

## Validation

- `uv run --with litellm --with anthropic pytest lib/crewai/tests/test_llm.py -k "does_not_mutate_file_messages" -q`
- `uv run ruff format --check lib/crewai/src/crewai/llm.py lib/crewai/tests/test_llm.py`
- `uv run ruff check lib/crewai/src/crewai/llm.py lib/crewai/tests/test_llm.py`