### PR TITLE
ci: stop Run Tests from starting on docs-only PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,35 +1,21 @@
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    # Do not start this workflow for docs/markdown/Actions-only PRs.
+    # Required check name `lint` for those PRs is reported by
+    # non-code-ci-status.yml so branch protection does not hang.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.github/**'
 
 permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
-        id: filter
-        with:
-          # Exclusion-only patterns match every non-excluded file under the
-          # default "some" quantifier. Require all patterns (including "**")
-          # so docs/markdown/Actions-only PRs correctly set code=false.
-          predicate-quantifier: every
-          filters: |
-            code:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!.github/**'
-
   lint-run:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -76,15 +62,11 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    needs: [changes, lint-run]
+    needs: [lint-run]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
-            echo "Non-code change, skipping lint"
-            exit 0
-          fi
           if [ "${{ needs.lint-run.result }}" == "success" ]; then
             echo "Lint passed"
           else

--- a/.github/workflows/non-code-ci-status.yml
+++ b/.github/workflows/non-code-ci-status.yml
@@ -1,0 +1,86 @@
+# Reports required branch-protection check names when the Python CI workflows
+# are skipped via paths-ignore (docs / markdown / Actions-only PRs).
+#
+# Creates check runs via the Checks API (instead of same-named jobs) so code
+# PRs do not get conflicting skipped `tests` / `lint` checks alongside the
+# real workflows.
+#
+# Required contexts (ruleset "main"): lint, type-checker, tests,
+# tests (3.10)–tests (3.13).
+name: Non-code CI status
+
+on:
+  pull_request:
+    # Only start when a non-code path changed. Mixed PRs (docs + code) still
+    # enter here, but `report` no-ops when dorny detects code changes so we
+    # do not create duplicate check runs alongside Run Tests / Lint / etc.
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.github/**'
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          # Exclusion-only patterns match every non-excluded file under the
+          # default "some" quantifier. Require all patterns (including "**")
+          # so docs/markdown/Actions-only PRs correctly set code=false.
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!.github/**'
+
+  report:
+    name: Report required checks
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create successful check runs for required contexts
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const headSha = context.payload.pull_request.head.sha;
+            const names = [
+              'lint',
+              'type-checker',
+              'tests',
+              'tests (3.10)',
+              'tests (3.11)',
+              'tests (3.12)',
+              'tests (3.13)',
+            ];
+            const summary =
+              'Non-code change (docs / markdown / Actions-only). ' +
+              'Python CI workflows were skipped via paths-ignore.';
+            for (const name of names) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'success',
+                output: {
+                  title: 'Skipped (non-code change)',
+                  summary,
+                },
+              });
+            }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,36 +1,22 @@
 name: Run Tests
 
-on: [pull_request]
+on:
+  pull_request:
+    # Do not start this workflow for docs/markdown/Actions-only PRs.
+    # Required check names for those PRs are reported by non-code-ci-status.yml
+    # so branch protection does not hang.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.github/**'
 
 permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
-        id: filter
-        with:
-          # Exclusion-only patterns match every non-excluded file under the
-          # default "some" quantifier. Require all patterns (including "**")
-          # so docs/markdown/Actions-only PRs correctly set code=false.
-          predicate-quantifier: every
-          filters: |
-            code:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!.github/**'
-
   tests-matrix:
     name: tests (${{ matrix.python-version }})
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -122,33 +108,15 @@ jobs:
             .venv
           key: uv-main-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
 
-  # Report the required check names (tests 3.10–3.13) when the matrix is skipped.
-  # Branch protection expects these names; a skipped matrix never reports them.
-  tests-skip:
-    name: tests (${{ matrix.python-version }})
-    needs: changes
-    if: needs.changes.outputs.code != 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    steps:
-      - name: Skip non-code change
-        run: echo "Non-code change, skipping tests"
-
   # Summary job to provide single status for branch protection
   tests:
     name: tests
     runs-on: ubuntu-latest
-    needs: [changes, tests-matrix, tests-skip]
+    needs: [tests-matrix]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
-            echo "Non-code change, skipping tests"
-            exit 0
-          fi
           if [ "${{ needs.tests-matrix.result }}" == "success" ]; then
             echo "All tests passed"
           else

--- a/.github/workflows/type-checker.yml
+++ b/.github/workflows/type-checker.yml
@@ -1,36 +1,22 @@
 name: Run Type Checks
 
-on: [pull_request]
+on:
+  pull_request:
+    # Do not start this workflow for docs/markdown/Actions-only PRs.
+    # Required check name `type-checker` for those PRs is reported by
+    # non-code-ci-status.yml so branch protection does not hang.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.github/**'
 
 permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
-        id: filter
-        with:
-          # Exclusion-only patterns match every non-excluded file under the
-          # default "some" quantifier. Require all patterns (including "**")
-          # so docs/markdown/Actions-only PRs correctly set code=false.
-          predicate-quantifier: every
-          filters: |
-            code:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!.github/**'
-
   type-checker-matrix:
     name: type-checker (${{ matrix.python-version }})
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -76,33 +62,15 @@ jobs:
             .venv
           key: uv-main-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
 
-  # Report the required check names when the matrix is skipped.
-  # Branch protection expects these names; a skipped matrix never reports them.
-  type-checker-skip:
-    name: type-checker (${{ matrix.python-version }})
-    needs: changes
-    if: needs.changes.outputs.code != 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - name: Skip non-code change
-        run: echo "Non-code change, skipping type checks"
-
   # Summary job to provide single status for branch protection
   type-checker:
     name: type-checker
     runs-on: ubuntu-latest
-    needs: [changes, type-checker-matrix, type-checker-skip]
+    needs: [type-checker-matrix]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
-            echo "Non-code change, skipping type checks"
-            exit 0
-          fi
           if [ "${{ needs.type-checker-matrix.result }}" == "success" ]; then
             echo "All type checks passed"
           else

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -33,6 +33,7 @@ jobs:
               - '**'
               - '!docs/**'
               - '!**/*.md'
+              - '!**/*.mdx'
               - '!.github/**'
       - name: Set code output
         id: set


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation

Docs-only PRs still showed **Run Tests** even after #6800 / #6818 / #6822.

**Why:** `tests.yml` used `on: [pull_request]` with no top-level path filter. The pytest matrix was correctly skipped via `dorny/paths-filter`, but the workflow still started so lightweight stub jobs could report required ruleset checks:

- `tests`, `tests (3.10)`–`tests (3.13)`, `lint`, `type-checker`

Without those statuses, merges hang on “Expected — Waiting for status to be reported.”

Verified on docs-only PRs (#6967, #6963): matrix skipped (~2s stubs), but **Run Tests** still appeared.

## Fix

| Change | Effect |
|---|---|
| `paths-ignore` on tests / lint / type-checker | Workflows do not start for docs / `*.md` / `*.mdx` / `.github/**`-only PRs |
| New `non-code-ci-status.yml` | Creates the required check runs via the Checks API when those workflows are skipped |
| Remove in-workflow skip scaffolding | Heavy CI workflows only run when they actually test code |

Mixed docs+code PRs still run the real Python CI (`paths-ignore` only skips when *all* files match).

## Verified on this PR

This PR only touches `.github/**`, so it exercises the non-code path:

- **Run Tests / Lint / Type Checks did not start**
- `Non-code CI status` reported `lint`, `type-checker`, `tests`, and `tests (3.10)`–`tests (3.13)` as success

## Follow-ups (repo settings, not in this PR)

Optional: narrow the `main` ruleset required checks to only the summary jobs (`tests`, `lint`, `type-checker`) so per-version stub names are unnecessary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3480b7c8-72b5-408f-866c-1d93de6dd02f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3480b7c8-72b5-408f-866c-1d93de6dd02f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

