### PR TITLE
fix: make pre-commit hooks cross-platform (Windows)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: bash -c 'source .venv/bin/activate && uv run ruff check --config pyproject.toml "$@"' --
+        entry: uv run ruff check --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: bash -c 'source .venv/bin/activate && uv run ruff format --config pyproject.toml "$@"' --
+        entry: uv run ruff format --config pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
       - id: mypy
         name: mypy
-        entry: bash -c 'source .venv/bin/activate && uv run mypy --config-file pyproject.toml "$@"' --
+        entry: uv run mypy --config-file pyproject.toml
         language: system
         pass_filenames: true
         types: [python]
@@ -30,7 +30,7 @@ repos:
         name: pip-audit
         # Keep this ignore list in sync with .github/workflows/vulnerability-scan.yml.
         entry: >-
-          bash -c 'source .venv/bin/activate && uv run pip-audit --skip-editable
+          uv run pip-audit --skip-editable
           --ignore-vuln PYSEC-2024-277
           --ignore-vuln PYSEC-2026-89
           --ignore-vuln PYSEC-2026-97
@@ -56,7 +56,7 @@ repos:
           --ignore-vuln PYSEC-2025-216
           --ignore-vuln PYSEC-2025-217
           --ignore-vuln PYSEC-2025-218
-          --ignore-vuln GHSA-f4j7-r4q5-qw2c' --
+          --ignore-vuln GHSA-f4j7-r4q5-qw2c
         language: system
         pass_filenames: false
         stages: [pre-push, manual]


### PR DESCRIPTION
## Summary

Fixes #6863 — pre-commit hooks (ruff, ruff-format, mypy, pip-audit) failed on Windows before executing because they wrapped every command in:

```bash
bash -c 'source .venv/bin/activate && uv run ...' --
```

`.venv/bin/activate` is Unix-only; Windows virtual environments use `.venv\\Scripts\\activate`.

## Change

Dropped the `bash -c 'source .venv/bin/activate && ...'` wrapper entirely and invoke `uv run` directly, which already activates the project virtual environment on every platform:

- `uv run ruff check --config pyproject.toml`
- `uv run ruff format --config pyproject.toml`
- `uv run mypy --config-file pyproject.toml`
- `uv run pip-audit --skip-editable ...`

## Why this is safe

- `uv run` resolves and activates the project env itself — the explicit `source` was redundant on POSIX too.
- Behavior on Linux/macOS is unchanged (same tools, same configs).
- Hooks now work under cmd/PowerShell on Windows without Git Bash.

## Verification

- YAML parses cleanly; entries render as expected.
- `ruff check` / `ruff format --check` run with the new entry shape.
- CI on the PR will exercise the hooks on all platforms.