### PR TITLE
fix(gemini): append user after model turn

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -7,8 +7,6 @@ import os
 import re
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
-
 from crewai.events.types.llm_events import LLMCallType
 from crewai.llms.base_llm import BaseLLM, llm_call_context
 from crewai.llms.hooks.base import BaseInterceptor
@@ -18,6 +16,7 @@ from crewai.utilities.exceptions.context_window_exceeding_exception import (
 )
 from crewai.utilities.pydantic_schema_utils import generate_model_description
 from crewai.utilities.types import LLMMessage
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 
 try:
@@ -671,6 +670,14 @@ class GeminiCompletion(BaseLLM):
 
                 gemini_content = types.Content(role=gemini_role, parts=parts)
                 contents.append(gemini_content)
+
+        if contents and contents[-1].role == "model":
+            contents.append(
+                types.Content(
+                    role="user",
+                    parts=[types.Part.from_text(text="Please continue.")],
+                )
+            )
 
         return contents, system_instruction
 

--- a/lib/crewai/tests/llms/google/test_google.py
+++ b/lib/crewai/tests/llms/google/test_google.py
@@ -535,6 +535,12 @@ def test_gemini_message_formatting_appends_user_after_model(
         "model",
         "user",
     ]
+    model_parts = formatted_contents[1].parts
+    if assistant_message.get("tool_calls"):
+        assert model_parts[0].function_call.name == "search"
+        assert model_parts[0].function_call.args == {}
+    else:
+        assert model_parts[0].text == "Partial response"
     assert formatted_contents[-1].parts[0].text == "Please continue."
 
 

--- a/lib/crewai/tests/llms/google/test_google.py
+++ b/lib/crewai/tests/llms/google/test_google.py
@@ -8,6 +8,7 @@ from crewai.llm import LLM
 from crewai.crew import Crew
 from crewai.agent import Agent
 from crewai.task import Task
+from crewai.utilities.types import LLMMessage
 
 
 @pytest.fixture(autouse=True)
@@ -498,6 +499,55 @@ def test_gemini_message_formatting():
 
     assert formatted_contents[0].role == "user"
     assert formatted_contents[1].role == "model"
+
+
+@pytest.mark.parametrize(
+    "assistant_message",
+    [
+        {"role": "assistant", "content": "Partial response"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+    ],
+)
+def test_gemini_message_formatting_appends_user_after_model(
+    assistant_message: LLMMessage,
+):
+    llm = LLM(model="google/gemini-2.0-flash-001")
+
+    formatted_contents, _ = llm._format_messages_for_gemini(
+        [
+            {"role": "user", "content": "Continue the task"},
+            assistant_message,
+        ]
+    )
+
+    assert [content.role for content in formatted_contents] == [
+        "user",
+        "model",
+        "user",
+    ]
+    assert formatted_contents[-1].parts[0].text == "Please continue."
+
+
+def test_gemini_message_formatting_preserves_user_ending():
+    llm = LLM(model="google/gemini-2.0-flash-001")
+
+    formatted_contents, _ = llm._format_messages_for_gemini(
+        [{"role": "user", "content": "Hello"}]
+    )
+
+    assert len(formatted_contents) == 1
+    assert formatted_contents[-1].role == "user"
+    assert formatted_contents[-1].parts[0].text == "Hello"
 
 
 def test_gemini_streaming_parameter():


### PR DESCRIPTION
## Summary

- ensure Gemini-formatted histories never end with a `model` turn
- append a minimal synthetic user continuation for both text and tool-call endings
- preserve histories that already end with a user turn

## Root cause

The native Gemini provider maps assistant messages to Gemini's `model` role but returned the formatted history unchanged. CrewAI retry paths can therefore call `generateContent` with a terminal model turn, which Gemini rejects with `Requests ending with a model turn are not supported`.

## Validation

- `ruff check` on the changed implementation and test files
- `ruff format --check` on the changed implementation and test files
- Python bytecode compilation for both changed files
- focused regression coverage for text assistant endings, tool-call endings, and existing user endings

Full dependency-backed pytest execution is left to CI because the local checkout is intentionally sparse.

Fixes #6984