### PR TITLE
fix(tools): reject stacked SQL in SingleStore search

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -400,6 +400,22 @@ class SingleStoreSearchTool(BaseTool):
                 f"INTO {into_clause.group(1).upper()} is not supported for security reasons.",
             )
 
+        # Reject locking clauses (FOR UPDATE, LOCK IN SHARE MODE) — a
+        # read-only search tool has no legitimate reason to acquire row
+        # locks, and they can deadlock or block other transactions.
+        if re.search(r"\bFOR\s+UPDATE\b", stripped, re.IGNORECASE):
+            return (
+                False,
+                "FOR UPDATE is not supported for security reasons.",
+            )
+        if re.search(
+            r"\bLOCK\s+IN\s+(?:SHARE\s+)?MODE\b", stripped, re.IGNORECASE
+        ):
+            return (
+                False,
+                "LOCK IN SHARE MODE is not supported for security reasons.",
+            )
+
         return True, "Valid query"
 
     def _run(self, search_query: str) -> Any:

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -380,9 +380,11 @@ class SingleStoreSearchTool(BaseTool):
 
         # Reject SQL comments — they can separate keywords and bypass
         # the regex-based pattern checks below (e.g. INTO/**/S3,
-        # FOR/**/UPDATE).  A legitimate search query has no reason to
-        # contain comment syntax.
-        if "/*" in stripped or "--" in stripped or "#" in stripped:
+        # FOR/**/UPDATE).  Strip single-quoted string literals first
+        # so that comment-like characters inside data values (e.g.
+        # WHERE name = 'uses -- dashes') do not trigger false rejections.
+        _comment_safe = re.sub(r"'(?:[^']*(?:''[^']*)*)'", "''", stripped)
+        if "/*" in _comment_safe or "--" in _comment_safe or "#" in _comment_safe:
             return (
                 False,
                 "SQL comments are not supported in search queries.",

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -382,6 +383,21 @@ class SingleStoreSearchTool(BaseTool):
             return (
                 False,
                 "Only SELECT and SHOW queries are supported for security reasons.",
+            )
+
+        # Reject SELECT … INTO clauses that can write to external resources
+        # (OUTFILE, FS, LINK, S3, HDFS, AZURE, GCS, KAFKA).  Although these
+        # start with a SELECT token, they grant FILE WRITE or OUTBOUND
+        # privileges and are not read-only.
+        into_clause = re.search(
+            r"\bINTO\s+(OUTFILE|DUMPFILE|FS|LINK|S3|HDFS|AZURE|GCS|KAFKA)\b",
+            stripped,
+            re.IGNORECASE,
+        )
+        if into_clause:
+            return (
+                False,
+                f"INTO {into_clause.group(1).upper()} is not supported for security reasons.",
             )
 
         return True, "Valid query"

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -396,11 +396,12 @@ class SingleStoreSearchTool(BaseTool):
             )
 
         # Reject SELECT … INTO clauses that can write to external resources
-        # (OUTFILE, FS, LINK, S3, HDFS, AZURE, GCS, KAFKA).  Although these
-        # start with a SELECT token, they grant FILE WRITE or OUTBOUND
-        # privileges and are not read-only.
+        # (OUTFILE, DUMPFILE, FS, LINK, S3, HDFS, AZURE, GCS, KAFKA, STAGE).
+        # Although these start with a SELECT token, they grant FILE WRITE
+        # or OUTBOUND privileges and are not read-only.  Also reject SELECT
+        # … INTO @<variable> (session-variable assignment).
         into_clause = re.search(
-            r"\bINTO\s+(OUTFILE|DUMPFILE|FS|LINK|S3|HDFS|AZURE|GCS|KAFKA)\b",
+            r"\bINTO\s+(OUTFILE|DUMPFILE|FS|LINK|S3|HDFS|AZURE|GCS|KAFKA|STAGE)\b",
             stripped,
             re.IGNORECASE,
         )
@@ -408,6 +409,12 @@ class SingleStoreSearchTool(BaseTool):
             return (
                 False,
                 f"INTO {into_clause.group(1).upper()} is not supported for security reasons.",
+            )
+        # Reject session-variable assignment (SELECT … INTO @var).
+        if re.search(r"\bINTO\s+@", stripped, re.IGNORECASE):
+            return (
+                False,
+                "INTO <variable> is not supported for security reasons.",
             )
 
         # Reject locking clauses (FOR UPDATE, LOCK IN SHARE MODE) — a

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -306,7 +306,7 @@ class SingleStoreSearchTool(BaseTool):
                             f"Please ensure the table is created."
                         )
 
-                    cursor.execute(f"SHOW COLUMNS FROM {table}")
+                    cursor.execute(f"SHOW COLUMNS FROM `{table.replace('`', '')}`")
                     columns = cursor.fetchall()
                     column_info = ", ".join(f"{row[0]} {row[1]}" for row in columns)
                     table_definitions.append(f"{table}({column_info})")
@@ -356,7 +356,9 @@ class SingleStoreSearchTool(BaseTool):
     def _validate_query(self, search_query: str) -> tuple[bool, str]:
         """Validate the search query to ensure it's safe to execute.
 
-        Only SELECT and SHOW statements are allowed for security reasons.
+        Only a single SELECT or SHOW statement is allowed. Stacked statements
+        such as ``SELECT 1; DROP TABLE users`` are rejected so a read-only
+        start token cannot hide a following write.
 
         Args:
             search_query: The SQL query to validate
@@ -367,10 +369,16 @@ class SingleStoreSearchTool(BaseTool):
         if not isinstance(search_query, str):
             return False, "Search query must be a string."
 
-        query_lower = search_query.strip().lower()
+        stripped = search_query.strip()
+        if stripped.endswith(";"):
+            stripped = stripped[:-1].rstrip()
+        if not stripped:
+            return False, "Search query must be a string."
+        if ";" in stripped:
+            return False, "Multiple SQL statements are not supported."
 
-        # Allow only SELECT and SHOW statements
-        if not (query_lower.startswith(("select", "show"))):
+        first_token = stripped.split(None, 1)[0].lower().rstrip("(")
+        if first_token not in {"select", "show"}:
             return (
                 False,
                 "Only SELECT and SHOW queries are supported for security reasons.",

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -382,7 +382,7 @@ class SingleStoreSearchTool(BaseTool):
         # the regex-based pattern checks below (e.g. INTO/**/S3,
         # FOR/**/UPDATE).  A legitimate search query has no reason to
         # contain comment syntax.
-        if "/*" in stripped or stripped.startswith("--"):
+        if "/*" in stripped or "--" in stripped or "#" in stripped:
             return (
                 False,
                 "SQL comments are not supported in search queries.",

--- a/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/singlestore_search_tool/singlestore_search_tool.py
@@ -378,6 +378,16 @@ class SingleStoreSearchTool(BaseTool):
         if ";" in stripped:
             return False, "Multiple SQL statements are not supported."
 
+        # Reject SQL comments — they can separate keywords and bypass
+        # the regex-based pattern checks below (e.g. INTO/**/S3,
+        # FOR/**/UPDATE).  A legitimate search query has no reason to
+        # contain comment syntax.
+        if "/*" in stripped or stripped.startswith("--"):
+            return (
+                False,
+                "SQL comments are not supported in search queries.",
+            )
+
         first_token = stripped.split(None, 1)[0].lower().rstrip("(")
         if first_token not in {"select", "show"}:
             return (

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -128,6 +128,18 @@ def test_validate_query_rejects_select_into_variable(query: str) -> None:
         "SELECT * FROM t FOR/**/UPDATE",
         "SELECT 1 INTO /* comment */ OUTFILE",
         "SELECT * FROM t /**/ LOCK IN SHARE MODE",
+        # Double-dash comments between restricted keyword pairs
+        "SELECT 1 INTO -- bypass\nS3",
+        "SELECT * FROM t FOR -- comment\nUPDATE",
+        "SELECT 1 INTO --comment OUTFILE",
+        # Hash comments between restricted keyword pairs
+        "SELECT 1 INTO # bypass\nS3",
+        "SELECT * FROM t FOR # comment\nUPDATE",
+        "SELECT 1 INTO #comment OUTFILE",
+        # Double-dash / hash mid-query
+        "SELECT * FROM employees -- rest ignored",
+        "SHOW TABLES # ignored rest",
+        "SELECT id FROM t WHERE x=1 --trail",
     ],
 )
 def test_validate_query_rejects_sql_comments(query: str) -> None:

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -102,3 +102,19 @@ def test_validate_query_rejects_locking_clauses(query: str) -> None:
     ok, message = _tool()._validate_query(query)
     assert ok is False
     assert ("FOR UPDATE" in message) or ("LOCK" in message)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1 INTO/**/S3",
+        "SELECT * FROM t FOR/**/UPDATE",
+        "SELECT 1 INTO /* comment */ OUTFILE",
+        "SELECT * FROM t /**/ LOCK IN SHARE MODE",
+    ],
+)
+def test_validate_query_rejects_sql_comments(query: str) -> None:
+    """SQL comments can separate keywords and bypass pattern checks."""
+    ok, message = _tool()._validate_query(query)
+    assert ok is False
+    assert "comments" in message

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -77,6 +77,8 @@ def test_validate_query_rejects_writes_and_non_strings(query: object) -> None:
         ("SELECT * FROM employees INTO GCS 'gs://bucket'", "GCS"),
         ("SELECT * FROM employees INTO KAFKA 'kafka:topic'", "KAFKA"),
         ("select id from t into outfile '/tmp/out.csv'", "OUTFILE"),
+        ("SELECT * FROM t INTO STAGE 'result.csv'", "STAGE"),
+        ("select id from employees into stage 'out.csv'", "STAGE"),
     ],
 )
 def test_validate_query_rejects_select_into_write_targets(query: str, keyword: str) -> None:
@@ -102,6 +104,21 @@ def test_validate_query_rejects_locking_clauses(query: str) -> None:
     ok, message = _tool()._validate_query(query)
     assert ok is False
     assert ("FOR UPDATE" in message) or ("LOCK" in message)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 3.14 INTO @pi",
+        "SELECT 1 INTO @result",
+        "select name from t into @x",
+    ],
+)
+def test_validate_query_rejects_select_into_variable(query: str) -> None:
+    """SELECT … INTO @<variable> assigns a session variable and is not read-only."""
+    ok, message = _tool()._validate_query(query)
+    assert ok is False
+    assert "variable" in message
 
 
 @pytest.mark.parametrize(

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -62,3 +62,25 @@ def test_validate_query_rejects_writes_and_non_strings(query: object) -> None:
     ok, message = _tool()._validate_query(query)  # type: ignore[arg-type]
     assert ok is False
     assert message
+
+
+@pytest.mark.parametrize(
+    "query,keyword",
+    [
+        ("SELECT * FROM employees INTO OUTFILE '/tmp/data.csv'", "OUTFILE"),
+        ("SELECT * FROM employees INTO DUMPFILE '/tmp/data.bin'", "DUMPFILE"),
+        ("SELECT * FROM employees INTO FS '/mnt/data'", "FS"),
+        ("SELECT * FROM employees INTO LINK 's3://bucket'", "LINK"),
+        ("SELECT * FROM employees INTO S3 's3://bucket/key'", "S3"),
+        ("SELECT * FROM employees INTO HDFS '/path'", "HDFS"),
+        ("SELECT * FROM employees INTO AZURE 'wasb://container'", "AZURE"),
+        ("SELECT * FROM employees INTO GCS 'gs://bucket'", "GCS"),
+        ("SELECT * FROM employees INTO KAFKA 'kafka:topic'", "KAFKA"),
+        ("select id from t into outfile '/tmp/out.csv'", "OUTFILE"),
+    ],
+)
+def test_validate_query_rejects_select_into_write_targets(query: str, keyword: str) -> None:
+    """SELECT … INTO <write-target> is rejected even though it starts with SELECT."""
+    ok, message = _tool()._validate_query(query)
+    assert ok is False
+    assert keyword in message

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -1,0 +1,64 @@
+"""Unit tests for SingleStoreSearchTool._validate_query.
+
+These do not need a SingleStore server — they construct the class without
+calling __init__ so we can exercise the read-only gate in isolation.
+"""
+
+import pytest
+
+from crewai_tools.tools.singlestore_search_tool.singlestore_search_tool import (
+    SingleStoreSearchTool,
+)
+
+
+def _tool() -> SingleStoreSearchTool:
+    return object.__new__(SingleStoreSearchTool)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1",
+        "select * from employees",
+        "  SELECT id FROM t  ",
+        "SELECT * FROM t;",
+        "SHOW TABLES",
+        "show columns from employees",
+    ],
+)
+def test_validate_query_allows_single_select_or_show(query: str) -> None:
+    ok, message = _tool()._validate_query(query)
+    assert ok is True
+    assert message == "Valid query"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1; DROP TABLE employees",
+        "select * from users; drop table users",
+        "SHOW TABLES; DELETE FROM employees",
+        "SHOW TABLES; DROP TABLE employees;--",
+    ],
+)
+def test_validate_query_rejects_stacked_statements(query: str) -> None:
+    ok, message = _tool()._validate_query(query)
+    assert ok is False
+    assert "Multiple SQL statements" in message
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "DELETE FROM employees",
+        "DROP TABLE employees",
+        "INSERT INTO employees VALUES (1)",
+        "UPDATE employees SET salary = 0",
+        "",
+        123,
+    ],
+)
+def test_validate_query_rejects_writes_and_non_strings(query: object) -> None:
+    ok, message = _tool()._validate_query(query)  # type: ignore[arg-type]
+    assert ok is False
+    assert message

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -84,3 +84,21 @@ def test_validate_query_rejects_select_into_write_targets(query: str, keyword: s
     ok, message = _tool()._validate_query(query)
     assert ok is False
     assert keyword in message
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM employees FOR UPDATE",
+        "SELECT id FROM t WHERE id = 1 FOR UPDATE",
+        "select * from users for update",
+        "SELECT * FROM employees LOCK IN SHARE MODE",
+        "SELECT * FROM employees LOCK IN SHARE MODE",
+        "select * from t lock in share mode",
+    ],
+)
+def test_validate_query_rejects_locking_clauses(query: str) -> None:
+    """FOR UPDATE and LOCK IN SHARE MODE acquire row locks that can deadlock."""
+    ok, message = _tool()._validate_query(query)
+    assert ok is False
+    assert ("FOR UPDATE" in message) or ("LOCK" in message)

--- a/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
+++ b/lib/crewai-tools/tests/tools/test_singlestore_query_validation.py
@@ -147,3 +147,19 @@ def test_validate_query_rejects_sql_comments(query: str) -> None:
     ok, message = _tool()._validate_query(query)
     assert ok is False
     assert "comments" in message
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM users WHERE name = 'uses -- dashes'",
+        "SELECT id FROM t WHERE bio = 'has # hashtag'",
+        "SELECT * FROM t WHERE note = 'block /* comment */ end'",
+        "SELECT * FROM users WHERE name = 'it''s a -- test'",
+    ],
+)
+def test_validate_query_allows_comment_chars_in_quoted_strings(query: str) -> None:
+    """Comment-like characters inside single-quoted strings are data, not comments."""
+    ok, message = _tool()._validate_query(query)
+    assert ok is True
+    assert message == "Valid query"


### PR DESCRIPTION
**AI disclosure:** authored with AI assistance. CONTRIBUTING requires the `llm-generated` label; this account cannot add labels on `crewAIInc/crewAI` (REST 403). Please apply `llm-generated`.

## Summary

`SingleStoreSearchTool._validate_query` treated any string that *started* with `SELECT`/`SHOW` as safe. That lets stacked writes through, e.g. `SELECT 1; DROP TABLE employees`.

Reject more than one statement (optional trailing `;` only), keep the SELECT/SHOW first-token rule, and quote `SHOW COLUMNS FROM` identifiers. Same class as the MySQL table-name check in #6341; NL2SQL already documents this `SELECT 1; DROP TABLE users` case.

Added unit tests that exercise the validator without a SingleStore server.

Generated by Grok.