### PR TITLE
feat(execution): introduce execution context management with UUID sup…

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1259,6 +1259,8 @@ class Crew(FlowTrackable, BaseModel):
         )
         token = attach(baggage_ctx)
 
+        execution_token = begin_execution()
+
         runtime_scope = crewai_event_bus._enter_runtime_scope()
         try:
             inputs = prepare_kickoff(self, inputs, input_files)
@@ -1297,6 +1299,7 @@ class Crew(FlowTrackable, BaseModel):
             self._drain_memory_writes()
             clear_files(self.id)
             detach(token)
+            end_execution(execution_token)
             crewai_event_bus._exit_runtime_scope(runtime_scope)
 
     async def akickoff_for_each(

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -92,6 +92,10 @@ from crewai.events.types.crew_events import (
     CrewTrainFailedEvent,
     CrewTrainStartedEvent,
 )
+from crewai.execution import (
+    begin_execution,
+    end_execution,
+)
 from crewai.flow.flow_trackable import FlowTrackable
 from crewai.knowledge.knowledge import Knowledge, _resolve_knowledge_sources
 from crewai.knowledge.source.base_knowledge_source import BaseKnowledgeSource
@@ -1038,6 +1042,8 @@ class Crew(FlowTrackable, BaseModel):
         )
         token = attach(baggage_ctx)
 
+        execution_token = begin_execution()
+
         runtime_scope = crewai_event_bus._enter_runtime_scope()
         try:
             inputs = prepare_kickoff(self, inputs, input_files)
@@ -1076,6 +1082,7 @@ class Crew(FlowTrackable, BaseModel):
             self._drain_memory_writes()
             clear_files(self.id)
             detach(token)
+            end_execution(execution_token)
             crewai_event_bus._exit_runtime_scope(runtime_scope)
 
     def _post_kickoff(self, result: CrewOutput) -> CrewOutput:

--- a/lib/crewai/src/crewai/execution.py
+++ b/lib/crewai/src/crewai/execution.py
@@ -1,0 +1,125 @@
+"""Per-run execution identity for OSS traces.
+
+Wharf keys spans by ``crewai.execution_uuid``. Enterprise stamps that from the
+Celery ``kickoff_id`` inside ``telemetry_session``. Standalone OSS has no such
+session, so crew/flow ``kickoff`` creates a uuid for the **outermost** run and
+nested kickoffs (crew-in-flow, AgentExecutor, child flows) inherit it via
+contextvars on the execution thread.
+
+Minting lives on the kickoff call path (not the event bus): bus handlers run
+on worker threads and cannot publish contextvars back to the user thread.
+
+Enterprise (or any host) can call :func:`set_execution_uuid` before kickoff;
+:func:`begin_execution` will not overwrite it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import contextvars
+from uuid import uuid4
+
+
+_current_execution_uuid: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "crewai_execution_uuid", default=None
+)
+
+
+def get_execution_uuid() -> str | None:
+    """Return the active execution uuid, if any."""
+    return _current_execution_uuid.get()
+
+
+def set_execution_uuid(execution_uuid: str) -> contextvars.Token[str | None]:
+    """Bind an execution uuid for the current context.
+
+    Use this from enterprise / hosts that already own the run id (e.g. Celery
+    ``kickoff_id``). Overwrites any previously bound value.
+    """
+    if not execution_uuid:
+        raise ValueError("execution_uuid must be a non-empty string")
+    return _current_execution_uuid.set(execution_uuid)
+
+
+def ensure_execution_uuid(preferred: str | None = None) -> str:
+    """Return the active execution uuid, creating one if needed.
+
+    Never overwrites an existing value — nested kickoffs and enterprise
+    sessions inherit the outer id.
+    """
+    existing = _current_execution_uuid.get()
+    if existing is not None:
+        return existing
+    value = preferred or str(uuid4())
+    if not value:
+        raise ValueError("execution_uuid must be a non-empty string")
+    _current_execution_uuid.set(value)
+    return value
+
+
+def clear_execution_uuid(token: contextvars.Token[str | None] | None = None) -> None:
+    """Reset the execution uuid.
+
+    Prefer passing the :class:`~contextvars.Token` returned when the value was
+    set so nested contexts restore correctly. Without a token, clears to
+    ``None``.
+    """
+    if token is not None:
+        _current_execution_uuid.reset(token)
+    else:
+        _current_execution_uuid.set(None)
+
+
+@contextmanager
+def execution_uuid_scope(
+    execution_uuid: str | None = None, *, force: bool = False
+) -> Iterator[str]:
+    """Bind an execution uuid for the duration of the block.
+
+    Args:
+        execution_uuid: Value to bind. When ``None`` and ``force`` is false,
+            reuses the active uuid or creates a new one.
+        force: When true, ``execution_uuid`` must be provided and replaces any
+            active value (enterprise / host path).
+    """
+    if force:
+        if not execution_uuid:
+            raise ValueError("execution_uuid is required when force=True")
+        token = set_execution_uuid(execution_uuid)
+        try:
+            yield execution_uuid
+        finally:
+            clear_execution_uuid(token)
+        return
+
+    existing = _current_execution_uuid.get()
+    if existing is not None:
+        yield existing
+        return
+
+    value = execution_uuid or str(uuid4())
+    token = set_execution_uuid(value)
+    try:
+        yield value
+    finally:
+        clear_execution_uuid(token)
+
+
+def begin_execution(
+    execution_uuid: str | None = None,
+) -> contextvars.Token[str | None] | None:
+    """Start an execution context unless one is already active.
+
+    The outermost crew or flow receives a new uuid by default. Nested
+    executions inherit the active value and return no reset token.
+    """
+    if _current_execution_uuid.get() is not None:
+        return None
+    return set_execution_uuid(execution_uuid or str(uuid4()))
+
+
+def end_execution(token: contextvars.Token[str | None] | None) -> None:
+    """End an execution context owned by the current kickoff."""
+    if token is not None:
+        clear_execution_uuid(token)

--- a/lib/crewai/src/crewai/execution.py
+++ b/lib/crewai/src/crewai/execution.py
@@ -15,8 +15,6 @@ Enterprise (or any host) can call :func:`set_execution_uuid` before kickoff;
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 import contextvars
 from uuid import uuid4
 
@@ -42,68 +40,12 @@ def set_execution_uuid(execution_uuid: str) -> contextvars.Token[str | None]:
     return _current_execution_uuid.set(execution_uuid)
 
 
-def ensure_execution_uuid(preferred: str | None = None) -> str:
-    """Return the active execution uuid, creating one if needed.
+def clear_execution_uuid(token: contextvars.Token[str | None]) -> None:
+    """Restore the execution uuid that was active before ``token`` was issued.
 
-    Never overwrites an existing value — nested kickoffs and enterprise
-    sessions inherit the outer id.
+    ``token`` is required so this cannot wipe an outer kickoff's uuid.
     """
-    existing = _current_execution_uuid.get()
-    if existing is not None:
-        return existing
-    value = preferred or str(uuid4())
-    if not value:
-        raise ValueError("execution_uuid must be a non-empty string")
-    _current_execution_uuid.set(value)
-    return value
-
-
-def clear_execution_uuid(token: contextvars.Token[str | None] | None = None) -> None:
-    """Reset the execution uuid.
-
-    Prefer passing the :class:`~contextvars.Token` returned when the value was
-    set so nested contexts restore correctly. Without a token, clears to
-    ``None``.
-    """
-    if token is not None:
-        _current_execution_uuid.reset(token)
-    else:
-        _current_execution_uuid.set(None)
-
-
-@contextmanager
-def execution_uuid_scope(
-    execution_uuid: str | None = None, *, force: bool = False
-) -> Iterator[str]:
-    """Bind an execution uuid for the duration of the block.
-
-    Args:
-        execution_uuid: Value to bind. When ``None`` and ``force`` is false,
-            reuses the active uuid or creates a new one.
-        force: When true, ``execution_uuid`` must be provided and replaces any
-            active value (enterprise / host path).
-    """
-    if force:
-        if not execution_uuid:
-            raise ValueError("execution_uuid is required when force=True")
-        token = set_execution_uuid(execution_uuid)
-        try:
-            yield execution_uuid
-        finally:
-            clear_execution_uuid(token)
-        return
-
-    existing = _current_execution_uuid.get()
-    if existing is not None:
-        yield existing
-        return
-
-    value = execution_uuid or str(uuid4())
-    token = set_execution_uuid(value)
-    try:
-        yield value
-    finally:
-        clear_execution_uuid(token)
+    _current_execution_uuid.reset(token)
 
 
 def begin_execution(
@@ -120,6 +62,9 @@ def begin_execution(
 
 
 def end_execution(token: contextvars.Token[str | None] | None) -> None:
-    """End an execution context owned by the current kickoff."""
+    """End an execution context owned by the current kickoff.
+
+    Nested kickoffs pass ``None`` and leave the outer uuid in place.
+    """
     if token is not None:
         clear_execution_uuid(token)

--- a/lib/crewai/src/crewai/flow/async_feedback/types.py
+++ b/lib/crewai/src/crewai/flow/async_feedback/types.py
@@ -38,7 +38,9 @@ class PendingFeedbackContext:
         llm: LLM model string for outcome collapsing
         requested_at: When the feedback was requested
         execution_uuid: Outermost kickoff uuid to restore on resume so traces
-            stay on the same run after HITL pause.
+            stay on the same run after HITL pause. ``None`` only for pending
+            rows persisted before this field existed; resume then creates a
+            new uuid. New pauses always store a value.
 
     Example:
         ```python

--- a/lib/crewai/src/crewai/flow/async_feedback/types.py
+++ b/lib/crewai/src/crewai/flow/async_feedback/types.py
@@ -37,6 +37,8 @@ class PendingFeedbackContext:
         metadata: Optional metadata for external system integration
         llm: LLM model string for outcome collapsing
         requested_at: When the feedback was requested
+        execution_uuid: Outermost kickoff uuid to restore on resume so traces
+            stay on the same run after HITL pause.
 
     Example:
         ```python
@@ -62,6 +64,7 @@ class PendingFeedbackContext:
     metadata: dict[str, Any] = field(default_factory=dict)
     llm: dict[str, Any] | str | None = None
     requested_at: datetime = field(default_factory=datetime.now)
+    execution_uuid: str | None = None
 
     @staticmethod
     def _make_json_safe(value: Any) -> Any:
@@ -106,6 +109,7 @@ class PendingFeedbackContext:
             "metadata": self._make_json_safe(self.metadata),
             "llm": self.llm,
             "requested_at": self.requested_at.isoformat(),
+            "execution_uuid": self.execution_uuid,
         }
 
     @classmethod
@@ -135,6 +139,7 @@ class PendingFeedbackContext:
             metadata=data.get("metadata", {}),
             llm=data.get("llm"),
             requested_at=requested_at,
+            execution_uuid=data.get("execution_uuid"),
         )
 
 

--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -78,6 +78,10 @@ from crewai.events.types.flow_events import (
     MethodExecutionStartedEvent,
 )
 from crewai.events.types.llm_events import LLMCallCompletedEvent
+from crewai.execution import (
+    begin_execution,
+    end_execution,
+)
 from crewai.flow.async_feedback.types import (
     HumanFeedbackPending,
     HumanFeedbackProvider,
@@ -2131,6 +2135,8 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
         if current_flow_request_id.get() is None:
             request_id_token = current_flow_request_id.set(self.flow_id)
 
+        execution_token = begin_execution()
+
         runtime_scope = crewai_event_bus._enter_runtime_scope()
 
         # Reentrant kickoffs on the same Flow share the outer call's
@@ -2486,6 +2492,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
                 current_flow_id.reset(flow_id_token)
             if flow_inputs_token is not None:
                 detach(flow_inputs_token)
+            end_execution(execution_token)
             detach(flow_token)
             crewai_event_bus._exit_runtime_scope(runtime_scope)
 

--- a/lib/crewai/src/crewai/flow/runtime/__init__.py
+++ b/lib/crewai/src/crewai/flow/runtime/__init__.py
@@ -81,6 +81,7 @@ from crewai.events.types.llm_events import LLMCallCompletedEvent
 from crewai.execution import (
     begin_execution,
     end_execution,
+    get_execution_uuid,
 )
 from crewai.flow.async_feedback.types import (
     HumanFeedbackPending,
@@ -1346,6 +1347,8 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
                 "No pending feedback context. Use from_pending() to restore a paused flow."
             )
 
+        execution_token = begin_execution(self._pending_feedback_context.execution_uuid)
+
         # Force `current_flow_id` to this flow's match id for the
         # duration of the resume so the usage listener's filter passes
         # even when resume runs under another flow's active context.
@@ -1372,6 +1375,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
             self._detach_usage_aggregation_listener()
             if flow_id_token is not None:
                 current_flow_id.reset(flow_id_token)
+            end_execution(execution_token)
 
     async def _resume_async_body(
         self, feedback: str = "", hook_state: dict[str, bool] | None = None
@@ -3539,6 +3543,7 @@ class Flow(BaseModel, Generic[T], metaclass=FlowMeta):
                 llm=llm
                 if llm is None or isinstance(llm, (str, dict))
                 else _serialize_llm_for_context(llm),
+                execution_uuid=get_execution_uuid(),
             )
             feedback_value = await asyncio.to_thread(
                 provider.request_feedback, context, self

--- a/lib/crewai/tests/test_execution_uuid.py
+++ b/lib/crewai/tests/test_execution_uuid.py
@@ -176,3 +176,74 @@ async def test_crew_akickoff_inherits_enterprise_execution_uuid() -> None:
         assert get_execution_uuid() == "celery-kickoff-id"
 
     assert get_execution_uuid() is None
+
+
+def test_flow_pause_persists_execution_uuid_and_resume_restores_it() -> None:
+    import os
+    import tempfile
+
+    from crewai.flow.async_feedback.types import (
+        HumanFeedbackPending,
+        PendingFeedbackContext,
+    )
+    from crewai.flow import Flow, human_feedback, listen, start
+    from crewai.flow.persistence import SQLiteFlowPersistence
+
+    seen: dict[str, str | None] = {}
+
+    class PausingProvider:
+        def request_feedback(
+            self, context: PendingFeedbackContext, flow: Flow
+        ) -> str:
+            raise HumanFeedbackPending(context=context)
+
+    class ReviewFlow(Flow):
+        @start()
+        @human_feedback(message="Review:", provider=PausingProvider())
+        def generate(self) -> str:
+            seen["during_kickoff"] = get_execution_uuid()
+            return "draft"
+
+        @listen(generate)
+        def process(self, result: object) -> str:
+            seen["during_resume"] = get_execution_uuid()
+            return "done"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        persistence = SQLiteFlowPersistence(os.path.join(tmpdir, "test.db"))
+        pending = ReviewFlow(persistence=persistence).kickoff()
+        assert isinstance(pending, HumanFeedbackPending)
+        paused_id = seen["during_kickoff"]
+        assert paused_id
+        assert pending.context.execution_uuid == paused_id
+        assert get_execution_uuid() is None
+
+        ReviewFlow.from_pending(pending.context.flow_id, persistence).resume("ok")
+        assert seen["during_resume"] == paused_id
+        assert get_execution_uuid() is None
+
+
+def test_pending_feedback_context_roundtrips_execution_uuid() -> None:
+    from crewai.flow.async_feedback.types import PendingFeedbackContext
+
+    original = PendingFeedbackContext(
+        flow_id="flow-1",
+        flow_class="test.Flow",
+        method_name="review",
+        method_output="draft",
+        message="Review:",
+        execution_uuid="kickoff-uuid",
+    )
+    restored = PendingFeedbackContext.from_dict(original.to_dict())
+    assert restored.execution_uuid == "kickoff-uuid"
+
+    legacy = PendingFeedbackContext.from_dict(
+        {
+            "flow_id": "flow-1",
+            "flow_class": "test.Flow",
+            "method_name": "review",
+            "method_output": "draft",
+            "message": "Review:",
+        }
+    )
+    assert legacy.execution_uuid is None

--- a/lib/crewai/tests/test_execution_uuid.py
+++ b/lib/crewai/tests/test_execution_uuid.py
@@ -1,0 +1,127 @@
+"""Tests for OSS execution uuid creation and nesting inheritance."""
+
+from __future__ import annotations
+
+import pytest
+
+from crewai.execution import (
+    begin_execution,
+    clear_execution_uuid,
+    end_execution,
+    ensure_execution_uuid,
+    execution_uuid_scope,
+    get_execution_uuid,
+    set_execution_uuid,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_execution_uuid() -> None:
+    clear_execution_uuid()
+    yield
+    clear_execution_uuid()
+
+
+def test_ensure_creates_when_empty() -> None:
+    assert get_execution_uuid() is None
+    first = ensure_execution_uuid()
+    second = ensure_execution_uuid()
+    assert first
+    assert first == second
+
+
+def test_ensure_does_not_overwrite_existing() -> None:
+    set_execution_uuid("enterprise-kickoff-id")
+    assert ensure_execution_uuid("should-not-win") == "enterprise-kickoff-id"
+
+
+def test_set_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        set_execution_uuid("")
+
+
+def test_execution_uuid_scope_creates_and_clears() -> None:
+    with execution_uuid_scope() as value:
+        assert value
+        assert get_execution_uuid() == value
+    assert get_execution_uuid() is None
+
+
+def test_execution_uuid_scope_inherits_without_clearing_parent() -> None:
+    set_execution_uuid("parent")
+    with execution_uuid_scope() as value:
+        assert value == "parent"
+    assert get_execution_uuid() == "parent"
+
+
+def test_execution_uuid_scope_force_overrides() -> None:
+    set_execution_uuid("parent")
+    with execution_uuid_scope("celery-id", force=True) as value:
+        assert value == "celery-id"
+        assert get_execution_uuid() == "celery-id"
+    assert get_execution_uuid() == "parent"
+
+
+def test_nested_execution_inherits_and_only_owner_clears() -> None:
+    parent_token = begin_execution()
+    parent_id = get_execution_uuid()
+    child_token = begin_execution()
+
+    assert parent_id
+    assert child_token is None
+    assert get_execution_uuid() == parent_id
+
+    end_execution(child_token)
+    assert get_execution_uuid() == parent_id
+
+    end_execution(parent_token)
+    assert get_execution_uuid() is None
+
+
+def test_two_sequential_outer_runs_get_distinct_uuids() -> None:
+    first_token = begin_execution()
+    first_id = get_execution_uuid()
+    end_execution(first_token)
+    second_token = begin_execution()
+    second_id = get_execution_uuid()
+    end_execution(second_token)
+
+    assert first_id != second_id
+
+
+def test_flow_kickoff_creates_and_clears_execution_uuid() -> None:
+    from crewai.flow.flow import Flow, start
+
+    seen: dict[str, str | None] = {}
+
+    class ProbeFlow(Flow):
+        @start()
+        def begin(self) -> str:
+            seen["during"] = get_execution_uuid()
+            return "ok"
+
+    flow = ProbeFlow()
+    assert get_execution_uuid() is None
+    flow.kickoff()
+    assert seen["during"]
+    assert get_execution_uuid() is None
+
+
+def test_flow_kickoff_inherits_enterprise_execution_uuid() -> None:
+    from crewai.flow.flow import Flow, start
+
+    seen: dict[str, str | None] = {}
+
+    class ProbeFlow(Flow):
+        @start()
+        def begin(self) -> str:
+            seen["during"] = get_execution_uuid()
+            return "ok"
+
+    with execution_uuid_scope("celery-kickoff-id", force=True):
+        ProbeFlow().kickoff()
+        assert seen["during"] == "celery-kickoff-id"
+        # Owner was enterprise scope, not the flow — still set here.
+        assert get_execution_uuid() == "celery-kickoff-id"
+
+    assert get_execution_uuid() is None

--- a/lib/crewai/tests/test_execution_uuid.py
+++ b/lib/crewai/tests/test_execution_uuid.py
@@ -5,61 +5,46 @@ from __future__ import annotations
 import pytest
 
 from crewai.execution import (
+    _current_execution_uuid,
     begin_execution,
     clear_execution_uuid,
     end_execution,
-    ensure_execution_uuid,
-    execution_uuid_scope,
     get_execution_uuid,
     set_execution_uuid,
 )
 
 
 @pytest.fixture(autouse=True)
-def _clear_execution_uuid() -> None:
-    clear_execution_uuid()
+def _isolate_execution_uuid() -> None:
+    token = _current_execution_uuid.set(None)
     yield
-    clear_execution_uuid()
+    _current_execution_uuid.reset(token)
 
 
-def test_ensure_creates_when_empty() -> None:
+def test_begin_creates_when_empty() -> None:
     assert get_execution_uuid() is None
-    first = ensure_execution_uuid()
-    second = ensure_execution_uuid()
+    first_token = begin_execution()
+    first = get_execution_uuid()
+    second_token = begin_execution()
     assert first
-    assert first == second
+    assert get_execution_uuid() == first
+    assert second_token is None
+    end_execution(second_token)
+    end_execution(first_token)
 
 
-def test_ensure_does_not_overwrite_existing() -> None:
-    set_execution_uuid("enterprise-kickoff-id")
-    assert ensure_execution_uuid("should-not-win") == "enterprise-kickoff-id"
+def test_begin_does_not_overwrite_existing() -> None:
+    token = set_execution_uuid("enterprise-kickoff-id")
+    try:
+        assert begin_execution("should-not-win") is None
+        assert get_execution_uuid() == "enterprise-kickoff-id"
+    finally:
+        clear_execution_uuid(token)
 
 
 def test_set_rejects_empty() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         set_execution_uuid("")
-
-
-def test_execution_uuid_scope_creates_and_clears() -> None:
-    with execution_uuid_scope() as value:
-        assert value
-        assert get_execution_uuid() == value
-    assert get_execution_uuid() is None
-
-
-def test_execution_uuid_scope_inherits_without_clearing_parent() -> None:
-    set_execution_uuid("parent")
-    with execution_uuid_scope() as value:
-        assert value == "parent"
-    assert get_execution_uuid() == "parent"
-
-
-def test_execution_uuid_scope_force_overrides() -> None:
-    set_execution_uuid("parent")
-    with execution_uuid_scope("celery-id", force=True) as value:
-        assert value == "celery-id"
-        assert get_execution_uuid() == "celery-id"
-    assert get_execution_uuid() == "parent"
 
 
 def test_nested_execution_inherits_and_only_owner_clears() -> None:
@@ -118,11 +103,14 @@ def test_flow_kickoff_inherits_enterprise_execution_uuid() -> None:
             seen["during"] = get_execution_uuid()
             return "ok"
 
-    with execution_uuid_scope("celery-kickoff-id", force=True):
+    token = set_execution_uuid("celery-kickoff-id")
+    try:
         ProbeFlow().kickoff()
         assert seen["during"] == "celery-kickoff-id"
-        # Owner was enterprise scope, not the flow — still set here.
+        # Owner was enterprise set(), not the flow — still set here.
         assert get_execution_uuid() == "celery-kickoff-id"
+    finally:
+        clear_execution_uuid(token)
 
     assert get_execution_uuid() is None
 
@@ -167,13 +155,14 @@ async def test_crew_akickoff_inherits_enterprise_execution_uuid() -> None:
         seen["during"] = get_execution_uuid()
         return TaskOutput(description="d", raw="ok", agent="r")
 
-    with (
-        patch("crewai.task.Task.aexecute_sync", side_effect=capture),
-        execution_uuid_scope("celery-kickoff-id", force=True),
-    ):
-        await crew.akickoff()
+    token = set_execution_uuid("celery-kickoff-id")
+    try:
+        with patch("crewai.task.Task.aexecute_sync", side_effect=capture):
+            await crew.akickoff()
         assert seen["during"] == "celery-kickoff-id"
         assert get_execution_uuid() == "celery-kickoff-id"
+    finally:
+        clear_execution_uuid(token)
 
     assert get_execution_uuid() is None
 
@@ -182,11 +171,11 @@ def test_flow_pause_persists_execution_uuid_and_resume_restores_it() -> None:
     import os
     import tempfile
 
+    from crewai.flow import Flow, human_feedback, listen, start
     from crewai.flow.async_feedback.types import (
         HumanFeedbackPending,
         PendingFeedbackContext,
     )
-    from crewai.flow import Flow, human_feedback, listen, start
     from crewai.flow.persistence import SQLiteFlowPersistence
 
     seen: dict[str, str | None] = {}

--- a/lib/crewai/tests/test_execution_uuid.py
+++ b/lib/crewai/tests/test_execution_uuid.py
@@ -125,3 +125,54 @@ def test_flow_kickoff_inherits_enterprise_execution_uuid() -> None:
         assert get_execution_uuid() == "celery-kickoff-id"
 
     assert get_execution_uuid() is None
+
+
+@pytest.mark.asyncio
+async def test_crew_akickoff_creates_and_clears_execution_uuid() -> None:
+    from unittest.mock import patch
+
+    from crewai import Agent, Crew, Task
+    from crewai.tasks.task_output import TaskOutput
+
+    seen: dict[str, str | None] = {}
+    agent = Agent(role="r", goal="g", backstory="b", llm="gpt-4o-mini")
+    task = Task(description="d", expected_output="o", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+
+    async def capture(*_args: object, **_kwargs: object) -> TaskOutput:
+        seen["during"] = get_execution_uuid()
+        return TaskOutput(description="d", raw="ok", agent="r")
+
+    with patch("crewai.task.Task.aexecute_sync", side_effect=capture):
+        assert get_execution_uuid() is None
+        await crew.akickoff()
+
+    assert seen["during"]
+    assert get_execution_uuid() is None
+
+
+@pytest.mark.asyncio
+async def test_crew_akickoff_inherits_enterprise_execution_uuid() -> None:
+    from unittest.mock import patch
+
+    from crewai import Agent, Crew, Task
+    from crewai.tasks.task_output import TaskOutput
+
+    seen: dict[str, str | None] = {}
+    agent = Agent(role="r", goal="g", backstory="b", llm="gpt-4o-mini")
+    task = Task(description="d", expected_output="o", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+
+    async def capture(*_args: object, **_kwargs: object) -> TaskOutput:
+        seen["during"] = get_execution_uuid()
+        return TaskOutput(description="d", raw="ok", agent="r")
+
+    with (
+        patch("crewai.task.Task.aexecute_sync", side_effect=capture),
+        execution_uuid_scope("celery-kickoff-id", force=True),
+    ):
+        await crew.akickoff()
+        assert seen["during"] == "celery-kickoff-id"
+        assert get_execution_uuid() == "celery-kickoff-id"
+
+    assert get_execution_uuid() is None


### PR DESCRIPTION
…port

- Added `execution.py` to manage execution UUIDs for tracking nested execution contexts.
- Implemented `begin_execution` and `end_execution` functions to handle the lifecycle of execution contexts.
- Updated `Crew` and `Flow` classes to utilize the new execution context management, ensuring proper tracking during execution.
- Added tests for execution UUID creation, inheritance, and lifecycle management to ensure functionality and correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core kickoff/resume paths for Crew and Flow; behavior is additive but incorrect UUID lifecycle could fragment traces or break enterprise id alignment.
> 
> **Overview**
> Adds **per-run execution identity** for OSS tracing: a new `crewai.execution` module uses a `contextvars`-backed `execution_uuid` so Wharf can key spans consistently. The **outermost** crew or flow `kickoff` / `akickoff` mints a UUID (unless enterprise already bound one via `set_execution_uuid`); nested kickoffs inherit it and only the owner clears it in `finally`.
> 
> **Crew** (`kickoff` / `akickoff`) and **Flow** (`kickoff_async` and resume) wrap runs with `begin_execution` / `end_execution` on the kickoff path (not the event bus).
> 
> For **human-in-the-loop**, `PendingFeedbackContext` gains optional `execution_uuid` (serialized in `to_dict` / `from_dict`). Pauses capture the active UUID; resume calls `begin_execution` with the stored value so traces stay on one run across pause. Legacy persisted rows without the field get `None` and may mint a new UUID on resume.
> 
> Tests cover nesting, enterprise pre-set IDs, crew/flow lifecycle, and pause/resume continuity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4ebc03034f0bf716417c72963b580c44beba70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->