### PR TITLE
fix(core): record the running release on every emitted span

### DIFF
--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -293,9 +293,12 @@ class Telemetry:
     def deploy_signup_error_span(self) -> None:
         """Records when an error occurs during the deployment signup process."""
 
+        from crewai_core.version import get_crewai_version
+
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Deploy Signup Error")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
             close_span(span)
 
         self._safe_telemetry_procedure(_operation)
@@ -313,9 +316,12 @@ class Telemetry:
             source: Where the deployment was initiated from.
         """
 
+        from crewai_core.version import get_crewai_version
+
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Start Deployment")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
             self._add_attribute(span, "source", source)
@@ -334,9 +340,12 @@ class Telemetry:
             source: Where the deployment was initiated from.
         """
 
+        from crewai_core.version import get_crewai_version
+
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Create Crew Deployment")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
             self._add_attribute(span, "source", source)
             close_span(span)
 
@@ -348,9 +357,12 @@ class Telemetry:
     ) -> None:
         """Records the retrieval of crew logs."""
 
+        from crewai_core.version import get_crewai_version
+
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Get Crew Logs")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
             self._add_attribute(span, "log_type", log_type)
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
@@ -361,9 +373,12 @@ class Telemetry:
     def remove_crew_span(self, uuid: str | None = None) -> None:
         """Records the removal of a crew."""
 
+        from crewai_core.version import get_crewai_version
+
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Remove Crew")
+            self._add_attribute(span, "crewai_version", get_crewai_version())
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
             close_span(span)

--- a/lib/crewai-core/tests/test_telemetry_deploy.py
+++ b/lib/crewai-core/tests/test_telemetry_deploy.py
@@ -167,9 +167,15 @@ class TestReleaseAttribution:
         args: tuple[object, ...],
     ) -> None:
         instance, span = telemetry
+        sentinel = "0.0.0-release-sentinel"
 
-        getattr(instance, method)(*args)
+        # Patched at the source module, not at crewai_core.telemetry: these
+        # methods import get_crewai_version inside the call, so a patch on the
+        # importing module would never be seen. An arbitrary sentinel also means
+        # a hard-coded literal cannot satisfy the assertion.
+        with patch("crewai_core.version.get_crewai_version", return_value=sentinel):
+            getattr(instance, method)(*args)
 
-        recorded = _attributes(span).get("crewai_version")
-        assert recorded, f"{method} recorded no crewai_version"
-        assert recorded[0].isdigit(), f"{method} recorded a non-version: {recorded!r}"
+        assert _attributes(span).get("crewai_version") == sentinel, (
+            f"{method} did not record the value returned by get_crewai_version()"
+        )

--- a/lib/crewai-core/tests/test_telemetry_deploy.py
+++ b/lib/crewai-core/tests/test_telemetry_deploy.py
@@ -136,3 +136,40 @@ class TestDisabledTelemetry:
             "deploy:created",
             "deploy:pushed",
         ]
+
+
+class TestReleaseAttribution:
+    """Every span this emitter produces must carry the running release.
+
+    A span without ``crewai_version`` cannot be attributed to a version, so a
+    version-filtered question returns nothing for it rather than something
+    visibly wrong. Covers all eight spans this module emits, not only the ones
+    that were missing it, so a regression on the others is caught too.
+    """
+
+    @pytest.mark.parametrize(
+        ("method", "args"),
+        [
+            ("deploy_signup_error_span", ()),
+            ("start_deployment_span", ("dep-123",)),
+            ("create_crew_deployment_span", ()),
+            ("get_crew_logs_span", ("dep-123", "deployment")),
+            ("remove_crew_span", ("dep-123",)),
+            ("feature_usage_span", ("memory:query",)),
+            ("flow_creation_span", ("ResearchFlow",)),
+            ("template_installed_span", ("my-template",)),
+        ],
+    )
+    def test_span_records_the_release(
+        self,
+        telemetry: tuple[Telemetry, MagicMock],
+        method: str,
+        args: tuple[object, ...],
+    ) -> None:
+        instance, span = telemetry
+
+        getattr(instance, method)(*args)
+
+        recorded = _attributes(span).get("crewai_version")
+        assert recorded, f"{method} recorded no crewai_version"
+        assert recorded[0].isdigit(), f"{method} recorded a non-version: {recorded!r}"

--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -508,6 +508,7 @@ class Telemetry:
             tracer = self.provider.get_tracer(TRACER_NAME)
 
             created_span = tracer.start_span("Task Created")
+            self._add_attribute(created_span, "crewai_version", version("crewai"))
 
             add_crew_and_task_attributes(created_span, crew, task, self._add_attribute)
 
@@ -543,6 +544,7 @@ class Telemetry:
             close_span(created_span)
 
             span = tracer.start_span("Task Execution")
+            self._add_attribute(span, "crewai_version", version("crewai"))
 
             add_crew_and_task_attributes(span, crew, task, self._add_attribute)
 
@@ -749,6 +751,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Deploy Signup Error")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             close_span(span)
 
         self._safe_telemetry_operation(_operation)
@@ -763,6 +766,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Start Deployment")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
             close_span(span)
@@ -775,6 +779,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Create Crew Deployment")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             close_span(span)
 
         self._safe_telemetry_operation(_operation)
@@ -792,6 +797,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Get Crew Logs")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             self._add_attribute(span, "log_type", log_type)
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
@@ -809,6 +815,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Remove Crew")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             if uuid:
                 self._add_attribute(span, "uuid", uuid)
             close_span(span)
@@ -985,6 +992,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Flow Plotting")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             self._add_attribute(span, "flow_name", flow_name)
             self._add_attribute(span, "node_names", json.dumps(node_names))
             close_span(span)
@@ -1211,6 +1219,7 @@ class Telemetry:
         def _operation() -> None:
             tracer = self.provider.get_tracer(TRACER_NAME)
             span = tracer.start_span("Human Feedback")
+            self._add_attribute(span, "crewai_version", version("crewai"))
             self._add_attribute(span, "event_type", event_type)
             self._add_attribute(span, "has_routing", has_routing)
             self._add_attribute(span, "num_outcomes", num_outcomes)

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -382,3 +382,98 @@ def test_paused_and_method_failed_record_flow_and_origin() -> None:
         _tracer, span = _emit(method, "ResearchFlow", "internal")
         span.set_attribute.assert_any_call("flow_name", "ResearchFlow")
         span.set_attribute.assert_any_call("origin", "internal")
+
+
+def _version_attr(span) -> str | None:
+    """The crewai_version value recorded on a mocked span, if any."""
+    for call in span.set_attribute.call_args_list:
+        if call.args and call.args[0] == "crewai_version":
+            return call.args[1]
+    return None
+
+
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [
+        ("flow_plotting_span", ("ResearchFlow", ["step_a", "step_b"])),
+        ("deploy_signup_error_span", ()),
+        ("start_deployment_span", ("dep-123",)),
+        ("create_crew_deployment_span", ()),
+        ("get_crew_logs_span", ("dep-123", "deployment")),
+        ("remove_crew_span", ("dep-123",)),
+        ("human_feedback_span", ("requested", False)),
+    ],
+)
+def test_span_records_the_crewai_version(method: str, args: tuple) -> None:
+    """Version-filtered queries silently drop any span kind missing this.
+
+    Without it a release cannot be attributed for that span, so version-adoption
+    and per-release regression analysis are blind to it.
+    """
+    _tracer, span = _emit(method, *args)
+
+    recorded = _version_attr(span)
+    assert recorded, f"{method} recorded no crewai_version"
+    assert recorded[0].isdigit(), f"{method} recorded a non-version: {recorded!r}"
+
+
+def test_task_spans_record_the_crewai_version() -> None:
+    """Task Created and Task Execution are the highest-volume span kinds.
+
+    They are emitted together by task_started, and both were missing the
+    version - so every version-filtered task metric returned nothing.
+    """
+    agent = Agent(role="R", goal="G", backstory="B")
+    task = Task(description="D", expected_output="E", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+
+    tracer, span = _emit("task_started", crew, task)
+
+    emitted = [c.args[0] for c in tracer.start_span.call_args_list]
+    assert emitted == ["Task Created", "Task Execution"]
+
+    # The harness hands the same mock back for both start_span calls, so the
+    # attribute writes accumulate: one crewai_version per span emitted.
+    versions = [
+        c.args[1]
+        for c in span.set_attribute.call_args_list
+        if c.args and c.args[0] == "crewai_version"
+    ]
+    assert len(versions) == 2, f"expected one version per task span, got {versions}"
+    assert all(v and v[0].isdigit() for v in versions)
+
+
+def test_every_span_records_the_crewai_version() -> None:
+    """Regression guard for span kinds added later.
+
+    Enumerating the source rather than emitting all 32 spans: the point is to
+    fail when someone adds a new span without the version, which a fixed list
+    of behavioural cases cannot do.
+    """
+    import ast
+    from pathlib import Path
+
+    import crewai
+    import crewai_core
+
+    missing: list[str] = []
+    for module in (crewai, crewai_core):
+        path = Path(module.__file__).parent / "telemetry" / "telemetry.py"
+        if not path.is_file():  # crewai_core keeps it flat
+            path = Path(module.__file__).parent / "telemetry.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            # Skip the nested closure: its enclosing method is already checked and
+            # is the name a reader needs to act on.
+            if node.name == "_operation":
+                continue
+            dumped = ast.dump(node)
+            if "start_span" in dumped and "crewai_version" not in dumped:
+                missing.append(f"{path.name}::{node.name}")
+
+    assert not missing, (
+        "these span methods create a span without recording crewai_version: "
+        + ", ".join(sorted(missing))
+    )

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -1,10 +1,14 @@
+import ast
+import inspect
 import os
+from pathlib import Path
 import threading
 from unittest.mock import Mock, patch
 
 import pytest
 from crewai import Agent, Crew, Task
 from crewai.telemetry import Telemetry
+from crewai_core.telemetry import Telemetry as CoreTelemetry
 from opentelemetry.sdk.trace import TracerProvider
 
 
@@ -443,37 +447,59 @@ def test_task_spans_record_the_crewai_version() -> None:
     assert all(v and v[0].isdigit() for v in versions)
 
 
+def _calls(node: ast.AST, attr: str, key: str | None = None) -> int:
+    """Count calls to ``.attr(...)`` beneath a node, optionally keyed on arg 2.
+
+    Used to compare how many spans a method opens against how many of them it
+    records ``crewai_version`` on.
+    """
+    total = 0
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        if not isinstance(func, ast.Attribute) or func.attr != attr:
+            continue
+        if key is None:
+            total += 1
+        elif len(sub.args) >= 2:
+            named = sub.args[1]
+            if isinstance(named, ast.Constant) and named.value == key:
+                total += 1
+    return total
+
+
 def test_every_span_records_the_crewai_version() -> None:
-    """Regression guard for span kinds added later.
+    """Regression guard for span kinds added later, in BOTH emitters.
 
     Enumerating the source rather than emitting all 32 spans: the point is to
-    fail when someone adds a new span without the version, which a fixed list
-    of behavioural cases cannot do.
+    fail when someone adds a new span without the version, which a fixed list of
+    behavioural cases cannot do.
+
+    Counts rather than merely detects. A method that opens two spans and records
+    the version on only one of them must fail - ``task_started`` is exactly that
+    shape, so "the method mentions crewai_version somewhere" is not enough.
     """
-    import ast
-    from pathlib import Path
-
-    import crewai
-    import crewai_core
-
-    missing: list[str] = []
-    for module in (crewai, crewai_core):
-        path = Path(module.__file__).parent / "telemetry" / "telemetry.py"
-        if not path.is_file():  # crewai_core keeps it flat
-            path = Path(module.__file__).parent / "telemetry.py"
+    shortfalls: list[str] = []
+    for cls in (Telemetry, CoreTelemetry):
+        path = Path(inspect.getfile(cls))
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
-            if not isinstance(node, ast.FunctionDef):
+            # The nested closure is reached via its enclosing method, whose name
+            # is the one a reader needs in the failure message.
+            if not isinstance(node, ast.FunctionDef) or node.name == "_operation":
                 continue
-            # Skip the nested closure: its enclosing method is already checked and
-            # is the name a reader needs to act on.
-            if node.name == "_operation":
+            spans = _calls(node, "start_span")
+            if not spans:
                 continue
-            dumped = ast.dump(node)
-            if "start_span" in dumped and "crewai_version" not in dumped:
-                missing.append(f"{path.name}::{node.name}")
+            versions = _calls(node, "_add_attribute", "crewai_version")
+            if versions < spans:
+                shortfalls.append(
+                    f"{path.name}::{node.name} "
+                    f"({spans} span(s), {versions} version attribute(s))"
+                )
 
-    assert not missing, (
-        "these span methods create a span without recording crewai_version: "
-        + ", ".join(sorted(missing))
+    assert not shortfalls, (
+        "these methods open more spans than they record crewai_version on: "
+        + ", ".join(sorted(shortfalls))
     )

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -94,7 +94,7 @@ def test_flow_execution_span_records_crewai_version():
             "crewai.telemetry.telemetry.TracerProvider",
             return_value=Mock(get_tracer=Mock(return_value=tracer)),
         ),
-        patch("crewai.telemetry.telemetry.version", return_value="9.9.9"),
+        patch("crewai.telemetry.telemetry.version", return_value=_EMITTED_VERSION),
     ):
         telemetry = Telemetry()
         telemetry.flow_execution_span("ResearchFlow", ["start", "finish"])
@@ -312,6 +312,11 @@ def test_event_listener_tracks_hook_dispatched_events():
     )
 
 
+# The version _emit injects. Assertions compare against this exact value, so a
+# hard-coded literal in an emitter cannot satisfy them.
+_EMITTED_VERSION = "9.9.9"
+
+
 def _emit(method: str, *args, **kwargs):
     """Run one telemetry span method against a mocked tracer.
 
@@ -416,9 +421,11 @@ def test_span_records_the_crewai_version(method: str, args: tuple) -> None:
     """
     _tracer, span = _emit(method, *args)
 
-    recorded = _version_attr(span)
-    assert recorded, f"{method} recorded no crewai_version"
-    assert recorded[0].isdigit(), f"{method} recorded a non-version: {recorded!r}"
+    # Exact equality with the value _emit injected: "looks like a version" would
+    # also accept a hard-coded literal in the emitter.
+    assert _version_attr(span) == _EMITTED_VERSION, (
+        f"{method} did not record the value returned by version('crewai')"
+    )
 
 
 def test_task_spans_record_the_crewai_version() -> None:
@@ -443,8 +450,9 @@ def test_task_spans_record_the_crewai_version() -> None:
         for c in span.set_attribute.call_args_list
         if c.args and c.args[0] == "crewai_version"
     ]
-    assert len(versions) == 2, f"expected one version per task span, got {versions}"
-    assert all(v and v[0].isdigit() for v in versions)
+    assert versions == [_EMITTED_VERSION, _EMITTED_VERSION], (
+        f"expected one version per task span, got {versions}"
+    )
 
 
 def _calls(node: ast.AST, attr: str, key: str | None = None) -> int:


### PR DESCRIPTION
- Records the running release on every emitted span. Nine of twenty-four span kinds never carried `crewai_version`, including the two highest-volume ones — `Task Created` and `Task Execution` — plus `Human Feedback`, `Flow Plotting`, and the whole deployment family (`Create Crew Deployment`, `Start Deployment`, `Remove Crew`, `Get Crew Logs`, `Deploy Signup Error`).
- The consequence was silent: `add_crew_attributes` writes `crew_key`, `crew_id` and `crew_fingerprint` but never the release, so any question filtered by version returned nothing at all for those spans rather than returning something wrong. Per-release comparison and adoption analysis were blind to the highest-volume data we collect.
- Fourteen call sites across both emitters, matching each module's existing convention rather than introducing a new one: `version("crewai")` in `crewai`, and `get_crewai_version()` with the file's established local-import pattern in `crewai_core`.
- Purely additive and no public API change. Every existing attribute, count and span name is untouched; the fifteen span kinds that already recorded the release are not modified.
- Covered by a regression guard that parses both modules with `ast` and fails when any method creates a span without recording the release — so a span added later cannot silently reintroduce the gap, which a fixed list of cases could not catch. Verified non-vacuous: removing the attribute from one span makes the test fail and names that method. Backed by behavioural tests driving seven of the fixed methods through a mocked tracer, plus one asserting both task spans record it.
- No docs change: the collected-data table already discloses that the CrewAI version is recorded, and this adds no new kind of data — it makes an already-disclosed field consistent across span kinds.
- Keeps this intentionally small: no new attributes, no changes to the fifteen spans that already had it, no consolidation of the repeated local imports in `crewai_core` (worth doing, but it would touch three methods this change has no other reason to open).
- Next: with this in place, per-release comparison finally works at task grain, which is where most of the volume is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry attributes only; no public API or runtime behavior changes beyond extra span metadata.
> 
> **Overview**
> Adds **`crewai_version`** to telemetry spans that previously omitted it, so version-filtered analytics include high-volume kinds like **Task Created**, **Task Execution**, deployment flows, **Flow Plotting**, and **Human Feedback**.
> 
> In **`crewai`**, emitters use `version("crewai")`; in **`crewai_core`**, they use `get_crewai_version()` with the existing local-import pattern. Span names and other attributes are unchanged—this only makes an already-disclosed field consistent.
> 
> Tests add parametrized checks on fixed methods, coverage for both task spans from `task_started`, and an **AST** guard on both `Telemetry` classes that fails when any method opens more spans than it records `crewai_version` on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1e0fc887601be3090480214e44b26c56aea372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->