### PR TITLE
fix: run before_llm_call hooks on async acall() path for all native providers

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -449,6 +449,11 @@ class AnthropicCompletion(BaseLLM):
                     self._format_messages_for_anthropic(messages)
                 )
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 completion_params = self._prepare_completion_params(
                     formatted_messages, system_message, tools, available_functions
                 )

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -603,6 +603,11 @@ class AzureCompletion(BaseLLM):
 
                 formatted_messages = self._format_messages_for_azure(messages)
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 completion_params = self._prepare_completion_params(
                     formatted_messages, tools, effective_response_model
                 )

--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -510,6 +510,11 @@ class BedrockCompletion(BaseLLM):
                     messages
                 )
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 body: BedrockConverseRequestBody = {
                     "inferenceConfig": self._get_inference_config(),
                 }

--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -397,6 +397,13 @@ class GeminiCompletion(BaseLLM):
                     self._format_messages_for_gemini(messages)
                 )
 
+                messages_for_hooks = self._convert_contents_to_dict(formatted_content)
+
+                if not self._invoke_before_llm_call_hooks(
+                    messages_for_hooks, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 config = self._prepare_generation_config(
                     system_instruction, tools, effective_response_model
                 )

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -600,6 +600,11 @@ class OpenAICompletion(BaseLLM):
 
                 formatted_messages = self._format_messages(messages)
 
+                if not self._invoke_before_llm_call_hooks(
+                    formatted_messages, from_agent
+                ):
+                    raise ValueError("LLM call blocked by before_llm_call hook")
+
                 if self._effective_api() == "responses":
                     return await self._acall_responses(
                         messages=formatted_messages,

--- a/lib/crewai/tests/llms/hooks/test_before_llm_call_async.py
+++ b/lib/crewai/tests/llms/hooks/test_before_llm_call_async.py
@@ -1,0 +1,248 @@
+"""Tests that before_llm_call hooks run on async acall() path for all native providers.
+
+Regression tests for issue #6739: before_llm_call hooks were never invoked on the
+async acall() path of the five native providers, meaning a blocking hook (PII gate,
+spend cap, policy check) silently failed to block the request whenever the caller
+used acall() / kickoff_async.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from crewai.llm import LLM
+
+# Async tests are skipped on Windows due to pytest-recording network guard
+# conflicting with asyncio's socket.socketpair() used for event loop creation.
+# CI runs on Linux and covers these paths fully.
+skip_async_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Async tests skipped on Windows (pytest-recording + asyncio compatibility)",
+)
+
+
+@skip_async_on_windows
+class TestBeforeLLMCallHookRunsOnAsyncOpenAI:
+    """Verify before_llm_call hook is invoked on OpenAI native async path."""
+
+    @pytest.mark.asyncio
+    async def test_acall_invokes_before_llm_call_hooks(self):
+        """acall() must invoke _invoke_before_llm_call_hooks before the API call."""
+        llm = LLM(model="gpt-4o-mini")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=True
+        ), patch.object(
+            provider, "_acall_completions", return_value="mocked response"
+        ), patch.object(
+            provider, "_acall_responses", return_value="mocked response"
+        ):
+            result = await llm.acall("Hello")
+
+            provider._invoke_before_llm_call_hooks.assert_called_once()
+            assert result == "mocked response"
+
+    @pytest.mark.asyncio
+    async def test_acall_blocks_when_hook_returns_false(self):
+        """acall() must raise ValueError and NOT call API when hook blocks."""
+        llm = LLM(model="gpt-4o-mini")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=False
+        ), patch.object(
+            provider, "_acall_completions"
+        ) as mock_acall_completions, patch.object(
+            provider, "_acall_responses"
+        ) as mock_acall_responses:
+            with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+                await llm.acall("Hello")
+
+            mock_acall_completions.assert_not_called()
+            mock_acall_responses.assert_not_called()
+
+
+@skip_async_on_windows
+class TestBeforeLLMCallHookRunsOnAsyncAnthropic:
+    """Verify before_llm_call hook is invoked on Anthropic native async path."""
+
+    @pytest.mark.asyncio
+    async def test_acall_invokes_before_llm_call_hooks(self):
+        """acall() must invoke _invoke_before_llm_call_hooks before the API call."""
+        llm = LLM(model="anthropic/claude-3-5-haiku-latest")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=True
+        ), patch.object(
+            provider, "_ahandle_completion", return_value="mocked response"
+        ), patch.object(
+            provider, "_ahandle_streaming_completion", return_value="mocked response"
+        ):
+            result = await llm.acall("Hello")
+
+            provider._invoke_before_llm_call_hooks.assert_called_once()
+            assert result == "mocked response"
+
+    @pytest.mark.asyncio
+    async def test_acall_blocks_when_hook_returns_false(self):
+        """acall() must raise ValueError and NOT call API when hook blocks."""
+        llm = LLM(model="anthropic/claude-3-5-haiku-latest")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=False
+        ), patch.object(
+            provider, "_ahandle_completion"
+        ) as mock_ahandle, patch.object(
+            provider, "_ahandle_streaming_completion"
+        ) as mock_ahandle_streaming:
+            with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+                await llm.acall("Hello")
+
+            mock_ahandle.assert_not_called()
+            mock_ahandle_streaming.assert_not_called()
+
+
+@skip_async_on_windows
+class TestBeforeLLMCallHookRunsOnAsyncBedrock:
+    """Verify before_llm_call hook is invoked on Bedrock native async path."""
+
+    @pytest.mark.asyncio
+    async def test_acall_invokes_before_llm_call_hooks(self):
+        """acall() must invoke _invoke_before_llm_call_hooks before the API call."""
+        llm = LLM(
+            model="bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        )
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=True
+        ), patch.object(
+            provider, "_ahandle_converse_response", return_value="mocked response"
+        ), patch.object(
+            provider, "_ahandle_streaming_converse", return_value="mocked response"
+        ):
+            result = await llm.acall("Hello")
+
+            provider._invoke_before_llm_call_hooks.assert_called_once()
+            assert result == "mocked response"
+
+    @pytest.mark.asyncio
+    async def test_acall_blocks_when_hook_returns_false(self):
+        """acall() must raise ValueError and NOT call API when hook blocks."""
+        llm = LLM(
+            model="bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        )
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=False
+        ), patch.object(
+            provider, "_ahandle_converse_response"
+        ) as mock_ahandle, patch.object(
+            provider, "_ahandle_streaming_converse"
+        ) as mock_ahandle_streaming:
+            with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+                await llm.acall("Hello")
+
+            mock_ahandle.assert_not_called()
+            mock_ahandle_streaming.assert_not_called()
+
+
+@skip_async_on_windows
+class TestBeforeLLMCallHookRunsOnAsyncGemini:
+    """Verify before_llm_call hook is invoked on Gemini native async path."""
+
+    @pytest.mark.asyncio
+    async def test_acall_invokes_before_llm_call_hooks(self):
+        """acall() must invoke _invoke_before_llm_call_hooks before the API call."""
+        llm = LLM(model="gemini/gemini-2.0-flash")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=True
+        ), patch.object(
+            provider, "_ahandle_completion", return_value="mocked response"
+        ), patch.object(
+            provider, "_ahandle_streaming_completion", return_value="mocked response"
+        ):
+            result = await llm.acall("Hello")
+
+            provider._invoke_before_llm_call_hooks.assert_called_once()
+            assert result == "mocked response"
+
+    @pytest.mark.asyncio
+    async def test_acall_blocks_when_hook_returns_false(self):
+        """acall() must raise ValueError and NOT call API when hook blocks."""
+        llm = LLM(model="gemini/gemini-2.0-flash")
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=False
+        ), patch.object(
+            provider, "_ahandle_completion"
+        ) as mock_ahandle, patch.object(
+            provider, "_ahandle_streaming_completion"
+        ) as mock_ahandle_streaming:
+            with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+                await llm.acall("Hello")
+
+            mock_ahandle.assert_not_called()
+            mock_ahandle_streaming.assert_not_called()
+
+
+@skip_async_on_windows
+class TestBeforeLLMCallHookRunsOnAsyncAzure:
+    """Verify before_llm_call hook is invoked on Azure AI native async path."""
+
+    @pytest.mark.asyncio
+    async def test_acall_invokes_before_llm_call_hooks(self):
+        """acall() must invoke _invoke_before_llm_call_hooks before the API call."""
+        llm = LLM(
+            model="azure/gpt-4o-mini",
+            base_url="https://example.openai.azure.com",
+            api_key="test-key",
+            api_version="2024-06-01",
+        )
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=True
+        ), patch.object(
+            provider, "_ahandle_completion", return_value="mocked response"
+        ), patch.object(
+            provider, "_ahandle_streaming_completion", return_value="mocked response"
+        ):
+            result = await llm.acall("Hello")
+
+            provider._invoke_before_llm_call_hooks.assert_called_once()
+            assert result == "mocked response"
+
+    @pytest.mark.asyncio
+    async def test_acall_blocks_when_hook_returns_false(self):
+        """acall() must raise ValueError and NOT call API when hook blocks."""
+        llm = LLM(
+            model="azure/gpt-4o-mini",
+            base_url="https://example.openai.azure.com",
+            api_key="test-key",
+            api_version="2024-06-01",
+        )
+        provider = llm._provider
+
+        with patch.object(
+            provider, "_invoke_before_llm_call_hooks", return_value=False
+        ), patch.object(
+            provider, "_ahandle_completion"
+        ) as mock_ahandle, patch.object(
+            provider, "_ahandle_streaming_completion"
+        ) as mock_ahandle_streaming:
+            with pytest.raises(ValueError, match="blocked by before_llm_call hook"):
+                await llm.acall("Hello")
+
+            mock_ahandle.assert_not_called()
+            mock_ahandle_streaming.assert_not_called()

--- a/lib/crewai/tests/llms/hooks/test_before_llm_call_async.py
+++ b/lib/crewai/tests/llms/hooks/test_before_llm_call_async.py
@@ -123,7 +123,7 @@ class TestBeforeLLMCallHookRunsOnAsyncBedrock:
         with patch.object(
             provider, "_invoke_before_llm_call_hooks", return_value=True
         ), patch.object(
-            provider, "_ahandle_converse_response", return_value="mocked response"
+            provider, "_ahandle_converse", return_value="mocked response"
         ), patch.object(
             provider, "_ahandle_streaming_converse", return_value="mocked response"
         ):
@@ -143,7 +143,7 @@ class TestBeforeLLMCallHookRunsOnAsyncBedrock:
         with patch.object(
             provider, "_invoke_before_llm_call_hooks", return_value=False
         ), patch.object(
-            provider, "_ahandle_converse_response"
+            provider, "_ahandle_converse"
         ) as mock_ahandle, patch.object(
             provider, "_ahandle_streaming_converse"
         ) as mock_ahandle_streaming:


### PR DESCRIPTION
## Problem

`before_llm_call` hooks are the only interception point that can **abort** an LLM call — returning `False` (or raising `HookAborted` via the reducer) is supposed to stop the request from ever reaching the provider. This works on the synchronous `call()` path of every native provider, but **none of the five native providers invoke the hook on their async `acall()` path**.

The consequence is not just "the hook didn't observe the messages" — the request is actually issued. A guardrail hook written to block a call (PII gate, spend cap, policy check, prompt-injection filter) silently permits it whenever the caller uses `acall()` / `kickoff_async`.

Coverage of `_invoke_before_llm_call_hooks` before this fix:

| provider | sync `call()` | async `acall()` |
|---|---|---|
| `llms/providers/openai/completion.py` | ✅ | ❌ missing |
| `llms/providers/anthropic/completion.py` | ✅ | ❌ missing |
| `llms/providers/bedrock/completion.py` | ✅ | ❌ missing |
| `llms/providers/gemini/completion.py` | ✅ | ❌ missing |
| `llms/providers/azure/completion.py` | ✅ | ❌ missing |

`llms/base_llm.py` (the LiteLLM fallback) already had the guard on both paths — the bug was specific to the native providers.

Closes #6739

## Solution

Add the same `_invoke_before_llm_call_hooks` check to each native provider's `acall()` method, placed immediately after message formatting (matching the sync path's position). The hook method itself is synchronous (it calls `dispatch()` which is sync), so it can be called directly from the async path without any changes to the hook infrastructure.

### Changes

**Provider fixes (5 files, ~30 lines total)**
- `lib/crewai/src/crewai/llms/providers/openai/completion.py` — add hook check in `acall()` after `_format_messages`
- `lib/crewai/src/crewai/llms/providers/anthropic/completion.py` — add hook check in `acall()` after `_format_messages_for_anthropic`
- `lib/crewai/src/crewai/llms/providers/bedrock/completion.py` — add hook check in `acall()` after `_format_messages_for_converse`
- `lib/crewai/src/crewai/llms/providers/gemini/completion.py` — add `_convert_contents_to_dict` + hook check in `acall()` (mirrors sync path's `messages_for_hooks` pattern)
- `lib/crewai/src/crewai/llms/providers/azure/completion.py` — add hook check in `acall()` after `_format_messages_for_azure`

**Tests**
- `lib/crewai/tests/llms/hooks/test_before_llm_call_async.py` — 10 unit tests across all 5 providers:
  - `test_acall_invokes_before_llm_call_hooks` — verifies the hook is called in the async path
  - `test_acall_blocks_when_hook_returns_false` — verifies `ValueError` is raised and the underlying API method is never called

## Design decisions

- **Minimal change** — each fix is 5-7 lines inserted at the exact same position as the sync path, making the change easy to review and verify
- **Same error message** — raises `ValueError("LLM call blocked by before_llm_call hook")`, identical to the sync path, so existing error handling works unchanged
- **`_invoke_before_llm_call_hooks` is synchronous** — the hook dispatch system uses sync `dispatch()`, so no async hook variant is needed; we call the same method from both sync and async paths
- **Gemini uses `messages_for_hooks`** — same pattern as the sync path: Gemini's native content format is converted back to dict messages before passing to the hook, so hook authors see a consistent format across all providers

## Testing

10 passed (on Linux CI), 10 skipped on Windows (pytest-recording network guard conflicts with asyncio's `socket.socketpair()` — same pattern as other async tests in the codebase).


tests/llms/hooks/test_before_llm_call_async.py TestBeforeLLMCallHookRunsOnAsyncOpenAI ✓ test_acall_invokes_before_llm_call_hooks ✓ test_acall_blocks_when_hook_returns_false TestBeforeLLMCallHookRunsOnAsyncAnthropic ✓ test_acall_invokes_before_llm_call_hooks ✓ test_acall_blocks_when_hook_returns_false TestBeforeLLMCallHookRunsOnAsyncBedrock ✓ test_acall_invokes_before_llm_call_hooks ✓ test_acall_blocks_when_hook_returns_false TestBeforeLLMCallHookRunsOnAsyncGemini ✓ test_acall_invokes_before_llm_call_hooks ✓ test_acall_blocks_when_hook_returns_false TestBeforeLLMCallHookRunsOnAsyncAzure ✓ test_acall_invokes_before_llm_call_hooks ✓ test_acall_blocks_when_hook_returns_false



ruff: ✅ all checks passed


<!-- crewai-require-issue-check -->