### PR TITLE
feat(tools): add guarded Taskmarket requester

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -198,6 +198,10 @@ from crewai_tools.tools.snowflake_search_tool.snowflake_search_tool import (
 )
 from crewai_tools.tools.spider_tool.spider_tool import SpiderTool
 from crewai_tools.tools.stagehand_tool.stagehand_tool import StagehandTool
+from crewai_tools.tools.taskmarket_requester_tool import (
+    TaskMarketRequesterSchema,
+    TaskMarketRequesterTool,
+)
 from crewai_tools.tools.tavily_extractor_tool.tavily_extractor_tool import (
     TavilyExtractorTool,
 )
@@ -324,6 +328,8 @@ __all__ = [
     "SpiderTool",
     "StagehandTool",
     "TXTSearchTool",
+    "TaskMarketRequesterSchema",
+    "TaskMarketRequesterTool",
     "TavilyExtractorTool",
     "TavilyGetResearchTool",
     "TavilyResearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -185,6 +185,10 @@ from crewai_tools.tools.snowflake_search_tool import (
 )
 from crewai_tools.tools.spider_tool.spider_tool import SpiderTool
 from crewai_tools.tools.stagehand_tool.stagehand_tool import StagehandTool
+from crewai_tools.tools.taskmarket_requester_tool import (
+    TaskMarketRequesterSchema,
+    TaskMarketRequesterTool,
+)
 from crewai_tools.tools.tavily_extractor_tool.tavily_extractor_tool import (
     TavilyExtractorTool,
 )
@@ -307,6 +311,8 @@ __all__ = [
     "SpiderTool",
     "StagehandTool",
     "TXTSearchTool",
+    "TaskMarketRequesterSchema",
+    "TaskMarketRequesterTool",
     "TavilyExtractorTool",
     "TavilyGetResearchTool",
     "TavilyResearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/README.md
@@ -41,8 +41,10 @@ if user_confirmed():
 
 Only then can the agent call `create` with that `preview_id`. Approval is bound to
 the exact prepared arguments, expires after five minutes by default, and is
-consumed before the CLI write. A timed-out or ambiguous write is never retried:
-the tool tells the operator to reconcile using Taskmarket inbox and wallet history.
+claimed atomically before preflight so concurrent calls cannot duplicate a spend.
+After any create attempt begins, a new preview and approval are required. A
+timed-out or ambiguous write is never retried: the tool tells the operator to
+reconcile using Taskmarket inbox and wallet history.
 
 Immediately before creation, the tool verifies:
 

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/README.md
@@ -1,0 +1,121 @@
+# Taskmarket Requester Tool
+
+`TaskMarketRequesterTool` lets a CrewAI agent prepare and monitor Taskmarket
+bounties while keeping spending authorization in trusted host code. It uses the
+first-party `taskmarket` CLI, never accepts wallet keys, and never exposes
+accept/reject operations to the model.
+
+## Setup
+
+```bash
+npm install -g @lucid-agents/taskmarket@latest
+taskmarket init
+taskmarket legal status
+```
+
+Fund the CLI wallet with Base mainnet USDC before enabling creation. Configure a
+hard per-task cap when constructing the tool:
+
+```python
+from decimal import Decimal
+
+from crewai_tools import TaskMarketRequesterTool
+
+tool = TaskMarketRequesterTool(max_reward_usdc=Decimal("5.00"))
+```
+
+## Human-approved creation
+
+The model first calls `prepare_create`. The result shows the exact description,
+deliverables, reward, projected UTC deadline, Base network, permanent visibility,
+maximum spend, and a SHA-256 fingerprint. Preparation does not transact.
+
+Trusted UI or controller code must display that exact preview and then approve it:
+
+```python
+preview = await_agent_preview()
+show_to_user(preview)
+if user_confirmed():
+    tool.approve(preview["preview_id"], preview["fingerprint_sha256"])
+```
+
+Only then can the agent call `create` with that `preview_id`. Approval is bound to
+the exact prepared arguments, expires after five minutes by default, and is
+consumed before the CLI write. A timed-out or ambiguous write is never retried:
+the tool tells the operator to reconcile using Taskmarket inbox and wallet history.
+
+Immediately before creation, the tool verifies:
+
+- Base chain ID `8453` and canonical Base USDC;
+- acting Taskmarket wallet and available USDC balance;
+- the current legal-bundle enforcement state;
+- reward does not exceed the configured maximum spend.
+
+Successful creation returns the task ID, Taskmarket link, acting wallet, maximum
+spend, and live task status when the follow-up read succeeds.
+
+## Review without autonomous selection
+
+Use `status` to retrieve current task state and `submissions` to present candidates.
+Both results state that human review is required. This tool intentionally provides
+no accept, reject, rate, or winner-selection operation.
+
+## Reproducible demo
+
+The following transcript uses an injected runner, so it exercises the complete
+approval and settlement-handling path without spending USDC or exposing secrets:
+
+```python
+import json
+from decimal import Decimal
+
+from crewai_tools import TaskMarketRequesterTool
+
+
+def recorded_runner(args, timeout):
+    command = tuple(args[1:])
+    responses = {
+        ("address",): {"ok": True, "data": {"address": "0x1111111111111111111111111111111111111111"}},
+        ("deposit",): {"ok": True, "data": {"chainId": 8453, "usdcContract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"}},
+        ("wallet", "balance"): {"ok": True, "data": {"balanceUsdc": "5.0"}},
+        ("legal", "status"): {"ok": True, "data": {"enforcementEnabled": False}},
+    }
+    if command[:2] == ("task", "create"):
+        payload = {"ok": True, "data": {"taskId": "0x" + "a" * 64}}
+    elif command[:2] == ("task", "get"):
+        payload = {"ok": True, "data": {"status": "open"}}
+    else:
+        payload = responses[command]
+    return 0, json.dumps(payload), ""
+
+
+tool = TaskMarketRequesterTool(
+    runner=recorded_runner,
+    max_reward_usdc=Decimal("2"),
+)
+preview = json.loads(
+    tool.run(
+        operation="prepare_create",
+        description="Audit the release candidate.",
+        deliverables=["Report", "Reproduction steps"],
+        reward_usdc=Decimal("1.25"),
+        duration_hours=24,
+    )
+)
+
+# This call belongs in trusted UI/controller code after displaying the preview.
+tool.approve(preview["preview_id"], preview["fingerprint_sha256"])
+created = json.loads(tool.run(operation="create", preview_id=preview["preview_id"]))
+assert created["created"] is True
+assert created["task_id"] == "0x" + "a" * 64
+```
+
+Run the focused behavior suite from the repository root:
+
+```bash
+uv run pytest lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py -q
+```
+
+The tests cover exact previews, spend caps, Base/USDC/legal/balance preflights,
+single-use authorization, unknown-settlement handling, and read-only submission
+review.

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/__init__.py
@@ -1,0 +1,9 @@
+"""Taskmarket requester tool."""
+
+from crewai_tools.tools.taskmarket_requester_tool.taskmarket_requester_tool import (
+    TaskMarketRequesterSchema,
+    TaskMarketRequesterTool,
+)
+
+
+__all__ = ["TaskMarketRequesterSchema", "TaskMarketRequesterTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
@@ -447,7 +447,7 @@ class TaskMarketRequesterTool(BaseTool):
             raise RuntimeError(
                 "Taskmarket CLI did not report the legal enforcement state."
             )
-        if enforcement_enabled and not legal_data.get("accepted"):
+        if enforcement_enabled and legal_data.get("accepted") is not True:
             raise RuntimeError(
                 "The current Taskmarket legal bundle requires acceptance."
             )
@@ -457,12 +457,16 @@ class TaskMarketRequesterTool(BaseTool):
             raise RuntimeError(
                 "Taskmarket CLI returned an invalid USDC balance."
             ) from exc
+        if not balance.is_finite():
+            raise RuntimeError(
+                "Taskmarket CLI returned a non-finite USDC balance."
+            )
         if balance < reward:
             raise RuntimeError(
                 f"Insufficient Base USDC: need {_format_usdc(reward)}, have {balance}."
             )
         wallet_address = address_data.get("address")
-        if not isinstance(wallet_address, str):
+        if not isinstance(wallet_address, str) or not wallet_address.strip():
             raise RuntimeError(
                 "Taskmarket CLI did not return the acting wallet address."
             )

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
@@ -98,6 +98,7 @@ class _PreparedCreate:
 
     @property
     def cli_args(self) -> list[str]:
+        """Return the exact argument vector approved for task creation."""
         args = [
             "task",
             "create",
@@ -124,10 +125,12 @@ class _UnknownSettlementError(RuntimeError):
 
 
 def _format_usdc(value: Decimal) -> str:
+    """Format a validated USDC amount with the canonical six decimals."""
     return format(value.quantize(Decimal("0.000001")), "f")
 
 
 def _json_result(payload: dict[str, Any]) -> str:
+    """Serialize a stable, human-readable tool result."""
     return json.dumps(payload, indent=2, sort_keys=True, default=str)
 
 
@@ -252,6 +255,7 @@ class TaskMarketRequesterTool(BaseTool):
         task_visibility: TaskVisibility,
         submission_visibility: SubmissionVisibility,
     ) -> str:
+        """Validate inputs and prepare a non-spending, approval-bound preview."""
         if not description or not description.strip():
             raise ValueError("description is required for prepare_create.")
         if not deliverables or not all(item.strip() for item in deliverables):
@@ -351,6 +355,7 @@ class TaskMarketRequesterTool(BaseTool):
         )
 
     def _create(self, preview_id: str | None) -> str:
+        """Consume one fresh host approval and attempt task creation once."""
         with self._lock:
             if not preview_id or preview_id not in self._previews:
                 raise ValueError("A valid preview_id is required for create.")
@@ -424,6 +429,7 @@ class TaskMarketRequesterTool(BaseTool):
         )
 
     def _preflight(self, reward: Decimal) -> dict[str, str]:
+        """Fail closed unless network, legal state, and balance are safe."""
         address_data = self._cli(["address"]).get("data", {})
         deposit_data = self._cli(["deposit"]).get("data", {})
         balance_data = self._cli(["wallet", "balance"]).get("data", {})
@@ -463,6 +469,7 @@ class TaskMarketRequesterTool(BaseTool):
         return {"network": "Base mainnet", "wallet_address": wallet_address}
 
     def _read_task(self, task_id: str | None) -> str:
+        """Retrieve live task state without enabling a marketplace write."""
         exact_id = self._validate_task_id(task_id)
         return _json_result(
             {
@@ -473,6 +480,7 @@ class TaskMarketRequesterTool(BaseTool):
         )
 
     def _read_submissions(self, task_id: str | None) -> str:
+        """Retrieve submissions for human review without judging them."""
         exact_id = self._validate_task_id(task_id)
         return _json_result(
             {
@@ -485,11 +493,13 @@ class TaskMarketRequesterTool(BaseTool):
 
     @staticmethod
     def _validate_task_id(task_id: str | None) -> str:
+        """Return a structurally valid Taskmarket task identifier."""
         if not task_id or not TASK_ID_PATTERN.fullmatch(task_id):
             raise ValueError("task_id must be a 0x-prefixed 32-byte hexadecimal value.")
         return task_id
 
     def _cli(self, args: list[str], *, write: bool = False) -> dict[str, Any]:
+        """Run the fixed first-party CLI and validate its JSON envelope."""
         try:
             returncode, stdout, stderr = self._runner(
                 [self.cli_path, *args], self.command_timeout_seconds
@@ -516,6 +526,7 @@ class TaskMarketRequesterTool(BaseTool):
 
     @staticmethod
     def _parse_envelope(stdout: str, stderr: str) -> dict[str, Any]:
+        """Find the last Taskmarket JSON envelope in either output stream."""
         for stream in (stdout, stderr):
             for line in reversed(stream.splitlines()):
                 try:
@@ -528,6 +539,7 @@ class TaskMarketRequesterTool(BaseTool):
 
     @staticmethod
     def _default_runner(args: Sequence[str], timeout: float) -> tuple[int, str, str]:
+        """Execute an argument vector without a shell and capture its output."""
         executable = shutil.which(args[0])
         if executable is None:
             raise RuntimeError("First-party taskmarket CLI is not installed.")

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
@@ -1,0 +1,524 @@
+"""Guarded requester workflow for Taskmarket."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+import re
+import shutil
+
+# Required for the fixed first-party CLI and always invoked without a shell.
+import subprocess  # nosec B404
+from typing import Any, Literal
+from uuid import uuid4
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, PrivateAttr
+
+
+BASE_CHAIN_ID = 8453
+BASE_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+TASK_ID_PATTERN = re.compile(r"^0x[0-9a-fA-F]{64}$")
+
+Operation = Literal["prepare_create", "create", "status", "submissions"]
+TaskVisibility = Literal["public", "unlisted"]
+SubmissionVisibility = Literal["public", "reveal_all", "winner_only", "never"]
+CommandRunner = Callable[[Sequence[str], float], tuple[int, str, str]]
+
+
+class TaskMarketRequesterSchema(BaseModel):
+    """Inputs exposed to a CrewAI agent."""
+
+    operation: Operation = Field(
+        ...,
+        description=(
+            "Operation to perform. prepare_create only prepares an exact preview; "
+            "create requires separate host approval of that preview."
+        ),
+    )
+    description: str | None = Field(
+        default=None,
+        description="Exact bounty brief, required only for prepare_create.",
+    )
+    deliverables: list[str] | None = Field(
+        default=None,
+        description="Concrete deliverables, required only for prepare_create.",
+    )
+    reward_usdc: Decimal | None = Field(
+        default=None,
+        gt=0,
+        description="Gross bounty reward in human-readable USDC.",
+    )
+    duration_hours: int | None = Field(
+        default=None,
+        ge=1,
+        le=24 * 30,
+        description="Submission window in whole hours.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Optional Taskmarket discovery tags.",
+    )
+    task_visibility: TaskVisibility = Field(
+        default="public",
+        description="Public or unlisted task visibility. Onchain activity stays public.",
+    )
+    submission_visibility: SubmissionVisibility = Field(
+        default="public",
+        description="Permanent submission visibility selected at task creation.",
+    )
+    preview_id: str | None = Field(
+        default=None,
+        description="Approved preview identifier, required only for create.",
+    )
+    task_id: str | None = Field(
+        default=None,
+        description="0x-prefixed 32-byte task ID for status or submissions.",
+    )
+
+
+@dataclass(frozen=True)
+class _PreparedCreate:
+    preview_id: str
+    fingerprint: str
+    description: str
+    deliverables: tuple[str, ...]
+    reward_usdc: Decimal
+    duration_hours: int
+    tags: tuple[str, ...]
+    task_visibility: TaskVisibility
+    submission_visibility: SubmissionVisibility
+    prepared_at: datetime
+    projected_deadline: datetime
+
+    @property
+    def cli_args(self) -> list[str]:
+        args = [
+            "task",
+            "create",
+            "--description",
+            self.description,
+            "--reward",
+            _format_usdc(self.reward_usdc),
+            "--duration",
+            str(self.duration_hours),
+            "--mode",
+            "bounty",
+            "--task-visibility",
+            self.task_visibility,
+            "--submission-visibility",
+            self.submission_visibility,
+        ]
+        if self.tags:
+            args.extend(["--tags", ",".join(self.tags)])
+        return args
+
+
+class _UnknownSettlementError(RuntimeError):
+    """The CLI attempt ended without a trustworthy settlement result."""
+
+
+def _format_usdc(value: Decimal) -> str:
+    return format(value.quantize(Decimal("0.000001")), "f")
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, default=str)
+
+
+class TaskMarketRequesterTool(BaseTool):
+    """Create and monitor Taskmarket bounties with host-controlled approval.
+
+    The model can prepare a byte-for-byte preview, but cannot approve it. Trusted
+    application code must call :meth:`approve` with the displayed preview ID and
+    fingerprint before the model-facing ``create`` operation can spend USDC.
+    """
+
+    name: str = "Taskmarket requester"
+    description: str = (
+        "Prepare an exact Taskmarket bounty for human approval, execute only a "
+        "host-approved preview, retrieve live task status, or present submissions "
+        "for human review. Never accepts or rejects submissions."
+    )
+    args_schema: type[BaseModel] = TaskMarketRequesterSchema
+
+    max_reward_usdc: Decimal = Field(
+        default=Decimal("10"),
+        gt=0,
+        description="Hard cap for one bounty reward and maximum USDC spend.",
+    )
+    cli_path: str = Field(
+        default="taskmarket",
+        description="First-party Taskmarket CLI executable.",
+    )
+    command_timeout_seconds: float = Field(
+        default=45,
+        gt=0,
+        description="Timeout for one CLI call. Timed-out writes are never retried.",
+    )
+    approval_ttl_seconds: int = Field(
+        default=300,
+        ge=1,
+        le=900,
+        description="Seconds before explicit host approval expires.",
+    )
+
+    _runner: CommandRunner = PrivateAttr()
+    _previews: dict[str, _PreparedCreate] = PrivateAttr(default_factory=dict)
+    _approved: dict[str, datetime] = PrivateAttr(default_factory=dict)
+    _attempted: set[str] = PrivateAttr(default_factory=set)
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the requester tool.
+
+        Args:
+            runner: Optional argument-array runner for tests or host isolation.
+            **kwargs: BaseTool and policy configuration.
+        """
+        super().__init__(**kwargs)
+        self._runner = runner or self._default_runner
+
+    def approve(self, preview_id: str, fingerprint: str) -> None:
+        """Approve one exact prepared action from trusted host code.
+
+        Args:
+            preview_id: Identifier returned by ``prepare_create``.
+            fingerprint: SHA-256 fingerprint shown with that preview.
+
+        Raises:
+            ValueError: If the preview is missing, changed, or already attempted.
+        """
+        preview = self._previews.get(preview_id)
+        if preview is None or preview.fingerprint != fingerprint:
+            raise ValueError("Preview ID or fingerprint does not match.")
+        if preview_id in self._attempted:
+            raise ValueError("This preview was already attempted and cannot be reused.")
+        self._approved[preview_id] = datetime.now(UTC)
+
+    def _run(
+        self,
+        operation: Operation,
+        description: str | None = None,
+        deliverables: list[str] | None = None,
+        reward_usdc: Decimal | None = None,
+        duration_hours: int | None = None,
+        tags: list[str] | None = None,
+        task_visibility: TaskVisibility = "public",
+        submission_visibility: SubmissionVisibility = "public",
+        preview_id: str | None = None,
+        task_id: str | None = None,
+    ) -> str:
+        """Run the selected requester operation."""
+        if operation == "prepare_create":
+            return self._prepare_create(
+                description=description,
+                deliverables=deliverables,
+                reward_usdc=reward_usdc,
+                duration_hours=duration_hours,
+                tags=tags,
+                task_visibility=task_visibility,
+                submission_visibility=submission_visibility,
+            )
+        if operation == "create":
+            return self._create(preview_id)
+        if operation == "status":
+            return self._read_task(task_id)
+        return self._read_submissions(task_id)
+
+    def _prepare_create(
+        self,
+        *,
+        description: str | None,
+        deliverables: list[str] | None,
+        reward_usdc: Decimal | None,
+        duration_hours: int | None,
+        tags: list[str] | None,
+        task_visibility: TaskVisibility,
+        submission_visibility: SubmissionVisibility,
+    ) -> str:
+        if not description or not description.strip():
+            raise ValueError("description is required for prepare_create.")
+        if not deliverables or not all(item.strip() for item in deliverables):
+            raise ValueError("At least one non-empty deliverable is required.")
+        if reward_usdc is None or duration_hours is None:
+            raise ValueError("reward_usdc and duration_hours are required.")
+        if len(description) > 8_000:
+            raise ValueError("description must not exceed 8,000 characters.")
+        if len(deliverables) > 30 or any(len(item) > 500 for item in deliverables):
+            raise ValueError("Provide at most 30 deliverables of 500 characters each.")
+        if duration_hours < 1 or duration_hours > 24 * 30:
+            raise ValueError("duration_hours must be between 1 and 720.")
+        if "\x00" in description or any("\x00" in item for item in deliverables):
+            raise ValueError("Description and deliverables cannot contain NUL bytes.")
+        try:
+            supplied_reward = Decimal(reward_usdc)
+        except InvalidOperation as exc:
+            raise ValueError("reward_usdc must be a decimal amount.") from exc
+        if not supplied_reward.is_finite():
+            raise ValueError("reward_usdc must be finite.")
+        try:
+            reward = supplied_reward.quantize(Decimal("0.000001"))
+        except InvalidOperation as exc:
+            raise ValueError("reward_usdc must have at most six decimals.") from exc
+        if reward != supplied_reward:
+            raise ValueError("reward_usdc must have at most six decimals.")
+        if reward <= 0 or reward > self.max_reward_usdc:
+            raise ValueError(
+                f"reward_usdc must be above zero and at most {self.max_reward_usdc}."
+            )
+
+        clean_tags = tuple(
+            dict.fromkeys(tag.strip() for tag in tags or [] if tag.strip())
+        )
+        if len(clean_tags) > 10 or any(len(tag) > 64 for tag in clean_tags):
+            raise ValueError("Provide at most 10 tags of 64 characters each.")
+        if any("," in tag for tag in clean_tags):
+            raise ValueError("Tags cannot contain commas.")
+        if any("\x00" in tag for tag in clean_tags):
+            raise ValueError("Tags cannot contain NUL bytes.")
+        exact_description = (
+            description.strip()
+            + "\n\nDeliverables:\n"
+            + "\n".join(f"- {item.strip()}" for item in deliverables)
+        )
+        prepared_at = datetime.now(UTC)
+        projected_deadline = prepared_at + timedelta(hours=duration_hours)
+        canonical = {
+            "description": exact_description,
+            "duration_hours": duration_hours,
+            "mode": "bounty",
+            "reward_usdc": _format_usdc(reward),
+            "submission_visibility": submission_visibility,
+            "tags": clean_tags,
+            "task_visibility": task_visibility,
+        }
+        fingerprint = hashlib.sha256(
+            json.dumps(canonical, separators=(",", ":"), sort_keys=True).encode()
+        ).hexdigest()
+        preview_id = uuid4().hex
+        preview = _PreparedCreate(
+            preview_id=preview_id,
+            fingerprint=fingerprint,
+            description=exact_description,
+            deliverables=tuple(item.strip() for item in deliverables),
+            reward_usdc=reward,
+            duration_hours=duration_hours,
+            tags=clean_tags,
+            task_visibility=task_visibility,
+            submission_visibility=submission_visibility,
+            prepared_at=prepared_at,
+            projected_deadline=projected_deadline,
+        )
+        self._previews[preview_id] = preview
+        return _json_result(
+            {
+                "approval_expires_seconds": self.approval_ttl_seconds,
+                "approval_required": True,
+                "base_chain_id": BASE_CHAIN_ID,
+                "description": exact_description,
+                "deliverables": preview.deliverables,
+                "deadline_policy": f"{duration_hours} hours after onchain creation",
+                "duration_hours": duration_hours,
+                "fingerprint_sha256": fingerprint,
+                "maximum_spend_usdc": _format_usdc(reward),
+                "network": "Base mainnet",
+                "preview_id": preview_id,
+                "projected_deadline_utc": projected_deadline.isoformat(),
+                "reward_usdc": _format_usdc(reward),
+                "submission_visibility": submission_visibility,
+                "task_visibility": task_visibility,
+                "trusted_host_next_step": (
+                    "Display this exact preview, then call tool.approve(preview_id, "
+                    "fingerprint_sha256) only after fresh user authorization."
+                ),
+            }
+        )
+
+    def _create(self, preview_id: str | None) -> str:
+        if not preview_id or preview_id not in self._previews:
+            raise ValueError("A valid preview_id is required for create.")
+        if preview_id in self._attempted:
+            raise PermissionError(
+                "This preview was already attempted and cannot be retried."
+            )
+        approved_at = self._approved.get(preview_id)
+        if approved_at is None:
+            raise PermissionError(
+                "This exact preview has not been approved by trusted host code."
+            )
+        if datetime.now(UTC) - approved_at > timedelta(
+            seconds=self.approval_ttl_seconds
+        ):
+            self._approved.pop(preview_id, None)
+            raise PermissionError(
+                "Approval expired; display the exact preview and request fresh "
+                "authorization before creating."
+            )
+
+        preview = self._previews[preview_id]
+        preflight = self._preflight(preview.reward_usdc)
+        self._approved.pop(preview_id, None)
+        self._attempted.add(preview_id)
+        try:
+            created = self._cli(preview.cli_args, write=True)
+        except _UnknownSettlementError as exc:
+            return _json_result(
+                {
+                    "created": "unknown",
+                    "error": str(exc),
+                    "preview_id": preview_id,
+                    "retry_allowed": False,
+                    "required_action": (
+                        "Reconcile with Taskmarket inbox and wallet history. Do not retry "
+                        "this preview because settlement may have succeeded."
+                    ),
+                }
+            )
+
+        data = created.get("data", {})
+        task_id = data.get("taskId") or data.get("id")
+        if not isinstance(task_id, str) or not TASK_ID_PATTERN.fullmatch(task_id):
+            return _json_result(
+                {
+                    "created": "unknown",
+                    "preview_id": preview_id,
+                    "raw_result": created,
+                    "retry_allowed": False,
+                    "required_action": "Reconcile with Taskmarket inbox before any new write.",
+                }
+            )
+
+        try:
+            live_status: dict[str, Any] | None = self._cli(["task", "get", task_id])
+        except RuntimeError:
+            live_status = None
+        return _json_result(
+            {
+                "created": True,
+                "maximum_spend_usdc": _format_usdc(preview.reward_usdc),
+                "network": preflight["network"],
+                "preview_id": preview_id,
+                "retry_allowed": False,
+                "task_id": task_id,
+                "task_url": f"https://taskmarket.dev/tasks/{task_id}",
+                "wallet_address": preflight["wallet_address"],
+                "live_status": live_status,
+            }
+        )
+
+    def _preflight(self, reward: Decimal) -> dict[str, str]:
+        address_data = self._cli(["address"]).get("data", {})
+        deposit_data = self._cli(["deposit"]).get("data", {})
+        balance_data = self._cli(["wallet", "balance"]).get("data", {})
+        legal_data = self._cli(["legal", "status"]).get("data", {})
+
+        if deposit_data.get("chainId") != BASE_CHAIN_ID:
+            raise RuntimeError("Taskmarket CLI is not configured for Base mainnet.")
+        contract = str(deposit_data.get("usdcContract", "")).lower()
+        if contract != BASE_USDC:
+            raise RuntimeError(
+                "Taskmarket CLI returned a non-canonical Base USDC contract."
+            )
+        if legal_data.get("enforcementEnabled") and not legal_data.get("accepted"):
+            raise RuntimeError(
+                "The current Taskmarket legal bundle requires acceptance."
+            )
+        try:
+            balance = Decimal(str(balance_data["balanceUsdc"]))
+        except (InvalidOperation, KeyError) as exc:
+            raise RuntimeError(
+                "Taskmarket CLI returned an invalid USDC balance."
+            ) from exc
+        if balance < reward:
+            raise RuntimeError(
+                f"Insufficient Base USDC: need {_format_usdc(reward)}, have {balance}."
+            )
+        wallet_address = address_data.get("address")
+        if not isinstance(wallet_address, str):
+            raise RuntimeError(
+                "Taskmarket CLI did not return the acting wallet address."
+            )
+        return {"network": "Base mainnet", "wallet_address": wallet_address}
+
+    def _read_task(self, task_id: str | None) -> str:
+        exact_id = self._validate_task_id(task_id)
+        return _json_result(
+            {
+                "human_review_required": True,
+                "task": self._cli(["task", "get", exact_id]),
+                "task_url": f"https://taskmarket.dev/tasks/{exact_id}",
+            }
+        )
+
+    def _read_submissions(self, task_id: str | None) -> str:
+        exact_id = self._validate_task_id(task_id)
+        return _json_result(
+            {
+                "accept_or_reject_enabled": False,
+                "human_review_required": True,
+                "submissions": self._cli(["task", "submissions", exact_id]),
+                "task_id": exact_id,
+            }
+        )
+
+    @staticmethod
+    def _validate_task_id(task_id: str | None) -> str:
+        if not task_id or not TASK_ID_PATTERN.fullmatch(task_id):
+            raise ValueError("task_id must be a 0x-prefixed 32-byte hexadecimal value.")
+        return task_id
+
+    def _cli(self, args: list[str], *, write: bool = False) -> dict[str, Any]:
+        try:
+            returncode, stdout, stderr = self._runner(
+                [self.cli_path, *args], self.command_timeout_seconds
+            )
+        except subprocess.TimeoutExpired as exc:
+            if write:
+                raise _UnknownSettlementError(
+                    "The create command timed out without a trustworthy settlement result."
+                ) from exc
+            raise RuntimeError("Taskmarket CLI read timed out.") from exc
+
+        result = self._parse_envelope(stdout, stderr)
+        if returncode != 0 or result.get("ok") is not True:
+            message = result.get("error", "Taskmarket CLI command failed.")
+            if write:
+                raise _UnknownSettlementError(str(message))
+            raise RuntimeError(str(message))
+        return result
+
+    @staticmethod
+    def _parse_envelope(stdout: str, stderr: str) -> dict[str, Any]:
+        for stream in (stdout, stderr):
+            for line in reversed(stream.splitlines()):
+                try:
+                    parsed = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict) and "ok" in parsed:
+                    return parsed
+        return {"ok": False, "error": "Taskmarket CLI returned no JSON envelope."}
+
+    @staticmethod
+    def _default_runner(args: Sequence[str], timeout: float) -> tuple[int, str, str]:
+        executable = shutil.which(args[0])
+        if executable is None:
+            raise RuntimeError("First-party taskmarket CLI is not installed.")
+        # Arguments remain an array and the executable is resolved explicitly; no shell.
+        completed = subprocess.run(  # noqa: S603  # nosec B603
+            [executable, *args[1:]],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout,
+        )
+        return completed.returncode, completed.stdout, completed.stderr

--- a/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool/taskmarket_requester_tool.py
@@ -13,6 +13,7 @@ import shutil
 
 # Required for the fixed first-party CLI and always invoked without a shell.
 import subprocess  # nosec B404
+from threading import Lock
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -171,6 +172,7 @@ class TaskMarketRequesterTool(BaseTool):
     _previews: dict[str, _PreparedCreate] = PrivateAttr(default_factory=dict)
     _approved: dict[str, datetime] = PrivateAttr(default_factory=dict)
     _attempted: set[str] = PrivateAttr(default_factory=set)
+    _lock: Any = PrivateAttr(default_factory=Lock)
 
     def __init__(
         self,
@@ -197,12 +199,15 @@ class TaskMarketRequesterTool(BaseTool):
         Raises:
             ValueError: If the preview is missing, changed, or already attempted.
         """
-        preview = self._previews.get(preview_id)
-        if preview is None or preview.fingerprint != fingerprint:
-            raise ValueError("Preview ID or fingerprint does not match.")
-        if preview_id in self._attempted:
-            raise ValueError("This preview was already attempted and cannot be reused.")
-        self._approved[preview_id] = datetime.now(UTC)
+        with self._lock:
+            preview = self._previews.get(preview_id)
+            if preview is None or preview.fingerprint != fingerprint:
+                raise ValueError("Preview ID or fingerprint does not match.")
+            if preview_id in self._attempted:
+                raise ValueError(
+                    "This preview was already attempted and cannot be reused."
+                )
+            self._approved[preview_id] = datetime.now(UTC)
 
     def _run(
         self,
@@ -232,7 +237,9 @@ class TaskMarketRequesterTool(BaseTool):
             return self._create(preview_id)
         if operation == "status":
             return self._read_task(task_id)
-        return self._read_submissions(task_id)
+        if operation == "submissions":
+            return self._read_submissions(task_id)
+        raise ValueError(f"Unsupported operation: {operation}")
 
     def _prepare_create(
         self,
@@ -344,30 +351,31 @@ class TaskMarketRequesterTool(BaseTool):
         )
 
     def _create(self, preview_id: str | None) -> str:
-        if not preview_id or preview_id not in self._previews:
-            raise ValueError("A valid preview_id is required for create.")
-        if preview_id in self._attempted:
-            raise PermissionError(
-                "This preview was already attempted and cannot be retried."
-            )
-        approved_at = self._approved.get(preview_id)
-        if approved_at is None:
-            raise PermissionError(
-                "This exact preview has not been approved by trusted host code."
-            )
-        if datetime.now(UTC) - approved_at > timedelta(
-            seconds=self.approval_ttl_seconds
-        ):
+        with self._lock:
+            if not preview_id or preview_id not in self._previews:
+                raise ValueError("A valid preview_id is required for create.")
+            if preview_id in self._attempted:
+                raise PermissionError(
+                    "This preview was already attempted and cannot be retried."
+                )
+            approved_at = self._approved.get(preview_id)
+            if approved_at is None:
+                raise PermissionError(
+                    "This exact preview has not been approved by trusted host code."
+                )
+            if datetime.now(UTC) - approved_at > timedelta(
+                seconds=self.approval_ttl_seconds
+            ):
+                self._approved.pop(preview_id, None)
+                raise PermissionError(
+                    "Approval expired; display the exact preview and request fresh "
+                    "authorization before creating."
+                )
+            preview = self._previews[preview_id]
             self._approved.pop(preview_id, None)
-            raise PermissionError(
-                "Approval expired; display the exact preview and request fresh "
-                "authorization before creating."
-            )
+            self._attempted.add(preview_id)
 
-        preview = self._previews[preview_id]
         preflight = self._preflight(preview.reward_usdc)
-        self._approved.pop(preview_id, None)
-        self._attempted.add(preview_id)
         try:
             created = self._cli(preview.cli_args, write=True)
         except _UnknownSettlementError as exc:
@@ -428,7 +436,12 @@ class TaskMarketRequesterTool(BaseTool):
             raise RuntimeError(
                 "Taskmarket CLI returned a non-canonical Base USDC contract."
             )
-        if legal_data.get("enforcementEnabled") and not legal_data.get("accepted"):
+        enforcement_enabled = legal_data.get("enforcementEnabled")
+        if not isinstance(enforcement_enabled, bool):
+            raise RuntimeError(
+                "Taskmarket CLI did not report the legal enforcement state."
+            )
+        if enforcement_enabled and not legal_data.get("accepted"):
             raise RuntimeError(
                 "The current Taskmarket legal bundle requires acceptance."
             )
@@ -494,6 +507,11 @@ class TaskMarketRequesterTool(BaseTool):
             if write:
                 raise _UnknownSettlementError(str(message))
             raise RuntimeError(str(message))
+        if not isinstance(result.get("data", {}), dict):
+            message = "Taskmarket CLI returned a malformed data payload."
+            if write:
+                raise _UnknownSettlementError(message)
+            raise RuntimeError(message)
         return result
 
     @staticmethod

--- a/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
+++ b/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
@@ -297,9 +297,11 @@ def test_concurrent_create_calls_cannot_duplicate_spend(
         first = executor.submit(tool._run, operation="create", preview_id=preview_id)
         assert runner.address_started.wait(timeout=5)
         second = executor.submit(tool._run, operation="create", preview_id=preview_id)
-        with pytest.raises(PermissionError, match="already attempted"):
-            second.result(timeout=5)
-        runner.release_address.set()
+        try:
+            with pytest.raises(PermissionError, match="already attempted"):
+                second.result(timeout=5)
+        finally:
+            runner.release_address.set()
         created = json.loads(first.result(timeout=5))
 
     assert created["created"] is True

--- a/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
+++ b/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
@@ -1,0 +1,367 @@
+from collections.abc import Sequence
+from datetime import timedelta
+from decimal import Decimal
+import json
+import subprocess
+
+from crewai_tools import TaskMarketRequesterTool
+from crewai_tools.tools.taskmarket_requester_tool import TaskMarketRequesterSchema
+from pydantic import ValidationError
+import pytest
+
+
+TASK_ID = "0x" + "a" * 64
+WALLET = "0x1111111111111111111111111111111111111111"
+BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+class RecordedRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.overrides: dict[tuple[str, ...], dict[str, object]] = {}
+        self.create_exception: Exception | None = None
+        self.create_result: dict[str, object] = {
+            "ok": True,
+            "data": {"taskId": TASK_ID},
+        }
+
+    def __call__(
+        self, args: Sequence[str], timeout: float
+    ) -> tuple[int, str, str]:
+        assert timeout == 45
+        command = tuple(args[1:])
+        self.calls.append(command)
+        if command[:2] == ("task", "create"):
+            if self.create_exception is not None:
+                raise self.create_exception
+            payload = self.create_result
+        else:
+            payload = self.overrides.get(command, self._default(command))
+        return (0 if payload.get("ok") is True else 1, json.dumps(payload), "")
+
+    @staticmethod
+    def _default(command: tuple[str, ...]) -> dict[str, object]:
+        responses: dict[tuple[str, ...], dict[str, object]] = {
+            ("address",): {"ok": True, "data": {"address": WALLET}},
+            ("deposit",): {
+                "ok": True,
+                "data": {"chainId": 8453, "usdcContract": BASE_USDC},
+            },
+            ("wallet", "balance"): {
+                "ok": True,
+                "data": {"balanceUsdc": "10.000000"},
+            },
+            ("legal", "status"): {
+                "ok": True,
+                "data": {"enforcementEnabled": False, "accepted": False},
+            },
+            ("task", "get", TASK_ID): {
+                "ok": True,
+                "data": {"id": TASK_ID, "status": "open"},
+            },
+            ("task", "submissions", TASK_ID): {
+                "ok": True,
+                "data": {"submissions": []},
+            },
+        }
+        if command not in responses:
+            raise AssertionError(f"Unexpected Taskmarket command: {command}")
+        return responses[command]
+
+
+@pytest.fixture
+def runner() -> RecordedRunner:
+    return RecordedRunner()
+
+
+@pytest.fixture
+def tool(runner: RecordedRunner) -> TaskMarketRequesterTool:
+    return TaskMarketRequesterTool(
+        runner=runner,
+        max_reward_usdc=Decimal("5"),
+    )
+
+
+def prepare(tool: TaskMarketRequesterTool, **overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "operation": "prepare_create",
+        "description": "Audit the release candidate.",
+        "deliverables": ["Written report", "Reproduction steps"],
+        "reward_usdc": Decimal("1.25"),
+        "duration_hours": 24,
+        "tags": ["audit", "python"],
+        "task_visibility": "public",
+        "submission_visibility": "winner_only",
+    }
+    inputs.update(overrides)
+    return json.loads(tool._run(**inputs))
+
+
+def approve_prepared(tool: TaskMarketRequesterTool) -> dict[str, object]:
+    preview = prepare(tool)
+    tool.approve(
+        str(preview["preview_id"]),
+        str(preview["fingerprint_sha256"]),
+    )
+    return preview
+
+
+def test_prepare_shows_exact_action_without_calling_cli(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    preview = prepare(tool)
+
+    assert preview["approval_required"] is True
+    assert preview["approval_expires_seconds"] == 300
+    assert preview["description"] == (
+        "Audit the release candidate.\n\nDeliverables:\n"
+        "- Written report\n- Reproduction steps"
+    )
+    assert preview["deliverables"] == ["Written report", "Reproduction steps"]
+    assert preview["reward_usdc"] == "1.250000"
+    assert preview["maximum_spend_usdc"] == "1.250000"
+    assert preview["duration_hours"] == 24
+    assert preview["deadline_policy"] == "24 hours after onchain creation"
+    assert preview["network"] == "Base mainnet"
+    assert preview["base_chain_id"] == 8453
+    assert preview["task_visibility"] == "public"
+    assert preview["submission_visibility"] == "winner_only"
+    assert str(preview["projected_deadline_utc"]).endswith("+00:00")
+    assert len(str(preview["fingerprint_sha256"])) == 64
+    assert runner.calls == []
+
+
+def test_public_tool_entrypoint_validates_and_prepares(
+    tool: TaskMarketRequesterTool,
+) -> None:
+    preview = json.loads(
+        tool.run(
+            operation="prepare_create",
+            description="Audit the release candidate.",
+            deliverables=["Written report"],
+            reward_usdc=Decimal("1.25"),
+            duration_hours=24,
+        )
+    )
+
+    assert preview["approval_required"] is True
+    assert preview["reward_usdc"] == "1.250000"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"description": "  "}, "description is required"),
+        ({"deliverables": []}, "At least one non-empty deliverable"),
+        ({"reward_usdc": Decimal("5.000001")}, "at most 5"),
+        ({"reward_usdc": Decimal("1.0000001")}, "at most six decimals"),
+        ({"reward_usdc": Decimal("Infinity")}, "must be finite"),
+        ({"duration_hours": 0}, "between 1 and 720"),
+        ({"duration_hours": 721}, "between 1 and 720"),
+        ({"description": "x" * 8_001}, "must not exceed 8,000"),
+        ({"deliverables": ["x" * 501]}, "at most 30 deliverables"),
+        ({"tags": ["safe,unsafe"]}, "Tags cannot contain commas"),
+        ({"tags": [str(index) for index in range(11)]}, "at most 10 tags"),
+        ({"tags": ["unsafe\x00tag"]}, "Tags cannot contain NUL"),
+    ],
+)
+def test_prepare_rejects_unsafe_or_ambiguous_inputs(
+    tool: TaskMarketRequesterTool,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        prepare(tool, **overrides)
+
+
+def test_create_requires_fresh_exact_host_approval(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    preview = prepare(tool)
+    preview_id = str(preview["preview_id"])
+
+    with pytest.raises(PermissionError, match="not been approved"):
+        tool._run(operation="create", preview_id=preview_id)
+    with pytest.raises(ValueError, match="does not match"):
+        tool.approve(preview_id, "0" * 64)
+
+    assert runner.calls == []
+
+
+def test_expired_approval_requires_fresh_authorization(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    preview = approve_prepared(tool)
+    preview_id = str(preview["preview_id"])
+    tool._approved[preview_id] -= timedelta(seconds=tool.approval_ttl_seconds + 1)
+
+    with pytest.raises(PermissionError, match="Approval expired"):
+        tool._run(operation="create", preview_id=preview_id)
+
+    assert runner.calls == []
+
+
+def test_approved_create_runs_preflight_and_returns_live_status(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    preview = approve_prepared(tool)
+
+    created = json.loads(
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
+    )
+
+    assert created["created"] is True
+    assert created["task_id"] == TASK_ID
+    assert created["task_url"] == f"https://taskmarket.dev/tasks/{TASK_ID}"
+    assert created["wallet_address"] == WALLET
+    assert created["maximum_spend_usdc"] == "1.250000"
+    assert created["live_status"]["data"]["status"] == "open"
+    assert runner.calls[:4] == [
+        ("address",),
+        ("deposit",),
+        ("wallet", "balance"),
+        ("legal", "status"),
+    ]
+    assert runner.calls[4] == (
+        "task",
+        "create",
+        "--description",
+        "Audit the release candidate.\n\nDeliverables:\n"
+        "- Written report\n- Reproduction steps",
+        "--reward",
+        "1.250000",
+        "--duration",
+        "24",
+        "--mode",
+        "bounty",
+        "--task-visibility",
+        "public",
+        "--submission-visibility",
+        "winner_only",
+        "--tags",
+        "audit,python",
+    )
+    assert runner.calls[5] == ("task", "get", TASK_ID)
+
+    with pytest.raises(PermissionError, match="already attempted"):
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
+
+
+@pytest.mark.parametrize(
+    ("command", "payload", "message"),
+    [
+        (
+            ("deposit",),
+            {"ok": True, "data": {"chainId": 1, "usdcContract": BASE_USDC}},
+            "not configured for Base",
+        ),
+        (
+            ("deposit",),
+            {"ok": True, "data": {"chainId": 8453, "usdcContract": "0xbad"}},
+            "non-canonical Base USDC",
+        ),
+        (
+            ("legal", "status"),
+            {"ok": True, "data": {"enforcementEnabled": True, "accepted": False}},
+            "requires acceptance",
+        ),
+        (
+            ("wallet", "balance"),
+            {"ok": True, "data": {"balanceUsdc": "0.10"}},
+            "Insufficient Base USDC",
+        ),
+    ],
+)
+def test_preflight_blocks_write_when_safety_check_fails(
+    tool: TaskMarketRequesterTool,
+    runner: RecordedRunner,
+    command: tuple[str, ...],
+    payload: dict[str, object],
+    message: str,
+) -> None:
+    runner.overrides[command] = payload
+    preview = approve_prepared(tool)
+
+    with pytest.raises(RuntimeError, match=message):
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
+
+    assert not any(call[:2] == ("task", "create") for call in runner.calls)
+
+
+def test_timed_out_write_is_unknown_and_cannot_be_retried(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    runner.create_exception = subprocess.TimeoutExpired("taskmarket", 45)
+    preview = approve_prepared(tool)
+    preview_id = str(preview["preview_id"])
+
+    result = json.loads(tool._run(operation="create", preview_id=preview_id))
+
+    assert result["created"] == "unknown"
+    assert result["retry_allowed"] is False
+    assert "Reconcile" in result["required_action"]
+    assert sum(call[:2] == ("task", "create") for call in runner.calls) == 1
+    with pytest.raises(PermissionError, match="already attempted"):
+        tool._run(operation="create", preview_id=preview_id)
+    assert sum(call[:2] == ("task", "create") for call in runner.calls) == 1
+
+
+def test_malformed_create_success_is_unknown_and_not_retriable(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    runner.create_result = {"ok": True, "data": {"taskId": "not-a-task-id"}}
+    preview = approve_prepared(tool)
+
+    result = json.loads(
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
+    )
+
+    assert result["created"] == "unknown"
+    assert result["retry_allowed"] is False
+    assert result["raw_result"] == runner.create_result
+
+
+def test_status_and_submissions_are_read_only_human_review_operations(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    status = json.loads(tool._run(operation="status", task_id=TASK_ID))
+    submissions = json.loads(tool._run(operation="submissions", task_id=TASK_ID))
+
+    assert status["human_review_required"] is True
+    assert submissions["human_review_required"] is True
+    assert submissions["accept_or_reject_enabled"] is False
+    assert runner.calls == [
+        ("task", "get", TASK_ID),
+        ("task", "submissions", TASK_ID),
+    ]
+    assert all("accept" not in call and "reject" not in call for call in runner.calls)
+
+
+def test_invalid_task_id_never_reaches_cli(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    with pytest.raises(ValueError, match="32-byte hexadecimal"):
+        tool._run(operation="status", task_id="0x123")
+    assert runner.calls == []
+
+
+def test_schema_rejects_unknown_operation() -> None:
+    with pytest.raises(ValidationError):
+        TaskMarketRequesterSchema(operation="accept")
+
+
+def test_parse_envelope_uses_last_json_line() -> None:
+    parsed = TaskMarketRequesterTool._parse_envelope(
+        'update available\n{"ok": true, "data": {"status": "open"}}\n',
+        "",
+    )
+
+    assert parsed == {"ok": True, "data": {"status": "open"}}
+
+
+def test_exported_from_package() -> None:
+    from crewai_tools import TaskMarketRequesterTool as ExportedTool
+    from crewai_tools.tools import TaskMarketRequesterTool as ToolsExportedTool
+
+    assert ExportedTool is TaskMarketRequesterTool
+    assert ToolsExportedTool is TaskMarketRequesterTool

--- a/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
+++ b/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
@@ -1,8 +1,10 @@
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from decimal import Decimal
 import json
 import subprocess
+from threading import Event
 
 from crewai_tools import TaskMarketRequesterTool
 from crewai_tools.tools.taskmarket_requester_tool import TaskMarketRequesterSchema
@@ -20,6 +22,8 @@ class RecordedRunner:
         self.calls: list[tuple[str, ...]] = []
         self.overrides: dict[tuple[str, ...], dict[str, object]] = {}
         self.create_exception: Exception | None = None
+        self.address_started: Event | None = None
+        self.release_address: Event | None = None
         self.create_result: dict[str, object] = {
             "ok": True,
             "data": {"taskId": TASK_ID},
@@ -31,6 +35,10 @@ class RecordedRunner:
         assert timeout == 45
         command = tuple(args[1:])
         self.calls.append(command)
+        if command == ("address",) and self.address_started is not None:
+            self.address_started.set()
+            assert self.release_address is not None
+            assert self.release_address.wait(timeout=5)
         if command[:2] == ("task", "create"):
             if self.create_exception is not None:
                 raise self.create_exception
@@ -94,7 +102,7 @@ def prepare(tool: TaskMarketRequesterTool, **overrides: object) -> dict[str, obj
         "submission_visibility": "winner_only",
     }
     inputs.update(overrides)
-    return json.loads(tool._run(**inputs))
+    return json.loads(tool.run(**inputs))
 
 
 def approve_prepared(tool: TaskMarketRequesterTool) -> dict[str, object]:
@@ -155,11 +163,10 @@ def test_public_tool_entrypoint_validates_and_prepares(
         ({"deliverables": []}, "At least one non-empty deliverable"),
         ({"reward_usdc": Decimal("5.000001")}, "at most 5"),
         ({"reward_usdc": Decimal("1.0000001")}, "at most six decimals"),
-        ({"reward_usdc": Decimal("Infinity")}, "must be finite"),
-        ({"duration_hours": 0}, "between 1 and 720"),
-        ({"duration_hours": 721}, "between 1 and 720"),
         ({"description": "x" * 8_001}, "must not exceed 8,000"),
+        ({"description": "unsafe\x00description"}, "cannot contain NUL"),
         ({"deliverables": ["x" * 501]}, "at most 30 deliverables"),
+        ({"deliverables": ["unsafe\x00deliverable"]}, "cannot contain NUL"),
         ({"tags": ["safe,unsafe"]}, "Tags cannot contain commas"),
         ({"tags": [str(index) for index in range(11)]}, "at most 10 tags"),
         ({"tags": ["unsafe\x00tag"]}, "Tags cannot contain NUL"),
@@ -172,6 +179,32 @@ def test_prepare_rejects_unsafe_or_ambiguous_inputs(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         prepare(tool, **overrides)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"reward_usdc": Decimal("Infinity")}, "must be finite"),
+        ({"duration_hours": 0}, "between 1 and 720"),
+        ({"duration_hours": 721}, "between 1 and 720"),
+    ],
+)
+def test_direct_run_repeats_guards_enforced_by_schema(
+    tool: TaskMarketRequesterTool,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    inputs: dict[str, object] = {
+        "operation": "prepare_create",
+        "description": "Audit the release candidate.",
+        "deliverables": ["Written report"],
+        "reward_usdc": Decimal("1.25"),
+        "duration_hours": 24,
+    }
+    inputs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tool._run(**inputs)
 
 
 def test_create_requires_fresh_exact_host_approval(
@@ -245,6 +278,32 @@ def test_approved_create_runs_preflight_and_returns_live_status(
 
     with pytest.raises(PermissionError, match="already attempted"):
         tool._run(operation="create", preview_id=str(preview["preview_id"]))
+    with pytest.raises(ValueError, match="already attempted"):
+        tool.approve(
+            str(preview["preview_id"]),
+            str(preview["fingerprint_sha256"]),
+        )
+
+
+def test_concurrent_create_calls_cannot_duplicate_spend(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    runner.address_started = Event()
+    runner.release_address = Event()
+    preview = approve_prepared(tool)
+    preview_id = str(preview["preview_id"])
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(tool._run, operation="create", preview_id=preview_id)
+        assert runner.address_started.wait(timeout=5)
+        second = executor.submit(tool._run, operation="create", preview_id=preview_id)
+        with pytest.raises(PermissionError, match="already attempted"):
+            second.result(timeout=5)
+        runner.release_address.set()
+        created = json.loads(first.result(timeout=5))
+
+    assert created["created"] is True
+    assert sum(call[:2] == ("task", "create") for call in runner.calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -264,6 +323,16 @@ def test_approved_create_runs_preflight_and_returns_live_status(
             ("legal", "status"),
             {"ok": True, "data": {"enforcementEnabled": True, "accepted": False}},
             "requires acceptance",
+        ),
+        (
+            ("legal", "status"),
+            {"ok": True, "data": {}},
+            "did not report the legal enforcement state",
+        ),
+        (
+            ("address",),
+            {"ok": True, "data": {}},
+            "did not return the acting wallet address",
         ),
         (
             ("wallet", "balance"),
@@ -286,6 +355,8 @@ def test_preflight_blocks_write_when_safety_check_fails(
         tool._run(operation="create", preview_id=str(preview["preview_id"]))
 
     assert not any(call[:2] == ("task", "create") for call in runner.calls)
+    with pytest.raises(PermissionError, match="already attempted"):
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
 
 
 def test_timed_out_write_is_unknown_and_cannot_be_retried(
@@ -321,6 +392,24 @@ def test_malformed_create_success_is_unknown_and_not_retriable(
     assert result["raw_result"] == runner.create_result
 
 
+def test_malformed_cli_data_fails_clearly_for_reads_and_writes(
+    tool: TaskMarketRequesterTool, runner: RecordedRunner
+) -> None:
+    runner.overrides[("task", "get", TASK_ID)] = {"ok": True, "data": None}
+    with pytest.raises(RuntimeError, match="malformed data payload"):
+        tool._run(operation="status", task_id=TASK_ID)
+
+    runner.create_result = {"ok": True, "data": None}
+    preview = approve_prepared(tool)
+    result = json.loads(
+        tool._run(operation="create", preview_id=str(preview["preview_id"]))
+    )
+
+    assert result["created"] == "unknown"
+    assert result["retry_allowed"] is False
+    assert "malformed data payload" in result["error"]
+
+
 def test_status_and_submissions_are_read_only_human_review_operations(
     tool: TaskMarketRequesterTool, runner: RecordedRunner
 ) -> None:
@@ -348,6 +437,11 @@ def test_invalid_task_id_never_reaches_cli(
 def test_schema_rejects_unknown_operation() -> None:
     with pytest.raises(ValidationError):
         TaskMarketRequesterSchema(operation="accept")
+
+
+def test_direct_run_rejects_unknown_operation() -> None:
+    with pytest.raises(ValueError, match="Unsupported operation"):
+        TaskMarketRequesterTool()._run(operation="accept")
 
 
 def test_parse_envelope_uses_last_json_line() -> None:

--- a/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
+++ b/lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py
@@ -332,14 +332,29 @@ def test_concurrent_create_calls_cannot_duplicate_spend(
             "did not report the legal enforcement state",
         ),
         (
+            ("legal", "status"),
+            {"ok": True, "data": {"enforcementEnabled": True, "accepted": "false"}},
+            "requires acceptance",
+        ),
+        (
             ("address",),
             {"ok": True, "data": {}},
+            "did not return the acting wallet address",
+        ),
+        (
+            ("address",),
+            {"ok": True, "data": {"address": "   "}},
             "did not return the acting wallet address",
         ),
         (
             ("wallet", "balance"),
             {"ok": True, "data": {"balanceUsdc": "0.10"}},
             "Insufficient Base USDC",
+        ),
+        (
+            ("wallet", "balance"),
+            {"ok": True, "data": {"balanceUsdc": "Infinity"}},
+            "non-finite USDC balance",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- add `TaskMarketRequesterTool` for preparing, creating, and monitoring Taskmarket bounties through the first-party CLI
- keep spending approval outside the model-facing tool schema: trusted host code approves an exact SHA-256-bound preview, and that approval expires after five minutes
- preflight the acting wallet, available balance, Base chain ID, canonical Base USDC contract, legal enforcement, and configured reward cap immediately before creation
- consume authorization before the write and permanently block blind retries when settlement is unknown
- return the created task ID, link, acting wallet, maximum spend, and live status; submission reads are explicitly human-review-only and expose no accept/reject operation

## Why a separate requester tool

Open PR #6992 combines discovery and creation, but its create authorization is a confirmation phrase inside the model-facing schema. This PR narrows the integration to requester workflows and strengthens that boundary with an out-of-band host approval API, a short approval TTL, exact preview fingerprinting, live network/balance/legal preflights, and single-attempt settlement semantics. It does not duplicate the public HTTP discovery tools proposed in #6873 and #6874.

## Safety

- no wallet keys, seed phrases, tokens, or payment credentials enter the tool
- only the fixed first-party `taskmarket` executable is invoked, using an argument array and no shell
- task descriptions and deliverables are bounded and validated
- USDC values are finite, capped, and limited to six decimals
- malformed, failed, or timed-out create results are treated as unknown settlement and cannot be retried with the same authorization
- models can inspect submissions but cannot accept, reject, rate, or select winners

## Validation

```text
uv run pytest lib/crewai-tools/tests/tools/taskmarket_requester_tool_test.py -q
35 passed

uv run ruff check <changed Python paths>
All checks passed!

uv run ruff format --check <changed Python paths>
4 files already formatted

uv run mypy lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool
Success: no issues found in 2 source files

uv run bandit -q -r lib/crewai-tools/src/crewai_tools/tools/taskmarket_requester_tool
No issues identified
```

A live read-only smoke test through the default runner retrieved an open Taskmarket task and returned `human_review_required: true`, its canonical link, and `status: open`. CodeRabbit's first review identified three safety issues; commit `97a1126579dac4e6afb31c39f5c1ffa404f4a847` fixes all of them and adds a deterministic concurrent-create regression test. Follow-up commit `8201cebbd7bae0479464662f114fb9e039fb8f35` guarantees the race harness releases its blocked worker even if an assertion fails. No USDC was spent during validation.

Taskmarket integration bounty: `0xfb182f610d57a6c056a8cfd1c9b691a0869c1e0d67c041ac27ed9f42a9c732a1`.

## AI disclosure

This contribution was authored with Codex assistance. Please apply the required `llm-generated` label; GitHub does not grant fork contributors permission to label upstream PRs.


<!-- crewai-require-issue-check -->