### PR TITLE
fix: correct log level and remove redundant warning prefixes

### DIFF
--- a/lib/crewai/src/crewai/events/listeners/tracing/trace_batch_manager.py
+++ b/lib/crewai/src/crewai/events/listeners/tracing/trace_batch_manager.py
@@ -437,7 +437,7 @@ class TraceBatchManager:
                 self.batch_sequence = 0
 
         except Exception as e:
-            logger.error(f"Warning: Error during cleanup: {e}")
+            logger.warning(f"Error during cleanup: {e}")
 
     def has_events(self) -> bool:
         """Check if there are events in the buffer"""

--- a/lib/crewai/src/crewai/experimental/evaluation/testing.py
+++ b/lib/crewai/src/crewai/experimental/evaluation/testing.py
@@ -47,7 +47,7 @@ def assert_experiment_no_regression(comparison_result: dict[str, list[str]]) -> 
     missing_tests = comparison_result.get("missing_tests", [])
     if missing_tests:
         warnings.warn(
-            f"Warning: {len(missing_tests)} tests from the baseline are missing in the current run: {missing_tests}",
+            f"{len(missing_tests)} tests from the baseline are missing in the current run: {missing_tests}",
             UserWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
This PR addresses: correct log level and remove redundant warning prefixes