### PR TITLE
fix(llms): warn on token-cap truncation for every provider

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2172,6 +2172,8 @@ class LLM(BaseLLM):
                 OTel GenAI enum.
             response_id: Raw provider response identifier. Optional.
         """
+        self._warn_if_truncated(finish_reason)
+
         crewai_event_bus.emit(
             self,
             event=LLMCallCompletedEvent(

--- a/lib/crewai/src/crewai/llms/_finish_reason_utils.py
+++ b/lib/crewai/src/crewai/llms/_finish_reason_utils.py
@@ -7,11 +7,36 @@ module centralises that introspection so every provider doesn't reinvent the
 defensive walk. Providers with genuinely different shapes — Anthropic
 (``stop_reason``), Bedrock (``stopReason``), Gemini (protobuf enum), OpenAI
 Responses (``status``) — keep their own helpers.
+
+It also owns :func:`is_truncation_finish_reason`, the single place that knows
+which of those provider-specific values mean "cut off by the token cap".
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
+
+
+TRUNCATION_FINISH_REASONS: Final[frozenset[str]] = frozenset(
+    {
+        "length",  # OpenAI Chat Completions, Azure, LiteLLM, openai_compatible
+        "max_tokens",  # Anthropic, Bedrock, and Gemini's MAX_TOKENS
+        "max_output_tokens",  # OpenAI Responses incomplete_details.reason
+        "max_completion_tokens",
+    }
+)
+
+
+def is_truncation_finish_reason(finish_reason: str | None) -> bool:
+    """Whether a raw provider finish reason means the token cap cut the response off.
+
+    The vocabulary differs per provider (``length``, ``max_tokens``,
+    ``MAX_TOKENS``), so comparison is case-insensitive and lives here rather
+    than being repeated at every call site.
+    """
+    if not isinstance(finish_reason, str):
+        return False
+    return finish_reason.lower() in TRUNCATION_FINISH_REASONS
 
 
 def _as_str(value: Any) -> str | None:

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -42,6 +42,7 @@ from crewai.events.types.tool_usage_events import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
+from crewai.llms._finish_reason_utils import is_truncation_finish_reason
 from crewai.types.streaming import StreamSession
 from crewai.types.usage_metrics import UsageMetrics
 from crewai.utilities.pydantic_schema_utils import serialize_model_class
@@ -549,6 +550,24 @@ class BaseLLM(BaseModel, ABC):
         """
         return self.max_tokens
 
+    def _warn_if_truncated(self, finish_reason: str | None) -> None:
+        """Warn when the provider stopped generating because of the token cap.
+
+        A truncated response is otherwise indistinguishable from a complete one
+        downstream: the partial text (sometimes an empty string, for reasoning
+        models that spend the whole budget thinking) is returned as a
+        successful result. Retrying does not help, since the same cap truncates
+        at the same place, so the message names the cap that needs raising.
+        """
+        if not is_truncation_finish_reason(finish_reason):
+            return
+        logging.warning(
+            "Response truncated by the token cap (finish_reason=%r). "
+            "Consider increasing max_tokens (current: %s).",
+            finish_reason,
+            self._effective_max_tokens(),
+        )
+
     def _emit_call_started_event(
         self,
         messages: str | list[LLMMessage],
@@ -625,6 +644,8 @@ class BaseLLM(BaseModel, ABC):
     ) -> None:
         """Emit LLM call completed event."""
         from crewai.utilities.serialization import to_serializable
+
+        self._warn_if_truncated(finish_reason)
 
         crewai_event_bus.emit(
             self,

--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -680,9 +680,7 @@ class BedrockCompletion(BaseLLM):
             stop_reason, response_id = self._extract_finish_reason_and_id(response)
             if stop_reason:
                 logging.debug(f"Response stop reason: {stop_reason}")
-                if stop_reason == "max_tokens":
-                    logging.warning("Response truncated due to max_tokens limit")
-                elif stop_reason == "content_filtered":
+                if stop_reason == "content_filtered":
                     logging.warning("Response was filtered due to content policy")
 
             # Extract content following AWS response structure
@@ -1118,11 +1116,7 @@ class BedrockCompletion(BaseLLM):
                         stop_reason = event["messageStop"].get("stopReason")
                         stream_finish_reason = stop_reason
                         logging.debug(f"Streaming message stopped: {stop_reason}")
-                        if stop_reason == "max_tokens":
-                            logging.warning(
-                                "Streaming response truncated due to max_tokens"
-                            )
-                        elif stop_reason == "content_filtered":
+                        if stop_reason == "content_filtered":
                             logging.warning(
                                 "Streaming response filtered due to content policy"
                             )
@@ -1282,9 +1276,7 @@ class BedrockCompletion(BaseLLM):
             stop_reason, response_id = self._extract_finish_reason_and_id(response)
             if stop_reason:
                 logging.debug(f"Response stop reason: {stop_reason}")
-                if stop_reason == "max_tokens":
-                    logging.warning("Response truncated due to max_tokens limit")
-                elif stop_reason == "content_filtered":
+                if stop_reason == "content_filtered":
                     logging.warning("Response was filtered due to content policy")
 
             output = response.get("output", {})
@@ -1720,11 +1712,7 @@ class BedrockCompletion(BaseLLM):
                         stop_reason = event["messageStop"].get("stopReason")
                         stream_finish_reason = stop_reason
                         logging.debug(f"Streaming message stopped: {stop_reason}")
-                        if stop_reason == "max_tokens":
-                            logging.warning(
-                                "Streaming response truncated due to max_tokens"
-                            )
-                        elif stop_reason == "content_filtered":
+                        if stop_reason == "content_filtered":
                             logging.warning(
                                 "Streaming response filtered due to content policy"
                             )

--- a/lib/crewai/tests/llms/test_truncation_warning.py
+++ b/lib/crewai/tests/llms/test_truncation_warning.py
@@ -1,0 +1,265 @@
+"""A response cut off by the token cap is otherwise indistinguishable from a
+complete one: the partial text is returned as a successful result. Only the
+Bedrock provider used to warn about it, so these tests pin the warning down at
+the shared emission point every provider funnels through.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crewai.events.types.llm_events import LLMCallType
+from crewai.llm import LLM
+from crewai.llms._finish_reason_utils import is_truncation_finish_reason
+from crewai.llms.base_llm import BaseLLM
+
+
+class _StubLLM(BaseLLM):
+    model: str = "test-model"
+
+    def call(self, *args: Any, **kwargs: Any) -> str:
+        return ""
+
+    async def acall(self, *args: Any, **kwargs: Any) -> str:
+        return ""
+
+    def supports_function_calling(self) -> bool:
+        return False
+
+
+def _truncation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and "truncated" in record.getMessage()
+    ]
+
+
+class TestIsTruncationFinishReason:
+    @pytest.mark.parametrize(
+        "finish_reason",
+        [
+            "length",  # OpenAI, Azure, LiteLLM, openai_compatible, Snowflake
+            "max_tokens",  # Anthropic, Bedrock
+            "MAX_TOKENS",  # Gemini
+            "max_output_tokens",
+            "max_completion_tokens",
+            "Length",
+        ],
+    )
+    def test_recognises_provider_truncation_vocabulary(self, finish_reason: str) -> None:
+        assert is_truncation_finish_reason(finish_reason)
+
+    @pytest.mark.parametrize(
+        "finish_reason",
+        [
+            "stop",
+            "end_turn",
+            "STOP",
+            "tool_calls",
+            "tool_use",
+            "content_filter",
+            "content_filtered",
+            "completed",
+            "",
+            None,
+            42,
+            MagicMock(),
+        ],
+    )
+    def test_ignores_everything_else(self, finish_reason: Any) -> None:
+        assert not is_truncation_finish_reason(finish_reason)
+
+
+class TestWarningAtSharedEmissionPoint:
+    # Every native provider reports completion through
+    # BaseLLM._emit_call_completed_event, so covering it covers all of them.
+    @pytest.mark.parametrize(
+        "finish_reason", ["length", "max_tokens", "MAX_TOKENS", "max_output_tokens"]
+    )
+    def test_warns_once_naming_the_cap(
+        self, finish_reason: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm = _StubLLM(model="test-model", max_tokens=16)
+
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="partial",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason=finish_reason,
+            )
+
+        warnings = _truncation_warnings(caplog)
+        assert len(warnings) == 1
+        assert finish_reason in warnings[0]
+        assert "max_tokens" in warnings[0]
+        assert "16" in warnings[0]
+
+    @pytest.mark.parametrize("finish_reason", ["stop", "tool_calls", None])
+    def test_stays_silent_for_complete_responses(
+        self, finish_reason: str | None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm = _StubLLM(model="test-model", max_tokens=16)
+
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="all of it",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason=finish_reason,
+            )
+
+        assert _truncation_warnings(caplog) == []
+
+    def test_reports_the_provider_specific_cap_field(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # OpenAI caps generation through max_completion_tokens, so the message
+        # has to name that value rather than the unset max_tokens.
+        llm = LLM(model="gpt-4o", max_completion_tokens=512)
+        assert llm.max_tokens is None
+
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="partial",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason="length",
+            )
+
+        warnings = _truncation_warnings(caplog)
+        assert len(warnings) == 1
+        assert "512" in warnings[0]
+
+    def test_warns_on_empty_response_that_spent_the_whole_budget(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Reasoning models can burn the cap on thinking and emit no text; the
+        # finish reason is the only thing separating that from a refusal.
+        llm = _StubLLM(model="test-model", max_tokens=200)
+
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason="length",
+            )
+
+        assert len(_truncation_warnings(caplog)) == 1
+
+
+class TestLiteLLMTruncationWarning:
+    def _model_response(self, finish_reason: str) -> Any:
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        return ModelResponse(
+            id="chatcmpl-truncated",
+            choices=[
+                Choices(
+                    finish_reason=finish_reason,
+                    index=0,
+                    message=Message(content="The TCP three-way handshake is", role="assistant"),
+                )
+            ],
+        )
+
+    def test_warns_on_truncated_completion(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, max_tokens=16)
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch(
+                "crewai.llm.litellm.completion",
+                return_value=self._model_response("length"),
+            ),
+        ):
+            llm.call("Explain the TCP three-way handshake in detail.")
+
+        warnings = _truncation_warnings(caplog)
+        assert len(warnings) == 1
+        assert "16" in warnings[0]
+
+    def test_stays_silent_on_complete_completion(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm = LLM(model="gpt-4o-mini", is_litellm=True, max_tokens=16)
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch(
+                "crewai.llm.litellm.completion",
+                return_value=self._model_response("stop"),
+            ),
+        ):
+            llm.call("Explain the TCP three-way handshake in detail.")
+
+        assert _truncation_warnings(caplog) == []
+
+
+class TestBedrockTruncationWarning:
+    # Bedrock warned on its own before the shared check existed; the provider
+    # check was dropped so a truncated Bedrock call still warns exactly once.
+    def _converse_response(self, stop_reason: str) -> dict[str, Any]:
+        return {
+            "stopReason": stop_reason,
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "The TCP three-way handshake is"}],
+                }
+            },
+            "usage": {"inputTokens": 10, "outputTokens": 16, "totalTokens": 26},
+        }
+
+    @pytest.fixture
+    def bedrock_llm(self):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "AWS_ACCESS_KEY_ID": "test-access-key",
+                    "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                    "AWS_DEFAULT_REGION": "us-east-1",
+                },
+            ),
+            patch(
+                "crewai.llms.providers.bedrock.completion.Session"
+            ) as mock_session_class,
+        ):
+            mock_client = MagicMock()
+            mock_session_instance = MagicMock()
+            mock_session_instance.client.return_value = mock_client
+            mock_session_class.return_value = mock_session_instance
+
+            llm = LLM(
+                model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+                max_tokens=16,
+            )
+            yield llm, mock_client
+
+    def test_warns_exactly_once(
+        self, bedrock_llm, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm, mock_client = bedrock_llm
+        mock_client.converse.return_value = self._converse_response("max_tokens")
+
+        with caplog.at_level(logging.WARNING):
+            llm.call("Explain the TCP three-way handshake in detail.")
+
+        assert len(_truncation_warnings(caplog)) == 1
+
+    def test_stays_silent_on_complete_response(
+        self, bedrock_llm, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm, mock_client = bedrock_llm
+        mock_client.converse.return_value = self._converse_response("end_turn")
+
+        with caplog.at_level(logging.WARNING):
+            llm.call("Explain the TCP three-way handshake in detail.")
+
+        assert _truncation_warnings(caplog) == []


### PR DESCRIPTION
Closes #7013

> AI-generated contribution. Per CONTRIBUTING.md this PR needs the `llm-generated` label. I cannot apply labels here — please add it.

## Problem

Only Bedrock checked whether generation stopped because it hit the token cap. On Anthropic, OpenAI, Azure, Gemini, openai_compatible, Snowflake, and LiteLLM, a truncated response was returned as success with no signal.

## Fix

Shared check at the two completion emitters (`BaseLLM._emit_call_completed_event` and `LLM._handle_emit_call_events`) via `is_truncation_finish_reason` (`length` / `max_tokens` / `MAX_TOKENS`). Bedrock's four now-duplicate `max_tokens` warnings are removed so it still warns once.

## Tests

`lib/crewai/tests/llms/test_truncation_warning.py` (31 cases). Core suite: 4809 passed, 65 skipped. ruff and mypy clean.