### PR TITLE
fix(knowledge): record collection_name and embedder on the Knowledge model

### DIFF
--- a/lib/crewai/src/crewai/knowledge/knowledge.py
+++ b/lib/crewai/src/crewai/knowledge/knowledge.py
@@ -117,6 +117,8 @@ class Knowledge(BaseModel):
         **data: object,
     ) -> None:
         super().__init__(**data)
+        self.collection_name = collection_name
+        self.embedder = embedder
         if storage is not None:
             self.storage = storage
         else:

--- a/lib/crewai/tests/knowledge/test_knowledge_init.py
+++ b/lib/crewai/tests/knowledge/test_knowledge_init.py
@@ -1,0 +1,48 @@
+"""Tests for Knowledge construction populating its declared model fields."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from crewai.knowledge.knowledge import Knowledge
+from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
+from crewai.rag.embeddings.types import EmbedderConfig
+
+
+def test_init_records_collection_name_and_embedder() -> None:
+    """The constructor arguments must land on the fields that declare them."""
+    embedder: EmbedderConfig = {
+        "provider": "openai",
+        "config": {"model": "text-embedding-3-small"},
+    }
+
+    knowledge = Knowledge(
+        collection_name="docs",
+        sources=[],
+        embedder=embedder,
+        storage=MagicMock(),
+    )
+
+    assert knowledge.collection_name == "docs"
+    assert knowledge.embedder == embedder
+
+
+def test_json_round_trip_preserves_the_backing_collection() -> None:
+    """A serialized Knowledge must rebuild storage against the same collection.
+
+    ``KnowledgeStorage`` falls back to the shared ``knowledge`` collection when
+    ``collection_name`` is None, so dropping it on the way out silently points a
+    restored Knowledge at a different collection than the one it wrote to.
+    """
+    original = Knowledge(collection_name="docs", sources=[], storage=MagicMock())
+
+    dumped: dict[str, Any] = original.model_dump(mode="json", exclude={"storage"})
+    assert dumped["collection_name"] == "docs"
+
+    restored = Knowledge(
+        collection_name=dumped["collection_name"],
+        sources=[],
+        embedder=dumped["embedder"],
+    )
+
+    assert isinstance(restored.storage, KnowledgeStorage)
+    assert restored.storage.collection_name == "docs"


### PR DESCRIPTION
## Summary
`Knowledge.__init__` accepts `collection_name` and `embedder`, uses them to build storage, then drops them. Both model fields stay `None` on every normally constructed instance, including `Crew.create_crew_knowledge` and `Agent.set_knowledge`.

A serialized `Knowledge` therefore carries `collection_name: null`, and rebuilding it points storage at the shared `"knowledge"` collection instead of `"knowledge_crew"` / `"knowledge_<role>"`.

Two lines assign the constructor arguments onto the declared fields, matching how `storage` and `sources` are already assigned.

## Test plan
- [x] New tests fail on current main (`None == 'docs'`) and pass after
- [x] `uv run pytest lib/crewai/tests/knowledge/test_knowledge_init.py -q` → 2 passed

## AI disclosure
This change was authored by an AI coding agent (Cursor / Claude Opus 5). Please apply the `llm-generated` label.