### PR TITLE
fix: reset agent retry budget per task

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -19,6 +19,7 @@ from typing import (
     NoReturn,
     cast,
 )
+from uuid import UUID
 import warnings
 
 from pydantic import (
@@ -206,6 +207,7 @@ class Agent(BaseAgent):
     model_config = ConfigDict()
 
     _times_executed: int = PrivateAttr(default=0)
+    _retried_task_id: UUID | None = PrivateAttr(default=None)
     _mcp_resolver: MCPToolResolver | None = PrivateAttr(default=None)
     _last_messages: list[LLMMessage] = PrivateAttr(default_factory=list)
     max_execution_time: int | None = Field(
@@ -694,6 +696,9 @@ class Agent(BaseAgent):
         if self.max_rpm and self._rpm_controller:
             self._rpm_controller.stop_rpm_counter()
 
+        self._times_executed = 0
+        self._retried_task_id = None
+
         result = process_tool_results(self, result)
 
         output_for_event = result
@@ -740,6 +745,12 @@ class Agent(BaseAgent):
             raise e
         if isinstance(e, _passthrough_exceptions):
             raise
+        # max_retry_limit is a per-task budget, but retries recurse through
+        # execute_task, so the counter can only be cleared once a different
+        # task starts failing.
+        if self._retried_task_id != task.id:
+            self._retried_task_id = task.id
+            self._times_executed = 0
         self._times_executed += 1
         if self._times_executed > self.max_retry_limit:
             crewai_event_bus.emit(

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1346,6 +1346,41 @@ def test_agent_max_retry_limit():
         )
 
 
+def test_agent_max_retry_limit_is_per_task():
+    agent = Agent(
+        role="test role",
+        goal="test goal",
+        backstory="test backstory",
+        max_retry_limit=1,
+    )
+
+    first_task = Task(
+        agent=agent,
+        description="Say the word: Hi",
+        expected_output="The word: Hi",
+    )
+    second_task = Task(
+        agent=agent,
+        description="Say the word: Bye",
+        expected_output="The word: Bye",
+    )
+
+    agent.create_agent_executor(task=first_task)
+
+    from crewai.experimental.agent_executor import AgentExecutor
+
+    with patch.object(AgentExecutor, "invoke") as invoke_mock:
+        invoke_mock.side_effect = [
+            Exception("transient failure"),
+            {"output": "Hi"},
+            Exception("transient failure"),
+            {"output": "Bye"},
+        ]
+
+        assert agent.execute_task(task=first_task) == "Hi"
+        assert agent.execute_task(task=second_task) == "Bye"
+
+
 def test_agent_with_llm():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
## Summary
`Agent._times_executed` is incremented on every transient failure and never cleared. A crew reuses the same Agent across tasks, so retries spent on task 1 reduce the budget for task 2. With the default `max_retry_limit=2`, two recovered failures anywhere in a run leave the agent with zero retries for everything that follows.

The field description says this is the maximum retries for an agent to execute **a task**. `_check_execution_error` now resets the counter when a different task starts failing, and `_finalize_task_execution` clears it when a task completes. The reset cannot go at the top of `execute_task` because retries recurse through that method.

Distinct from #6997 (event scope / hook aborts on the same function) and from #5822/#6048 (tool idempotency on retry).

## Test plan
- [x] New test fails on current main (`Exception: transient failure` on the second task) and passes after
- [x] `uv run pytest lib/crewai/tests/agents/test_agent.py -k max_retry_limit -p no:randomly -n 0` → 2 passed

## AI disclosure
This change was authored by an AI coding agent (Cursor / Claude Opus 5). Please apply the `llm-generated` label.