### PR TITLE
fix: allow unregistering hooks that were registered with a filter

### DIFF
--- a/lib/crewai/src/crewai/hooks/decorators.py
+++ b/lib/crewai/src/crewai/hooks/decorators.py
@@ -70,6 +70,9 @@ def _create_hook_decorator(
 
                 if not is_method:
                     register_function(filtered_hook)
+                    # Remember the actually-registered callable so the
+                    # unregister helpers can resolve the filter wrapper.
+                    f._registered_hook = filtered_hook  # type: ignore[attr-defined]
 
                 return f
 

--- a/lib/crewai/src/crewai/hooks/llm_hooks.py
+++ b/lib/crewai/src/crewai/hooks/llm_hooks.py
@@ -9,6 +9,7 @@ from crewai.hooks.dispatch import (
     HookAborted,
     InterceptionPoint,
     get_global_hook_list,
+    unregister,
 )
 from crewai.hooks.types import (
     AfterLLMCallHookCallable,
@@ -291,11 +292,7 @@ def unregister_before_llm_call_hook(
         >>> unregister_before_llm_call_hook(my_hook)
         True
     """
-    try:
-        _before_llm_call_hooks.remove(hook)
-        return True
-    except ValueError:
-        return False
+    return unregister(InterceptionPoint.PRE_MODEL_CALL, hook)
 
 
 def unregister_after_llm_call_hook(
@@ -317,11 +314,7 @@ def unregister_after_llm_call_hook(
         >>> unregister_after_llm_call_hook(my_hook)
         True
     """
-    try:
-        _after_llm_call_hooks.remove(hook)
-        return True
-    except ValueError:
-        return False
+    return unregister(InterceptionPoint.POST_MODEL_CALL, hook)
 
 
 def clear_before_llm_call_hooks() -> int:

--- a/lib/crewai/src/crewai/hooks/tool_hooks.py
+++ b/lib/crewai/src/crewai/hooks/tool_hooks.py
@@ -10,6 +10,7 @@ from crewai.hooks.dispatch import (
     InterceptionPoint,
     dispatch,
     get_global_hook_list,
+    unregister,
 )
 from crewai.hooks.types import (
     AfterToolCallHookCallable,
@@ -314,11 +315,7 @@ def unregister_before_tool_call_hook(
         >>> unregister_before_tool_call_hook(my_hook)
         True
     """
-    try:
-        _before_tool_call_hooks.remove(hook)
-        return True
-    except ValueError:
-        return False
+    return unregister(InterceptionPoint.PRE_TOOL_CALL, hook)
 
 
 def unregister_after_tool_call_hook(
@@ -340,11 +337,7 @@ def unregister_after_tool_call_hook(
         >>> unregister_after_tool_call_hook(my_hook)
         True
     """
-    try:
-        _after_tool_call_hooks.remove(hook)
-        return True
-    except ValueError:
-        return False
+    return unregister(InterceptionPoint.POST_TOOL_CALL, hook)
 
 
 def clear_before_tool_call_hooks() -> int:

--- a/lib/crewai/tests/hooks/test_decorators.py
+++ b/lib/crewai/tests/hooks/test_decorators.py
@@ -13,6 +13,10 @@ from crewai.hooks import (
     get_after_tool_call_hooks,
     get_before_llm_call_hooks,
     get_before_tool_call_hooks,
+    unregister_after_llm_call_hook,
+    unregister_after_tool_call_hook,
+    unregister_before_llm_call_hook,
+    unregister_before_tool_call_hook,
 )
 from crewai.hooks.llm_hooks import LLMCallHookContext
 from crewai.hooks.tool_hooks import ToolCallHookContext
@@ -306,6 +310,62 @@ class TestDecoratorAttributes:
         assert test_hook._filter_tools == ["delete_file"]
         assert hasattr(test_hook, "_filter_agents")
         assert test_hook._filter_agents == ["Dev"]
+
+
+class TestUnregisterFilteredHooks:
+    """Filtered decorators register a wrapper, which unregister must resolve."""
+
+    def test_unregister_before_llm_call_with_agent_filter(self):
+        """Test that a filtered @before_llm_call hook can be unregistered."""
+
+        @before_llm_call(agents=["Researcher"])
+        def filtered_hook(context):
+            pass
+
+        assert len(get_before_llm_call_hooks()) == 1
+        assert unregister_before_llm_call_hook(filtered_hook) is True
+        assert get_before_llm_call_hooks() == []
+
+    def test_unregister_after_llm_call_with_agent_filter(self):
+        """Test that a filtered @after_llm_call hook can be unregistered."""
+
+        @after_llm_call(agents=["Researcher"])
+        def filtered_hook(context):
+            return None
+
+        assert len(get_after_llm_call_hooks()) == 1
+        assert unregister_after_llm_call_hook(filtered_hook) is True
+        assert get_after_llm_call_hooks() == []
+
+    def test_unregister_before_tool_call_with_tool_filter(self):
+        """Test that a filtered @before_tool_call hook can be unregistered."""
+
+        @before_tool_call(tools=["delete_file"])
+        def filtered_hook(context):
+            return None
+
+        assert len(get_before_tool_call_hooks()) == 1
+        assert unregister_before_tool_call_hook(filtered_hook) is True
+        assert get_before_tool_call_hooks() == []
+
+    def test_unregister_after_tool_call_with_combined_filters(self):
+        """Test that a filtered @after_tool_call hook can be unregistered."""
+
+        @after_tool_call(tools=["web_search"], agents=["Researcher"])
+        def filtered_hook(context):
+            return None
+
+        assert len(get_after_tool_call_hooks()) == 1
+        assert unregister_after_tool_call_hook(filtered_hook) is True
+        assert get_after_tool_call_hooks() == []
+
+    def test_unregister_unknown_hook_returns_false(self):
+        """Test that unregistering a hook that was never registered is a no-op."""
+
+        def never_registered(context):
+            return None
+
+        assert unregister_before_tool_call_hook(never_registered) is False
 
 
 class TestMultipleDecorators:


### PR DESCRIPTION
## Summary
`@before_tool_call(tools=["delete_file"])` (and the other three legacy filtered decorators) register an internal wrapper but return the original function. `unregister_*_hook` then searched for the original function in a queue that only holds wrappers, so it returned `False` and the hook kept firing.

Stash the wrapper on `_registered_hook` the same way `@on(...)` already does, and route the four legacy unregister helpers through `dispatch.unregister`. Distinct from #7017/#7018.

## Test plan
- [x] New `TestUnregisterFilteredHooks` cases fail on current main and pass after
- [x] `uv run pytest lib/crewai/tests/hooks/ lib/crewai/tests/project/ -q` → 237 passed

## AI disclosure
This change was authored by an AI coding agent (Cursor / Claude Opus 5). Please apply the `llm-generated` label.