### PR TITLE
fix: clear Agent.tools_results between tasks

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -556,6 +556,9 @@ class Agent(BaseAgent):
         get_env_context()
 
         self.reset_tool_failures()
+        # Tool results are scoped to a single task; carrying them over lets a
+        # previous task's result_as_answer tool override this task's answer.
+        self.tools_results = []
 
         if self.tools_handler:
             self.tools_handler.last_used_tool = None

--- a/lib/crewai/tests/agents/test_agent.py
+++ b/lib/crewai/tests/agents/test_agent.py
@@ -1289,6 +1289,47 @@ def test_agent_use_trained_data_skips_load_when_file_missing(tmp_path, monkeypat
     assert result == "What is 1 + 1?"
 
 
+def test_agent_result_as_answer_does_not_leak_into_the_next_task():
+    agent = Agent(
+        role="test role",
+        goal="test goal",
+        backstory="test backstory",
+    )
+
+    first_task = Task(
+        agent=agent,
+        description="Say the word: Hi",
+        expected_output="The word: Hi",
+    )
+    second_task = Task(
+        agent=agent,
+        description="Say the word: Bye",
+        expected_output="The word: Bye",
+    )
+
+    agent.create_agent_executor(task=first_task)
+
+    outputs = iter(["Hi", "Bye"])
+
+    def invoke(_inputs):
+        output = next(outputs)
+        if output == "Hi":
+            # Only the first task uses a tool declaring result_as_answer=True.
+            agent.tools_results.append(
+                {
+                    "result": "Howdy!",
+                    "tool_name": "get_greetings",
+                    "tool_args": {},
+                    "result_as_answer": True,
+                }
+            )
+        return {"output": output}
+
+    with patch.object(AgentExecutor, "invoke", side_effect=invoke):
+        assert agent.execute_task(task=first_task) == "Howdy!"
+        assert agent.execute_task(task=second_task) == "Bye"
+
+
 def test_agent_max_retry_limit():
     agent = Agent(
         role="test role",


### PR DESCRIPTION
Agent.tools_results is never cleared between tasks. process_tool_results scans the whole list for result_as_answer=True, so a tool used in one task silently overrides the answer of every later task on that agent. LiteAgent.kickoff already clears it per run.

Reset the list in _prepare_task_execution so both execute_task and aexecute_task are covered. Tests: uv run pytest lib/crewai/tests/agents/test_agent.py -k result_as_answer_does_not_leak -q -> passed.

Distinct from #7018 (retry budget) and #7019.

This change was generated with Claude Opus 5 via a Cursor cloud agent.