### PR TITLE
fix: reset upload-cache LRU order when the cache is cleared

### DIFF
--- a/lib/crewai-files/src/crewai_files/cache/upload_cache.py
+++ b/lib/crewai-files/src/crewai_files/cache/upload_cache.py
@@ -375,6 +375,7 @@ class UploadCache:
         count = sum(len(keys) for keys in self._provider_keys.values())
         await self._cache.clear(namespace=self.namespace)
         self._provider_keys.clear()
+        self._key_access_order.clear()
 
         if count > 0:
             logger.debug(f"Cleared {count} cache entries")

--- a/lib/crewai-files/tests/test_upload_cache.py
+++ b/lib/crewai-files/tests/test_upload_cache.py
@@ -187,6 +187,30 @@ class TestUploadCache:
         assert cleared == 2
         assert len(cache) == 0
 
+    def test_max_entries_enforced_after_clear(self):
+        """Test max_entries is still enforced once the cache is refilled."""
+        cache = UploadCache(max_entries=3)
+
+        for i in range(3):
+            cache.set_by_hash(
+                file_hash=f"hash-{i}",
+                content_type="image/png",
+                provider="gemini",
+                file_id=f"file-{i}",
+            )
+
+        cache.clear()
+
+        for i in range(4):
+            cache.set_by_hash(
+                file_hash=f"refill-{i}",
+                content_type="image/png",
+                provider="gemini",
+                file_id=f"refill-file-{i}",
+            )
+
+        assert len(cache) == 3
+
     def test_get_all_for_provider(self):
         """Test getting all cached uploads for a provider."""
         cache = UploadCache()


### PR DESCRIPTION
UploadCache.aclear() reset _provider_keys but left _key_access_order populated. Eviction then popped stale keys that no longer exist, so max_entries stopped being enforced after a clear (cleanup_uploaded_files calls clear()).

Now also clears _key_access_order.

Tests: uv run pytest lib/crewai-files/tests/ -q — 168 passed, 4 skipped.

## AI Usage
This PR was fully AI-generated (Claude Opus 5, Cursor cloud agent).