### PR TITLE
fix: resolve file constraints from routing prefix, not model id

### DIFF
--- a/lib/crewai-files/src/crewai_files/processing/constraints.py
+++ b/lib/crewai-files/src/crewai_files/processing/constraints.py
@@ -355,13 +355,18 @@ def get_constraints_for_provider(
 
     provider_lower = provider.lower()
 
-    # Model identifiers are commonly "<provider>/<model>" and the model part can
-    # name a different provider (e.g. "bedrock/anthropic.claude-..."), so the
-    # routing prefix has to win over a substring match anywhere in the string.
-    matched = _match_provider_prefix(provider_lower.split("/", 1)[0])
+    # For "<provider>/<model>" identifiers the routing prefix is the only
+    # authority, because the model part can name a different provider
+    # (e.g. "bedrock/anthropic.claude-..." is served by Bedrock, not Anthropic).
+    if "/" in provider_lower:
+        return _match_provider_prefix(provider_lower.split("/", 1)[0])
+
+    matched = _match_provider_prefix(provider_lower)
     if matched is not None:
         return matched
 
+    # A bare model id can still embed a provider name, as in the Bedrock
+    # inference profile id "us.anthropic.claude-sonnet-4".
     for key, constraints in _PROVIDER_CONSTRAINTS_MAP.items():
         if key in provider_lower:
             return constraints

--- a/lib/crewai-files/src/crewai_files/processing/constraints.py
+++ b/lib/crewai-files/src/crewai_files/processing/constraints.py
@@ -319,6 +319,25 @@ _PROVIDER_CONSTRAINTS_MAP: dict[str, ProviderConstraints] = {
 }
 
 
+def _match_provider_prefix(prefix: str) -> ProviderConstraints | None:
+    """Match the routing prefix of a model identifier to a known provider.
+
+    Args:
+        prefix: Lowercased provider prefix, e.g. "bedrock" or "azure_openai".
+
+    Returns:
+        ProviderConstraints for the prefix, or None if it names no known provider.
+    """
+    if prefix in _PROVIDER_CONSTRAINTS_MAP:
+        return _PROVIDER_CONSTRAINTS_MAP[prefix]
+
+    for key, constraints in _PROVIDER_CONSTRAINTS_MAP.items():
+        if prefix.startswith(key):
+            return constraints
+
+    return None
+
+
 @lru_cache(maxsize=32)
 def get_constraints_for_provider(
     provider: str | ProviderConstraints,
@@ -336,8 +355,12 @@ def get_constraints_for_provider(
 
     provider_lower = provider.lower()
 
-    if provider_lower in _PROVIDER_CONSTRAINTS_MAP:
-        return _PROVIDER_CONSTRAINTS_MAP[provider_lower]
+    # Model identifiers are commonly "<provider>/<model>" and the model part can
+    # name a different provider (e.g. "bedrock/anthropic.claude-..."), so the
+    # routing prefix has to win over a substring match anywhere in the string.
+    matched = _match_provider_prefix(provider_lower.split("/", 1)[0])
+    if matched is not None:
+        return matched
 
     for key, constraints in _PROVIDER_CONSTRAINTS_MAP.items():
         if key in provider_lower:

--- a/lib/crewai-files/tests/processing/test_constraints.py
+++ b/lib/crewai-files/tests/processing/test_constraints.py
@@ -233,6 +233,9 @@ class TestGetConstraintsForProvider:
         result = get_constraints_for_provider("gemini-pro")
         assert result == GEMINI_CONSTRAINTS
 
+        result = get_constraints_for_provider("us.anthropic.claude-sonnet-4")
+        assert result == ANTHROPIC_CONSTRAINTS
+
     def test_routing_prefix_wins_over_model_id(self):
         """Test the provider prefix beats a provider name inside the model id."""
         result = get_constraints_for_provider(
@@ -250,3 +253,8 @@ class TestGetConstraintsForProvider:
         """Test a compound provider prefix matches its most specific provider."""
         result = get_constraints_for_provider("azure_openai/gpt-4o")
         assert result == AZURE_CONSTRAINTS
+
+    def test_unknown_prefix_does_not_fall_back_to_model_id(self):
+        """Test an unrecognized provider prefix returns None instead of guessing."""
+        assert get_constraints_for_provider("unknown/anthropic.claude-3") is None
+        assert get_constraints_for_provider("unknown/gpt-4o") is None

--- a/lib/crewai-files/tests/processing/test_constraints.py
+++ b/lib/crewai-files/tests/processing/test_constraints.py
@@ -2,6 +2,7 @@
 
 from crewai_files.processing.constraints import (
     ANTHROPIC_CONSTRAINTS,
+    AZURE_CONSTRAINTS,
     BEDROCK_CONSTRAINTS,
     GEMINI_CONSTRAINTS,
     OPENAI_CONSTRAINTS,
@@ -231,3 +232,21 @@ class TestGetConstraintsForProvider:
 
         result = get_constraints_for_provider("gemini-pro")
         assert result == GEMINI_CONSTRAINTS
+
+    def test_routing_prefix_wins_over_model_id(self):
+        """Test the provider prefix beats a provider name inside the model id."""
+        result = get_constraints_for_provider(
+            "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+        )
+        assert result == BEDROCK_CONSTRAINTS
+
+        result = get_constraints_for_provider("bedrock/us.anthropic.claude-sonnet-4")
+        assert result == BEDROCK_CONSTRAINTS
+
+        result = get_constraints_for_provider("azure/openai/gpt-4o")
+        assert result == AZURE_CONSTRAINTS
+
+    def test_get_by_partial_provider_prefix(self):
+        """Test a compound provider prefix matches its most specific provider."""
+        result = get_constraints_for_provider("azure_openai/gpt-4o")
+        assert result == AZURE_CONSTRAINTS


### PR DESCRIPTION
get_constraints_for_provider substring-scanned the whole string, so a provider name inside the model id beat the routing prefix. bedrock/anthropic.claude-* resolved to Anthropic (supports_file_upload=True, 32MB PDF) instead of Bedrock (False, 3.84MB). azure/openai/gpt-4o resolved to OpenAI.

Prefix is matched first (exact or startswith); substring scan stays as fallback for unprefixed ids.

Tests: uv run pytest lib/crewai-files/tests -q — 169 passed, 4 skipped. Distinct from #7015-#7021.

## AI Usage
This change is AI-generated.