### PR TITLE
fix: handle asyncio.run() RuntimeError when async tools called from running event loop

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -40,6 +40,7 @@ from crewai.tools.structured_tool import (
 )
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy, ToolFailureReason
 from crewai.types.callback import SerializableCallable, _resolve_dotted_path
+from crewai.utilities.async_utils import run_coroutine_sync
 from crewai.utilities.string_utils import sanitize_tool_name
 
 
@@ -338,7 +339,7 @@ class BaseTool(BaseModel, ABC):
         result = self._run(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_coroutine_sync(result)
 
         return result
 
@@ -549,7 +550,7 @@ class Tool(BaseTool, Generic[P, R]):
         result = self.func(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_coroutine_sync(result)
 
         return result  # type: ignore[return-value]
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -22,6 +22,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy
+from crewai.utilities.async_utils import run_coroutine_sync
 from crewai.utilities.logger import Logger
 from crewai.utilities.pydantic_schema_utils import (
     create_model_from_schema,
@@ -438,12 +439,12 @@ class CrewStructuredTool(BaseModel):
         self._increment_usage_count()
 
         if inspect.iscoroutinefunction(self.func):
-            return asyncio.run(self.func(**parsed_args, **kwargs))
+            return run_coroutine_sync(self.func(**parsed_args, **kwargs))
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            return asyncio.run(result)
+            return run_coroutine_sync(result)
 
         return result
 

--- a/lib/crewai/src/crewai/utilities/async_utils.py
+++ b/lib/crewai/src/crewai/utilities/async_utils.py
@@ -1,0 +1,30 @@
+"""Utilities for running async code from sync contexts."""
+
+import asyncio
+import concurrent.futures
+import contextvars
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+def run_coroutine_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine synchronously, handling an already-running event loop.
+
+    ``asyncio.run()`` raises ``RuntimeError`` when called from within a running
+    event loop (e.g. inside a FastAPI handler, Jupyter cell, or any ``async
+    def``).  This helper detects that case and offloads the coroutine to a
+    dedicated thread with its own loop, preserving the calling context.
+    """
+    try:
+        asyncio.get_running_loop()
+        has_running_loop = True
+    except RuntimeError:
+        has_running_loop = False
+
+    if has_running_loop:
+        ctx = contextvars.copy_context()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(ctx.run, asyncio.run, coro).result()
+    return asyncio.run(coro)

--- a/lib/crewai/tests/tools/test_base_tool.py
+++ b/lib/crewai/tests/tools/test_base_tool.py
@@ -207,6 +207,38 @@ def test_run_does_not_call_asyncio_run_for_sync_tools():
         assert sync_result == "Processed test synchronously"
 
 
+def test_run_from_running_event_loop_does_not_raise():
+    """Test that run() works when called from within a running event loop.
+
+    Regression test for the RuntimeError raised by asyncio.run() when a
+    coroutine-returning tool is invoked from an async context (FastAPI
+    handler, Jupyter cell, etc.).
+    """
+
+    async def invoke_from_running_loop():
+        tool = AsyncTool()
+        return tool.run(input_text="test")
+
+    result = asyncio.run(invoke_from_running_loop())
+    assert result == "Processed test asynchronously"
+
+
+def test_tool_decorator_run_from_running_event_loop_does_not_raise():
+    """Test that the @tool decorator's run() works inside a running loop."""
+
+    @tool("echo_tool")
+    async def echo_tool(value: str) -> str:
+        """Echo the value."""
+        await asyncio.sleep(0.01)
+        return f"echo: {value}"
+
+    async def invoke_from_running_loop():
+        return echo_tool.run(value="hi")
+
+    result = asyncio.run(invoke_from_running_loop())
+    assert result == "echo: hi"
+
+
 @pytest.mark.vcr()
 def test_max_usage_count_is_respected():
     class IteratingTool(BaseTool):

--- a/lib/crewai/tests/tools/test_structured_tool.py
+++ b/lib/crewai/tests/tools/test_structured_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 from crewai.tools.structured_tool import CrewStructuredTool
@@ -219,6 +220,28 @@ async def test_ainvoke(basic_function):
 
     result = await tool.ainvoke(input={"param1": "test"})
     assert result == "test 0"
+
+
+def test_invoke_from_running_event_loop_does_not_raise():
+    """Test that invoke() works when called from within a running event loop.
+
+    Regression test for the RuntimeError raised by asyncio.run() when a
+    coroutine-returning tool is invoked from an async context (FastAPI
+    handler, Jupyter cell, etc.).
+    """
+
+    async def async_echo(value: str) -> str:
+        """Echo the value."""
+        await asyncio.sleep(0.01)
+        return f"echo: {value}"
+
+    tool = CrewStructuredTool.from_function(func=async_echo, name="echo_tool")
+
+    async def invoke_from_running_loop():
+        return tool.invoke(input={"value": "hi"})
+
+    result = asyncio.run(invoke_from_running_loop())
+    assert result == "echo: hi"
 
 
 def test_parse_args_dict(basic_function):


### PR DESCRIPTION
## Problem

Fixes #6978

When an async tool (a `BaseTool` subclass with an async `_run`, or a `CrewStructuredTool` wrapping a coroutine-returning function) is invoked from within an already-running event loop — e.g. a FastAPI request handler, a Jupyter cell, or any `async def` — `asyncio.run()` raises:

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```

Synchronous scripts are unaffected, which is why this slips through basic testing but breaks every async-server deployment.

## Root cause

`BaseTool.run()` (two call sites) and `CrewStructuredTool.invoke()` (two call sites) all use the bare pattern:

```python
result = self._run(*args, **kwargs)
if asyncio.iscoroutine(result):
    result = asyncio.run(result)   # raises under a running loop
```

## Fix

The codebase already solves this exact problem in `llm_guardrail.py` with `_run_coroutine_sync`, which detects a running event loop and offloads the coroutine to a dedicated thread. This PR:

1. Extracts that pattern into a shared `crewai.utilities.async_utils.run_coroutine_sync` module
2. Replaces all four `asyncio.run()` call sites in `base_tool.py` and `structured_tool.py` with `run_coroutine_sync()`

The helper preserves `contextvars` and falls back to plain `asyncio.run()` when no loop is running, so sync behavior is unchanged.

## Tests

Three new tests cover the three affected entry points:

- `test_run_from_running_event_loop_does_not_raise` — `BaseTool` subclass with async `_run`, called from inside `async def`
- `test_tool_decorator_run_from_running_event_loop_does_not_raise` — `@tool` decorator wrapping an async function, called from inside `async def`
- `test_invoke_from_running_event_loop_does_not_raise` — `CrewStructuredTool.from_function` with an async function, `.invoke()` called from inside `async def`

All 76 existing tool tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)