### PR TITLE
fix(mcp): don't call asyncio.run() from a running Flow loop

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -11,6 +11,8 @@ into a standalone MCPToolResolver. It handles three flavours of MCP reference:
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
+import concurrent.futures
 import contextvars
 import time
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -40,6 +42,33 @@ MCP_MAX_RETRIES: Final[int] = 3
 
 _mcp_schema_cache: dict[str, Any] = {}
 _cache_ttl: Final[int] = 300  # 5 minutes
+
+
+def _run_coro_from_sync(factory: Callable[[], Any]) -> Any:
+    """Run an async zero-arg factory from sync code.
+
+    ``asyncio.run()`` raises ``RuntimeError`` when a loop is already running
+    (CrewAI Flows start one in ``flow.runtime``). In that case, run the
+    coroutine on a worker thread that owns its own event loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(factory())
+
+    ctx = contextvars.copy_context()
+
+    def _in_thread() -> Any:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(factory())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(ctx.run, _in_thread).result()
 
 
 class MCPToolResolver:
@@ -98,7 +127,7 @@ class MCPToolResolver:
                     await client.disconnect()
 
         try:
-            asyncio.run(_disconnect_all())
+            _run_coro_from_sync(_disconnect_all)
         except Exception as e:
             self._logger.log("error", f"Error during MCP client cleanup: {e}")
         finally:
@@ -354,31 +383,20 @@ class MCPToolResolver:
 
         try:
             try:
-                asyncio.get_running_loop()
-                import concurrent.futures
-
-                ctx = contextvars.copy_context()
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(
-                        ctx.run, asyncio.run, _setup_client_and_list_tools()
-                    )
-                    tools_list = future.result()
-            except RuntimeError:
-                try:
-                    tools_list = asyncio.run(_setup_client_and_list_tools())
-                except RuntimeError as e:
-                    error_msg = str(e).lower()
-                    if "cancel scope" in error_msg or "task" in error_msg:
-                        raise ConnectionError(
-                            "MCP connection failed due to event loop cleanup issues. "
-                            "This may be due to authentication errors or server unavailability."
-                        ) from e
-                    raise
-                except asyncio.CancelledError as e:
+                tools_list = _run_coro_from_sync(_setup_client_and_list_tools)
+            except RuntimeError as e:
+                error_msg = str(e).lower()
+                if "cancel scope" in error_msg or "task" in error_msg:
                     raise ConnectionError(
-                        "MCP connection was cancelled. This may indicate an authentication "
-                        "error or server unavailability."
+                        "MCP connection failed due to event loop cleanup issues. "
+                        "This may be due to authentication errors or server unavailability."
                     ) from e
+                raise
+            except asyncio.CancelledError as e:
+                raise ConnectionError(
+                    "MCP connection was cancelled. This may indicate an authentication "
+                    "error or server unavailability."
+                ) from e
 
             if mcp_config.tool_filter:
                 filtered_tools = []
@@ -458,7 +476,7 @@ class MCPToolResolver:
             return cast(list[BaseTool], tools), []
         except Exception as e:
             if discovery_client.connected:
-                asyncio.run(discovery_client.disconnect())
+                _run_coro_from_sync(discovery_client.disconnect)
 
             raise RuntimeError(f"Failed to get native MCP tools: {e}") from e
 
@@ -509,7 +527,11 @@ class MCPToolResolver:
                 return cached_data  # type: ignore[no-any-return]
 
         try:
-            schemas = asyncio.run(self._get_mcp_tool_schemas_async(server_params))
+
+            def _fetch() -> Any:
+                return self._get_mcp_tool_schemas_async(server_params)
+
+            schemas = _run_coro_from_sync(_fetch)
             _mcp_schema_cache[cache_key] = (schemas, current_time)
             return schemas
         except Exception as e:

--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -386,7 +386,7 @@ class MCPToolResolver:
                 tools_list = _run_coro_from_sync(_setup_client_and_list_tools)
             except RuntimeError as e:
                 error_msg = str(e).lower()
-                if "cancel scope" in error_msg or "task" in error_msg:
+                if "cancel scope" in error_msg:
                     raise ConnectionError(
                         "MCP connection failed due to event loop cleanup issues. "
                         "This may be due to authentication errors or server unavailability."

--- a/lib/crewai/tests/mcp/test_tool_resolver_running_loop.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_running_loop.py
@@ -84,4 +84,5 @@ class TestResolveNativeFromRunningLoop:
             messages.append(str(cause))
             cause = cause.__cause__
         blob = "\n".join(messages)
+        assert "Session terminated" in blob
         assert "cannot be called from a running event loop" not in blob

--- a/lib/crewai/tests/mcp/test_tool_resolver_running_loop.py
+++ b/lib/crewai/tests/mcp/test_tool_resolver_running_loop.py
@@ -1,0 +1,87 @@
+"""Regression tests for GitHub issue #6843.
+
+Native MCP HTTP / streamable discovery is invoked from sync code while a
+CrewAI Flow already has an event loop running. ``asyncio.run()`` must not
+be used on that thread, and a connection failure must not be rewritten
+into "cannot be called from a running event loop".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from crewai.mcp.config import MCPServerHTTP
+from crewai.mcp.tool_resolver import MCPToolResolver
+
+
+def _resolver() -> MCPToolResolver:
+    return MCPToolResolver(agent=MagicMock(), logger=MagicMock())
+
+
+def _http_config() -> MCPServerHTTP:
+    return MCPServerHTTP(
+        url="https://mcp.example.com/mcp",
+        streamable=True,
+        cache_tools_list=True,
+    )
+
+
+def _mock_client(
+    *,
+    tools: list | None = None,
+    connect_error: Exception | None = None,
+) -> AsyncMock:
+    mock_client = AsyncMock()
+    mock_client.connected = False
+    if connect_error is not None:
+        mock_client.connect = AsyncMock(side_effect=connect_error)
+    else:
+        mock_client.connect = AsyncMock()
+    mock_client.list_tools = AsyncMock(return_value=tools or [])
+    mock_client.disconnect = AsyncMock()
+    return mock_client
+
+
+class TestResolveNativeFromRunningLoop:
+    @pytest.mark.asyncio
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    async def test_does_not_call_asyncio_run_when_loop_already_running(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client_class.return_value = _mock_client()
+        resolver = _resolver()
+        assert asyncio.get_running_loop() is not None
+
+        with patch(
+            "crewai.mcp.tool_resolver.asyncio.run", wraps=asyncio.run
+        ) as mock_run:
+            tools = resolver.resolve([_http_config()])
+
+        assert tools == []
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("crewai.mcp.tool_resolver.MCPClient")
+    async def test_connection_error_does_not_raise_nested_event_loop_error(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client_class.return_value = _mock_client(
+            connect_error=ConnectionError("Session terminated")
+        )
+        resolver = _resolver()
+        assert asyncio.get_running_loop() is not None
+
+        with pytest.raises(
+            RuntimeError, match="Failed to get native MCP tools"
+        ) as exc_info:
+            resolver._resolve_native(_http_config())
+
+        messages = [str(exc_info.value)]
+        cause = exc_info.value.__cause__
+        while cause is not None:
+            messages.append(str(cause))
+            cause = cause.__cause__
+        blob = "\n".join(messages)
+        assert "cannot be called from a running event loop" not in blob


### PR DESCRIPTION
## Summary

`MCPToolResolver._resolve_native` already tries to offload `asyncio.run()` onto a worker thread when a Flow loop is running, but the `except RuntimeError` around that path is too broad. A failed MCP connect raises `RuntimeError` from the worker, the handler treats it as "no running loop", and retries `asyncio.run()` on the caller — which then crashes with `asyncio.run() cannot be called from a running event loop`. The agent gets no tools.

Use a small `_run_coro_from_sync` helper: `asyncio.run()` only when no loop is running; otherwise a worker thread with its own `new_event_loop` / `run_until_complete`. The same helper covers cleanup, HTTPS schema discovery, and disconnect-on-error so those paths do not hit the same nested-loop crash.

Fixes #6843

## Test plan

- [x] `lib/crewai/tests/mcp/test_tool_resolver_running_loop.py` calls native HTTP/streamable resolve from an already-running asyncio loop, asserts `asyncio.run` is not invoked, and asserts a connection failure is not rewritten into the nested-loop RuntimeError
- [x] existing `lib/crewai/tests/mcp/test_tool_resolver_native.py` still wraps unmatched RuntimeError

Please add the `llm-generated` label if the repository uses it. Drafted with AI assistance.


<!-- crewai-require-issue-check -->