### PR TITLE
fix(crew): resolve error handling bugs in config and callbacks

### DIFF
--- a/docs/residual-review-findings/fix-crew-error-handling-6439.md
+++ b/docs/residual-review-findings/fix-crew-error-handling-6439.md
@@ -1,0 +1,14 @@
+# Residual Review Findings
+
+Source: ce-code-review run `20260817-233222-aa369bf8` on branch `fix/crew-error-handling-6439`, head `6dce35b`.
+Plan: `docs/plans/2026-08-17-001-fix-crew-error-handling-plan.md`.
+
+## Findings
+
+- **P2 (settled_conflict: KTD3)** - `lib/crewai/src/crewai/task.py:120` - Third+ copy of run-coroutine-from-sync idiom. The new `_run_awaitable_from_sync` duplicates the await-response pattern in `lib/crewai/src/crewai/utilities/agent_utils.py:99-128` (and ~7 other files). Extract into a shared utility module (e.g. `lib/crewai/src/crewai/utilities/async_utils.py`) and implement both callers on top of it. Defer failed: GitHub issue creation returned HTTP 503 (GitHub API service outage) - `gh returned 503: No server is currently available`. Recorded here as the durable sink. This is preference-grade against session-settled KTD3 (the in-module mirror was chosen deliberately to avoid importing agent_utils into task.py), so it is report-only and deferred for future consolidation.
+
+## Source run context
+
+- Reviewers: correctness, project-standards, testing, reliability, maintainability, adversarial-codex (cross-model, independence verified)
+- Actionable findings applied in `6dce35b`: #1 (P1 loop-bound Task/Future guard), #2 (P2 async akickoff replace-result test), #4 (P2 crew.task_callback async path test)
+- Verdict: Ready with fixes

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1066,7 +1066,9 @@ class Crew(FlowTrackable, BaseModel):
                 )
 
             for after_callback in self.after_kickoff_callbacks:
-                result = after_callback(result)
+                callback_result = after_callback(result)
+                if callback_result is not None:
+                    result = callback_result
 
             result = self._post_kickoff(result)
 
@@ -1283,7 +1285,9 @@ class Crew(FlowTrackable, BaseModel):
                 )
 
             for after_callback in self.after_kickoff_callbacks:
-                result = after_callback(result)
+                callback_result = after_callback(result)
+                if callback_result is not None:
+                    result = callback_result
 
             result = self._post_kickoff(result)
 

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -918,11 +918,19 @@ class Crew(FlowTrackable, BaseModel):
         Returns:
             A task instance.
         """
+        task_agent_role = task_config.get("agent")
         task_agent = next(
-            agt for agt in self.agents if agt.role == task_config["agent"]
+            (agt for agt in self.agents if agt.role == task_agent_role), None
         )
-        del task_config["agent"]
-        return Task(**task_config, agent=task_agent)
+        if task_agent is None:
+            available_roles = [agt.role for agt in self.agents]
+            raise ValueError(
+                f"Task references agent role '{task_agent_role}' which doesn't "
+                f"match any agent. Available roles: {available_roles}"
+            )
+        task_kwargs = dict(task_config)
+        del task_kwargs["agent"]
+        return Task(**task_kwargs, agent=task_agent)
 
     def _setup_for_training(self, filename: str) -> None:
         """Sets up the crew for training."""

--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 import contextvars
 from copy import copy as shallow_copy
 import datetime
@@ -115,6 +115,34 @@ def _deserialize_model_class(v: Any) -> type[BaseModel] | None:
 
         return create_model_from_schema(v)
     return None
+
+
+def _run_awaitable_from_sync(value: Any) -> None:
+    """Run an awaitable callback result from synchronous code.
+
+    Mirrors the await-response pattern in utilities/agent_utils.py: when a
+    loop is already running, asyncio.run() cannot be used, so the awaitable
+    is executed in a worker thread with its own loop, carrying a copy of the
+    caller's context. Non-coroutine awaitables (Tasks/Futures) are wrapped in
+    a helper coroutine first.
+    """
+    if not inspect.isawaitable(value):
+        return
+
+    async def await_callback() -> Any:
+        return await value
+
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if running_loop is not None:
+        ctx = contextvars.copy_context()
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(ctx.run, asyncio.run, await_callback()).result()
+    else:
+        asyncio.run(await_callback())
 
 
 class Task(BaseModel):
@@ -921,8 +949,7 @@ class Task(BaseModel):
 
             if self.callback:
                 cb_result = self.callback(self.output)
-                if inspect.iscoroutine(cb_result):
-                    asyncio.run(cb_result)
+                _run_awaitable_from_sync(cb_result)
 
             crew = self.agent.crew  # type: ignore[union-attr]
             if (
@@ -932,8 +959,7 @@ class Task(BaseModel):
                 and crew.task_callback != self.callback
             ):
                 cb_result = crew.task_callback(self.output)
-                if inspect.iscoroutine(cb_result):
-                    asyncio.run(cb_result)
+                _run_awaitable_from_sync(cb_result)
 
             if self.output_file:
                 content = (

--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -123,11 +123,18 @@ def _run_awaitable_from_sync(value: Any) -> None:
     Mirrors the await-response pattern in utilities/agent_utils.py: when a
     loop is already running, asyncio.run() cannot be used, so the awaitable
     is executed in a worker thread with its own loop, carrying a copy of the
-    caller's context. Non-coroutine awaitables (Tasks/Futures) are wrapped in
-    a helper coroutine first.
+    caller's context. Coroutines are wrapped in a helper coroutine first;
+    Tasks/Futures already bound to a running loop are rejected with a
+    TypeError because they cannot be awaited from another loop.
     """
     if not inspect.isawaitable(value):
         return
+
+    if isinstance(value, asyncio.Future):
+        raise TypeError(
+            "Task callbacks must return a coroutine, not a Task or Future "
+            "already bound to a running loop."
+        )
 
     async def await_callback() -> Any:
         return await value

--- a/lib/crewai/tests/crew/test_async_crew.py
+++ b/lib/crewai/tests/crew/test_async_crew.py
@@ -259,6 +259,45 @@ class TestAsyncCrewKickoff:
         assert result is not None
         assert result.raw == "Task result"
 
+    @pytest.mark.asyncio
+    @patch("crewai.task.Task.aexecute_sync", new_callable=AsyncMock)
+    async def test_akickoff_after_callback_returning_result_replaces_result(
+        self, mock_execute: AsyncMock, test_agent: Agent
+    ) -> None:
+        """A result-returning after_kickoff callback replaces the crew result."""
+        callback_called = False
+
+        def after_callback(result: CrewOutput) -> CrewOutput:
+            nonlocal callback_called
+            callback_called = True
+            result.raw = "adjusted"
+            return result
+
+        task = Task(
+            description="Test task",
+            expected_output="Test output",
+            agent=test_agent,
+        )
+        crew = Crew(
+            agents=[test_agent],
+            tasks=[task],
+            verbose=False,
+            after_kickoff_callbacks=[after_callback],
+        )
+
+        mock_output = TaskOutput(
+            description="Test task",
+            raw="Task result",
+            agent="Test Agent",
+        )
+        mock_execute.return_value = mock_output
+
+        result = await crew.akickoff()
+
+        assert callback_called
+        assert result is not None
+        assert result.raw == "adjusted"
+
 
 class TestAsyncCrewKickoffForEach:
     """Tests for async crew kickoff_for_each methods."""

--- a/lib/crewai/tests/crew/test_async_crew.py
+++ b/lib/crewai/tests/crew/test_async_crew.py
@@ -270,8 +270,7 @@ class TestAsyncCrewKickoff:
         def after_callback(result: CrewOutput) -> CrewOutput:
             nonlocal callback_called
             callback_called = True
-            result.raw = "adjusted"
-            return result
+            return CrewOutput(raw="adjusted")
 
         task = Task(
             description="Test task",

--- a/lib/crewai/tests/crew/test_async_crew.py
+++ b/lib/crewai/tests/crew/test_async_crew.py
@@ -221,6 +221,44 @@ class TestAsyncCrewKickoff:
 
         assert callback_called
 
+    @pytest.mark.asyncio
+    @patch("crewai.task.Task.aexecute_sync", new_callable=AsyncMock)
+    async def test_akickoff_after_callback_returning_none_preserves_result(
+        self, mock_execute: AsyncMock, test_agent: Agent
+    ) -> None:
+        """A None-returning after_kickoff callback must not replace the result."""
+        callback_called = False
+
+        def after_callback(result: CrewOutput) -> None:
+            nonlocal callback_called
+            callback_called = True
+            # Intentionally does not return the result.
+
+        task = Task(
+            description="Test task",
+            expected_output="Test output",
+            agent=test_agent,
+        )
+        crew = Crew(
+            agents=[test_agent],
+            tasks=[task],
+            verbose=False,
+            after_kickoff_callbacks=[after_callback],
+        )
+
+        mock_output = TaskOutput(
+            description="Test task",
+            raw="Task result",
+            agent="Test Agent",
+        )
+        mock_execute.return_value = mock_output
+
+        result = await crew.akickoff()
+
+        assert callback_called
+        assert result is not None
+        assert result.raw == "Task result"
+
 
 class TestAsyncCrewKickoffForEach:
     """Tests for async crew kickoff_for_each methods."""

--- a/lib/crewai/tests/task/test_async_task.py
+++ b/lib/crewai/tests/task/test_async_task.py
@@ -1,5 +1,7 @@
 """Tests for async task execution."""
 
+import asyncio
+
 import pytest
 from pydantic import BaseModel
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -344,6 +346,49 @@ class TestAsyncTaskExecution:
 
         assert callback_called
         assert result.raw == "Sync result"
+
+    @pytest.mark.asyncio
+    @patch("crewai.Agent.execute_task")
+    async def test_sync_execute_rejects_loop_bound_task_callback(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """A callback returning a loop-bound asyncio.Task raises TypeError on the sync path."""
+        mock_execute.return_value = "Sync result"
+
+        def task_returning_callback(output: TaskOutput):
+            return asyncio.ensure_future(asyncio.sleep(0))
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+            callback=task_returning_callback,
+        )
+
+        with pytest.raises(TypeError, match="must return a coroutine"):
+            task.execute_sync()
+
+    @pytest.mark.asyncio
+    @patch("crewai.Agent.execute_task")
+    async def test_sync_execute_rejects_loop_bound_future_callback(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """A callback returning a loop-bound asyncio.Future raises TypeError on the sync path."""
+        mock_execute.return_value = "Sync result"
+        loop = asyncio.get_running_loop()
+
+        def future_creating_callback(output: TaskOutput):
+            return loop.create_future()
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+            callback=future_creating_callback,
+        )
+
+        with pytest.raises(TypeError, match="must return a coroutine"):
+            task.execute_sync()
 
 
 class TestAsyncGuardrails:

--- a/lib/crewai/tests/task/test_async_task.py
+++ b/lib/crewai/tests/task/test_async_task.py
@@ -232,6 +232,55 @@ class TestAsyncTaskExecution:
         assert "Test error" in str(exc_info.value)
         assert task.end_time is not None
 
+    @pytest.mark.asyncio
+    @patch("crewai.Agent.execute_task")
+    async def test_sync_execute_runs_async_callback_inside_running_loop(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """Async task callback on the sync path must not crash inside a running loop."""
+        mock_execute.return_value = "Sync result"
+        callback_called = False
+
+        async def async_callback(output: TaskOutput) -> None:
+            nonlocal callback_called
+            callback_called = True
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+            callback=async_callback,
+        )
+
+        result = task.execute_sync()
+
+        assert callback_called
+        assert result.raw == "Sync result"
+
+    @patch("crewai.Agent.execute_task")
+    def test_sync_execute_runs_async_callback_without_running_loop(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """Async task callback on the sync path runs via asyncio.run when no loop is running."""
+        mock_execute.return_value = "Sync result"
+        callback_called = False
+
+        async def async_callback(output: TaskOutput) -> None:
+            nonlocal callback_called
+            callback_called = True
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+            callback=async_callback,
+        )
+
+        result = task.execute_sync()
+
+        assert callback_called
+        assert result.raw == "Sync result"
+
 
 class TestAsyncGuardrails:
     """Tests for async guardrail invocation."""

--- a/lib/crewai/tests/task/test_async_task.py
+++ b/lib/crewai/tests/task/test_async_task.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from crewai.agent import Agent
+from crewai.crew import Crew
 from crewai.task import Task
 from crewai.tasks.task_output import TaskOutput
 from crewai.tasks.output_format import OutputFormat
@@ -275,6 +276,69 @@ class TestAsyncTaskExecution:
             agent=test_agent,
             callback=async_callback,
         )
+
+        result = task.execute_sync()
+
+        assert callback_called
+        assert result.raw == "Sync result"
+
+    @pytest.mark.asyncio
+    @patch("crewai.Agent.execute_task")
+    async def test_sync_execute_runs_async_crew_task_callback_inside_running_loop(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """Async crew.task_callback on the sync path must not crash inside a running loop."""
+        mock_execute.return_value = "Sync result"
+        callback_called = False
+
+        async def async_callback(output: TaskOutput) -> None:
+            nonlocal callback_called
+            callback_called = True
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+        )
+
+        crew = Crew(
+            agents=[test_agent],
+            tasks=[task],
+            task_callback=async_callback,
+            verbose=False,
+        )
+        task.agent.crew = crew  # type: ignore[union-attr]
+
+        result = task.execute_sync()
+
+        assert callback_called
+        assert result.raw == "Sync result"
+
+    @patch("crewai.Agent.execute_task")
+    def test_sync_execute_runs_async_crew_task_callback_without_running_loop(
+        self, mock_execute: MagicMock, test_agent: Agent
+    ) -> None:
+        """Async crew.task_callback on the sync path runs via asyncio.run when no loop is running."""
+        mock_execute.return_value = "Sync result"
+        callback_called = False
+
+        async def async_callback(output: TaskOutput) -> None:
+            nonlocal callback_called
+            callback_called = True
+
+        task = Task(
+            description="Test task description",
+            expected_output="Test expected output",
+            agent=test_agent,
+        )
+
+        crew = Crew(
+            agents=[test_agent],
+            tasks=[task],
+            task_callback=async_callback,
+            verbose=False,
+        )
+        task.agent.crew = crew  # type: ignore[union-attr]
 
         result = task.execute_sync()
 

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -2177,6 +2177,78 @@ def test_task_callback_on_crew():
         assert isinstance(args[0], TaskOutput)
 
 
+def test_after_kickoff_callback_returning_none_preserves_result():
+    """A None-returning after_kickoff callback must not replace the crew result."""
+    researcher_agent = Agent(
+        role="Researcher",
+        goal="Make the best research and analysis on content about AI and AI agents",
+        backstory="You're an expert researcher, specialized in technology, software engineering, AI and startups. You work as a freelancer and is now working on doing research and analysis for a new customer.",
+        allow_delegation=False,
+    )
+
+    task = Task(
+        description="Give me a list of 5 interesting ideas to explore for an article.",
+        expected_output="Bullet point list of 5 important events.",
+        agent=researcher_agent,
+    )
+
+    callback_called = False
+
+    def logging_callback(result):
+        nonlocal callback_called
+        callback_called = True
+        # Intentionally does not return the result.
+
+    crew = Crew(
+        agents=[researcher_agent],
+        process=Process.sequential,
+        tasks=[task],
+        after_kickoff_callbacks=[logging_callback],
+    )
+
+    with patch.object(Agent, "execute_task") as execute:
+        execute.return_value = "ok"
+        result = crew.kickoff()
+
+        assert callback_called
+        assert result is not None
+        assert result.raw == "ok"
+
+
+def test_after_kickoff_callback_returning_result_still_replaces_result():
+    """A result-returning after_kickoff callback still replaces the crew result."""
+    researcher_agent = Agent(
+        role="Researcher",
+        goal="Make the best research and analysis on content about AI and AI agents",
+        backstory="You're an expert researcher, specialized in technology, software engineering, AI and startups. You work as a freelancer and is now working on doing research and analysis for a new customer.",
+        allow_delegation=False,
+    )
+
+    task = Task(
+        description="Give me a list of 5 interesting ideas to explore for an article.",
+        expected_output="Bullet point list of 5 important events.",
+        agent=researcher_agent,
+    )
+
+    def replacing_callback(result):
+        result.raw = "adjusted"
+        return result
+
+    crew = Crew(
+        agents=[researcher_agent],
+        process=Process.sequential,
+        tasks=[task],
+        after_kickoff_callbacks=[replacing_callback],
+    )
+
+    with patch.object(Agent, "execute_task") as execute:
+        execute.return_value = "ok"
+        result = crew.kickoff()
+
+        assert result is not None
+        assert result.raw == "adjusted"
+
+
 def test_task_callback_both_on_task_and_crew():
     mock_callback_on_task = MagicMock()
     mock_callback_on_crew = MagicMock()

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -2177,8 +2177,8 @@ def test_task_callback_on_crew():
         assert isinstance(args[0], TaskOutput)
 
 
-def test_after_kickoff_callback_returning_none_preserves_result():
-    """A None-returning after_kickoff callback must not replace the crew result."""
+def _make_after_kickoff_crew(after_kickoff_callbacks):
+    """Build a minimal single-agent crew with after_kickoff_callbacks set."""
     researcher_agent = Agent(
         role="Researcher",
         goal="Make the best research and analysis on content about AI and AI agents",
@@ -2192,19 +2192,23 @@ def test_after_kickoff_callback_returning_none_preserves_result():
         agent=researcher_agent,
     )
 
+    return Crew(
+        agents=[researcher_agent],
+        process=Process.sequential,
+        tasks=[task],
+        after_kickoff_callbacks=after_kickoff_callbacks,
+    )
+
+
+def test_after_kickoff_callback_returning_none_preserves_result():
+    """A None-returning after_kickoff callback must not replace the crew result."""
     callback_called = False
 
     def logging_callback(result):
         nonlocal callback_called
         callback_called = True
-        # Intentionally does not return the result.
 
-    crew = Crew(
-        agents=[researcher_agent],
-        process=Process.sequential,
-        tasks=[task],
-        after_kickoff_callbacks=[logging_callback],
-    )
+    crew = _make_after_kickoff_crew([logging_callback])
 
     with patch.object(Agent, "execute_task") as execute:
         execute.return_value = "ok"
@@ -2217,29 +2221,11 @@ def test_after_kickoff_callback_returning_none_preserves_result():
 
 def test_after_kickoff_callback_returning_result_still_replaces_result():
     """A result-returning after_kickoff callback still replaces the crew result."""
-    researcher_agent = Agent(
-        role="Researcher",
-        goal="Make the best research and analysis on content about AI and AI agents",
-        backstory="You're an expert researcher, specialized in technology, software engineering, AI and startups. You work as a freelancer and is now working on doing research and analysis for a new customer.",
-        allow_delegation=False,
-    )
-
-    task = Task(
-        description="Give me a list of 5 interesting ideas to explore for an article.",
-        expected_output="Bullet point list of 5 important events.",
-        agent=researcher_agent,
-    )
-
     def replacing_callback(result):
         result.raw = "adjusted"
         return result
 
-    crew = Crew(
-        agents=[researcher_agent],
-        process=Process.sequential,
-        tasks=[task],
-        after_kickoff_callbacks=[replacing_callback],
-    )
+    crew = _make_after_kickoff_crew([replacing_callback])
 
     with patch.object(Agent, "execute_task") as execute:
         execute.return_value = "ok"

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -2222,8 +2222,7 @@ def test_after_kickoff_callback_returning_none_preserves_result():
 def test_after_kickoff_callback_returning_result_still_replaces_result():
     """A result-returning after_kickoff callback still replaces the crew result."""
     def replacing_callback(result):
-        result.raw = "adjusted"
-        return result
+        return CrewOutput(raw="adjusted")
 
     crew = _make_after_kickoff_crew([replacing_callback])
 

--- a/lib/crewai/tests/test_crew.py
+++ b/lib/crewai/tests/test_crew.py
@@ -284,6 +284,57 @@ def test_crew_config_with_wrong_keys():
         Crew(process=Process.sequential, config=no_agents_config)
 
 
+def test_crew_config_unknown_agent_role_raises_helpful_value_error():
+    """A task referencing an unknown agent role raises a ValueError naming the role."""
+    config = {
+        "agents": [
+            {
+                "role": "Researcher",
+                "goal": "Research",
+                "backstory": "Expert researcher",
+            }
+        ],
+        "tasks": [
+            {
+                "description": "Write an article",
+                "expected_output": "An article",
+                "agent": "Writer",
+            }
+        ],
+    }
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Task references agent role 'Writer' which doesn't match any agent"),
+    ) as exc_info:
+        Crew(process=Process.sequential, config=config)
+    assert "Researcher" in str(exc_info.value)
+
+
+def test_crew_config_dict_is_not_mutated_by_task_creation():
+    """Reusing the same config dict across two Crew constructions must not raise KeyError."""
+    config = {
+        "agents": [
+            {
+                "role": "Researcher",
+                "goal": "Research",
+                "backstory": "Expert researcher",
+            }
+        ],
+        "tasks": [
+            {
+                "description": "Write an article",
+                "expected_output": "An article",
+                "agent": "Researcher",
+            }
+        ],
+    }
+    first_crew = Crew(process=Process.sequential, config=config)
+    assert len(first_crew.tasks) == 1
+    assert first_crew.tasks[0].agent.role == "Researcher"
+    second_crew = Crew(process=Process.sequential, config=config)
+    assert len(second_crew.tasks) == 1
+
+
 @pytest.mark.vcr()
 def test_crew_creation(researcher, writer):
     tasks = [


### PR DESCRIPTION
## Summary

Fixes #6439 — four error-handling defects in Crew config-based construction and callback execution that produced cryptic runtime failures.

**Before:** a task referencing an unknown agent role raised a bare `StopIteration`; reusing the same config dict across two `Crew(config=...)` constructions raised `KeyError: 'agent'`; a side-effect `after_kickoff_callbacks` function that didn't return the result replaced the crew result with `None`; and an async task callback on the synchronous execution path crashed with `asyncio.run() cannot be called from a running event loop` inside Jupyter/`akickoff()`.

**After:** the unknown-role case raises a `ValueError` naming the missing role and available roles; the caller's config dict is no longer mutated; a `None`-returning `after_kickoff_callbacks` preserves the crew result; and async task callbacks run safely from the sync path, using a worker thread when an event loop is already running. Loop-bound Task/Future returns are rejected with a clear `TypeError` (mirroring `utilities/agent_utils.py`), so the crash class the fix targets cannot resurface.

## Changes

- `_create_task`: helpful `ValueError` on unknown agent role; config dict copied before removing `agent`.
- `kickoff` / `akickoff`: `after_kickoff_callbacks` returning `None` no longer overwrites the result; a returned value still replaces it.
- `_execute_core`: async task callbacks routed through a worker-thread fallback when a loop is running (with `contextvars` copied), otherwise `asyncio.run` directly.
- Regression tests for each bug, including the running-loop and no-loop async callback branches and the crew-level `task_callback` path.

## Test Plan

- `uv run pytest lib/crewai/tests/task/ lib/crewai/tests/crew/test_async_crew.py lib/crewai/tests/test_crew.py` — 169 passed, 1 skipped; the single failure (`test_crew_kickoff_streaming_usage_metrics`) is a pre-existing environment issue (LiteLLM not installed) confirmed on the base commit.
- `uv run ruff check` on changed files — clean.
- `uv run mypy` on `crew.py` and `task.py` — clean.

Fixes #6439

<!-- crewai-require-issue-check -->