### PR TITLE
feat(flow): make conversational opt-in unmistakable

### DIFF
--- a/lib/crewai/src/crewai/experimental/conversational.py
+++ b/lib/crewai/src/crewai/experimental/conversational.py
@@ -96,8 +96,17 @@ class ConversationConfig:
     defer_trace_finalization: bool = True
 
     def __call__(self, flow_cls: type[Any]) -> type[Any]:
-        """Use this config as a class decorator."""
+        """Use this config as a class decorator.
+
+        Decorating a Flow also opts it into conversational mode. Every field
+        here is consumed only by the conversational runtime, so a decorated Flow
+        that was not conversational would silently discard its whole config:
+        ``handle_turn()`` would return ``None`` without appending or raising.
+        Setting ``conversational = True`` explicitly is still supported and is
+        the way to opt in without a config.
+        """
         flow_cls.conversational_config = self
+        flow_cls.conversational = True
         return flow_cls
 
 

--- a/lib/crewai/src/crewai/experimental/conversational_mixin.py
+++ b/lib/crewai/src/crewai/experimental/conversational_mixin.py
@@ -293,11 +293,22 @@ class _ConversationalMixin:
            conversational ``Flow``. Signature and semantics may change before
            the feature graduates from ``crewai.experimental``.
 
-        Available only when ``conversational = True`` is set on the subclass.
-        Stashes the message + session_id as pending turn state, runs kickoff
-        (which restores from persist and then applies the pending turn), and
-        promotes the result to an assistant message when the handler didn't.
+        Available only when ``conversational = True`` is set on the subclass
+        (``@ConversationConfig`` sets it for you). Stashes the message +
+        session_id as pending turn state, runs kickoff (which restores from
+        persist and then applies the pending turn), and promotes the result to
+        an assistant message when the handler didn't.
+
+        Raises:
+            ValueError: If the flow is not conversational. Without this the
+                turn is a silent no-op: no route handlers are registered, the
+                message is never appended, and ``None`` comes back.
         """
+        if not self._is_conversational_enabled():
+            raise ValueError(
+                "Flow.handle_turn() is only available on conversational flows"
+            )
+
         state = cast(ConversationState, self.state)
         sid = session_id or state.id
         crewai_event_bus.emit(

--- a/lib/crewai/src/crewai/flow/conversational_definition.py
+++ b/lib/crewai/src/crewai/flow/conversational_definition.py
@@ -26,9 +26,21 @@ class FlowConversationalRouterDefinition(BaseModel):
 
 
 class FlowConversationalDefinition(BaseModel):
-    """Static conversational Flow configuration."""
+    """Static conversational Flow configuration.
 
-    enabled: bool = False
+    The block is absent (``FlowDefinition.conversational is None``) on flows
+    that are not conversational, so declaring it at all is the opt-in.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Whether conversational mode is active. Declaring the conversational "
+            "block is the opt-in, so this defaults to true; set it to false to "
+            "keep the configuration while turning chat off."
+        ),
+        examples=[True],
+    )
     system_prompt: str | None = None
     llm: Any = None
     router: FlowConversationalRouterDefinition | None = None

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -2136,3 +2136,136 @@ class TestNestedCrewTracing:
                 "nested AgentExecutor flows inside a deferred parent Flow must "
                 "not finalize the parent trace batch"
             )
+
+
+class TestConversationalOptIn:
+    """``@ConversationConfig`` opts a Flow into conversational mode."""
+
+    def test_decorator_alone_enables_conversational_mode(self) -> None:
+        @ConversationConfig(llm="gpt-4o-mini")
+        class DecoratedFlow(Flow[ConversationState]):
+            @listen("order")
+            def handle_order(self) -> str:
+                """Order status questions."""
+                return "on the way"
+
+        definition = DecoratedFlow.flow_definition()
+
+        assert definition.conversational is not None
+        assert definition.conversational.enabled is True
+        assert definition.conversational.llm == "gpt-4o-mini"
+
+    def test_decorator_alone_registers_the_builtin_methods(self) -> None:
+        @ConversationConfig()
+        class DecoratedFlow(Flow[ConversationState]):
+            pass
+
+        methods = DecoratedFlow.flow_definition().methods
+
+        assert "route_conversation" in methods
+        assert methods["route_conversation"].start is True
+        assert methods["route_conversation"].router is True
+        assert "converse_turn" in methods
+        assert "end_conversation" in methods
+
+    def test_decorator_alone_runs_a_turn(self) -> None:
+        @ConversationConfig()
+        class DecoratedFlow(Flow[ConversationState]):
+            @listen("converse")
+            def converse_turn(self) -> str:
+                return "handled"
+
+        flow = DecoratedFlow()
+
+        assert flow.handle_turn("hello") == "handled"
+        assert [(m.role, m.content) for m in flow.state.messages] == [
+            ("user", "hello"),
+            ("assistant", "handled"),
+        ]
+
+    def test_decorator_alone_defers_trace_finalization(self) -> None:
+        @ConversationConfig()
+        class DecoratedFlow(Flow[ConversationState]):
+            pass
+
+        assert DecoratedFlow()._should_defer_trace_finalization() is True
+
+    def test_explicit_flag_without_a_config_still_opts_in(self) -> None:
+        class FlagOnlyFlow(Flow[ConversationState]):
+            conversational = True
+
+        definition = FlagOnlyFlow.flow_definition()
+
+        assert definition.conversational is not None
+        assert definition.conversational.enabled is True
+        assert FlagOnlyFlow()._is_conversational_enabled() is True
+
+    def test_flow_with_neither_stays_non_conversational(self) -> None:
+        class PlainFlow(Flow):
+            @start()
+            def begin(self) -> str:
+                return "begin"
+
+        definition = PlainFlow.flow_definition()
+
+        assert definition.conversational is None
+        assert set(definition.methods) == {"begin"}
+        assert PlainFlow.conversational is False
+
+    def test_decorator_does_not_leak_the_flag_onto_other_flows(self) -> None:
+        @ConversationConfig()
+        class DecoratedFlow(Flow[ConversationState]):
+            pass
+
+        class LaterPlainFlow(Flow):
+            @start()
+            def begin(self) -> str:
+                return "begin"
+
+        assert DecoratedFlow.conversational is True
+        assert LaterPlainFlow.conversational is False
+        assert Flow.conversational is False
+        assert LaterPlainFlow.flow_definition().conversational is None
+
+
+class TestHandleTurnGuard:
+    """``handle_turn`` fails loudly on a non-conversational Flow."""
+
+    def test_handle_turn_rejects_non_conversational_flows(self) -> None:
+        class PlainFlow(Flow[ConversationState]):
+            @start()
+            def begin(self) -> str:
+                return "begin"
+
+        with pytest.raises(
+            ValueError,
+            match="Flow.handle_turn\\(\\) is only available on conversational flows",
+        ):
+            PlainFlow().handle_turn("hello")
+
+    def test_handle_turn_guard_matches_chat_and_stream_turn(self) -> None:
+        class PlainFlow(Flow[ConversationState]):
+            @start()
+            def begin(self) -> str:
+                return "begin"
+
+        flow = PlainFlow()
+
+        for call in (
+            lambda: flow.handle_turn("hi"),
+            lambda: flow.stream_turn("hi"),
+            flow.chat,
+        ):
+            with pytest.raises(
+                ValueError, match="only available on conversational flows"
+            ):
+                call()
+
+    def test_guard_does_not_fire_on_a_conversational_flow(self) -> None:
+        @ConversationConfig()
+        class DecoratedFlow(Flow[ConversationState]):
+            @listen("converse")
+            def converse_turn(self) -> str:
+                return "ok"
+
+        assert DecoratedFlow().handle_turn("hi") == "ok"

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -43,17 +43,6 @@ from crewai.flow.conversation import (
     prepare_conversational_turn,
 )
 
-# The built-in conversational graph lives on ``_ConversationalMixin`` and is
-# inherited by ``conversational = True`` subclasses. The definition-first start
-# migration intentionally stopped scanning inherited methods, so that graph no
-# longer registers. These end-to-end conversational tests are out of scope
-# until conversational mode is migrated onto the FlowDefinition.
-conversational_graph_broken = pytest.mark.skip(
-    reason="Experimental conversational registry behavior is out of scope for "
-    "the definition-first start migration."
-)
-
-
 class ConversationalFlow(Flow[ConversationState]):
     """Test base: a ``Flow[ConversationState]`` with conversational mode enabled.
 
@@ -309,7 +298,6 @@ class TestConversationalFlow:
         assert flow.state.events[0].agent_name == "researcher"
         assert flow.state.events[0].visibility == "public"
 
-    @conversational_graph_broken
     def test_private_agent_results_stay_out_of_shared_history(self) -> None:
         class PrivateFlow(ConversationalFlow):
             def route_turn(self, context: dict[str, Any]) -> str | None:
@@ -326,7 +314,6 @@ class TestConversationalFlow:
         assert flow.state.events[0].visibility == "private"
         assert flow.state.agent_threads["planner"][0].content == "private scratch"
 
-    @conversational_graph_broken
     def test_answer_from_history_uses_configured_llm_and_appends_reply(self) -> None:
         @ConversationConfig(answer_from_history_llm="gpt-4o-mini")
         class HistoryFlow(ConversationalFlow):
@@ -357,7 +344,6 @@ class TestConversationalFlow:
         assert flow.state.messages[-1].content == "summary from history"
         llm.call.assert_called_once()
 
-    @conversational_graph_broken
     def test_router_config_uses_structured_intent_response(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "clarify"]
@@ -394,7 +380,6 @@ class TestConversationalFlow:
         assert llm.call.call_args.kwargs["response_format"] is ResearchRoute
         assert flow.state.messages[-1].content == "researched"
 
-    @conversational_graph_broken
     def test_router_config_falls_back_for_invalid_intent(self) -> None:
         class ResearchRoute(BaseModel):
             intent: str
@@ -453,7 +438,6 @@ class TestConversationalFlow:
             "end",
         }
 
-    @conversational_graph_broken
     def test_router_infers_custom_routes_without_internal_routes(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "converse", "end"]
@@ -477,7 +461,6 @@ class TestConversationalFlow:
             "end",
         }
 
-    @conversational_graph_broken
     def test_router_config_uses_conversational_defaults(self) -> None:
         llm = MagicMock()
 
@@ -504,7 +487,6 @@ class TestConversationalFlow:
         )
         assert flow.state.messages[-1].content == "researched"
 
-    @conversational_graph_broken
     def test_builtin_converse_appends_assistant_message_and_uses_history(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "converse", "end"]
@@ -552,7 +534,6 @@ class TestConversationalFlow:
         assert any(message["content"] == "prior findings" for message in messages)
         assert any(message["content"] == "summarize findings" for message in messages)
 
-    @conversational_graph_broken
     def test_conversational_turn_emits_message_and_route_events(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "converse", "end"]
@@ -603,7 +584,6 @@ class TestConversationalFlow:
         assert routes[0].user_message == "just chat"
         assert routes[0].session_id == messages[0].session_id
 
-    @conversational_graph_broken
     def test_builtin_end_marks_conversation_ended(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "converse", "end"]
@@ -632,7 +612,6 @@ class TestConversationalFlow:
         assert flow.state.ended is True
         assert flow.state.messages[-1].content == "Conversation ended."
 
-    @conversational_graph_broken
     def test_router_auto_enables_when_custom_routes_declared_and_no_explicit_config(
         self,
     ) -> None:
@@ -665,7 +644,6 @@ class TestConversationalFlow:
         # Router LLM should have been invoked.
         assert router_llm.call.call_count >= 1
 
-    @conversational_graph_broken
     def test_router_auto_enable_skipped_when_only_builtin_routes(self) -> None:
         """No custom routes → no auto-enable; falls through to converse."""
 
@@ -683,7 +661,6 @@ class TestConversationalFlow:
         # chat_llm was used by converse_turn, not as a router.
         assert chat_llm.call.call_count == 1
 
-    @conversational_graph_broken
     def test_router_auto_enable_skipped_when_default_intents_set(self) -> None:
         """Legacy ``default_intents`` opts out of router auto-enable."""
 
@@ -814,7 +791,6 @@ class TestConversationalFlow:
         assert bootstrap_calls == ["ran"]
         assert flow.state.messages[-1].content == "worked"
 
-    @conversational_graph_broken
     def test_handle_turn_reruns_graph_after_prior_turn_completed(self) -> None:
         """Multi-turn must not flip ``_is_execution_resuming`` and short-circuit.
 
@@ -870,7 +846,6 @@ class TestConversationalFlow:
         assert flow.state.messages[-1].content == "fresh research"
         assert flow._is_execution_resuming is False
 
-    @conversational_graph_broken
     def test_route_catalog_combines_docstrings_builtins_and_overrides(self) -> None:
         """Catalog precedence: route_descriptions > built-in > docstring."""
 
@@ -902,7 +877,6 @@ class TestConversationalFlow:
         assert "Ordinary chat" in catalog["converse"]
         assert "finished" in catalog["end"]
 
-    @conversational_graph_broken
     def test_route_catalog_falls_back_to_empty_when_no_docstring(self) -> None:
         @ConversationConfig(router=RouterConfig(routes=["BARE"]))
         class BareFlow(ConversationalFlow):
@@ -915,7 +889,6 @@ class TestConversationalFlow:
 
         assert catalog["BARE"] == ""
 
-    @conversational_graph_broken
     def test_router_messages_include_route_catalog(self) -> None:
         """The router system prompt must enumerate routes with descriptions."""
 
@@ -949,7 +922,6 @@ class TestConversationalFlow:
         assert "- converse: Ordinary chat" in system_message
         assert system_message.startswith("A research-focused assistant.")
 
-    @conversational_graph_broken
     def test_router_decision_persists_last_intent_and_passes_it_next_turn(
         self,
     ) -> None:
@@ -994,7 +966,6 @@ class TestConversationalFlow:
         ]
         assert '"last_intent": "research"' in second_call_user_content
 
-    @conversational_graph_broken
     def test_custom_route_still_runs_with_builtin_routes(self) -> None:
         class ResearchRoute(BaseModel):
             intent: Literal["research", "converse", "end"]
@@ -1041,7 +1012,6 @@ class TestConversationalFlow:
         assert flow.state.current_user_message is None
         assert flow.state.session_ready is False
 
-    @conversational_graph_broken
     def test_mixin_handle_turn_resolves_on_flow_subclass(self) -> None:
         """``Flow`` mixes in ``_ConversationalMixin`` — opt-in subclasses get its methods.
 
@@ -1074,7 +1044,6 @@ class TestConversationalFlow:
         flow.handle_turn("anything")
         assert flow.state.messages[-1].content == "worked"
 
-    @conversational_graph_broken
     def test_chat_runs_repl_over_handle_turn_and_finalizes(self) -> None:
         @ConversationConfig(defer_trace_finalization=False)
         class MyChat(ConversationalFlow):
@@ -1115,7 +1084,6 @@ class TestConversationalFlow:
         mock_finalize.assert_called_once_with()
         assert flow.defer_trace_finalization is False
 
-    @conversational_graph_broken
     def test_chat_stringifies_repl_output_like_conversation_helpers(self) -> None:
         class RawResult:
             raw = "raw assistant output"

--- a/lib/crewai/tests/test_flow_definition.py
+++ b/lib/crewai/tests/test_flow_definition.py
@@ -452,6 +452,67 @@ def test_flow_definition_uses_collapsed_conversational_router_start():
     assert methods["route_conversation"].router is True
 
 
+def test_declaring_the_conversational_block_opts_in_without_enabled():
+    definition = flow_definition.FlowDefinition.from_declaration(
+        contents={
+            "schema": "crewai.flow/v1",
+            "name": "JsonChat",
+            "conversational": {"llm": "gpt-4o-mini"},
+            "methods": {
+                "begin": {"do": {"call": "expression", "expr": "'x'"}, "start": True}
+            },
+        }
+    )
+
+    assert definition.conversational is not None
+    assert definition.conversational.enabled is True
+    assert definition.conversational.llm == "gpt-4o-mini"
+
+
+def test_conversational_block_can_be_explicitly_disabled():
+    definition = flow_definition.FlowDefinition.from_declaration(
+        contents={
+            "schema": "crewai.flow/v1",
+            "name": "JsonChat",
+            "conversational": {"enabled": False, "llm": "gpt-4o-mini"},
+            "methods": {
+                "begin": {"do": {"call": "expression", "expr": "'x'"}, "start": True}
+            },
+        }
+    )
+
+    assert definition.conversational is not None
+    assert definition.conversational.enabled is False
+    assert definition.conversational.llm == "gpt-4o-mini"
+
+
+def test_omitting_the_conversational_block_leaves_it_none():
+    definition = flow_definition.FlowDefinition.from_declaration(
+        contents={
+            "schema": "crewai.flow/v1",
+            "name": "PlainJson",
+            "methods": {
+                "begin": {"do": {"call": "expression", "expr": "'x'"}, "start": True}
+            },
+        }
+    )
+
+    assert definition.conversational is None
+
+
+def test_flow_definition_includes_conversational_from_decorator_alone():
+    @ConversationConfig(llm="gpt-4o-mini")
+    class DecoratedFlow(Flow):
+        pass
+
+    definition = DecoratedFlow.flow_definition()
+
+    assert definition.conversational is not None
+    assert definition.conversational.enabled is True
+    assert "route_conversation" in definition.methods
+    assert "converse_turn" in definition.methods
+
+
 def test_flow_definition_degrades_human_feedback_metadata(caplog):
     caplog.set_level(logging.WARNING, logger="crewai.flow.dsl._utils")
     marker = object()


### PR DESCRIPTION
- Makes `@ConversationConfig(...)` opt a Flow into conversational mode on its own, so chat no longer needs two statements that must agree. Every field on the config is consumed only by the conversational graph, so a decorated non-conversational Flow could only ever discard it.
- Public API consequence, called out deliberately: `ConversationConfig` is re-exported from `crewai.experimental`, and decorating a Flow now sets `conversational = True` on it. `handle_turn()` also raises `ValueError` on a non-conversational Flow instead of returning `None` — matching the guards `chat()` and `stream_turn()` already have. Every in-repo `handle_turn` caller is on a conversational Flow; an out-of-repo caller relying on the `None` return will now see the error, which is the point. And `FlowConversationalDefinition.enabled` now defaults to `true`, so declaring the block in JSON/YAML is the opt-in; `enabled: false` keeps the config while turning chat off.
- Preserved: `conversational = True` by hand still opts in with no config; a Flow with neither stays non-conversational with `conversational is None` in its definition; both existing `FlowConversationalDefinition` constructors already passed `enabled=True` explicitly, and nothing asserted the old `False` default.
- Tests: 194 lines of new tests against 40 of production. Covers the decorator alone enabling the mode, registering the built-in graph, running a full turn and deferring trace finalization; the bare flag still working; a Flow with neither staying plain; the decorator not leaking the flag onto later Flow subclasses or onto `Flow` itself; the `handle_turn` guard and its parity with `chat`/`stream_turn`; and the three JSON cases (block without `enabled`, explicit `enabled: false`, no block at all). Ran green: `test_flow_conversation` + `test_flow_definition` + `test_flow_from_definition` = 290 passed; all flow + telemetry suites = 726 passed; mirrored CLI tests = 269 passed. `ruff check`/`format` clean; `mypy` on the three changed files adds zero errors over the clean-tree baseline.
- No docs touched — the declarative conversational surface is documented in a later PR in this sequence, once it executes.
- Keeps this intentionally small: no inference from `Flow[ConversationState]` (verified unsafe — `Flow[ChatState]` + `conversational = True` raises today), no deprecation of the bare `conversational = True` flag, no removal of the `enabled` field, no conversational resolver, no built-in graph synthesis, no state-precedence fix.
- Next: route every conversational config read through a resolver that prefers the instance `_definition` over the class projection, so a JSON/YAML declaration can actually drive chat — and fix state precedence in the same change, because flipping the gates without it destroys declared state fields.

Stacked on #7030; retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for callers that invoked handle_turn on non-conversational flows and relied on None; conversational JSON semantics change because enabled now defaults to true when the block is present.
> 
> **Overview**
> **`@ConversationConfig` alone opts a Flow into conversational mode** by setting `conversational = True` on the class, so decorators no longer need a separate flag that could disagree and silently drop config.
> 
> **`handle_turn()` now raises `ValueError` on non-conversational flows** instead of returning `None`, aligning with `chat()` and `stream_turn()`.
> 
> **Declarative flows:** `FlowConversationalDefinition.enabled` defaults to `true`, so a JSON/YAML `conversational` block is the opt-in; `enabled: false` keeps settings while turning chat off. Omitting the block still leaves `conversational` as `None`.
> 
> Tests cover decorator-only opt-in, guards, JSON declaration cases, and that the flag does not leak to other Flow subclasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafa3c8a6f1e8bc34780cd1d091c7f460163514f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->