### PR TITLE
fix(flow): let an agent or crew handler reply in a conversation

### DIFF
--- a/lib/crewai/src/crewai/experimental/conversational_mixin.py
+++ b/lib/crewai/src/crewai/experimental/conversational_mixin.py
@@ -1343,9 +1343,19 @@ class _ConversationalMixin:
         return "private"
 
     def _is_public_turn_result(self, result: Any) -> bool:
-        if not isinstance(result, str):
+        """Whether a handler's return value should become the assistant reply.
+
+        Declarative ``agent`` and ``crew`` actions return ``LiteAgentOutput`` /
+        ``CrewOutput`` rather than a string, so the text lives on ``.raw``.
+        Without unwrapping it here their reply never reaches the transcript.
+        """
+        text = result
+        raw = getattr(result, "raw", None)
+        if not isinstance(text, str) and isinstance(raw, str):
+            text = raw
+        if not isinstance(text, str):
             return False
-        if result in {
+        if text in {
             "conversation",
             "converse",
             "end",
@@ -1353,7 +1363,7 @@ class _ConversationalMixin:
             "route_to_flow",
         }:
             return False
-        return result != cast(ConversationState, self.state).last_intent
+        return text != cast(ConversationState, self.state).last_intent
 
     @staticmethod
     def _coerce_user_message_text(user_message: str | dict[str, Any] | Any) -> str:

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -2893,3 +2893,90 @@ class TestDeclarativeTurnMatrix:
             "bye",
         ]
         assert len(outputs) == 2
+
+
+class TestHandlerReplyPromotion:
+    """An agent or crew handler's reply reaches the transcript."""
+
+    class _AgentOutput:
+        """Shape of ``LiteAgentOutput`` / ``CrewOutput``: text lives on ``.raw``."""
+
+        def __init__(self, raw: str) -> None:
+            self.raw = raw
+
+        def __str__(self) -> str:
+            return f"<output {self.raw!r}>"
+
+    @staticmethod
+    def _chat(handler_result: Any) -> Flow[Any]:
+        @ConversationConfig()
+        class HandlerChat(Flow[ConversationState]):
+            @listen("converse")
+            def converse_turn(self) -> Any:
+                return handler_result
+
+        return HandlerChat()
+
+    def test_output_object_reply_reaches_history(self) -> None:
+        flow = self._chat(self._AgentOutput("Your order shipped Tuesday."))
+
+        flow.handle_turn("where is my order?")
+
+        assert [(m.role, m.content) for m in flow.state.messages] == [
+            ("user", "where is my order?"),
+            ("assistant", "Your order shipped Tuesday."),
+        ]
+
+    def test_string_reply_still_reaches_history(self) -> None:
+        flow = self._chat("A plain string reply.")
+
+        flow.handle_turn("hi")
+
+        assert flow.state.messages[-1].content == "A plain string reply."
+
+    def test_route_label_output_is_not_promoted(self) -> None:
+        flow = self._chat(self._AgentOutput("converse"))
+
+        flow.handle_turn("hi")
+
+        assert [m.role for m in flow.state.messages] == ["user"]
+
+    def test_output_matching_this_turns_intent_is_not_promoted(self) -> None:
+        @ConversationConfig()
+        class RoutedChat(Flow[ConversationState]):
+            def route_turn(self, context: dict[str, Any]) -> str:
+                return "order"
+
+            @listen("order")
+            def handle_order(self) -> Any:
+                # Echoing the route label is a routing artefact, not a reply.
+                return TestHandlerReplyPromotion._AgentOutput("order")
+
+        flow = RoutedChat()
+        flow.handle_turn("where is my order?")
+
+        assert flow.state.last_intent == "order"
+        assert [m.role for m in flow.state.messages] == ["user"]
+
+    def test_non_text_output_is_not_promoted(self) -> None:
+        flow = self._chat(self._AgentOutput(raw=None))  # type: ignore[arg-type]
+
+        flow.handle_turn("hi")
+
+        assert [m.role for m in flow.state.messages] == ["user"]
+
+    def test_handler_that_already_replied_is_not_double_promoted(self) -> None:
+        @ConversationConfig()
+        class ExplicitReplyChat(Flow[ConversationState]):
+            @listen("converse")
+            def converse_turn(self) -> Any:
+                self.append_assistant_message("explicit")
+                return TestHandlerReplyPromotion._AgentOutput("returned")
+
+        flow = ExplicitReplyChat()
+        flow.handle_turn("hi")
+
+        assert [(m.role, m.content) for m in flow.state.messages] == [
+            ("user", "hi"),
+            ("assistant", "explicit"),
+        ]


### PR DESCRIPTION
- Lets a conversational handler that runs an agent or a crew actually reply. `handle_turn` promotes a handler's return value to the assistant message when the handler did not append one itself, but the check required `isinstance(result, str)` — and declarative `agent` / `crew` actions return `LiteAgentOutput` / `CrewOutput`, whose text lives on `.raw`. The most natural declarative handler was the one whose reply silently never reached the transcript.
- `_is_public_turn_result` now unwraps `.raw` before deciding, matching `_stringify_result` which already did. No public signature changes; this is a shared conversational path, so the behavior change is that a previously-dropped reply now appears.
- Preserved: the routing-artefact guards still apply, now to the unwrapped text — an output echoing a built-in route label (`converse`, `end`, `answer_from_history`, `route_to_flow`) or this turn's `last_intent` is still not promoted, and a handler that already called `append_assistant_message` is still not double-promoted. Plain string replies are unchanged.
- Tests: 87 lines covering an output object reaching history, plain strings still working, a route-label output being suppressed, an output matching this turn's routed intent being suppressed, a non-text `.raw` being ignored, and no double promotion when the handler already replied. Ran green: 1027 passed across all flow, telemetry and mirrored-CLI suites. `ruff check`/`format` clean; `mypy` at the clean-tree baseline with 0 errors in the changed file.
- No docs touched — documented in the final PR of this sequence.
- Keeps this intentionally small: no `ConversationState` composition into inline `json_schema` state, no `str | LLMDefinition` resolution for declared LLMs, no message-list input for the `agent` action, no declarative way to mark which action's output *is* the reply.
- Next: docs and the authoring skill, which currently tell LLM authors to write a `conversational` block while documenting none of its fields.

Two known-issue notes. `test_flow_multimodal` (7 tests) fails on a clean tree here for missing local provider credentials. `test_flow_telemetry.py::test_a_deferred_session_still_reports_a_failed_turn` records a duplicate duration span roughly 1 run in 4 when the telemetry, flow and mirrored-CLI files run together under `--dist=loadfile`; reproduced at the same rate on the parent branch with none of these changes, so it is pre-existing and wants its own ticket.

Stacked on #7033; retarget once the chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to experimental conversational reply promotion with regression tests; previously dropped replies now appear in the transcript.
> 
> **Overview**
> **Fixes silent missing replies** when a conversational flow handler returns `LiteAgentOutput` / `CrewOutput` (declarative `agent` / `crew` actions) instead of a plain string.
> 
> `handle_turn` only auto-appends the handler return value when `_is_public_turn_result` passes; that helper previously required `isinstance(result, str)`, so object-shaped outputs never qualified even though `_stringify_result` already reads `.raw`. **`_is_public_turn_result` now unwraps a string `.raw` before** applying the existing guards (built-in route labels, match to `last_intent`, non-text outputs).
> 
> Plain string returns, explicit `append_assistant_message`, and suppression of routing artefacts behave as before—now evaluated on the unwrapped text. New tests cover promotion, string paths, route-label suppression, intent echo suppression, non-text `.raw`, and no double promotion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934cfb31badc7e9b2e126a3e0c3ba8bbe5083ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->