### PR TITLE
docs(llms): add QwenCloud provider configuration guide

### DIFF
--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1012,6 +1012,67 @@ mode: "wide"
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="QwenCloud">
+    يوفر [QwenCloud](https://www.qwencloud.com/) إمكانية الوصول إلى عائلة نماذج Qwen اللغوية الكبيرة من Alibaba عبر واجهات برمجة تطبيقات متوافقة مع OpenAI.
+
+    عيّن متغيرات البيئة التالية في ملف `.env`:
+    ```toml Code
+    # Required
+    DASHSCOPE_API_KEY=<your-api-key>
+    ```
+
+    احصل على مفتاح API الخاص بك من [صفحة مفاتيح API في QwenCloud](https://home.qwencloud.com/api-keys).
+
+    **الطريقة 1 — بادئة DashScope / LiteLLM (موصى بها):**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="dashscope/qwen-max",
+        temperature=0.7,
+        max_tokens=4096
+    )
+    ```
+
+    **الطريقة 2 — نقطة نهاية متوافقة مع OpenAI:**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/qwen-plus",
+        base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        api_key="your-api-key",
+        temperature=0.7
+    )
+    ```
+
+    **النماذج المتاحة:**
+
+    | النموذج | نافذة السياق | الأفضل لـ |
+    |---|---|---|
+    | `dashscope/qwen-max` | 32,768 | الاستدلال المعقد |
+    | `dashscope/qwen-plus` | 131,072 | مهام السياق الطويل |
+    | `dashscope/qwen-turbo` | 131,072 | الاستنتاج السريع |
+    | `dashscope/qwen-long` | 1,000,000 | المستندات فائقة الطول |
+    | `dashscope/qwen2.5-72b-instruct` | 131,072 | اتباع التعليمات |
+
+    <Info>
+      ميزات QwenCloud:
+      - واجهات برمجة تطبيقات متوافقة مع OpenAI و Anthropic
+      - نقطة نهاية دولية (`dashscope-intl.aliyuncs.com`) ونقطة نهاية الصين (`dashscope.aliyuncs.com`)
+      - أسعار تنافسية مع نماذج عالية السعة
+      - دعم استدعاء الدوال لنماذج Qwen
+    </Info>
+
+    للحصول على قائمة النماذج الكاملة، راجع [نماذج QwenCloud](https://www.qwencloud.com/models).
+    لتفاصيل الأسعار، راجع [أسعار QwenCloud](https://docs.qwencloud.com/developer-guides/getting-started/pricing).
+
+    **ملاحظة:** يستخدم هذا المزود LiteLLM. أضفه كتبعية لمشروعك:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## بث الاستجابات

--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1054,12 +1054,12 @@ mode: "wide"
     | `dashscope/qwen-max` | 32,768 | الاستدلال المعقد |
     | `dashscope/qwen-plus` | 131,072 | مهام السياق الطويل |
     | `dashscope/qwen-turbo` | 131,072 | الاستنتاج السريع |
-    | `dashscope/qwen-long` | 1,000,000 | المستندات فائقة الطول |
+    | `dashscope/qwen-long` | 10,000,000 | المستندات فائقة الطول |
     | `dashscope/qwen2.5-72b-instruct` | 131,072 | اتباع التعليمات |
 
     <Info>
       ميزات QwenCloud:
-      - واجهات برمجة تطبيقات متوافقة مع OpenAI و Anthropic
+      - واجهات برمجة تطبيقات متوافقة مع OpenAI وتكامل DashScope الأصلي
       - نقطة نهاية دولية (`dashscope-intl.aliyuncs.com`) ونقطة نهاية الصين (`dashscope.aliyuncs.com`)
       - أسعار تنافسية مع نماذج عالية السعة
       - دعم استدعاء الدوال لنماذج Qwen

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1155,6 +1155,69 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="QwenCloud">
+    [QwenCloud](https://www.qwencloud.com/) provides access to Alibaba's Qwen
+    family of large language models through OpenAI-compatible APIs.
+
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    # Required
+    DASHSCOPE_API_KEY=<your-api-key>
+    ```
+
+    Get your API key from the [QwenCloud API Keys page](https://home.qwencloud.com/api-keys).
+
+    **Method 1 — DashScope / LiteLLM Prefix (Recommended):**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="dashscope/qwen-max",
+        temperature=0.7,
+        max_tokens=4096
+    )
+    ```
+
+    **Method 2 — OpenAI-Compatible Endpoint:**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/qwen-plus",
+        base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        api_key="your-api-key",
+        temperature=0.7
+    )
+    ```
+
+    **Available Models:**
+
+    | Model | Context Window | Best For |
+    |-------|---------------|----------|
+    | `dashscope/qwen-max` | 32,768 | Complex reasoning |
+    | `dashscope/qwen-plus` | 131,072 | Long-context tasks |
+    | `dashscope/qwen-turbo` | 131,072 | Fast inference |
+    | `dashscope/qwen-long` | 1,000,000 | Ultra-long documents |
+    | `dashscope/qwen2.5-72b-instruct` | 131,072 | Instruction following |
+
+    <Info>
+      QwenCloud features:
+      - OpenAI- and Anthropic-compatible APIs
+      - International endpoint (`dashscope-intl.aliyuncs.com`) and China
+        mainland endpoint (`dashscope.aliyuncs.com`)
+      - Competitive pricing with high-capacity models
+      - Function calling support for Qwen models
+    </Info>
+
+    For the full model list, see [QwenCloud Models](https://www.qwencloud.com/models).
+    For pricing details, see [QwenCloud Pricing](https://docs.qwencloud.com/developer-guides/getting-started/pricing).
+
+    **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1198,12 +1198,12 @@ In this section, you'll find detailed examples that help you select, configure, 
     | `dashscope/qwen-max` | 32,768 | Complex reasoning |
     | `dashscope/qwen-plus` | 131,072 | Long-context tasks |
     | `dashscope/qwen-turbo` | 131,072 | Fast inference |
-    | `dashscope/qwen-long` | 1,000,000 | Ultra-long documents |
+    | `dashscope/qwen-long` | 10,000,000 | Ultra-long documents |
     | `dashscope/qwen2.5-72b-instruct` | 131,072 | Instruction following |
 
     <Info>
       QwenCloud features:
-      - OpenAI- and Anthropic-compatible APIs
+      - OpenAI-compatible APIs and native DashScope integration
       - International endpoint (`dashscope-intl.aliyuncs.com`) and China
         mainland endpoint (`dashscope.aliyuncs.com`)
       - Competitive pricing with high-capacity models

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -797,12 +797,12 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     | `dashscope/qwen-max` | 32,768 | 복잡한 추론 |
     | `dashscope/qwen-plus` | 131,072 | 긴 문맥 작업 |
     | `dashscope/qwen-turbo` | 131,072 | 빠른 추론 |
-    | `dashscope/qwen-long` | 1,000,000 | 초장문 문서 처리 |
+    | `dashscope/qwen-long` | 10,000,000 | 초장문 문서 처리 |
     | `dashscope/qwen2.5-72b-instruct` | 131,072 | 지시사항 준수 |
 
     <Info>
       QwenCloud 특징:
-      - OpenAI 및 Anthropic 호환 API
+      - OpenAI 호환 API 및 네이티브 DashScope 통합
       - 글로벌 엔드포인트(`dashscope-intl.aliyuncs.com`) 및 중국 본토 엔드포인트(`dashscope.aliyuncs.com`) 지원
       - 고성능 모델과 경쟁력 있는 가격
       - Qwen 모델용 함수 호출(Function Calling) 지원

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -755,6 +755,67 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="QwenCloud">
+    [QwenCloud](https://www.qwencloud.com/)는 OpenAI 호환 API를 통해 Alibaba의 Qwen 대형 언어 모델 제품군에 대한 액세스를 제공합니다.
+
+    `.env` 파일에 다음 환경 변수를 설정하세요:
+    ```toml Code
+    # Required
+    DASHSCOPE_API_KEY=<your-api-key>
+    ```
+
+    [QwenCloud API 키 페이지](https://home.qwencloud.com/api-keys)에서 API 키를 발급받으세요.
+
+    **방법 1 — DashScope / LiteLLM 접두사 (권장):**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="dashscope/qwen-max",
+        temperature=0.7,
+        max_tokens=4096
+    )
+    ```
+
+    **방법 2 — OpenAI 호환 엔드포인트:**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/qwen-plus",
+        base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        api_key="your-api-key",
+        temperature=0.7
+    )
+    ```
+
+    **사용 가능한 모델:**
+
+    | 모델 | 컨텍스트 윈도우 | 적합한 작업 |
+    |---|---|---|
+    | `dashscope/qwen-max` | 32,768 | 복잡한 추론 |
+    | `dashscope/qwen-plus` | 131,072 | 긴 문맥 작업 |
+    | `dashscope/qwen-turbo` | 131,072 | 빠른 추론 |
+    | `dashscope/qwen-long` | 1,000,000 | 초장문 문서 처리 |
+    | `dashscope/qwen2.5-72b-instruct` | 131,072 | 지시사항 준수 |
+
+    <Info>
+      QwenCloud 특징:
+      - OpenAI 및 Anthropic 호환 API
+      - 글로벌 엔드포인트(`dashscope-intl.aliyuncs.com`) 및 중국 본토 엔드포인트(`dashscope.aliyuncs.com`) 지원
+      - 고성능 모델과 경쟁력 있는 가격
+      - Qwen 모델용 함수 호출(Function Calling) 지원
+    </Info>
+
+    전체 모델 목록은 [QwenCloud 모델](https://www.qwencloud.com/models)을 확인하세요.
+    요금 정보는 [QwenCloud 요금 안내](https://docs.qwencloud.com/developer-guides/getting-started/pricing)를 참고하세요.
+
+    **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## 스트리밍 응답

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -728,6 +728,67 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="QwenCloud">
+    O [QwenCloud](https://www.qwencloud.com/) fornece acesso à família de modelos de linguagem de grande escala Qwen da Alibaba através de APIs compatíveis com OpenAI.
+
+    Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
+    ```toml Code
+    # Required
+    DASHSCOPE_API_KEY=<your-api-key>
+    ```
+
+    Obtenha sua chave de API na [página de chaves de API do QwenCloud](https://home.qwencloud.com/api-keys).
+
+    **Método 1 — Prefixo DashScope / LiteLLM (Recomendado):**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="dashscope/qwen-max",
+        temperature=0.7,
+        max_tokens=4096
+    )
+    ```
+
+    **Método 2 — Endpoint compatível com OpenAI:**
+    ```python Code
+    from crewai import LLM
+
+    llm = LLM(
+        model="openai/qwen-plus",
+        base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        api_key="your-api-key",
+        temperature=0.7
+    )
+    ```
+
+    **Modelos disponíveis:**
+
+    | Modelo | Janela de Contexto | Melhor Para |
+    |---|---|---|
+    | `dashscope/qwen-max` | 32.768 | Raciocínio complexo |
+    | `dashscope/qwen-plus` | 131.072 | Tarefas de contexto longo |
+    | `dashscope/qwen-turbo` | 131.072 | Inferência rápida |
+    | `dashscope/qwen-long` | 1.000.000 | Documentos ultralongos |
+    | `dashscope/qwen2.5-72b-instruct` | 131.072 | Instruções detalhadas |
+
+    <Info>
+      Recursos do QwenCloud:
+      - APIs compatíveis com OpenAI e Anthropic
+      - Endpoint internacional (`dashscope-intl.aliyuncs.com`) e endpoint da China (`dashscope.aliyuncs.com`)
+      - Preços competitivos com modelos de alta capacidade
+      - Suporte a chamadas de função (function calling) para modelos Qwen
+    </Info>
+
+    Para a lista completa de modelos, consulte [Modelos QwenCloud](https://www.qwencloud.com/models).
+    Para detalhes de preços, consulte [Preços QwenCloud](https://docs.qwencloud.com/developer-guides/getting-started/pricing).
+
+    **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Respostas em streaming

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -770,12 +770,12 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     | `dashscope/qwen-max` | 32.768 | Raciocínio complexo |
     | `dashscope/qwen-plus` | 131.072 | Tarefas de contexto longo |
     | `dashscope/qwen-turbo` | 131.072 | Inferência rápida |
-    | `dashscope/qwen-long` | 1.000.000 | Documentos ultralongos |
+    | `dashscope/qwen-long` | 10.000.000 | Documentos ultralongos |
     | `dashscope/qwen2.5-72b-instruct` | 131.072 | Instruções detalhadas |
 
     <Info>
       Recursos do QwenCloud:
-      - APIs compatíveis com OpenAI e Anthropic
+      - APIs compatíveis com OpenAI e integração nativa com DashScope
       - Endpoint internacional (`dashscope-intl.aliyuncs.com`) e endpoint da China (`dashscope.aliyuncs.com`)
       - Preços competitivos com modelos de alta capacidade
       - Suporte a chamadas de função (function calling) para modelos Qwen


### PR DESCRIPTION
> **Note:** This contribution was authored with the assistance of an AI coding assistant and adheres to CrewAI's [CONTRIBUTING.md](https://github.com/crewAIInc/crewAI/blob/main/.github/CONTRIBUTING.md) policy. Please ensure the `llm-generated` label is applied.

## What does this PR do?

Adds official QwenCloud configuration guidance and examples to the LLM concepts documentation, providing clear instructions for users connecting to Alibaba Qwen models.

Resolves #6970

## Changes Made

- **English Docs** (`docs/edge/en/concepts/llms.mdx`):
  - Added `QwenCloud` accordion provider section
  - Documented `DASHSCOPE_API_KEY` configuration
  - Method 1: LiteLLM / DashScope native model prefix (`dashscope/qwen-*`)
  - Method 2: OpenAI-compatible base URL endpoint
  - Model catalog table with context windows (up to 1M tokens with `qwen-long`)
  - Links to official QwenCloud portal, models, and pricing

- **Synchronized Translations** (per `DOCS_TRANSLATIONS.md`):
  - `docs/edge/ar/concepts/llms.mdx` (Arabic)
  - `docs/edge/ko/concepts/llms.mdx` (Korean)
  - `docs/edge/pt-BR/concepts/llms.mdx` (Portuguese - Brazil)

## Checklist

- [x] Read and followed `CONTRIBUTING.md` and `AGENTS.md`
- [x] Applied / requested the `llm-generated` label
- [x] Branch name follows `<type>/<short-description>` format (`docs/add-qwencloud-provider`)
- [x] Commit follows Conventional Commits: `docs(llms): add QwenCloud provider configuration guide`
- [x] Maintained parity across all 4 locales (`en`, `ar`, `ko`, `pt-BR`)
- [x] Did not modify frozen `docs/v*/` snapshots
