### PR TITLE
fix(tools): replace bare raise with explicit ToolUsageError (#6430)

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -884,7 +884,7 @@ class ToolUsage:
 
         except Exception:
             if raise_error:
-                raise
+                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         if not isinstance(arguments, dict):

--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -889,7 +889,7 @@ class ToolUsage:
 
         if not isinstance(arguments, dict):
             if raise_error:
-                raise
+                raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
             return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
 
         return ToolCalling(

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -903,3 +903,30 @@ def test_tool_error_does_not_emit_finished_event():
     assert len(finished_events) == 0, (
         "ToolUsageFinishedEvent should NOT be emitted after ToolUsageErrorEvent"
     )
+
+
+def test_original_tool_calling_non_dict_arguments_raises_tool_usage_error():
+    mock_agent = MagicMock()
+    mock_agent.key = "test_key"
+    mock_agent.role = "test_role"
+
+    class TestTool(BaseTool):
+        name: str = "test_tool"
+        description: str = "A test tool"
+
+        def _run(self, input: dict) -> str:
+            return "test result"
+
+    test_tool = TestTool()
+    tool_usage = ToolUsage(
+        tools_handler=MagicMock(),
+        tools=[test_tool],
+        task=MagicMock(),
+        function_calling_llm=None,
+        agent=mock_agent,
+        action=MagicMock(tool="test_tool", tool_input="[1, 2, 3]"),
+    )
+
+    with pytest.raises(ToolUsageError):
+        tool_usage._original_tool_calling("test_string", raise_error=True)
+

--- a/lib/crewai/tests/tools/test_tool_usage.py
+++ b/lib/crewai/tests/tools/test_tool_usage.py
@@ -906,6 +906,11 @@ def test_tool_error_does_not_emit_finished_event():
 
 
 def test_original_tool_calling_non_dict_arguments_raises_tool_usage_error():
+    from crewai.utilities.i18n import I18N
+
+    i18n = I18N()
+    expected_error = f"{i18n.errors('tool_arguments_error')}"
+
     mock_agent = MagicMock()
     mock_agent.key = "test_key"
     mock_agent.role = "test_role"
@@ -927,6 +932,13 @@ def test_original_tool_calling_non_dict_arguments_raises_tool_usage_error():
         action=MagicMock(tool="test_tool", tool_input="[1, 2, 3]"),
     )
 
-    with pytest.raises(ToolUsageError):
+    with pytest.raises(ToolUsageError) as exc_info:
         tool_usage._original_tool_calling("test_string", raise_error=True)
+
+    assert str(exc_info.value) == expected_error
+
+    result = tool_usage._original_tool_calling("test_string", raise_error=False)
+    assert isinstance(result, ToolUsageError)
+    assert str(result) == expected_error
+
 


### PR DESCRIPTION
## Summary

Resolves #6430.

This PR fixes a bug in `ToolUsage._original_tool_calling()` (`lib/crewai/src/crewai/tools/tool_usage.py`) where a bare `raise` statement outside of an `except` block caused Python to raise `RuntimeError: No active exception to reraise` when non-dictionary tool arguments were passed with `raise_error=True`.

## Root Cause

In `_original_tool_calling()`:
```python
if not isinstance(arguments, dict):
    if raise_error:
        raise  # <- bare raise outside except block!
    return ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")
```
Because `if not isinstance(arguments, dict):` is outside of any exception handler (`except:`), calling `raise` here attempted to re-raise a non-existent active exception, triggering a `RuntimeError`.

## Fix

Replaced the bare `raise` with an explicit `raise ToolUsageError(f"{I18N_DEFAULT.errors('tool_arguments_error')}")` so the method correctly raises a `ToolUsageError` as intended by the API contract.

## Testing

- Added unit test `test_original_tool_calling_non_dict_arguments_raises_tool_usage_error` in `lib/crewai/tests/tools/test_tool_usage.py`.
- Verified that passing non-dict tool inputs (e.g. list `[1, 2, 3]`) with `raise_error=True` raises `ToolUsageError` instead of crashing with `RuntimeError`.

Fixes #6430

<!-- crewai-require-issue-check -->