### PR TITLE
fix(tools): support coroutine results inside active event loops

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -41,6 +41,7 @@ from crewai.tools.structured_tool import (
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy, ToolFailureReason
 from crewai.types.callback import SerializableCallable, _resolve_dotted_path
 from crewai.utilities.string_utils import sanitize_tool_name
+from crewai.utilities.async_utils import run_coroutine_sync
 
 
 P = ParamSpec("P")
@@ -338,7 +339,7 @@ class BaseTool(BaseModel, ABC):
         result = self._run(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_coroutine_sync(result)
 
         return result
 
@@ -549,7 +550,7 @@ class Tool(BaseTool, Generic[P, R]):
         result = self.func(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_coroutine_sync(result)
 
         return result  # type: ignore[return-value]
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -28,6 +28,7 @@ from crewai.utilities.pydantic_schema_utils import (
     generate_model_description,
 )
 from crewai.utilities.string_utils import sanitize_tool_name
+from crewai.utilities.async_utils import run_coroutine_sync
 
 
 def _serialize_schema(v: type[BaseModel] | None) -> dict[str, Any] | None:
@@ -438,12 +439,12 @@ class CrewStructuredTool(BaseModel):
         self._increment_usage_count()
 
         if inspect.iscoroutinefunction(self.func):
-            return asyncio.run(self.func(**parsed_args, **kwargs))
+            return run_coroutine_sync(self.func(**parsed_args, **kwargs))
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            return asyncio.run(result)
+            return run_coroutine_sync(result)
 
         return result
 

--- a/lib/crewai/src/crewai/utilities/async_utils.py
+++ b/lib/crewai/src/crewai/utilities/async_utils.py
@@ -1,0 +1,22 @@
+"""Utilities for bridging asynchronous work into synchronous APIs."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+def run_coroutine_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine from synchronous code, including inside an event loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    context = copy_context()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(context.run, asyncio.run, coro).result()

--- a/lib/crewai/tests/tools/test_async_tools.py
+++ b/lib/crewai/tests/tools/test_async_tools.py
@@ -50,6 +50,21 @@ class TestBaseTool:
         assert result == "Sync processed: hello"
 
     @pytest.mark.asyncio
+    async def test_tool_run_handles_coroutine_inside_running_loop(self) -> None:
+        class CoroutineReturningTool(BaseTool):
+            name: str = "coroutine_returning_tool"
+            description: str = "Returns a coroutine from its synchronous method"
+
+            def _run(self, value: str):
+                async def produce() -> str:
+                    await asyncio.sleep(0)
+                    return value
+
+                return produce()
+
+        assert CoroutineReturningTool().run(value="hello") == "hello"
+
+    @pytest.mark.asyncio
     async def test_sync_tool_arun_raises_not_implemented(self) -> None:
         """Test that sync tool arun() raises NotImplementedError."""
         tool = SyncTool()
@@ -140,6 +155,15 @@ class TestToolDecorator:
 
         result = await async_func.arun(value="test")
         assert result == "async: test"
+
+    @pytest.mark.asyncio
+    async def test_async_decorated_tool_run_inside_running_loop(self) -> None:
+        @tool("async_decorated_in_loop")
+        async def async_func(value: str) -> str:
+            await asyncio.sleep(0)
+            return value
+
+        assert async_func.run(value="test") == "test"
 
 
 class TestAsyncToolWithIO:


### PR DESCRIPTION
## Summary
- run coroutine-returning tools safely when a synchronous API is called inside an active event loop
- share the bridge across BaseTool, @tool, and CrewStructuredTool
- add regression coverage for async-context calls

## Root cause
The synchronous tool paths always called `asyncio.run`, which raises when the caller already owns a running event loop (for example FastAPI or Jupyter).

## Validation
- Python bytecode compilation passed
- Targeted pytest was attempted but the repository test harness requires the missing `vcr` dependency in this checkout

Fixes #6978