### PR TITLE
fix(events): attribute tool errors to the tool that failed

### DIFF
--- a/lib/crewai/src/crewai/tools/tool_usage.py
+++ b/lib/crewai/src/crewai/tools/tool_usage.py
@@ -331,7 +331,10 @@ class ToolUsage:
                     message=usage_limit_error,
                     reason=ToolFailureReason.USAGE_LIMIT,
                 )
-                self._telemetry.tool_usage_error(llm=self.function_calling_llm)
+                self._telemetry.tool_usage_error(
+                    llm=self.function_calling_llm,
+                    tool_name=sanitize_tool_name(tool.name),
+                )
                 result = self._format_result(result=result)
             elif result is None:
                 try:
@@ -450,7 +453,10 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
-                        self._telemetry.tool_usage_error(llm=self.function_calling_llm)
+                        self._telemetry.tool_usage_error(
+                            llm=self.function_calling_llm,
+                            tool_name=sanitize_tool_name(tool.name),
+                        )
                         error_message = I18N_DEFAULT.errors(
                             "tool_usage_exception"
                         ).format(
@@ -582,7 +588,10 @@ class ToolUsage:
                     message=usage_limit_error,
                     reason=ToolFailureReason.USAGE_LIMIT,
                 )
-                self._telemetry.tool_usage_error(llm=self.function_calling_llm)
+                self._telemetry.tool_usage_error(
+                    llm=self.function_calling_llm,
+                    tool_name=sanitize_tool_name(tool.name),
+                )
                 result = self._format_result(result=result)
             elif result is None:
                 try:
@@ -701,7 +710,10 @@ class ToolUsage:
                     error_event_emitted = True
                     self._run_attempts += 1
                     if self._run_attempts > self._max_parsing_attempts:
-                        self._telemetry.tool_usage_error(llm=self.function_calling_llm)
+                        self._telemetry.tool_usage_error(
+                            llm=self.function_calling_llm,
+                            tool_name=sanitize_tool_name(tool.name),
+                        )
                         error_message = I18N_DEFAULT.errors(
                             "tool_usage_exception"
                         ).format(
@@ -910,6 +922,10 @@ class ToolUsage:
         except Exception as e:
             self._run_attempts += 1
             if self._run_attempts > self._max_parsing_attempts:
+                # No tool_name here, deliberately: this is a tool-CALL PARSING failure, so the
+                # tool the model wanted was never identified. Passing tool_string would put raw,
+                # unbounded model output into a metrics dimension. Parse failures are counted as
+                # tool errors with an empty name, which is the honest representation.
                 self._telemetry.tool_usage_error(llm=self.function_calling_llm)
                 if self.task:
                     self.task.increment_tools_errors()

--- a/lib/crewai/tests/tools/test_tool_usage_error_attribution.py
+++ b/lib/crewai/tests/tools/test_tool_usage_error_attribution.py
@@ -1,0 +1,145 @@
+"""`Tool Usage Error` spans must carry the tool name.
+
+The emitter has accepted `tool_name` since it was written
+(`Telemetry.tool_usage_error`, which writes the attribute only `if tool_name:`), but no caller
+passed it, so tool errors were attributed to the empty string and no per-tool error rate could
+be computed at all. The omission is silent by construction - a missing kwarg simply produces a
+span without the attribute - so it needs tests rather than review attention.
+
+Both error paths exist twice, once in the sync `_use` and once in the async `_ause`, so the
+matrix here is (usage-limit, execution-error) x (sync, async). The parsing failure in
+`_tool_calling` is covered too, pinning the opposite expectation: it must stay unattributed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from crewai.tools import BaseTool
+from crewai.tools.tool_usage import ToolUsage
+from crewai.tools.tool_calling import ToolCalling
+from crewai.utilities.string_utils import sanitize_tool_name
+
+
+class ExplodingTool(BaseTool):
+    name: str = "Exploding Tool"
+    description: str = "Raises on every call, to exercise the execution-error path"
+
+    def _run(self, text: str) -> str:
+        raise RuntimeError("boom")
+
+
+class LimitedTool(BaseTool):
+    name: str = "Limited Tool"
+    description: str = "Has a usage limit, to exercise the usage-limit path"
+    max_usage_count: int = 1
+
+    def _run(self, text: str) -> str:
+        return f"ok {text}"
+
+
+def build_usage(tool: BaseTool) -> ToolUsage:
+    """A ToolUsage wired to one tool, with a mocked telemetry sink."""
+    # Real strings on the mocks: ToolUsageStartedEvent is a pydantic model and rejects
+    # MagicMock attributes, so a bare MagicMock() fails validation before the code under
+    # test is reached.
+    task = MagicMock()
+    task.name = "some task"
+    agent = MagicMock()
+    agent.role = "some role"
+    agent.key = "agent-key"
+    agent._original_role = "some role"
+    agent.verbose = False
+    action = MagicMock()
+    action.tool = tool.name
+    action.tool_input = {"text": "x"}
+
+    usage = ToolUsage(
+        tools_handler=MagicMock(cache=None, last_used_tool=None),
+        tools=[tool],
+        task=task,
+        function_calling_llm=None,
+        agent=agent,
+        action=action,
+    )
+    usage._telemetry = MagicMock()
+    # Report the error on the first failure instead of after the retry budget.
+    usage._max_parsing_attempts = 0
+    return usage
+
+
+def recorded_tool_name(usage: ToolUsage) -> str | None:
+    """The tool_name the code under test handed to telemetry."""
+    assert usage._telemetry.tool_usage_error.called, (
+        "expected a Tool Usage Error span to be emitted"
+    )
+    return usage._telemetry.tool_usage_error.call_args.kwargs.get("tool_name")
+
+
+def calling_for(tool: BaseTool) -> ToolCalling:
+    return ToolCalling(tool_name=tool.name, arguments={"text": "x"})
+
+
+def test_sync_execution_error_reports_the_tool_name():
+    tool = ExplodingTool()
+    usage = build_usage(tool)
+
+    usage.use(calling=calling_for(tool), tool_string="Action: Exploding Tool")
+
+    recorded = recorded_tool_name(usage)
+    assert recorded == sanitize_tool_name(tool.name)
+    assert recorded, "an empty tool_name reproduces the bug: the emitter skips falsy values"
+
+
+@pytest.mark.asyncio
+async def test_async_execution_error_reports_the_tool_name():
+    tool = ExplodingTool()
+    usage = build_usage(tool)
+
+    await usage.ause(calling=calling_for(tool), tool_string="Action: Exploding Tool")
+
+    recorded = recorded_tool_name(usage)
+    assert recorded == sanitize_tool_name(tool.name)
+    assert recorded, "an empty tool_name reproduces the bug: the emitter skips falsy values"
+
+
+def test_sync_usage_limit_error_reports_the_tool_name():
+    tool = LimitedTool()
+    tool.current_usage_count = tool.max_usage_count
+    usage = build_usage(tool)
+
+    usage.use(calling=calling_for(tool), tool_string="Action: Limited Tool")
+
+    recorded = recorded_tool_name(usage)
+    assert recorded == sanitize_tool_name(tool.name)
+    assert recorded, "an empty tool_name reproduces the bug: the emitter skips falsy values"
+
+
+@pytest.mark.asyncio
+async def test_async_usage_limit_error_reports_the_tool_name():
+    tool = LimitedTool()
+    tool.current_usage_count = tool.max_usage_count
+    usage = build_usage(tool)
+
+    await usage.ause(calling=calling_for(tool), tool_string="Action: Limited Tool")
+
+    recorded = recorded_tool_name(usage)
+    assert recorded == sanitize_tool_name(tool.name)
+    assert recorded, "an empty tool_name reproduces the bug: the emitter skips falsy values"
+
+
+def test_parsing_failure_stays_unattributed():
+    """A tool-call parsing failure has no tool identity, and must not invent one.
+
+    Passing the raw tool_string here would put unbounded model output into a metrics
+    dimension, which is worse than an honest empty name.
+    """
+    usage = build_usage(ExplodingTool())
+    # Force both parse attempts to raise. Without this the fallback returns a ToolUsageError
+    # object instead of raising, so the telemetry branch is never reached and the test would
+    # pass for the wrong reason.
+    usage._original_tool_calling = MagicMock(side_effect=RuntimeError("unparseable"))
+
+    usage._tool_calling("not a parseable tool call at all")
+
+    assert recorded_tool_name(usage) is None


### PR DESCRIPTION
- Passes `tool_name` to `Telemetry.tool_usage_error` at the four call sites where the failing tool is known, so `Tool Usage Error` spans identify which tool failed. The emitter already accepted the argument and writes the attribute when truthy — no caller ever passed it, so every error span landed with an empty name and per-tool error rates were not computable at all: named tools read zero errors while the unnamed bucket held all of them.
- The four sites are not four unrelated edits — they are the same two failure modes in both execution paths: usage-limit and execution-error, each once in the sync `_use` and once in the async `_ause`. The fix is symmetric across that matrix.
- **Leaves the fifth site unattributed on purpose**, with a comment recording why. `_tool_calling` is a tool-call *parsing* failure, so the tool the model wanted was never identified; the only string in scope is raw unparsed model output, and putting that into a metrics dimension would give it unbounded cardinality. An empty name is the honest representation there.
- No public API, signature, or event-schema change. `tool_usage_error(llm, agent=None, tool_name=None)` is unchanged and every existing caller keeps working — the argument is optional and was already declared.
- Covered by tests across the full matrix: sync usage-limit, async usage-limit, sync execution-error, async execution-error, plus the parsing case pinning the opposite expectation. **Verified the tests catch the regression** — against the unpatched module the four attribution tests fail and the parsing test still passes, which is the intended split. `241 passed` for the existing `lib/crewai/tests/tools/` suite, `ruff check` clean, `ruff format` applied, `mypy` clean on the changed module.
- No docs change: this alters an internal telemetry attribute, not documented behaviour or public API.
- Keeps this intentionally small: no new span, no schema change, no attempt to attribute the parsing failure, and no change to how the errors are counted or aggregated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal telemetry attribute wiring only; no public API or runtime behavior change beyond richer span metadata.
> 
> **Overview**
> **Tool Usage Error** telemetry spans now include the failing tool’s name when the failure happens during actual tool execution, so per-tool error rates can be computed instead of lumping everything into an unnamed bucket.
> 
> `tool_usage_error` already accepted an optional `tool_name`, but `ToolUsage` never passed it. The change wires `sanitize_tool_name(tool.name)` into that call on **usage-limit** and **execution-error** paths in both sync `_use` and async `_ause`. The **tool-call parsing** path in `_tool_calling` is unchanged: it still omits `tool_name`, with an inline comment that the tool identity is unknown and raw model output must not become a metrics dimension.
> 
> New tests cover the sync/async × usage-limit/execution-error matrix and assert parsing failures stay unattributed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec73a42500a7db6977ce9c5aa0e2469d98acefb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->