### PR TITLE
fix: use hostname as MCP HTTP/SSE server_name

### DIFF
--- a/lib/crewai/src/crewai/mcp/client.py
+++ b/lib/crewai/src/crewai/mcp/client.py
@@ -8,6 +8,7 @@ import logging
 import sys
 import time
 from typing import Any, NamedTuple, TypeVar
+from urllib.parse import urlparse
 
 from typing_extensions import Self
 
@@ -49,6 +50,10 @@ _T = TypeVar("_T")
 
 _mcp_schema_cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
 _cache_ttl = 300  # 5 minutes
+
+
+def _server_name_from_url(url: str) -> str:
+    return urlparse(url).hostname or url
 
 
 class MCPClient:
@@ -122,12 +127,12 @@ class MCPClient:
             server_url = None
             transport_type = self.transport.transport_type.value
         elif isinstance(self.transport, HTTPTransport):
-            server_name = self.transport.url
             server_url = self.transport.url
+            server_name = _server_name_from_url(server_url)
             transport_type = self.transport.transport_type.value
         elif isinstance(self.transport, SSETransport):
-            server_name = self.transport.url
             server_url = self.transport.url
+            server_name = _server_name_from_url(server_url)
             transport_type = self.transport.transport_type.value
         else:
             server_name = "Unknown MCP Server"

--- a/lib/crewai/tests/mcp/test_client_server_info.py
+++ b/lib/crewai/tests/mcp/test_client_server_info.py
@@ -1,0 +1,41 @@
+from crewai.mcp.client import MCPClient
+from crewai.mcp.transports.http import HTTPTransport
+from crewai.mcp.transports.sse import SSETransport
+from crewai.mcp.transports.stdio import StdioTransport
+
+
+BRIGHTDATA_URL = "https://mcp.brightdata.com/mcp?groups=advanced_scraping"
+
+
+def test_http_server_info_uses_hostname_not_url():
+    client = MCPClient(HTTPTransport(url=BRIGHTDATA_URL))
+    name, server_url, transport = client._get_server_info()
+    assert name == "mcp.brightdata.com"
+    assert server_url == BRIGHTDATA_URL
+    assert transport == "streamable-http"
+
+
+def test_http_server_info_strips_port_from_hostname():
+    url = "https://localhost:8080/mcp"
+    client = MCPClient(HTTPTransport(url=url))
+    name, server_url, transport = client._get_server_info()
+    assert name == "localhost"
+    assert server_url == url
+    assert transport == "streamable-http"
+
+
+def test_sse_server_info_uses_hostname_not_url():
+    url = "https://mcp.notion.so/sse"
+    client = MCPClient(SSETransport(url=url))
+    name, server_url, transport = client._get_server_info()
+    assert name == "mcp.notion.so"
+    assert server_url == url
+    assert transport == "sse"
+
+
+def test_stdio_server_info_uses_command():
+    client = MCPClient(StdioTransport(command="python", args=["server.py"]))
+    name, server_url, transport = client._get_server_info()
+    assert name == "python server.py"
+    assert server_url is None
+    assert transport == "stdio"


### PR DESCRIPTION
HTTP and SSE MCP connections used the raw URL as server_name, so traces titled the row with the full endpoint including query params. `_get_server_info` now emits the hostname and keeps the full URL on `server_url`.