### PR TITLE
feat(llms): add Eden AI as an openai-compatible provider

### DIFF
--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1012,6 +1012,38 @@ mode: "wide"
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Eden AI">
+    عيّن متغيرات البيئة التالية في ملف `.env`:
+    ```toml Code
+    # Required
+    EDENAI_API_KEY=<your-api-key>
+
+    # اختياري، يوجّه الطلبات عبر بوابة Eden AI في الاتحاد الأوروبي بدلًا من البوابة العامة
+    EDENAI_BASE_URL=https://api.eu.edenai.run/v3
+    ```
+
+    مثال الاستخدام في مشروع CrewAI:
+    ```python Code
+    llm = LLM(
+        model="edenai/mistral/mistral-large-2512",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      ميزات Eden AI:
+      - مفتاح واحد للوصول إلى عدة مزوّدين
+      - مقرّها في الاتحاد الأوروبي، مع نقطة نهاية أوروبية منفصلة لإقامة البيانات
+      - قدرات كل موديل معروضة عبر نقطة نهاية الكتالوج
+    </Info>
+
+    معرّفات الموديلات مكتوبة أصلًا بصيغة `vendor/model`، لذا يحتوي المرجع الكامل على ثلاثة أجزاء،
+    مثل `edenai/anthropic/claude-sonnet-5`. راجع
+    [كتالوج موديلات Eden AI](https://api.edenai.run/v3/models)، وهو عام ولا يحتاج إلى مصادقة،
+    للحصول على المعرّفات الحالية.
+  </Accordion>
+
 </AccordionGroup>
 
 ## بث الاستجابات

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1155,6 +1155,37 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Eden AI">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    # Required
+    EDENAI_API_KEY=<your-api-key>
+
+    # Optional, routes through Eden AI's EU gateway instead of the global one
+    EDENAI_BASE_URL=https://api.eu.edenai.run/v3
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="edenai/mistral/mistral-large-2512",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      Eden AI features:
+      - One API key across many upstream vendors
+      - EU-based, with a separate EU endpoint for data residency
+      - Per-model capabilities exposed by the catalogue endpoint
+    </Info>
+
+    Model ids are already in `vendor/model` form, so a full reference carries three
+    segments, for example `edenai/anthropic/claude-sonnet-5`. See the
+    [Eden AI model catalogue](https://api.edenai.run/v3/models), which is public and needs
+    no authentication, for current ids.
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -755,6 +755,37 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Eden AI">
+    `.env` 파일에 다음 환경 변수를 설정하십시오:
+    ```toml Code
+    # Required
+    EDENAI_API_KEY=<your-api-key>
+
+    # 선택 사항, 글로벌 게이트웨이 대신 Eden AI의 EU 게이트웨이로 요청을 보냅니다
+    EDENAI_BASE_URL=https://api.eu.edenai.run/v3
+    ```
+
+    CrewAI 프로젝트에서의 예시 사용법:
+    ```python Code
+    llm = LLM(
+        model="edenai/mistral/mistral-large-2512",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      Eden AI 특징:
+      - 여러 상위 제공자에 대해 하나의 API 키
+      - EU 기반이며, 데이터 레지던시를 위한 별도의 EU 엔드포인트 제공
+      - 카탈로그 엔드포인트를 통해 모델별 기능 제공
+    </Info>
+
+    모델 ID는 이미 `vendor/model` 형식이므로 전체 참조는 세 부분으로 구성됩니다.
+    예: `edenai/anthropic/claude-sonnet-5`. 현재 사용 가능한 ID는 인증이 필요 없는 공개
+    [Eden AI 모델 카탈로그](https://api.edenai.run/v3/models)에서 확인하십시오.
+  </Accordion>
+
 </AccordionGroup>
 
 ## 스트리밍 응답

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -728,6 +728,38 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Eden AI">
+    Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
+    ```toml Code
+    # Required
+    EDENAI_API_KEY=<your-api-key>
+
+    # Opcional, roteia as requisições pelo gateway da Eden AI na UE em vez do global
+    EDENAI_BASE_URL=https://api.eu.edenai.run/v3
+    ```
+
+    Exemplo de uso em seu projeto CrewAI:
+    ```python Code
+    llm = LLM(
+        model="edenai/mistral/mistral-large-2512",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      Recursos do Eden AI:
+      - Uma única chave de API para muitos provedores
+      - Sediada na UE, com um endpoint europeu separado para residência de dados
+      - Capacidades por modelo expostas pelo endpoint do catálogo
+    </Info>
+
+    Os ids de modelo já estão no formato `vendor/model`, portanto uma referência completa tem
+    três segmentos, por exemplo `edenai/anthropic/claude-sonnet-5`. Consulte o
+    [catálogo de modelos da Eden AI](https://api.edenai.run/v3/models), que é público e não
+    exige autenticação, para os ids atuais.
+  </Accordion>
+
 </AccordionGroup>
 
 ## Respostas em streaming

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -345,6 +345,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "cerebras",
     "dashscope",
     "snowflake",
+    "edenai",
 ]
 
 
@@ -450,6 +451,7 @@ class LLM(BaseLLM):
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
                 "snowflake": "snowflake",
+                "edenai": "edenai",
             }
 
             canonical_provider = provider_mapping.get(prefix.lower())
@@ -577,6 +579,11 @@ class LLM(BaseLLM):
 
         if provider == "openrouter":
             # OpenRouter uses org/model format but accepts anything
+            return True
+
+        if provider == "edenai":
+            # Eden AI ids are vendor/model, so the full reference is
+            # edenai/<vendor>/<model>. Any vendor id the gateway routes to is valid.
             return True
 
         if provider == "snowflake":
@@ -720,6 +727,7 @@ class LLM(BaseLLM):
             "hosted_vllm",
             "cerebras",
             "dashscope",
+            "edenai",
         }
         if provider in openai_compatible_providers:
             from crewai.llms.providers.openai_compatible.completion import (

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -582,9 +582,11 @@ class LLM(BaseLLM):
             return True
 
         if provider == "edenai":
-            # Eden AI ids are vendor/model, so the full reference is
-            # edenai/<vendor>/<model>. Any vendor id the gateway routes to is valid.
-            return True
+            # Eden AI ids are vendor/model, so a full reference is
+            # edenai/<vendor>/<model>. The vendor segment is whatever the gateway
+            # routes to, but both halves have to be present.
+            vendor, _, name = model_lower.partition("/")
+            return bool(vendor and name)
 
         if provider == "snowflake":
             return True

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -89,6 +89,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         base_url_env="DASHSCOPE_BASE_URL",
         api_key_required=True,
     ),
+    "edenai": ProviderConfig(
+        base_url="https://api.edenai.run/v3",
+        api_key_env="EDENAI_API_KEY",
+        base_url_env="EDENAI_BASE_URL",
+        api_key_required=True,
+    ),
 }
 
 
@@ -125,6 +131,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         - hosted_vllm: vLLM server (https://github.com/vllm-project/vllm)
         - cerebras: Cerebras (https://cerebras.ai)
         - dashscope: Alibaba Dashscope/Qwen (https://dashscope.aliyun.com)
+        - edenai: Eden AI (https://www.edenai.co)
 
     Example:
         # Using provider prefix

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -95,6 +95,14 @@ class TestProviderRegistry:
         assert config.api_key_env == "DASHSCOPE_API_KEY"
         assert config.api_key_required is True
 
+    def test_edenai_config(self):
+        """Test Eden AI provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["edenai"]
+        assert config.base_url == "https://api.edenai.run/v3"
+        assert config.api_key_env == "EDENAI_API_KEY"
+        assert config.base_url_env == "EDENAI_BASE_URL"
+        assert config.api_key_required is True
+
 
 class TestNormalizeOllamaBaseUrl:
     """Tests for _normalize_ollama_base_url helper."""
@@ -270,6 +278,29 @@ class TestLLMIntegration:
             llm = LLM(model="dashscope/qwen-turbo")
             assert isinstance(llm, OpenAICompatibleCompletion)
             assert llm.provider == "dashscope"
+
+    def test_llm_creates_openai_compatible_for_edenai(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for Eden AI."""
+        with patch.dict(os.environ, {"EDENAI_API_KEY": "test-key"}):
+            llm = LLM(model="edenai/anthropic/claude-sonnet-5")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "edenai"
+            # Eden AI ids are vendor/model, so the segment after the provider
+            # prefix is itself two parts and must survive intact.
+            assert llm.model == "anthropic/claude-sonnet-5"
+
+    def test_edenai_base_url_env_selects_the_eu_gateway(self):
+        """Test EDENAI_BASE_URL redirects Eden AI to its EU endpoint."""
+        with patch.dict(
+            os.environ,
+            {
+                "EDENAI_API_KEY": "test-key",
+                "EDENAI_BASE_URL": "https://api.eu.edenai.run/v3",
+            },
+        ):
+            llm = LLM(model="edenai/mistral/mistral-large-2512")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.base_url == "https://api.eu.edenai.run/v3"
 
     def test_llm_with_explicit_provider(self):
         """Test LLM with explicit provider parameter."""

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -302,6 +302,22 @@ class TestLLMIntegration:
             assert isinstance(llm, OpenAICompatibleCompletion)
             assert llm.base_url == "https://api.eu.edenai.run/v3"
 
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("anthropic/claude-sonnet-5", True),
+            ("mistral/mistral-large-2512", True),
+            ("deepinfra/openai/gpt-oss-120b", True),
+            ("", False),
+            ("mistral", False),
+            ("mistral/", False),
+            ("/mistral-large-2512", False),
+        ],
+    )
+    def test_edenai_requires_a_vendor_and_a_model(self, model, expected):
+        """Eden AI references carry a vendor segment, so both halves are required."""
+        assert LLM._matches_provider_pattern(model, "edenai") is expected
+
     def test_llm_with_explicit_provider(self):
         """Test LLM with explicit provider parameter."""
         with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "test-key"}):


### PR DESCRIPTION
## What this does

Registers `edenai` as an OpenAI-compatible provider. Eden AI is an EU-based gateway that
addresses models as `vendor/model`, so it fits the existing `openai_compatible` path and
needs no new provider module. It gives a fairly small PR as a result.

Closes #6615.

**Code**, 15 lines across two files. An entry in `OPENAI_COMPATIBLE_PROVIDERS` with
`base_url`, `api_key_env` and `base_url_env`, plus the four `llm.py` anchors that
`openrouter` already occupies: `SUPPORTED_NATIVE_PROVIDERS`, `provider_mapping`, the
model-validation branch, and the `openai_compatible_providers` set.

`base_url_env="EDENAI_BASE_URL"` is how a user selects our EU gateway, so data residency
needs no extra code on your side.

Model validation returns `True` for any id, as it does for `openrouter`. A full reference
is `edenai/<vendor>/<model>`, so three segments, and the middle one is whatever the gateway
routes to.

**Docs**, an accordion in `concepts/llms.mdx` in all four locales, following the Cerebras
shape rather than the OpenRouter one, for a reason I mention at the bottom.

## Verification

Live, against the real API, with the exact snippet that is in the docs:

```
gateway  base_url=https://api.edenai.run/v3     -> 'integration works'
EU       base_url=https://api.eu.edenai.run/v3  -> 'integration works'
```

Tool calling end to end, `edenai/anthropic/claude-sonnet-5` with a `get_weather` tool asked
about Lyon, France. The model selected the tool, CrewAI executed it, and the output came
back as `18C and clear in Lyon`. That was the part I most wanted to see work rather than
assume, since a gateway that quietly drops tool fidelity is worse than one that fails loudly.

- `pytest lib/crewai/tests/llms/`: 657 passed, 20 skipped
- `pytest lib/crewai/tests/test_llm.py`: 89 passed, 3 skipped
- `mypy` on both changed files: clean
- pre-commit `ruff`, `ruff-format` and `mypy`: all pass
- All four locale files compile with `@mdx-js/mdx` v3

Tests added in `tests/llms/openai_compatible/`: the registry entry, the factory returning
`OpenAICompatibleCompletion` with the three-segment model preserved, and `EDENAI_BASE_URL`
resolving to the EU endpoint.

## On the architecture comments in the issue

Thanks to everyone who weighed in on #6615, the point about capability fidelity in
particular was a good one and shaped how I scoped this.

Two of the four items raised there are addressable on this side. `GET /v3/models` exposes
per-model `supports_function_calling`, `supports_tool_choice` and `supports_response_schema`,
which is what a capability allowlist or a refuse-before-acting policy would read. **This PR
deliberately does not add such a gate**; it keeps the change to registration, and perhaps
that is a follow-up worth having as its own discussion rather than smuggling a policy change
into a provider entry.

The other two, a durable request id across retries and checking expected against actual
before marking success, sit in the retry path rather than in a provider. For what it is
worth our responses already carry an `id`, so the building block is there if that is ever
built.

## Notes

The three non-English accordions are translations I wrote, reusing the standard phrasing
already present in each file. I am French, so feel free to correct me on the Arabic, Korean
or Portuguese wording.

I left out the "This provider uses LiteLLM" note that the OpenRouter accordion carries,
since it looks stale now that #5042 made OpenRouter native. Happy to be told otherwise.

@Prince1314-patel offered to help with testing on the issue and I said I would ping him
here, so, pinging. Any coverage you think is missing from the outside would be genuinely
useful.

I do work at Eden AI.



<!-- crewai-require-issue-check -->