### PR TITLE
fix: synchronize Telemetry singleton initialization to prevent duplic…

### DIFF
--- a/lib/crewai/src/crewai/telemetry/telemetry.py
+++ b/lib/crewai/src/crewai/telemetry/telemetry.py
@@ -113,18 +113,25 @@ class Telemetry:
         return cls._instance
 
     def __init__(self) -> None:
-        if hasattr(self, "_initialized") and self._initialized:
+        if getattr(self, "_initialized", False):
             return
 
-        self.ready: bool = False
-        self.trace_set: bool = False
-        self._initialized: bool = True
-        self._coding_agent_reported: bool = False
-        self._coding_agent_lock = threading.Lock()
+        with self._lock:
+            if getattr(self, "_initialized", False):
+                return
 
-        if self._is_telemetry_disabled():
-            return
+            self.ready: bool = False
+            self.trace_set: bool = False
+            self._coding_agent_reported: bool = False
+            self._coding_agent_lock = threading.Lock()
+            self._initialized = True
 
+            if self._is_telemetry_disabled():
+                return
+
+            self._setup_telemetry()
+
+    def _setup_telemetry(self) -> None:
         try:
             self.resource = Resource(
                 attributes={SERVICE_NAME: CREWAI_TELEMETRY_SERVICE_NAME},

--- a/lib/crewai/tests/telemetry/test_telemetry.py
+++ b/lib/crewai/tests/telemetry/test_telemetry.py
@@ -3,6 +3,7 @@ import inspect
 import os
 from pathlib import Path
 import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -511,3 +512,51 @@ def test_every_span_records_the_crewai_version() -> None:
         "these methods open more spans than they record crewai_version on: "
         + ", ".join(sorted(shortfalls))
     )
+
+
+def test_telemetry_singleton_race_condition():
+    """
+    Verify that concurrent Telemetry() calls initialize telemetry exactly once.
+
+    Multiple threads may construct the singleton concurrently, but initialization
+    must be serialized so the telemetry setup runs only once.
+    """
+    NUM_THREADS = 5
+    calls = 0
+
+    def mocked_setup_telemetry(self):
+        nonlocal calls
+        # Sleep briefly to ensure concurrent threads pile up on the lock.
+        # This guarantees we test the contention without a 1.0s CI delay.
+        time.sleep(0.05)
+        calls += 1
+        # Mock the essential state changes
+        self.ready = True
+        self._initialized = True
+
+    # Setup mocks and thread execution
+    instances = []
+
+    def worker():
+        instances.append(Telemetry())
+
+    with patch.object(Telemetry, '_setup_telemetry', autospec=True) as mock_setup, \
+         patch.object(Telemetry, '_is_telemetry_disabled', return_value=False):
+        mock_setup.side_effect = mocked_setup_telemetry
+
+        threads = [threading.Thread(target=worker) for _ in range(NUM_THREADS)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Assertions
+
+        # A. All threads received the exact same Singleton object
+        assert len(instances) == NUM_THREADS
+        assert len({id(instance) for instance in instances}) == 1
+
+        # B. How many times did we run the expensive setup?
+        # The initialization lock guarantees that setup runs exactly once.
+        assert calls == 1, f"Expected 1 initialization, got {calls}"


### PR DESCRIPTION
## Description

This PR fixes a thread-safety issue in the `Telemetry` singleton initialization that can occur when CrewAI initializes telemetry concurrently.

While singleton allocation in `__new__` was protected by a class lock, the initialization logic in `__init__` was not. When concurrent `ToolUsage` instances invoke `Telemetry()` from multiple threads, multiple callers could pass the `_initialized` guard before initialization completed.

This could result in:
- Multiple `BatchSpanProcessor` instances and their background workers being created.
- Duplicate `atexit` shutdown handlers being registered.
- Earlier `TracerProvider` instances potentially being replaced and left without the singleton's active reference.

## Changes Made

- **Synchronized Initialization:** Wrapped the `Telemetry` initialization phase in `__init__` with the existing class `_lock`, using double-checked locking to ensure initialization is performed only once.
- **Refactored Setup:** Extracted the OpenTelemetry setup logic into a private `_setup_telemetry()` method to isolate the initialization boundary and keep `__init__` focused on singleton state management.
- **Preserved Semantics:** Preserved the existing initialization behavior by setting `_initialized` before telemetry setup. If setup fails, `self.ready` is set to `False`, while subsequent `Telemetry()` calls do not repeatedly re-run initialization.
- **Regression Testing:** Added a deterministic multi-threaded regression test that verifies concurrent `Telemetry()` calls are serialized and `_setup_telemetry()` executes exactly once, with all threads receiving the same singleton instance.

## Testing

- Added a deterministic concurrent-construction regression test verifying exactly one telemetry setup execution.
- Verified the fixed implementation performs initialization exactly once under concurrent construction.
- All telemetry tests pass:
  `uv run pytest lib/crewai/tests/telemetry -q`
  → **227 passed**