### PR TITLE
fix(events): always emit project_id so absent and empty stay distinct

### DIFF
--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -136,8 +136,10 @@ def common_span_attributes() -> dict[str, str]:
 
     Returns:
         Attributes to stamp on every span. ``project_id`` is always present and
-        is the empty string for projects that do not declare one -- see the
-        comment at the assignment for why absent and empty must stay distinct.
+        is the empty string whenever no id is available -- both for projects that
+        declare none and when the lookup itself failed, which are deliberately
+        indistinguishable here because neither yields an id. See the comment at
+        the assignment for why empty and *absent* must stay distinct.
     """
     attributes = {
         "coding_agent": detect_coding_agent(),
@@ -155,9 +157,11 @@ def common_span_attributes() -> dict[str, str]:
     # Always set the key, even when empty. Absent and empty mean different things
     # and only this distinction can tell them apart: absent means the client is too
     # old to report a project id at all, empty means the client asked and the project
-    # declares none. Collapsing both into "absent" makes the share of clients that
-    # COULD have reported one unknowable, and that share is the denominator every
-    # attribution rate needs.
+    # declares none -- or the lookup failed, which lands here too and is treated the
+    # same, since an unreadable pyproject.toml also means no id is available.
+    # Collapsing empty into "absent" makes the share of clients that COULD have
+    # reported one unknowable, and that share is the denominator every attribution
+    # rate needs.
     attributes["project_id"] = project_id or ""
 
     return attributes

--- a/lib/crewai-core/src/crewai_core/telemetry.py
+++ b/lib/crewai-core/src/crewai_core/telemetry.py
@@ -135,8 +135,9 @@ def common_span_attributes() -> dict[str, str]:
     imports ``crewai``, still reports the same process-wide context.
 
     Returns:
-        Attributes to stamp on every span. ``project_id`` is omitted for
-        projects that do not declare one.
+        Attributes to stamp on every span. ``project_id`` is always present and
+        is the empty string for projects that do not declare one -- see the
+        comment at the assignment for why absent and empty must stay distinct.
     """
     attributes = {
         "coding_agent": detect_coding_agent(),
@@ -151,8 +152,13 @@ def common_span_attributes() -> dict[str, str]:
         logger.debug("Failed to read project id: %s", e)
         project_id = None
 
-    if project_id:
-        attributes["project_id"] = project_id
+    # Always set the key, even when empty. Absent and empty mean different things
+    # and only this distinction can tell them apart: absent means the client is too
+    # old to report a project id at all, empty means the client asked and the project
+    # declares none. Collapsing both into "absent" makes the share of clients that
+    # COULD have reported one unknowable, and that share is the denominator every
+    # attribution rate needs.
+    attributes["project_id"] = project_id or ""
 
     return attributes
 

--- a/lib/crewai/tests/telemetry/test_coding_agent_detection.py
+++ b/lib/crewai/tests/telemetry/test_coding_agent_detection.py
@@ -547,15 +547,27 @@ def test_common_attributes_include_project_id_when_declared(clean_env, monkeypat
     assert attributes["project_id"] == "proj-123"
 
 
-def test_project_id_is_omitted_when_absent(clean_env, monkeypatch):
-    """Projects without an id must not report a placeholder."""
+def test_project_id_is_empty_rather_than_absent_when_undeclared(clean_env, monkeypatch):
+    """An undeclared project reports an EMPTY id, not a missing key.
+
+    This used to assert the key was omitted. It is now always present, because
+    absent and empty answer different questions and only the caller can tell them
+    apart: a missing key means the client is too old to report a project id at all,
+    an empty one means the client asked and the project declares none. With both
+    collapsed into "absent", the share of clients that COULD have reported an id is
+    unknowable -- and that share is the denominator any attribution rate needs.
+    """
     attributes = _common_attributes(monkeypatch, project_id=None)
 
-    assert "project_id" not in attributes
+    assert attributes["project_id"] == ""
+    assert "project_id" in attributes, (
+        "the key must be present even when empty, or absent and undeclared "
+        "become indistinguishable"
+    )
 
 
 def test_project_id_lookup_never_breaks_telemetry(clean_env, monkeypatch):
-    """A failed lookup degrades to omitting the attribute."""
+    """A failed lookup degrades to an empty id, and never to a raised exception."""
     from crewai_core.telemetry import common_span_attributes
 
     def boom(*args, **kwargs):
@@ -566,8 +578,24 @@ def test_project_id_lookup_never_breaks_telemetry(clean_env, monkeypatch):
 
     attributes = common_span_attributes()
 
-    assert "project_id" not in attributes
+    assert attributes["project_id"] == ""
     assert "coding_agent" in attributes
+
+
+def test_a_declared_id_is_distinguishable_from_an_undeclared_one(
+    clean_env, monkeypatch
+):
+    """The whole point of the change: the two cases produce different values.
+
+    Both are present, so a reader can always tell "no project" from "old client",
+    which is what makes an attribution denominator computable.
+    """
+    declared = _common_attributes(monkeypatch, project_id="proj-123")
+    undeclared = _common_attributes(monkeypatch, project_id=None)
+
+    assert declared["project_id"] == "proj-123"
+    assert undeclared["project_id"] == ""
+    assert declared["project_id"] != undeclared["project_id"]
 
 
 def test_common_attributes_are_computed_once(clean_env, monkeypatch):


### PR DESCRIPTION
- Makes `project_id` always present on every span, as the empty string when the project declares none. It was previously omitted, which made two different situations indistinguishable downstream: **a client too old to report a project id at all, versus a current client whose project simply declares none.**
- **Why this is not cosmetic.** The share of clients that *could* have reported an id is the denominator of every attribution rate. With both cases collapsed into "key absent" that denominator cannot be computed — it can only be inferred from a version floor, which is fragile and silently wrong for anyone who pins or backports. Measured on the warehouse before making the change: on spans that carry `coding_agent`, `coding_agent` is present on **100%**, `runtime_context` on **81.6%** and `project_id` on **3.465%** — same processor, same dict, and no way to tell which part of that 96.5% is "too old" and which is "no project".
- **It still never invents an identity.** `get_project_id()` stays read-only and minting remains with the CLI commands a user explicitly invoked. An empty string means *"asked, and there is none"* — it is not a placeholder id.
- Consistent with the two attributes beside it: `coding_agent` and `runtime_context` already always emit a value, so this makes the third member of `common_span_attributes()` behave like the other two.
- **Two existing tests asserted the old contract and are updated, not deleted** — `test_project_id_is_omitted_when_absent` is renamed to `test_project_id_is_empty_rather_than_absent_when_undeclared` because its name described the behaviour that changed, and `test_project_id_lookup_never_breaks_telemetry` now asserts a failed lookup degrades to an empty id rather than an omitted key. A third test is added pinning the distinction itself.
- **One existing test deliberately left alone:** the one asserting a foreign application's spans are never annotated. This changes what our processor stamps, not where it is attached, so that guarantee is untouched and still passes.
- Verified locally: `96 passed` across `lib/crewai/tests/telemetry/test_coding_agent_detection.py` and `lib/crewai-core/tests/test_runtime_env.py`; `ruff check`, `ruff format --check` and `mypy` all clean.
- Keeps this intentionally small: no change to where the processor is attached, no change to minting, no new attribute, and no change to `get_project_id()` itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small telemetry attribute contract change with no auth, minting, or execution-path impact; downstream must treat empty string as "no id" rather than absent key.
> 
> **Overview**
> **Telemetry spans now always include `project_id`**, using `""` when the project has no id or lookup fails, instead of omitting the attribute.
> 
> That separates **legacy clients** (key missing) from **current clients with no declared id** (key present, empty), so warehouse metrics can compute attribution denominators without inferring from version floors. `get_project_id()` stays read-only; empty string does not mint an id. Behaviour aligns with `coding_agent` and `runtime_context`, which already always emit values.
> 
> Tests in `test_coding_agent_detection.py` were updated for the new contract and a case was added asserting declared vs undeclared ids differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a16d1666ec96b53f7121ec454382a092211814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->