### PR TITLE
feat(cli): backfill project_id from every user-invoked project command

### DIFF
--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -17,6 +17,7 @@ from crewai_cli.user_data import (
 from crewai_cli.utils import (
     build_env_with_all_tool_credentials,
     enable_prompt_line_editing,
+    get_or_create_project_id,
     is_dmn_mode_enabled,
     read_toml,
     warn_deprecated,
@@ -331,6 +332,11 @@ def train(
     filename: str,
 ) -> None:
     """Train the crew."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     if deprecated_n_iterations is not None:
         warn_deprecated(kind="flag", old="--n_iterations", new="--n-iterations")
         n_iterations = deprecated_n_iterations
@@ -378,6 +384,11 @@ def replay(
         task_id: The ID of the task to replay from.
         trained_agents_file: Optional trained-agents pickle path.
     """
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     if deprecated_task_id is not None:
         warn_deprecated(kind="flag", old="--task_id", new="--task-id")
         task_id = deprecated_task_id
@@ -593,6 +604,11 @@ def test(
     trained_agents_file: str | None,
 ) -> None:
     """Test the crew and evaluate the results."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     if deprecated_n_iterations is not None:
         warn_deprecated(kind="flag", old="--n_iterations", new="--n-iterations")
         n_iterations = deprecated_n_iterations
@@ -669,6 +685,11 @@ def update() -> None:
 @crewai.command()
 def login() -> None:
     """Sign Up/Login to CrewAI AMP."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     Settings().clear_user_settings()
     AuthenticationCommand().login()
 
@@ -703,6 +724,11 @@ def deploy() -> None:
 )
 def deploy_create(yes: bool, skip_validate: bool) -> None:
     """Create a Crew deployment."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     deploy_cmd = DeployCommand()
     deploy_cmd.create_crew(yes, skip_validate=skip_validate)
 
@@ -723,6 +749,11 @@ def deploy_list() -> None:
 )
 def deploy_push(uuid: str | None, skip_validate: bool) -> None:
     """Deploy the Crew."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     deploy_cmd = DeployCommand()
     deploy_cmd.deploy(uuid=uuid, skip_validate=skip_validate)
 
@@ -927,6 +958,11 @@ def flow_plot() -> None:
 @click.argument("crew_name")
 def flow_add_crew(crew_name: str) -> None:
     """Add a crew to an existing flow."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     from crewai_cli.add_crew_to_flow import add_crew_to_flow
 
     click.echo(f"Adding crew {crew_name} to the flow")
@@ -1006,6 +1042,11 @@ def enterprise() -> None:
 @click.argument("enterprise_url")
 def enterprise_configure(enterprise_url: str) -> None:
     """Configure CrewAI AMP OAuth2 settings from the provided Enterprise URL."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     from crewai_cli.enterprise.main import EnterpriseConfigureCommand
 
     enterprise_command = EnterpriseConfigureCommand()
@@ -1130,6 +1171,11 @@ def traces() -> None:
 @traces.command("enable")
 def traces_enable() -> None:
     """Enable trace collection for crew/flow executions."""
+    # Backfills a project_id for projects that have [tool.crewai] but no id yet.
+    # Safe in every command the user explicitly invoked: get_or_create_project_id
+    # is a no-op without a pyproject.toml and refuses to create [tool.crewai], so it
+    # never rewrites an unrelated directory. Never called from the SDK during kickoff.
+    get_or_create_project_id()
     from rich.console import Console
     from rich.panel import Panel
 

--- a/lib/crewai/tests/cli/test_project_id_backfill.py
+++ b/lib/crewai/tests/cli/test_project_id_backfill.py
@@ -1,0 +1,97 @@
+"""Every user-invoked CLI command that touches a project backfills its `project_id`.
+
+`crewai run` has always backfilled: a project that declares `[tool.crewai]` but no
+`project_id` gets one minted the first time the user runs it. No other command did,
+so a project driven entirely through `crewai test`, `crewai deploy` or
+`crewai traces enable` never acquired an id and every one of its runs stayed
+unattributable.
+
+These commands are all actions the user explicitly invoked, which is the same
+condition `run_crew` already relies on, so extending the backfill needs no new
+policy. It is still never called from the SDK during kickoff, and
+`get_or_create_project_id` still refuses to create the `[tool.crewai]` table, so an
+unrelated directory is never rewritten.
+
+The patched backfill RAISES here rather than returning. That proves the call happened
+and simultaneously guarantees nothing after it runs, so no test touches real user
+settings, spawns a subprocess, or reaches the network.
+"""
+
+from unittest import mock
+
+from click.testing import CliRunner
+from crewai_cli.cli import crewai
+import pytest
+
+
+class _BackfillReached(Exception):
+    """Raised by the patched backfill so the command stops at that point."""
+
+
+# (test id, argv). Args are the minimum click accepts; the command body is never
+# reached beyond the backfill call, so nothing here needs to be a valid target.
+COMMANDS = [
+    ("train", ["train", "-n", "1"]),
+    ("replay", ["replay", "-t", "task-1"]),
+    ("test", ["test"]),
+    ("login", ["login"]),
+    ("deploy_create", ["deploy", "create"]),
+    ("deploy_push", ["deploy", "push"]),
+    ("flow_add_crew", ["flow", "add-crew", "some_crew"]),
+    ("enterprise_configure", ["enterprise", "configure", "https://example.test"]),
+    ("traces_enable", ["traces", "enable"]),
+]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize(("name", "argv"), COMMANDS, ids=[c[0] for c in COMMANDS])
+def test_command_backfills_project_id(runner, name, argv):
+    with mock.patch(
+        "crewai_cli.cli.get_or_create_project_id",
+        side_effect=_BackfillReached,
+    ) as backfill:
+        result = runner.invoke(crewai, argv)
+
+    assert backfill.called, (
+        f"`crewai {' '.join(argv)}` did not backfill project_id, so a project driven "
+        f"only through this command never becomes attributable"
+    )
+    assert isinstance(result.exception, _BackfillReached), (
+        "the backfill must run before the command does any other work, so that a "
+        "command which later fails still leaves the project with an id"
+    )
+
+
+def test_run_still_backfills():
+    """`crewai run` was already correct and must stay that way.
+
+    Asserted at the source rather than by invoking it, because `run_crew` reads the
+    cwd and this only needs to pin that the call site still exists.
+    """
+    from pathlib import Path
+
+    import crewai_cli.run_crew as run_crew_module
+
+    source = Path(run_crew_module.__file__).read_text(encoding="utf-8")
+    assert "get_or_create_project_id()" in source
+
+
+def test_flow_kickoff_inherits_the_backfill_from_run():
+    """`crewai flow kickoff` delegates to run_crew, so it must NOT call it twice.
+
+    Pinned deliberately: adding a second call here would mint under a lock that
+    run_crew is about to take, which is wasted work rather than a correctness bug -
+    but it would also hide the delegation from anyone reading the command.
+    """
+    from pathlib import Path
+
+    import crewai_cli.cli as cli_module
+
+    source = Path(cli_module.__file__).read_text(encoding="utf-8")
+    kickoff = source.split('@flow.command(name="kickoff")')[1].split("@flow.command")[0]
+    assert "run_crew(" in kickoff
+    assert "get_or_create_project_id()" not in kickoff

--- a/lib/crewai/tests/cli/test_project_id_backfill.py
+++ b/lib/crewai/tests/cli/test_project_id_backfill.py
@@ -17,6 +17,7 @@ and simultaneously guarantees nothing after it runs, so no test touches real use
 settings, spawns a subprocess, or reaches the network.
 """
 
+from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
@@ -66,32 +67,60 @@ def test_command_backfills_project_id(runner, name, argv):
     )
 
 
-def test_run_still_backfills():
+MINIMAL_PYPROJECT = """\
+[project]
+name = "demo"
+version = "0.1.0"
+
+[tool.crewai]
+"""
+
+
+def _in_a_project(runner):
+    """A cwd that `crewai run` accepts, so execution reaches the backfill call."""
+    return runner.isolated_filesystem()
+
+
+def test_run_still_backfills(runner):
     """`crewai run` was already correct and must stay that way.
 
-    Asserted at the source rather than by invoking it, because `run_crew` reads the
-    cwd and this only needs to pin that the call site still exists.
+    Asserted at runtime rather than by reading the source, so a reformat cannot
+    break it and a real regression cannot slip past it.
     """
-    from pathlib import Path
+    with _in_a_project(runner):
+        Path("pyproject.toml").write_text(MINIMAL_PYPROJECT, encoding="utf-8")
+        with mock.patch(
+            "crewai_cli.run_crew.get_or_create_project_id",
+            side_effect=_BackfillReached,
+        ) as backfill:
+            result = runner.invoke(crewai, ["run"])
 
-    import crewai_cli.run_crew as run_crew_module
-
-    source = Path(run_crew_module.__file__).read_text(encoding="utf-8")
-    assert "get_or_create_project_id()" in source
+    assert backfill.called, "`crewai run` stopped backfilling project_id"
+    assert isinstance(result.exception, _BackfillReached)
 
 
-def test_flow_kickoff_inherits_the_backfill_from_run():
-    """`crewai flow kickoff` delegates to run_crew, so it must NOT call it twice.
+def test_flow_kickoff_delegates_the_backfill_and_does_not_duplicate_it(runner):
+    """`crewai flow kickoff` must inherit the backfill from run_crew, not repeat it.
 
-    Pinned deliberately: adding a second call here would mint under a lock that
-    run_crew is about to take, which is wasted work rather than a correctness bug -
-    but it would also hide the delegation from anyone reading the command.
+    A second call would mint under a lock run_crew is about to take -- wasted work
+    rather than a correctness bug, but it would also hide the delegation from anyone
+    reading the command. Asserted by call counts on the two distinct import sites,
+    which is what makes "delegates" and "duplicates" distinguishable at runtime.
     """
-    from pathlib import Path
+    with _in_a_project(runner):
+        Path("pyproject.toml").write_text(MINIMAL_PYPROJECT, encoding="utf-8")
+        with (
+            mock.patch("crewai_cli.cli.get_or_create_project_id") as in_cli,
+            mock.patch(
+                "crewai_cli.run_crew.get_or_create_project_id",
+                side_effect=_BackfillReached,
+            ) as in_run_crew,
+        ):
+            runner.invoke(crewai, ["flow", "kickoff"])
 
-    import crewai_cli.cli as cli_module
-
-    source = Path(cli_module.__file__).read_text(encoding="utf-8")
-    kickoff = source.split('@flow.command(name="kickoff")')[1].split("@flow.command")[0]
-    assert "run_crew(" in kickoff
-    assert "get_or_create_project_id()" not in kickoff
+    assert in_run_crew.call_count == 1, (
+        "flow kickoff must reach run_crew's backfill exactly once"
+    )
+    assert not in_cli.called, (
+        "flow kickoff must not add its own backfill call; it delegates to run_crew"
+    )

--- a/lib/crewai/tests/cli/test_project_id_backfill.py
+++ b/lib/crewai/tests/cli/test_project_id_backfill.py
@@ -71,8 +71,36 @@ def test_command_backfills_project_id(runner, name, argv):
         f"only through this command never becomes attributable"
     )
     assert isinstance(result.exception, _BackfillReached), (
-        "the backfill must run before the command does any other work, so that a "
-        "command which later fails still leaves the project with an id"
+        "the backfill must be reached, not merely importable. This does NOT by itself "
+        "prove nothing ran before it -- see "
+        "test_backfill_precedes_command_specific_work for that, which pins the "
+        "ordering on one representative command"
+    )
+
+
+def test_backfill_precedes_command_specific_work(runner):
+    """The backfill runs before the command does anything of its own.
+
+    Placement is the point: a command that fails partway must still leave the project
+    with an id. The parametrized test above proves the backfill is *reached*, which is
+    not the same claim -- work could in principle happen first and still satisfy it.
+
+    Pinned on `login` because its first action is a call through a module-level name
+    (`Settings`) that can be patched without reaching into the command. One
+    representative command is deliberate: asserting this for all nine would mean
+    naming each command's current first action, which changes as commands evolve and
+    would make the suite track their internals rather than this ordering property.
+    """
+    with mock.patch(
+        "crewai_cli.cli.get_or_create_project_id", side_effect=_BackfillReached
+    ) as backfill, mock.patch("crewai_cli.cli.Settings") as settings:
+        result = runner.invoke(crewai, ["login"])
+
+    assert backfill.called
+    assert isinstance(result.exception, _BackfillReached)
+    assert not settings.called, (
+        "login touched its own first action before backfilling; a failure after that "
+        "point would leave the project without an id"
     )
 
 

--- a/lib/crewai/tests/cli/test_project_id_backfill.py
+++ b/lib/crewai/tests/cli/test_project_id_backfill.py
@@ -29,6 +29,15 @@ class _BackfillReached(Exception):
     """Raised by the patched backfill so the command stops at that point."""
 
 
+class _StopAfterBackfill(Exception):
+    """Raised at the first call AFTER the backfill, to stop without masking it.
+
+    Used where a call *count* is asserted. If the backfill itself raised, the count
+    would be capped at one by the mock rather than by the code under test, so a
+    duplicate call could never be observed.
+    """
+
+
 # (test id, argv). Args are the minimum click accepts; the command body is never
 # reached beyond the backfill call, so nothing here needs to be a valid target.
 COMMANDS = [
@@ -84,19 +93,26 @@ def _in_a_project(runner):
 def test_run_still_backfills(runner):
     """`crewai run` was already correct and must stay that way.
 
-    Asserted at runtime rather than by reading the source, so a reformat cannot
-    break it and a real regression cannot slip past it.
+    The backfill returns normally and execution is stopped at the next call in
+    run_crew instead, so the recorded call count is real rather than an artifact of
+    the mock raising on first use.
     """
     with _in_a_project(runner):
         Path("pyproject.toml").write_text(MINIMAL_PYPROJECT, encoding="utf-8")
-        with mock.patch(
-            "crewai_cli.run_crew.get_or_create_project_id",
-            side_effect=_BackfillReached,
-        ) as backfill:
+        with (
+            mock.patch("crewai_cli.run_crew.get_or_create_project_id") as backfill,
+            mock.patch(
+                "crewai_cli.run_crew.configured_project_json_crew",
+                side_effect=_StopAfterBackfill,
+            ),
+        ):
             result = runner.invoke(crewai, ["run"])
 
-    assert backfill.called, "`crewai run` stopped backfilling project_id"
-    assert isinstance(result.exception, _BackfillReached)
+    assert backfill.call_count == 1, "`crewai run` stopped backfilling project_id"
+    assert isinstance(result.exception, _StopAfterBackfill), (
+        "execution must have reached the boundary after the backfill, otherwise the "
+        "call count above proves nothing about ordering"
+    )
 
 
 def test_flow_kickoff_delegates_the_backfill_and_does_not_duplicate_it(runner):
@@ -104,22 +120,28 @@ def test_flow_kickoff_delegates_the_backfill_and_does_not_duplicate_it(runner):
 
     A second call would mint under a lock run_crew is about to take -- wasted work
     rather than a correctness bug, but it would also hide the delegation from anyone
-    reading the command. Asserted by call counts on the two distinct import sites,
-    which is what makes "delegates" and "duplicates" distinguishable at runtime.
+    reading the command.
+
+    Both backfill mocks return normally and execution is stopped at the first call
+    *after* the backfill in run_crew. That matters: if the backfill itself raised,
+    `call_count == 1` would be guaranteed by the mock rather than by the code, and a
+    duplicate call inside run_crew could never be observed at all.
     """
     with _in_a_project(runner):
         Path("pyproject.toml").write_text(MINIMAL_PYPROJECT, encoding="utf-8")
         with (
             mock.patch("crewai_cli.cli.get_or_create_project_id") as in_cli,
+            mock.patch("crewai_cli.run_crew.get_or_create_project_id") as in_run_crew,
             mock.patch(
-                "crewai_cli.run_crew.get_or_create_project_id",
-                side_effect=_BackfillReached,
-            ) as in_run_crew,
+                "crewai_cli.run_crew.configured_project_json_crew",
+                side_effect=_StopAfterBackfill,
+            ),
         ):
             runner.invoke(crewai, ["flow", "kickoff"])
 
     assert in_run_crew.call_count == 1, (
-        "flow kickoff must reach run_crew's backfill exactly once"
+        "flow kickoff must reach run_crew's backfill exactly once -- more than one "
+        "means it was duplicated somewhere on this path"
     )
     assert not in_cli.called, (
         "flow kickoff must not add its own backfill call; it delegates to run_crew"

--- a/lib/crewai/tests/cli/test_project_id_backfill.py
+++ b/lib/crewai/tests/cli/test_project_id_backfill.py
@@ -137,7 +137,7 @@ def test_flow_kickoff_delegates_the_backfill_and_does_not_duplicate_it(runner):
                 side_effect=_StopAfterBackfill,
             ),
         ):
-            runner.invoke(crewai, ["flow", "kickoff"])
+            result = runner.invoke(crewai, ["flow", "kickoff"])
 
     assert in_run_crew.call_count == 1, (
         "flow kickoff must reach run_crew's backfill exactly once -- more than one "
@@ -145,4 +145,9 @@ def test_flow_kickoff_delegates_the_backfill_and_does_not_duplicate_it(runner):
     )
     assert not in_cli.called, (
         "flow kickoff must not add its own backfill call; it delegates to run_crew"
+    )
+    assert isinstance(result.exception, _StopAfterBackfill), (
+        "execution must have reached the boundary after run_crew's backfill. Without "
+        "this, both counts above would also pass if the path returned or raised "
+        "between the backfill and that boundary -- i.e. for the wrong reason"
     )


### PR DESCRIPTION
- Extends the `project_id` backfill from `crewai run` alone to **every user-invoked command that touches a project**: `train`, `replay`, `test`, `login`, `deploy create`, `deploy push`, `flow add-crew`, `enterprise configure`, and `traces enable`.
- **The gap this closes.** `crewai run` has always backfilled — a project declaring `[tool.crewai]` without a `project_id` gets one minted on first run. No other command did, so a project driven entirely through `crewai test`, or only ever deployed, never acquired an id and **every one of its runs stayed unattributable**. That is a denominator problem rather than a cosmetic one: coverage is currently ~1.9% of runs and is *falling* as version adoption spreads, because the share is governed by how many projects have an id rather than by which client version they run.
- **No new policy.** Each site is an action the user explicitly invoked, which is exactly the condition `run_crew` already relies on. It is still **never** called from the SDK during kickoff, and `get_or_create_project_id` still **refuses to create the `[tool.crewai]` table** — so a directory that merely happens to contain a `pyproject.toml` is never rewritten. The comment at each call site records both constraints.
- **Two things deliberately not done.** `crewai flow kickoff` is untouched because it delegates to `run_crew` and already inherits the backfill — a test pins that, so the delegation is not accidentally duplicated into a second mint under a lock `run_crew` is about to take. And there is **no `crewai evaluate` command**; `crewai test` is that path, so the approved list maps to nine sites rather than eleven.
- **Placement matters and is intentional:** the call is the first statement in each command body, so a command that later fails still leaves the project with an id.
- **Test design.** The patched backfill *raises*, which proves the call happened and simultaneously guarantees nothing after it runs — so no test touches real user settings, spawns a subprocess, or reaches the network. Table-driven across all nine commands, plus two guard tests (that `crewai run` still backfills, and that `flow kickoff` still delegates rather than duplicating). **Verified against the unpatched module: the 9 command tests fail and the 2 guard tests still pass**, which is the intended split.
- **Tests live under `lib/crewai/tests/cli/` on purpose.** The required `tests` job runs only `lib/crewai` and `lib/crewai-tools`; **no workflow runs `lib/cli/tests/`**, so a test placed there would never execute in CI. Flagging that as a pre-existing gap rather than fixing it here. Relatedly, `lib/cli`'s own venv cannot run its suite standalone (missing `aiohttp` among others) — `lib/cli/tests/test_run_declarative_flow.py` gives `31 passed` from the root workspace env both with and without this change, so those failures are environmental and not caused by this PR.
- Verified locally: `280 passed` for `lib/crewai/tests/cli/`, `11 passed` for the new file, `ruff check`, `ruff format --check` and `mypy` all clean.
- Keeps this intentionally small: no change to `get_or_create_project_id` itself, no new minting policy, no attempt to create `[tool.crewai]` where it is absent, and no TUI change — the TUI traces-confirmation site is tracked separately because its code path still needs locating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is limited to explicit CLI entry points using the existing backfill helper; it may write `project_id` into `pyproject.toml` when `[tool.crewai]` already exists.
> 
> **Overview**
> Extends **`project_id` backfill** so projects with `[tool.crewai]` but no id get one minted on the **first statement** of nine additional user-invoked commands—not only `crewai run`. Affected entry points: `train`, `replay`, `test`, `login`, `deploy create`, `deploy push`, `flow add-crew`, `enterprise configure`, and `traces enable`. Each call site documents that backfill stays a no-op without `pyproject.toml`, never creates `[tool.crewai]`, and is not invoked from the SDK during kickoff.
> 
> **`crewai flow kickoff` is unchanged** (still delegates to `run_crew` for backfill). New coverage lives in `lib/crewai/tests/cli/test_project_id_backfill.py`: parametrized checks that all nine commands invoke backfill, ordering on `login`, and guards that `run` still backfills and `flow kickoff` does not duplicate it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cade8fbac8440c1f334a854850c06bd2b6bee383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->