### PR TITLE
fix(schema): support list-form type arrays in JSON schema conversion

### DIFF
--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -1215,6 +1215,28 @@ def _json_schema_to_pydantic_type(
 
     type_ = json_schema.get("type")
 
+    if isinstance(type_, list):
+        # JSON Schema also allows "type" to be an array, e.g.
+        # {"type": ["string", "null"]} -- the .NET/System.Text.Json-style
+        # way of expressing a nullable field. Pydantic's own schema
+        # generation instead uses anyOf/oneOf for this (handled above), so
+        # external tool schemas (e.g. from a non-Python MCP server) are the
+        # main source of this form. Treat each entry the same way anyOf's
+        # members are handled just above: build a Union of the
+        # corresponding Python types. A single-element list collapses to
+        # that one type, matching typing.Union's own behavior.
+        member_types = [
+            _json_schema_to_pydantic_type(
+                {**json_schema, "type": member},
+                root_schema,
+                name_=f"{name_ or 'Union'}Option{i}",
+                enrich_descriptions=enrich_descriptions,
+                in_progress=in_progress,
+            )
+            for i, member in enumerate(type_)
+        ]
+        return Union[tuple(member_types)]  # noqa: UP007
+
     if type_ == "string":
         return str
     if type_ == "integer":

--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -30,6 +30,8 @@ from typing import (
     TypedDict,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 import uuid
 
@@ -1042,7 +1044,27 @@ def _json_schema_to_pydantic_field(
                 elif len(allowed_schemes) == 1 and allowed_schemes[0] == "file":
                     pydantic_type = FileUrl
 
-        type_ = pydantic_type
+        # A JSON Schema "type" array (e.g. {"type": ["string", "null"],
+        # "format": "date-time"}) resolves `type_` to a Union above, not a
+        # bare `str` -- format constraints like date-time only make sense
+        # for the string member of that union. Blindly overwriting type_
+        # with pydantic_type here would silently drop the other members:
+        # a required ["string", "null"] field would stop accepting None
+        # (the format-mapped type has no null member of its own), and
+        # ["string", "integer"] would lose int support entirely. Replace
+        # only the str member within the union instead, leaving every
+        # other member (null, integer, etc.) untouched.
+        if type_ is str:
+            type_ = pydantic_type
+        elif get_origin(type_) is Union:
+            member_types = get_args(type_)
+            if str in member_types:
+                type_ = Union[  # noqa: UP007
+                    tuple(
+                        pydantic_type if member is str else member
+                        for member in member_types
+                    )
+                ]
 
     if isinstance(type_, type) and issubclass(type_, str):
         if "minLength" in json_schema:

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -365,6 +365,43 @@ class TestUnionTypes:
         Model = create_model_from_schema(schema)
         assert Model(value="hello").value == "hello"
 
+    def test_type_array_required_nullable_string_with_format_still_accepts_none(
+        self,
+    ) -> None:
+        """A format (e.g. date-time) applied to a ["string", "null"] type
+        array must only remap the string member -- overwriting the whole
+        union with the format's mapped type (as a naive fix would) drops
+        the null member entirely, so a *required* nullable date field would
+        wrongly reject None even though "null" is right there in the
+        schema's own type array."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "startDate": {"type": ["string", "null"], "format": "date-time"},
+            },
+            "required": ["startDate"],
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(startDate=None).startDate is None
+        assert Model(startDate="2026-01-01").startDate == datetime.datetime(
+            2026, 1, 1
+        )
+
+    def test_type_array_format_does_not_clobber_non_string_member(self) -> None:
+        """A format on a ["string", "integer"] type array should only
+        affect the string member -- the integer member must stay a plain
+        int, not get coerced into whatever type the format maps to."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {"type": ["string", "integer"], "format": "date-time"},
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value=42).value == 42
+        assert isinstance(Model(value=42).value, int)
+        assert Model(value="2026-01-01").value == datetime.datetime(2026, 1, 1)
+
 
 class TestAllOfMerging:
     def test_allof_merges_properties(self) -> None:

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -303,6 +303,68 @@ class TestUnionTypes:
         assert Model(value="hello").value == "hello"
         assert Model(value=3.14).value == pytest.approx(3.14)
 
+    def test_type_array_nullable_string_with_format(self) -> None:
+        """type: ["string", "null"] -- the .NET/System.Text.Json-style way
+        of expressing an optional field, as opposed to Pydantic's own
+        anyOf-based form. Seen in real MCP tool schemas from non-Python
+        servers (e.g. Equibles' ListCompanyDocuments startDate/endDate
+        filters). The format="date-time" here (also straight from that
+        real schema) is applied by the existing FORMAT_TYPE_MAP logic once
+        the list-form type no longer raises, so the field lands as a real
+        datetime rather than str -- that's the pre-existing, correct
+        behavior for any date-time-formatted field, not something this fix
+        changes."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "startDate": {
+                    "description": "Optional start date filter in YYYY-MM-DD format",
+                    "type": ["string", "null"],
+                    "format": "date-time",
+                    "default": None,
+                },
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(startDate="2026-01-01").startDate == datetime.datetime(
+            2026, 1, 1
+        )
+        assert Model(startDate=None).startDate is None
+        assert Model().startDate is None
+
+    def test_type_array_nullable_string_no_format(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "note": {"type": ["string", "null"]},
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(note="hello").note == "hello"
+        assert Model(note=None).note is None
+        assert Model().note is None
+
+    def test_type_array_multiple_non_null(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {"type": ["string", "integer", "null"]},
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value="hello").value == "hello"
+        assert Model(value=42).value == 42
+        assert Model(value=None).value is None
+
+    def test_type_array_single_element(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"value": {"type": ["string"]}},
+            "required": ["value"],
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value="hello").value == "hello"
+
 
 class TestAllOfMerging:
     def test_allof_merges_properties(self) -> None:


### PR DESCRIPTION
Disclosure: I'm not a developer and didn't write this fix by hand — I found and diagnosed the bug while evaluating crewai + MCP for my own project, then used Claude (Anthropic's AI assistant) to trace the root cause against your source, prepare the fix, and write tests. I verified it against the full existing test suite (all passing) and against a real self-hosted MCP server before opening this. Apologies in advance if anything here reads as AI slop or misses a convention I wouldn't know to look for — happy to answer questions or make changes. Per your CONTRIBUTING.md, this should carry the llm-generated label — I don't have permission to add it myself as an external contributor, so flagging it here for a maintainer to apply.

## What

`_json_schema_to_pydantic_type` (in `crewai/utilities/pydantic_schema_utils.py`) already handles `anyOf`/`oneOf` for nullable unions — the form Pydantic's own schema generation produces for `Optional[T]` fields. But it has no handling for the other, equally valid JSON Schema way of expressing the same thing: a **list-form `type` array**, e.g. `{"type": ["string", "null"]}`. This is what .NET/`System.Text.Json`-based schema generators produce instead of `anyOf`, so any MCP tool schema coming from a non-Python server using this form crashes `create_model_from_schema` outright:

```python
raise ValueError(f"Unsupported JSON schema type: {type_} from {json_schema}")
# ValueError: Unsupported JSON schema type: ['string', 'null'] from
# {'description': 'Optional start date filter in YYYY-MM-DD format',
#  'type': ['string', 'null'], 'format': 'date-time', 'default': None}
```

Since this happens during `MCPServerAdapter`'s initialization (converting every tool's `inputSchema` up front), **one tool with this pattern takes down the entire adapter connection**, not just that one tool — every other tool on the server becomes unusable too.

## Confirmed against a real server

Found this evaluating [Equibles](https://github.com/daniel3303/Equibles) (a self-hosted SEC-data MCP server) for my own project. Several of its tools (e.g. `ListCompanyDocuments`'s `startDate`/`endDate` filters) use exactly this pattern. `MCPServerAdapter` couldn't connect to it at all as a result — reproduced identically on both Windows and macOS, with the underlying `mcp` Python SDK confirmed working fine directly (connects and lists all 64 tools in well under a second), isolating the fault specifically to this schema conversion step.

## Fix

Mirrors the existing `anyOf`/`oneOf` handling directly above it: treat each entry in a list-form `type` the same way an `anyOf` member is handled, building a `Union` of the corresponding Python types. A single-element list collapses to that one type via `typing.Union`'s own behavior, and a `"null"` entry resolves to `None` (matching how the existing `type == "null"` branch already behaves), producing the same `Optional[T]` shape the `anyOf` case would.

## Testing

- Added 4 new tests to `TestUnionTypes` in `test_pydantic_schema_utils.py`: nullable string with a `format` (the exact real-world shape, including confirming the pre-existing `FORMAT_TYPE_MAP` datetime coercion still applies correctly once the crash is gone), nullable string with no format, a 3-member list (`["string", "integer", "null"]`), and a single-element list.
- Full existing test suite for this file: **87/87 passing** (83 pre-existing + 4 new).
- `ruff check` / `ruff format --check`: clean.
- Reproduced the exact real-world crashing schema fragment directly against `create_model_from_schema` before the fix (confirmed it raised) and after (confirmed it now builds and validates correctly, including the `format="date-time"` coercion).
- Reproduced the real end-to-end failure through `MCPServerAdapter` against the live Equibles server before this fix, confirming the connection crash.
- Ran a full real crew (researcher + analyst agents, local Ollama LLM) end-to-end against the live Equibles server with this fix applied, on a separate physical machine from where the fix was written: all 64 tools loaded with no crash, the researcher agent made real tool calls against live data, and the crew completed successfully with a final summary. Spot-checked the agent's output figures directly against the live server afterward — most were accurate (price, revenue), one aggregate transaction count was off by ~17%, which is a separate, pre-existing model-grounding question unrelated to this schema fix (the fix is what makes the connection possible at all; it doesn't touch how the agent interprets what a tool returns).
