### PR TITLE
docs(hooks): fix nonexistent crewai.hooks decorator names in translated guides

### DIFF
--- a/docs/edge/ar/learn/execution-hooks.mdx
+++ b/docs/edge/ar/learn/execution-hooks.mdx
@@ -51,16 +51,16 @@ def block_dangerous_tools(context):
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_llm_call_crew, after_tool_call_crew
+from crewai.hooks import before_llm_call, after_tool_call
 
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         print(f"LLM call in {self.__class__.__name__}")
         return None
 
-    @after_tool_call_crew
+    @after_tool_call
     def log_results(self, context):
         print(f"Tool result: {context.tool_result[:50]}...")
         return None

--- a/docs/edge/ar/learn/llm-hooks.mdx
+++ b/docs/edge/ar/learn/llm-hooks.mdx
@@ -122,14 +122,14 @@ def sanitize_response(context):
 ```python
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         # Only applies to this crew
         if context.iterations == 0:
             print(f"Starting task: {context.task.description}")
         return None
 
-    @after_llm_call_crew
+    @after_llm_call
     def log_responses(self, context):
         # Crew-specific response logging
         print(f"Response length: {len(context.response)}")

--- a/docs/edge/ar/learn/tool-hooks.mdx
+++ b/docs/edge/ar/learn/tool-hooks.mdx
@@ -123,7 +123,7 @@ def sanitize_results(context):
 ```python
 @CrewBase
 class MyProjCrew:
-    @before_tool_call_crew
+    @before_tool_call
     def validate_tool_inputs(self, context):
         # Only applies to this crew
         if context.tool_name == "web_search":
@@ -132,7 +132,7 @@ class MyProjCrew:
                 return False
         return None
 
-    @after_tool_call_crew
+    @after_tool_call
     def log_tool_results(self, context):
         # Crew-specific tool logging
         print(f"✅ {context.tool_name} completed")

--- a/docs/edge/ko/learn/execution-hooks.mdx
+++ b/docs/edge/ko/learn/execution-hooks.mdx
@@ -86,17 +86,17 @@ def log_tool_result(context):
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_llm_call_crew, after_tool_call_crew
+from crewai.hooks import before_llm_call, after_tool_call
 
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         # 이 크루에만 적용됩니다
         print(f"{self.__class__.__name__}에서 LLM 호출")
         return None
 
-    @after_tool_call_crew
+    @after_tool_call
     def log_results(self, context):
         # 크루별 로깅
         print(f"도구 결과: {context.tool_result[:50]}...")

--- a/docs/edge/ko/learn/llm-hooks.mdx
+++ b/docs/edge/ko/learn/llm-hooks.mdx
@@ -110,18 +110,18 @@ def sanitize_response(context):
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_llm_call_crew, after_llm_call_crew
+from crewai.hooks import before_llm_call, after_llm_call
 
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         # 이 크루에만 적용됩니다
         if context.iterations == 0:
             print(f"작업 시작: {context.task.description}")
         return None
     
-    @after_llm_call_crew
+    @after_llm_call
     def log_responses(self, context):
         # 크루별 응답 로깅
         print(f"응답 길이: {len(context.response)}")

--- a/docs/edge/ko/learn/tool-hooks.mdx
+++ b/docs/edge/ko/learn/tool-hooks.mdx
@@ -110,11 +110,11 @@ def sanitize_results(context):
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_tool_call_crew, after_tool_call_crew
+from crewai.hooks import before_tool_call, after_tool_call
 
 @CrewBase
 class MyProjCrew:
-    @before_tool_call_crew
+    @before_tool_call
     def validate_tool_inputs(self, context):
         # 이 크루에만 적용됩니다
         if context.tool_name == "web_search":
@@ -123,7 +123,7 @@ class MyProjCrew:
                 return False
         return None
     
-    @after_tool_call_crew
+    @after_tool_call
     def log_tool_results(self, context):
         # 크루별 도구 로깅
         print(f"✅ {context.tool_name} 완료됨")

--- a/docs/edge/pt-BR/learn/execution-hooks.mdx
+++ b/docs/edge/pt-BR/learn/execution-hooks.mdx
@@ -86,17 +86,17 @@ Aplica hooks apenas a instâncias específicas de crew:
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_llm_call_crew, after_tool_call_crew
+from crewai.hooks import before_llm_call, after_tool_call
 
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         # Aplica-se apenas a esta crew
         print(f"Chamada LLM em {self.__class__.__name__}")
         return None
 
-    @after_tool_call_crew
+    @after_tool_call
     def log_results(self, context):
         # Logging específico da crew
         print(f"Resultado da ferramenta: {context.tool_result[:50]}...")

--- a/docs/edge/pt-BR/learn/llm-hooks.mdx
+++ b/docs/edge/pt-BR/learn/llm-hooks.mdx
@@ -110,18 +110,18 @@ Registre hooks para uma instância específica de crew:
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_llm_call_crew, after_llm_call_crew
+from crewai.hooks import before_llm_call, after_llm_call
 
 @CrewBase
 class MyProjCrew:
-    @before_llm_call_crew
+    @before_llm_call
     def validate_inputs(self, context):
         # Aplica-se apenas a esta crew
         if context.iterations == 0:
             print(f"Iniciando tarefa: {context.task.description}")
         return None
     
-    @after_llm_call_crew
+    @after_llm_call
     def log_responses(self, context):
         # Logging específico da crew
         print(f"Comprimento da resposta: {len(context.response)}")

--- a/docs/edge/pt-BR/learn/tool-hooks.mdx
+++ b/docs/edge/pt-BR/learn/tool-hooks.mdx
@@ -110,11 +110,11 @@ Registre hooks para uma instância específica de crew:
 ```python
 from crewai import CrewBase
 from crewai.project import crew
-from crewai.hooks import before_tool_call_crew, after_tool_call_crew
+from crewai.hooks import before_tool_call, after_tool_call
 
 @CrewBase
 class MyProjCrew:
-    @before_tool_call_crew
+    @before_tool_call
     def validate_tool_inputs(self, context):
         # Aplica-se apenas a esta crew
         if context.tool_name == "web_search":
@@ -123,7 +123,7 @@ class MyProjCrew:
                 return False
         return None
     
-    @after_tool_call_crew
+    @after_tool_call
     def log_tool_results(self, context):
         # Logging de ferramenta específico da crew
         print(f"✅ {context.tool_name} concluída")


### PR DESCRIPTION
## Problem

The translated (ar / ko / pt-BR) "crew-scoped hooks" guides import and apply decorators that do not exist in `crewai.hooks`:

```python
from crewai.hooks import before_llm_call_crew, after_llm_call_crew  # ImportError
```

`crewai/hooks/__init__.py` `__all__` only exposes `before_llm_call`, `after_llm_call`, `before_tool_call`, `after_tool_call` (defined in `crewai/hooks/decorators.py`) — there are no `*_crew`-suffixed variants. So any reader who copies these examples hits `ImportError: cannot import name 'before_llm_call_crew'`.

The canonical English guide (`docs/edge/en/learn/llm-hooks.mdx`) already uses the correct names and documents that crew-scoping is done by applying the same decorator to a `@CrewBase` method:

> **Filters and crew-scoping** work the same way: `@before_llm_call(agents=[...])`, and applying the decorator to a `@CrewBase` method scopes it to that crew.

The translations were simply not updated when the `*_crew` decorators were unified into the base names.

## Fix

Drop the stale `_crew` suffix in the edge translations so the imports and decorators match the real API (`before_llm_call`, `after_llm_call`, `before_tool_call`, `after_tool_call`). Only the current (`docs/edge/`) ar/ko/pt-BR hook guides are touched; the English canonical is already correct and frozen version snapshots are left untouched.

## Verification

- `grep -rn 'before_llm_call_crew\|after_llm_call_crew\|before_tool_call_crew\|after_tool_call_crew' lib/` → no matches (names don't exist in code).
- `crewai/hooks/__init__.py` `__all__` lists only the non-suffixed names.
- After the change, `grep -rn '_llm_call_crew\|_tool_call_crew' docs/edge/` → no matches; the translated examples now import names that actually resolve, matching `docs/edge/en/`.
