### PR TITLE
feat(flow): let a declarative agent action receive the conversation

### DIFF
--- a/lib/crewai/src/crewai/flow/runtime/_actions.py
+++ b/lib/crewai/src/crewai/flow/runtime/_actions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 import contextvars
 import inspect
 import os
@@ -29,6 +29,7 @@ from crewai.utilities.declarative_refs import (
     resolve_class_ref,
     resolve_ref,
 )
+from crewai.utilities.types import LLMMessage
 
 
 if TYPE_CHECKING:
@@ -184,8 +185,7 @@ class AgentAction:
             self.flow,
             local_context=local_context,
         ).render_template()
-        if not isinstance(rendered_input, str):
-            raise ValueError("agent input must render to a string")
+        agent_input = _normalize_agent_input(rendered_input)
 
         agent, response_format = await asyncio.to_thread(
             load_agent_from_definition,
@@ -193,9 +193,44 @@ class AgentAction:
             source="agent action",
         )
         return await agent.kickoff_async(
-            rendered_input,
+            agent_input,
             response_format=response_format,
         )
+
+
+def _normalize_agent_input(rendered: Any) -> str | list[LLMMessage]:
+    """Accept a prompt string or a rendered conversation.
+
+    A whole-string ``${...}`` template keeps its evaluated type, so a CEL
+    expression over ``state.messages`` renders a list. ``message_to_llm_dict``
+    drops the metadata and ``None`` keys a serialized message carries, which
+    the agent event schema rejects.
+    """
+    if isinstance(rendered, str):
+        return rendered
+    if isinstance(rendered, list) and all(
+        isinstance(item, Mapping) for item in rendered
+    ):
+        from crewai.experimental.conversational import message_to_llm_dict
+
+        # ``message_to_llm_dict`` only drops ``None`` keys for a model input;
+        # a CEL render is plain dicts, so a serialized message keeps its
+        # ``name: None`` -- which the agent event schema rejects.
+        return [
+            cast(
+                LLMMessage,
+                {
+                    key: value
+                    for key, value in message_to_llm_dict(item).items()
+                    if value is not None or key == "content"
+                },
+            )
+            for item in rendered
+        ]
+    raise ValueError(
+        "agent input must render to a string or a list of messages; "
+        f"got {type(rendered).__name__}"
+    )
 
 
 class ExpressionAction:

--- a/lib/crewai/src/crewai/project/crew_definition.py
+++ b/lib/crewai/src/crewai/project/crew_definition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -222,9 +223,16 @@ class AgentDefinition(CrewAgentDefinition):
         description="Additional agent settings passed to the loader.",
         examples=[{"llm": "openai/gpt-4o-mini"}],
     )
-    input: str = Field(
-        description="Input passed to the individual agent kickoff outside of a crew.",
-        examples=["${state.ticket.body}"],
+    input: str | list[dict[str, Any]] = Field(
+        description=(
+            "Input passed to the individual agent kickoff outside of a crew. "
+            "A string, or a list of {role, content} messages to give the agent "
+            "a conversation instead of a single prompt."
+        ),
+        examples=[
+            "${state.ticket.body}",
+            "${state.messages.map(m, {'role': m.role, 'content': m.content})}",
+        ],
     )
     response_format: PythonReferenceDefinition | None = Field(
         default=None,
@@ -235,9 +243,11 @@ class AgentDefinition(CrewAgentDefinition):
     @field_validator("input", mode="before")
     @classmethod
     def _validate_input(cls, value: Any) -> Any:
-        if not isinstance(value, str):
-            raise ValueError("agent.input must be a string")
-        return value
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list) and all(isinstance(item, Mapping) for item in value):
+            return value
+        raise ValueError("agent.input must be a string or a list of messages")
 
 
 class CrewTaskDefinition(BaseModel):

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -1332,6 +1332,55 @@ methods:
     }
 
 
+def test_agent_action_delivers_a_rendered_conversation_to_the_agent(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The whole path: `${state.messages}` -> normalization -> `kickoff_async`."""
+    from crewai import Agent
+
+    received: list[Any] = []
+
+    async def fake_kickoff_async(self: Agent, messages: Any, **_kwargs: Any) -> str:
+        received.append(messages)
+        return "answered"
+
+    monkeypatch.setattr(Agent, "kickoff_async", fake_kickoff_async)
+
+    yaml_str = """
+schema: crewai.flow/v1
+name: HistoryAgentFlow
+methods:
+  answer:
+    do:
+      call: agent
+      with:
+        role: Analyst
+        goal: Answer questions
+        backstory: Knows things.
+        input: "${state.messages}"
+    start: true
+"""
+
+    flow = Flow.from_declaration(contents=yaml_str)
+    result = flow.kickoff(
+        inputs={
+            "messages": [
+                {"role": "user", "content": "my order id is 42", "name": None},
+                {"role": "assistant", "content": "thanks, checking"},
+            ]
+        }
+    )
+
+    assert result == "answered"
+    # A list, not a stringified blob, and the serialization noise is gone.
+    assert received == [
+        [
+            {"role": "user", "content": "my order id is 42"},
+            {"role": "assistant", "content": "thanks, checking"},
+        ]
+    ]
+
+
 def test_agent_action_runs_inside_each(monkeypatch: pytest.MonkeyPatch):
     from crewai import Agent
 

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -4063,6 +4063,30 @@ def test_agent_action_strips_serialized_message_metadata():
     assert normalized == [{"role": "user", "content": "hi"}]
 
 
+def test_agent_action_keeps_a_none_content_tool_call_message():
+    """A tool-call turn has no content; dropping the key breaks the sequence."""
+    from crewai.flow.runtime._actions import _normalize_agent_input
+
+    normalized = _normalize_agent_input(
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "function": {"name": "lookup"}}],
+                "name": None,
+            }
+        ]
+    )
+
+    assert normalized == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "c1", "function": {"name": "lookup"}}],
+        }
+    ]
+
+
 def test_agent_action_still_accepts_a_string():
     from crewai.flow.runtime._actions import _normalize_agent_input
 

--- a/lib/crewai/tests/test_flow_from_definition.py
+++ b/lib/crewai/tests/test_flow_from_definition.py
@@ -4039,6 +4039,71 @@ methods: {}
         FlowDefinition.from_declaration(contents=yaml_str)
 
 
+
+def test_agent_action_accepts_a_rendered_message_list():
+    """A chat handler can hand the agent the conversation, not just a string."""
+    from crewai.flow.runtime._actions import _normalize_agent_input
+
+    rendered = [
+        {"role": "user", "content": "my order id is 42"},
+        {"role": "assistant", "content": "thanks, checking"},
+    ]
+
+    assert _normalize_agent_input(rendered) == rendered
+
+
+def test_agent_action_strips_serialized_message_metadata():
+    """A raw `${state.messages}` render carries None keys the event rejects."""
+    from crewai.flow.runtime._actions import _normalize_agent_input
+
+    normalized = _normalize_agent_input(
+        [{"role": "user", "content": "hi", "name": None, "metadata": {}}]
+    )
+
+    assert normalized == [{"role": "user", "content": "hi"}]
+
+
+def test_agent_action_still_accepts_a_string():
+    from crewai.flow.runtime._actions import _normalize_agent_input
+
+    assert _normalize_agent_input("just a prompt") == "just a prompt"
+
+
+def test_agent_action_rejects_a_shape_that_is_neither():
+    from crewai.flow.runtime._actions import _normalize_agent_input
+
+    with pytest.raises(
+        ValueError, match="must render to a string or a list of messages"
+    ):
+        _normalize_agent_input(1234)
+
+
+def test_agent_definition_accepts_a_message_list_input():
+    from crewai.project.crew_definition import AgentDefinition
+
+    definition = AgentDefinition.model_validate(
+        {
+            "role": "R",
+            "goal": "G",
+            "backstory": "B",
+            "input": [{"role": "user", "content": "hi"}],
+        }
+    )
+
+    assert definition.input == [{"role": "user", "content": "hi"}]
+
+
+def test_agent_definition_rejects_a_non_message_input():
+    from crewai.project.crew_definition import AgentDefinition
+
+    with pytest.raises(
+        ValidationError, match="must be a string or a list of messages"
+    ):
+        AgentDefinition.model_validate(
+            {"role": "R", "goal": "G", "backstory": "B", "input": [1, 2]}
+        )
+
+
 def test_definition_method_missing_from_class_fails_loudly():
     class VanishingFlow(Flow):
         @start()


### PR DESCRIPTION
- Lets a declarative chat handler hand its agent the conversation instead of a single string. Two guards blocked it: `AgentDefinition.input` was `str` with a validator rejecting anything else, and `AgentAction.run` raised `"agent input must render to a string"` once a CEL template rendered to a list.
- No new CEL machinery needed. A whole-string `${...}` template keeps its evaluated type, so `input: "${state.messages.map(m, {'role': m.role, 'content': m.content})}"` renders exactly `[{role, content}, ...]` — verified against the real evaluator. `input` now accepts a string or a list of mappings, and the action normalizes rather than rejecting.
- Verified live end to end on a YAML chat flow with a real LLM: turn 1 "My order id is 9931", turn 2 "Where is that order?" — the agent answered with `9931`, i.e. the earlier turn reached it with roles intact.
- Serialized messages carry `name: None` and `metadata` that the agent event schema rejects, and `message_to_llm_dict` only drops `None` for a *model* input, not the plain dicts a CEL render produces. The normalizer drops them, keeping `content: None` since that is a valid message shape (a tool-call turn). Found by a test failing, not by inspection.
- Preserved: a string `input` behaves exactly as before; a shape that is neither raises a message naming both accepted forms. **Declarative crews are unaffected** — they use `CrewAgentDefinition`, which has no `input` field at all; `AgentDefinition` is referenced only by `FlowAgentActionDefinition.with_`, `load_agent_from_definition` and the authoring skill (grepped across `lib/`). `AgentDefinition` is re-exported from `crewai.project`, so widening a required field's type is additive.
- Tests: a rendered message list passing through, serialized metadata being stripped, a string still accepted, a non-message shape rejected with its message, and the contract accepting/rejecting at validation time. `ruff` clean; `mypy` 0 errors on both changed files. Remaining suite failures are the pre-existing agent (25-26, wobbles) and multimodal (7) sets — verified by failing-test *names*, not counts.
- Keeps this intentionally small: no `messages` field alongside `input`, no CEL helper function, no docs change yet.
- Next: document the message-list form in the conversational guide (en + ar/ko/pt-BR).

Stacked on #7065, which makes `Agent.kickoff` keep message roles — without it this would deliver a flattened conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive widening of flow-only `AgentDefinition.input` with normalization before existing `kickoff_async`; string prompts unchanged and declarative crews are unaffected.
> 
> **Overview**
> Declarative **flow agent actions** can pass a full conversation into `kickoff_async`, not only a single string prompt.
> 
> **`AgentDefinition.input`** now accepts a string or a list of message mappings (with updated validation and schema examples). **`AgentAction.run`** no longer requires rendered input to be a string; it routes through **`_normalize_agent_input`**, which passes strings through unchanged, converts CEL-rendered message lists via `message_to_llm_dict`, and strips `None` metadata keys the agent event schema rejects while preserving valid shapes like `content: None` on tool-call turns.
> 
> String `input` behavior is unchanged; invalid rendered types get a clearer error. Tests cover normalization edge cases and an end-to-end YAML flow with `input: "${state.messages}"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 650985fed7296d134424da283595244d52a54c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->