### PR TITLE
fix(azure): cached and reasoning token counts are always reported as 0

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 import os
 from typing import Any, Literal, TypedDict
 from urllib.parse import urlparse
@@ -11,6 +12,7 @@ from typing_extensions import Self
 
 from crewai.llms._finish_reason_utils import extract_choices_finish_reason_and_id
 from crewai.llms.hooks.base import BaseInterceptor
+from crewai.types.usage_metrics import _coerce_int
 from crewai.utilities.agent_utils import is_context_length_exceeded
 from crewai.utilities.exceptions.context_window_exceeding_exception import (
     LLMContextLengthExceededError,
@@ -1335,19 +1337,35 @@ class AzureCompletion(BaseLLM):
         return extract_choices_finish_reason_and_id(response_or_update)
 
     @staticmethod
+    def _read_usage_field(source: Any, key: str) -> Any:
+        """Read ``key`` off an Azure usage object.
+
+        ``CompletionsUsage`` only declares prompt/completion/total as real
+        fields, so the detail dicts the service sends arrive as extra mapping
+        entries and attribute access returns ``None`` for them. Try the
+        attribute first, since other providers and mocks expose these as
+        attributes, then fall back to mapping access.
+        """
+        value = getattr(source, key, None)
+        if value is None and isinstance(source, Mapping):
+            value = source.get(key)
+        return value
+
+    @staticmethod
     def _extract_azure_token_usage(response: ChatCompletions) -> dict[str, Any]:
         """Extract token usage and response metadata from Azure response."""
         if hasattr(response, "usage") and response.usage:
             usage = response.usage
+            read = AzureCompletion._read_usage_field
             cached_tokens = 0
-            prompt_details = getattr(usage, "prompt_tokens_details", None)
+            prompt_details = read(usage, "prompt_tokens_details")
             if prompt_details:
-                cached_tokens = getattr(prompt_details, "cached_tokens", 0) or 0
+                cached_tokens = _coerce_int(read(prompt_details, "cached_tokens"))
             reasoning_tokens = 0
-            completion_details = getattr(usage, "completion_tokens_details", None)
+            completion_details = read(usage, "completion_tokens_details")
             if completion_details:
-                reasoning_tokens = (
-                    getattr(completion_details, "reasoning_tokens", 0) or 0
+                reasoning_tokens = _coerce_int(
+                    read(completion_details, "reasoning_tokens")
                 )
             result: dict[str, Any] = {
                 "prompt_tokens": getattr(usage, "prompt_tokens", 0),

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -1433,6 +1433,41 @@ def test_azure_reasoning_tokens_and_cached_tokens():
     assert usage["reasoning_tokens"] == 60
 
 
+def test_azure_cached_and_reasoning_tokens_from_real_usage_model():
+    """The detail dicts arrive as mapping entries on a real ``CompletionsUsage``.
+
+    ``CompletionsUsage`` declares only prompt/completion/total as fields, so
+    ``prompt_tokens_details`` and ``completion_tokens_details`` come back from
+    the service as extra mapping entries and attribute access returns ``None``
+    for them. The other tests here build the usage object with ``MagicMock``,
+    where every attribute exists, so they pass either way.
+    """
+    from azure.ai.inference.models import CompletionsUsage
+
+    llm = LLM(model="azure/gpt-4")
+
+    usage = CompletionsUsage(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "total_tokens": 110,
+            "prompt_tokens_details": {"cached_tokens": 75},
+            "completion_tokens_details": {"reasoning_tokens": 8},
+        }
+    )
+    assert getattr(usage, "prompt_tokens_details", None) is None
+    assert usage["prompt_tokens_details"] == {"cached_tokens": 75}
+
+    mock_response = MagicMock()
+    mock_response.usage = usage
+
+    extracted = llm._extract_azure_token_usage(mock_response)
+    assert extracted["prompt_tokens"] == 100
+    assert extracted["completion_tokens"] == 10
+    assert extracted["cached_prompt_tokens"] == 75
+    assert extracted["reasoning_tokens"] == 8
+
+
 def test_azure_no_detail_fields():
     """Test Azure extraction without detail fields."""
     llm = LLM(model="azure/gpt-4")


### PR DESCRIPTION
Azure prompt-cache and reasoning token counts always come back as 0.

`_extract_azure_token_usage` reads the sub-counts like this:

```python
prompt_details = getattr(usage, "prompt_tokens_details", None)
if prompt_details:
    cached_tokens = getattr(prompt_details, "cached_tokens", 0) or 0
```

`CompletionsUsage` in azure-ai-inference only declares `prompt_tokens`, `completion_tokens` and `total_tokens` as real fields. It is a mapping underneath, so anything else the service sends arrives as a mapping entry and attribute access returns `None` for it. Both guards are unreachable, so `cached_prompt_tokens` and `reasoning_tokens` end up 0 on every Azure call, and that flows into `UsageMetrics` and whatever anyone reads off it.

Reproduced against azure-ai-inference:

```python
from azure.ai.inference.models import CompletionsUsage

usage = CompletionsUsage({
    "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110,
    "prompt_tokens_details": {"cached_tokens": 75},
})
getattr(usage, "prompt_tokens_details", None)   # None
usage["prompt_tokens_details"]                  # {'cached_tokens': 75}
```

and through the real method, on main:

```
{'prompt_tokens': 100, 'completion_tokens': 10, 'total_tokens': 110,
 'cached_prompt_tokens': 0, 'reasoning_tokens': 0}
```

with the service having reported 75 cached and 8 reasoning tokens.

The reason this has not shown up is that `test_azure_reasoning_tokens_and_cached_tokens` builds the usage object with `MagicMock`, where every attribute exists, so it passes either way. I have left that test alone and added one built on a real `CompletionsUsage`, which fails on main with `assert 0 == 75`.

The change reads the attribute first, since other providers and the existing mocks expose these as attributes, and only falls back to mapping access when the object really is a `Mapping`. I tried a plain `hasattr(source, "get")` fallback first and it broke `test_azure_no_detail_fields`, because a MagicMock answers `.get()` with a truthy mock.

Scope: only the Azure extractor. I have not touched the other providers, and I have not changed the streaming paths, which build their own usage dict with three keys and so never carried these sub-counts either. Happy to follow up on the streaming side separately if you want it.

`pytest lib/crewai/tests/llms/azure/test_azure.py`: 60 passed against 59 on main, same 8 pre-existing failures and 1 error on both, which look network and credential related here.