### PR TITLE
fix(llm): match context window size for provider-prefixed model names

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2470,8 +2470,10 @@ class LLM(BaseLLM):
         self.context_window_size = int(
             DEFAULT_CONTEXT_WINDOW_SIZE * CONTEXT_WINDOW_USAGE_RATIO
         )
+        model_name = self.model or ""
+        model_clean = model_name.split("/", 1)[1] if "/" in model_name else model_name
         for key, value in LLM_CONTEXT_WINDOW_SIZES.items():
-            if self.model.startswith(key):
+            if model_name.startswith(key) or model_clean.startswith(key):
                 self.context_window_size = int(value * CONTEXT_WINDOW_USAGE_RATIO)
         return self.context_window_size
 

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2471,9 +2471,12 @@ class LLM(BaseLLM):
             DEFAULT_CONTEXT_WINDOW_SIZE * CONTEXT_WINDOW_USAGE_RATIO
         )
         model_name = self.model or ""
-        model_clean = model_name.split("/", 1)[1] if "/" in model_name else model_name
+        model_parts = model_name.split("/")
+        model_candidates = [
+            "/".join(model_parts[start:]) for start in range(len(model_parts))
+        ]
         for key, value in LLM_CONTEXT_WINDOW_SIZES.items():
-            if model_name.startswith(key) or model_clean.startswith(key):
+            if any(candidate.startswith(key) for candidate in model_candidates):
                 self.context_window_size = int(value * CONTEXT_WINDOW_USAGE_RATIO)
         return self.context_window_size
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1213,9 +1213,11 @@ def test_get_context_window_size_with_provider_prefix():
     """Verify context window size matches correctly when provider prefix is present."""
     llm_plain = LLM(model="gpt-4o", is_litellm=True)
     llm_prefixed = LLM(model="openai/gpt-4o", is_litellm=True)
+    llm_nested = LLM(model="openrouter/deepseek/deepseek-chat", is_litellm=True)
     llm_ollama = LLM(model="ollama/llama-3.1-70b-versatile", is_litellm=True)
 
     assert llm_plain.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
     assert llm_prefixed.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+    assert llm_nested.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
     assert llm_ollama.get_context_window_size() == int(131072 * CONTEXT_WINDOW_USAGE_RATIO)
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1207,3 +1207,15 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+def test_get_context_window_size_with_provider_prefix():
+    """Verify context window size matches correctly when provider prefix is present."""
+    llm_plain = LLM(model="gpt-4o", is_litellm=True)
+    llm_prefixed = LLM(model="openai/gpt-4o", is_litellm=True)
+    llm_ollama = LLM(model="ollama/llama-3.1-70b-versatile", is_litellm=True)
+
+    assert llm_plain.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+    assert llm_prefixed.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+    assert llm_ollama.get_context_window_size() == int(131072 * CONTEXT_WINDOW_USAGE_RATIO)
+


### PR DESCRIPTION
## Summary

Fixes model context window matching in `LLM.get_context_window_size()` when model names include provider prefixes (e.g. `openai/gpt-4o`, `ollama/llama-3.1-70b-versatile`, `azure/gpt-4o`).

## Motivation

Previously, `LLM.get_context_window_size()` checked `self.model.startswith(key)`. When users configured models with provider prefixes such as `openai/gpt-4o` or `ollama/...`, the check evaluated to `False` and silently defaulted to `DEFAULT_CONTEXT_WINDOW_SIZE` (8,192 tokens), prematurely triggering context compaction / trimming on large-context models.

## Changes

- `lib/crewai/src/crewai/llm.py`: Match both the full model string and the stripped `model_clean` against `LLM_CONTEXT_WINDOW_SIZES`.
- `lib/crewai/tests/test_llm.py`: Added test verifying context window resolution with and without provider prefixes.

## Tests

- Added `test_get_context_window_size_with_provider_prefix`.
