### PR TITLE
fix(llms): warn on token-cap truncation for every provider (#7013)

### DIFF
--- a/lib/crewai/src/crewai/llms/_finish_reason_utils.py
+++ b/lib/crewai/src/crewai/llms/_finish_reason_utils.py
@@ -11,7 +11,7 @@ Responses (``status``) — keep their own helpers.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 
 def _as_str(value: Any) -> str | None:
@@ -53,3 +53,26 @@ def extract_choices_finish_reason_and_id(
             finish_reason = _as_str(raw_finish)
 
     return finish_reason, response_id
+
+
+TRUNCATION_FINISH_REASONS: Final[frozenset[str]] = frozenset({"length", "max_tokens"})
+"""Normalised finish-reason spellings that mean "stopped at the token cap".
+
+Every provider crewAI ships surfaces one of these, modulo case:
+``length`` (OpenAI, Azure, LiteLLM, and the ``openai_compatible``/Snowflake
+subclasses), ``max_tokens`` (Anthropic ``stop_reason``, Bedrock ``stopReason``)
+and ``MAX_TOKENS`` (the Gemini protobuf enum's ``.name``).
+"""
+
+
+def is_truncated_finish_reason(finish_reason: str | None) -> bool:
+    """Return whether ``finish_reason`` means the model hit its token cap.
+
+    Providers spell this differently, so callers should not compare against a
+    single literal. Anything unrecognised — including ``None`` and the
+    non-string values provider helpers may return — is reported as not
+    truncated, so this never turns an unknown reason into a false alarm.
+    """
+    if not isinstance(finish_reason, str):
+        return False
+    return finish_reason.strip().lower() in TRUNCATION_FINISH_REASONS

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -42,6 +42,7 @@ from crewai.events.types.tool_usage_events import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
+from crewai.llms._finish_reason_utils import is_truncated_finish_reason
 from crewai.types.streaming import StreamSession
 from crewai.types.usage_metrics import UsageMetrics
 from crewai.utilities.pydantic_schema_utils import serialize_model_class
@@ -618,6 +619,15 @@ class BaseLLM(BaseModel, ABC):
     ) -> None:
         """Emit LLM call completed event."""
         from crewai.utilities.serialization import to_serializable
+
+        if is_truncated_finish_reason(finish_reason):
+            logging.warning(
+                "Response from %s was truncated because it reached the token cap "
+                "(finish_reason=%r); the content is incomplete. Raise max_tokens "
+                "if the answer needs to be longer.",
+                self.model,
+                finish_reason,
+            )
 
         crewai_event_bus.emit(
             self,

--- a/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/bedrock/completion.py
@@ -680,9 +680,7 @@ class BedrockCompletion(BaseLLM):
             stop_reason, response_id = self._extract_finish_reason_and_id(response)
             if stop_reason:
                 logging.debug(f"Response stop reason: {stop_reason}")
-                if stop_reason == "max_tokens":
-                    logging.warning("Response truncated due to max_tokens limit")
-                elif stop_reason == "content_filtered":
+                if stop_reason == "content_filtered":
                     logging.warning("Response was filtered due to content policy")
 
             # Extract content following AWS response structure
@@ -1118,11 +1116,7 @@ class BedrockCompletion(BaseLLM):
                         stop_reason = event["messageStop"].get("stopReason")
                         stream_finish_reason = stop_reason
                         logging.debug(f"Streaming message stopped: {stop_reason}")
-                        if stop_reason == "max_tokens":
-                            logging.warning(
-                                "Streaming response truncated due to max_tokens"
-                            )
-                        elif stop_reason == "content_filtered":
+                        if stop_reason == "content_filtered":
                             logging.warning(
                                 "Streaming response filtered due to content policy"
                             )
@@ -1282,9 +1276,7 @@ class BedrockCompletion(BaseLLM):
             stop_reason, response_id = self._extract_finish_reason_and_id(response)
             if stop_reason:
                 logging.debug(f"Response stop reason: {stop_reason}")
-                if stop_reason == "max_tokens":
-                    logging.warning("Response truncated due to max_tokens limit")
-                elif stop_reason == "content_filtered":
+                if stop_reason == "content_filtered":
                     logging.warning("Response was filtered due to content policy")
 
             output = response.get("output", {})
@@ -1720,11 +1712,7 @@ class BedrockCompletion(BaseLLM):
                         stop_reason = event["messageStop"].get("stopReason")
                         stream_finish_reason = stop_reason
                         logging.debug(f"Streaming message stopped: {stop_reason}")
-                        if stop_reason == "max_tokens":
-                            logging.warning(
-                                "Streaming response truncated due to max_tokens"
-                            )
-                        elif stop_reason == "content_filtered":
+                        if stop_reason == "content_filtered":
                             logging.warning(
                                 "Streaming response filtered due to content policy"
                             )

--- a/lib/crewai/tests/events/test_llm_finish_reason_response_id.py
+++ b/lib/crewai/tests/events/test_llm_finish_reason_response_id.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -12,7 +13,10 @@ from crewai.events.types.llm_events import (
     LLMStreamChunkEvent,
 )
 from crewai.llm import LLM
-from crewai.llms._finish_reason_utils import extract_choices_finish_reason_and_id
+from crewai.llms._finish_reason_utils import (
+    extract_choices_finish_reason_and_id,
+    is_truncated_finish_reason,
+)
 from crewai.llms.base_llm import BaseLLM
 
 
@@ -27,6 +31,15 @@ class _StubLLM(BaseLLM):
 
     def supports_function_calling(self) -> bool:
         return False
+
+
+def _truncation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Only the truncation warnings, so unrelated WARNING records don't leak in."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "truncated" in r.getMessage()
+    ]
 
 
 @pytest.fixture
@@ -524,3 +537,74 @@ class TestExtractChoicesFinishReasonAndIdHelper:
         finish_reason, response_id = extract_choices_finish_reason_and_id(bad_input)
         assert finish_reason is None or isinstance(finish_reason, str)
         assert response_id is None or isinstance(response_id, str)
+
+
+class TestTruncationDetection:
+    """Every provider must flag a response cut short by the token cap.
+
+    Before this, only Bedrock did; OpenAI/Azure/Anthropic/Gemini and the
+    ``openai_compatible``/Snowflake subclasses returned the partial text as a
+    successful result with nothing to distinguish it from a complete answer.
+    """
+
+    @pytest.mark.parametrize(
+        "finish_reason",
+        [
+            "length",  # OpenAI, Azure, LiteLLM, openai_compatible, Snowflake
+            "max_tokens",  # Anthropic stop_reason, Bedrock stopReason
+            "MAX_TOKENS",  # Gemini protobuf enum .name
+            "Length",
+            "  max_tokens  ",
+        ],
+    )
+    def test_predicate_accepts_every_provider_spelling(self, finish_reason: str):
+        assert is_truncated_finish_reason(finish_reason) is True
+
+    @pytest.mark.parametrize(
+        "finish_reason",
+        [
+            "stop",
+            "end_turn",
+            "tool_use",
+            "content_filtered",
+            "stop_sequence",
+            "",
+            None,
+            42,
+            MagicMock(),
+        ],
+    )
+    def test_predicate_rejects_everything_else(self, finish_reason: Any):
+        assert is_truncated_finish_reason(finish_reason) is False
+
+    @pytest.mark.parametrize("finish_reason", ["length", "max_tokens", "MAX_TOKENS"])
+    def test_emitter_warns_once_on_truncation(
+        self, finish_reason: str, caplog: pytest.LogCaptureFixture, mock_emit
+    ):
+        llm = _StubLLM(model="test-model")
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="partial answer",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason=finish_reason,
+            )
+
+        warnings = _truncation_warnings(caplog)
+        assert len(warnings) == 1
+        assert finish_reason in warnings[0]
+        assert mock_emit.call_count == 1
+
+    @pytest.mark.parametrize("finish_reason", ["stop", "end_turn", None])
+    def test_emitter_stays_quiet_on_a_complete_response(
+        self, finish_reason: str | None, caplog: pytest.LogCaptureFixture, mock_emit
+    ):
+        llm = _StubLLM(model="test-model")
+        with caplog.at_level(logging.WARNING):
+            llm._emit_call_completed_event(
+                response="complete answer",
+                call_type=LLMCallType.LLM_CALL,
+                finish_reason=finish_reason,
+            )
+
+        assert _truncation_warnings(caplog) == []
+        assert mock_emit.call_count == 1


### PR DESCRIPTION
Closes #7013

> **AI-assisted contribution, human reviewed.** Per `.github/CONTRIBUTING.md` this PR
> needs the `llm-generated` label. I do not have triage permission on this repo, so
> could a maintainer please apply it.

## Problem

Only Bedrock checked whether generation stopped because it hit the token cap. Verified
against `main` @ `f4731f5`:

```
$ grep -rnE 'stop_reason *== *"max_tokens"|finish_reason *== *"length"|== *"MAX_TOKENS"' \
      lib/crewai/src/crewai/
lib/crewai/src/crewai/llms/providers/bedrock/completion.py:683
lib/crewai/src/crewai/llms/providers/bedrock/completion.py:1121
lib/crewai/src/crewai/llms/providers/bedrock/completion.py:1285
lib/crewai/src/crewai/llms/providers/bedrock/completion.py:1723
```

So on Anthropic, OpenAI, Azure, Gemini, `openai_compatible` and Snowflake, a response cut
off mid-sentence is returned as a successful task result with nothing to distinguish it
from a complete answer.

## Fix — one shared check, at the point every provider already converges

Rather than add a branch to each provider, this puts the check where they already meet.
Every provider that surfaces a finish reason routes it through
`BaseLLM._emit_call_completed_event`:

| provider | `_emit_call_completed_event` calls | all pass `finish_reason` |
|---|---|---|
| anthropic | 16 | ✅ |
| openai | 27 | ✅ |
| bedrock | 10 | ✅ |
| azure | 5 | ✅ |
| gemini | 5 | ✅ |

`openai_compatible` and `snowflake` subclass `OpenAICompletion`, so they inherit the same
path. That makes the emitter a single choke point covering all seven.

Two changes:

1. **`llms/_finish_reason_utils.py`** — add `is_truncated_finish_reason()`, centralising
   the three spellings the providers actually surface. These are read off each provider's
   own extractor, not guessed:
   - `"length"` — OpenAI / Azure / LiteLLM (`extract_choices_finish_reason_and_id`)
   - `"max_tokens"` — Anthropic `stop_reason`, Bedrock `stopReason`
   - `"MAX_TOKENS"` — Gemini, the protobuf enum's `.name`

   Anything unrecognised (including `None` and the non-string values provider helpers may
   return) is reported as *not* truncated, so an unknown reason never becomes a false alarm.

2. **`llms/base_llm.py`** — warn once from `_emit_call_completed_event`.

### Why this warns once per call, not once per chunk

10 of the 64 emit call sites sit inside a loop, which would be a log flood if any of them
ran per stream chunk. Checked with an AST walk over every provider: all 10 are immediately
followed by a `return`, so each fires exactly once.

```
anthropic  emit@1017 loop@1014 for block in response.content:  next=Return
bedrock    emit@1056 loop@964  for event in stream:            next=Return
...        (10/10 terminate)
```

### Bedrock de-duplication

Bedrock already warned locally, so it would now warn twice. Its four redundant
`max_tokens` branches are removed; the four `content_filtered` warnings alongside them are
untouched.

One behaviour note, stated plainly: at `completion.py:683` there is an early
`if not content: return` between the old warning and the emit, so a Bedrock response that
is *both* truncated *and* has zero content blocks no longer gets the truncation warning.
That path still logs its own `"No content in Bedrock response"` warning.

## Verification

Ran `tests/events/`, `tests/llms/bedrock`, `tests/llms/openai`, `tests/llms/anthropic`
with `ruff==0.15.1` (the pinned version) and the repo config.

| | passed | failed | errors |
|---|---|---|---|
| baseline (unpatched) | 346 | 41 | 62 |
| with this PR | **366** | 41 | 62 |

`+20` passing = exactly the new tests; the 41 failures and 62 errors are identical before
and after (pre-existing on Windows: async proactor teardown and network-disabled cassettes).

Isolating the behaviour change — reverting only the emitter warning while keeping the
tests turns the three positive cases red:

```
FAILED TestTruncationDetection::test_emitter_warns_once_on_truncation[length]
FAILED TestTruncationDetection::test_emitter_warns_once_on_truncation[max_tokens]
FAILED TestTruncationDetection::test_emitter_warns_once_on_truncation[MAX_TOKENS]
assert 0 == 1   # no warning was logged
```

`ruff check` and `ruff format --diff` both clean.

## Tests

Added `TestTruncationDetection` to the existing
`tests/events/test_llm_finish_reason_response_id.py` (20 cases):

- the predicate accepts every provider spelling, including case and whitespace variants
- it rejects `stop` / `end_turn` / `tool_use` / `content_filtered` / `stop_sequence` /
  `""` / `None` / non-strings
- the emitter warns exactly once, and the message names the finish reason
- the emitter stays quiet on a complete response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
