### PR TITLE
docs: fix broken links and stale anchors (edge docs and lib READMEs)

### DIFF
--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -30,7 +30,7 @@ Large Language Models(LLM)는 CrewAI 에이전트의 핵심 지능입니다. 에
 
 ## LLM 설정하기
 
-CrewAI 코드 내에는 사용할 모델을 지정할 수 있는 여러 위치가 있습니다. 모델을 지정한 후에는 사용하는 각 모델 제공자에 대한 설정(예: API 키)을 제공해야 합니다. 각 제공자에 맞는 [제공자 설정 예제](#provider-configuration-examples) 섹션을 참고하세요.
+CrewAI 코드 내에는 사용할 모델을 지정할 수 있는 여러 위치가 있습니다. 모델을 지정한 후에는 사용하는 각 모델 제공자에 대한 설정(예: API 키)을 제공해야 합니다. 각 제공자에 맞는 [제공자 설정 예제](/concepts/llms#provider-configuration-examples) 섹션을 참고하세요.
 
 <Tabs>
   <Tab title="1. 환경 변수">

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -30,7 +30,7 @@ Modelos de Linguagem de Grande Escala (LLMs) são a inteligência central por tr
 
 ## Configurando seu LLM
 
-Existem diferentes locais no código do CrewAI onde você pode especificar o modelo a ser utilizado. Após definir o modelo usado, será necessário fornecer a configuração (como uma chave de API) para cada provedor de modelo. Veja a seção de [exemplos de configuração de provedores](#provider-configuration-examples) para seu provedor.
+Existem diferentes locais no código do CrewAI onde você pode especificar o modelo a ser utilizado. Após definir o modelo usado, será necessário fornecer a configuração (como uma chave de API) para cada provedor de modelo. Veja a seção de [exemplos de configuração de provedores](/concepts/llms#provider-configuration-examples) para seu provedor.
 
 <Tabs>
   <Tab title="1. Variáveis de Ambiente">

--- a/docs/edge/pt-BR/learn/human-feedback-in-flows.mdx
+++ b/docs/edge/pt-BR/learn/human-feedback-in-flows.mdx
@@ -72,7 +72,7 @@ Quando este flow é executado, ele irá:
 | `llm` | `str \| BaseLLM` | Quando `emit` especificado | LLM usado para interpretar o feedback e mapear para um outcome |
 | `default_outcome` | `str` | Não | Outcome a usar se nenhum feedback for fornecido. Deve estar em `emit` |
 | `metadata` | `dict` | Não | Dados adicionais para integrações enterprise |
-| `provider` | `HumanFeedbackProvider` | Não | Provider customizado para feedback assíncrono/não-bloqueante. Veja [Feedback Humano Assíncrono](#feedback-humano-assíncrono-não-bloqueante) |
+| `provider` | `HumanFeedbackProvider` | Não | Provider customizado para feedback assíncrono/não-bloqueante. Veja [Feedback Humano Assíncrono](#feedback-humano-assíncrono-não-bloqueante---human-in-the-loop) |
 | `learn` | `bool` | Não | Habilitar aprendizado HITL: destila lições do feedback e pré-revisa saídas futuras. Padrão `False`. Veja [Aprendendo com Feedback](#aprendendo-com-feedback) |
 | `learn_limit` | `int` | Não | Máximo de lições passadas para recuperar na pré-revisão. Padrão `5` |
 

--- a/docs/edge/pt-BR/observability/galileo.mdx
+++ b/docs/edge/pt-BR/observability/galileo.mdx
@@ -22,14 +22,14 @@ transparência e melhoria contínua em todo o ciclo de vida da IA.
 
 ## Primeiros passos
 
-Este tutorial segue o [CrewAI Quickstart](pt-BR/quickstart) e mostra como adicionar
+Este tutorial segue o [CrewAI Quickstart](/pt-BR/quickstart) e mostra como adicionar
 [CrewAIEventListener] do Galileo(https://v2docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
 um manipulador de eventos.
 Para mais informações, consulte Galileu
 [Adicionar Galileo a um aplicativo CrewAI](https://v2docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
 guia prático.
 
-> **Observação**Este tutorial pressupõe que você concluiu o [CrewAI Quickstart](pt-BR/quickstart).
+> **Observação**Este tutorial pressupõe que você concluiu o [CrewAI Quickstart](/pt-BR/quickstart).
 Se você quiser um exemplo completo e abrangente, consulte o Galileo
 [Repositório de exemplo SDK da CrewAI](https://github.com/rungalileo/sdk-examples/tree/main/python/agent/crew-ai).
 

--- a/lib/crewai-tools/README.md
+++ b/lib/crewai-tools/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![Logo of crewAI, two people rowing on a boat](./assets/crewai_logo.png)
+![Logo of crewAI, two people rowing on a boat](../../docs/images/crewai_logo.png)
 
 <div align="left">
 

--- a/lib/crewai/README.md
+++ b/lib/crewai/README.md
@@ -677,9 +677,9 @@ CrewAI is released under the [MIT License](https://github.com/crewAIInc/crewAI/b
 
 ### Enterprise Features
 
-- [What additional features does CrewAI AMP offer?](#q-what-additional-features-does-crewai-enterprise-offer)
-- [Is CrewAI AMP available for cloud and on-premise deployments?](#q-is-crewai-enterprise-available-for-cloud-and-on-premise-deployments)
-- [Can I try CrewAI AMP for free?](#q-can-i-try-crewai-enterprise-for-free)
+- [What additional features does CrewAI AMP offer?](#q-what-additional-features-does-crewai-amp-offer)
+- [Is CrewAI AMP available for cloud and on-premise deployments?](#q-is-crewai-amp-available-for-cloud-and-on-premise-deployments)
+- [Can I try CrewAI AMP for free?](#q-can-i-try-crewai-amp-for-free)
 
 ### Q: What exactly is CrewAI?
 


### PR DESCRIPTION
- `lib/crewai/README.md`: FAQ headings were renamed to "CrewAI AMP" but the TOC anchors still said `crewai-enterprise` — updated the three stale anchors
- `lib/crewai-tools/README.md`: logo path `./assets/crewai_logo.png` never existed; points to `docs/images/crewai_logo.png`
- `docs/edge/pt-BR/observability/galileo.mdx`: `pt-BR/quickstart` resolves to a nested `observability/pt-BR/` path; uses root-absolute `/pt-BR/quickstart`
- `docs/edge/{ko,pt-BR}/concepts/llms.mdx`: linked `#provider-configuration-examples` which only exists in the English page; links across to `/concepts/llms#provider-configuration-examples`
- `docs/edge/pt-BR/learn/human-feedback-in-flows.mdx`: async-feedback anchor missing the `-human-in-the-loop` suffix of the actual heading

Versioned docs snapshots (`docs/v1.x`) left untouched.