### PR TITLE
docs: replace retired Gemini model IDs with gemini-3.7-flash

### DIFF
--- a/docs/edge/en/concepts/memory.mdx
+++ b/docs/edge/en/concepts/memory.mdx
@@ -740,7 +740,7 @@ memory = Memory(llm="anthropic/claude-3-haiku-20240307")
 memory = Memory(llm="ollama/llama3.2")
 
 # Use Google Gemini
-memory = Memory(llm="gemini/gemini-2.0-flash")
+memory = Memory(llm="gemini/gemini-3.7-flash")
 
 # Pass a pre-configured LLM instance with custom settings
 llm = LLM(model="gpt-4o", temperature=0)

--- a/docs/edge/en/guides/crews/first-crew.mdx
+++ b/docs/edge/en/guides/crews/first-crew.mdx
@@ -77,7 +77,7 @@ Replace the generated `agents/researcher.jsonc` file and add `agents/analyst.jso
 }
 ```
 
-Replace `provider/model-id` with the model you use, for example `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, or `gemini/gemini-2.0-flash-001`.
+Replace `provider/model-id` with the model you use, for example `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, or `gemini/gemini-3.7-flash`.
 
 ## Step 3: Define Tasks and Crew Settings
 

--- a/docs/edge/en/guides/flows/first-flow.mdx
+++ b/docs/edge/en/guides/flows/first-flow.mdx
@@ -136,7 +136,7 @@ Now, let's configure the content writer crew with JSONC. We'll set up two specia
 }
 ```
 
-Replace `provider/model-id` with the model you use, for example `openai/gpt-4o`, `gemini/gemini-2.0-flash-001`, or `anthropic/claude-sonnet-4-6`.
+Replace `provider/model-id` with the model you use, for example `openai/gpt-4o`, `gemini/gemini-3.7-flash`, or `anthropic/claude-sonnet-4-6`.
 
 3. Create `src/guide_creator_flow/crews/content_crew/crew.jsonc`:
 
@@ -483,7 +483,7 @@ Flows allow you to make direct calls to language models when you need simple, st
 
 ```python
 llm = LLM(
-    model="model-id-here",  # gpt-4o, gemini-2.0-flash, anthropic/claude...
+    model="model-id-here",  # gpt-4o, gemini-3.7-flash, anthropic/claude...
     response_format=GuideOutline
 )
 response = llm.call(messages=messages)

--- a/docs/edge/en/learn/litellm-removal-guide.mdx
+++ b/docs/edge/en/learn/litellm-removal-guide.mdx
@@ -176,7 +176,7 @@ grep -r "llm:" --include="*.yaml" .
     # llm = LLM(model="mistral/mistral-large-latest")
 
     # After (Native):
-    llm = LLM(model="gemini/gemini-2.0-flash")
+    llm = LLM(model="gemini/gemini-3.7-flash")
     ```
 
     ```bash
@@ -399,7 +399,7 @@ llm = LLM(model="anthropic/claude-haiku-3-5")    # Fast & affordable
 # Together AI → OpenAI or Gemini
 # llm = LLM(model="together_ai/meta-llama/Meta-Llama-3.1-70B")
 llm = LLM(model="openai/gpt-4o")                 # High quality
-llm = LLM(model="gemini/gemini-2.0-flash")       # Fast & capable
+llm = LLM(model="gemini/gemini-3.7-flash")       # Fast & capable
 
 # Mistral → Anthropic or OpenAI
 # llm = LLM(model="mistral/mistral-large-latest")

--- a/docs/edge/en/learn/llm-connections.mdx
+++ b/docs/edge/en/learn/llm-connections.mdx
@@ -141,7 +141,7 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
         # Example using Gemini's OpenAI-compatible API.
         os.environ["OPENAI_API_KEY"] = "your-gemini-key"  # Should start with AIza...
         os.environ["OPENAI_API_BASE"] = "https://generativelanguage.googleapis.com/v1beta/openai/"
-        os.environ["OPENAI_MODEL_NAME"] = "openai/gemini-2.0-flash"  # Add your Gemini model here, under openai/
+        os.environ["OPENAI_MODEL_NAME"] = "openai/gemini-3.7-flash"  # Add your Gemini model here, under openai/
         ```
         </CodeGroup>
     </Tab>
@@ -159,7 +159,7 @@ You can connect to OpenAI-compatible LLMs using either environment variables or 
             ```python Google
             # Example using Gemini's OpenAI-compatible API
             llm = LLM(
-                model="openai/gemini-2.0-flash",
+                model="openai/gemini-3.7-flash",
                 base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
                 api_key="your-gemini-key",  # Should start with AIza...
             )

--- a/docs/edge/en/learn/llm-selection-guide.mdx
+++ b/docs/edge/en/learn/llm-selection-guide.mdx
@@ -147,7 +147,7 @@ Planning agents benefit from reasoning models that can handle complex strategic 
 from crewai import Agent, Task, Crew, LLM
 
 # High-capability reasoning model for strategic planning
-manager_llm = LLM(model="gemini-2.5-flash-preview-05-20", temperature=0.1)
+manager_llm = LLM(model="gemini-3.7-flash", temperature=0.1)
 
 # Creative model for content generation
 content_llm = LLM(model="claude-3-5-sonnet-20241022", temperature=0.7)
@@ -412,7 +412,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
     # Manager or coordination agents
     manager_agent = Agent(
         role="Project Manager",
-        llm=LLM(model="gemini-2.5-flash-preview-05-20"),  # Premium for coordination
+        llm=LLM(model="gemini-3.7-flash"),  # Premium for coordination
         # ... rest of config
     )
 


### PR DESCRIPTION
## What

Replace Gemini model IDs that the Generative Language API no longer serves with `gemini-3.7-flash`, which returns HTTP 200.

Fixes #7002

## Why

Six pages under `docs/edge/en/` reference `gemini-2.0-flash`, `gemini-2.0-flash-001`, and `gemini-2.5-flash-preview-05-20`. A reader who copies the snippet gets a 404 on their first API call.

## Changes

| File | Retired ID | Replacement |
|------|-----------|-------------|
| `guides/crews/first-crew.mdx` | `gemini/gemini-2.0-flash-001` | `gemini/gemini-3.7-flash` |
| `guides/flows/first-flow.mdx` | `gemini/gemini-2.0-flash-001`, `gemini-2.0-flash` | `gemini/gemini-3.7-flash` |
| `concepts/memory.mdx` | `gemini/gemini-2.0-flash` | `gemini/gemini-3.7-flash` |
| `learn/litellm-removal-guide.mdx` | `gemini/gemini-2.0-flash` | `gemini/gemini-3.7-flash` |
| `learn/llm-connections.mdx` | `openai/gemini-2.0-flash` | `openai/gemini-3.7-flash` |
| `learn/llm-selection-guide.mdx` | `gemini-2.5-flash-preview-05-20` | `gemini-3.7-flash` |

## How verified

- `gemini-3.7-flash` confirmed HTTP 200 against the live Generative Language API
- Only `docs/edge/en/` is touched; frozen `docs/v*` snapshots are not modified