### PR TITLE
fix(gemini): append trailing user turn when conversation ends with model message

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -672,6 +672,15 @@ class GeminiCompletion(BaseLLM):
                 gemini_content = types.Content(role=gemini_role, parts=parts)
                 contents.append(gemini_content)
 
+        # Gemini requires the conversation to end with a user turn.
+        # Agent loops (max_iterations exceeded, guardrail retries) can leave
+        # an assistant/model message as the last entry, which causes a 400:
+        # "Requests ending with a model turn are not supported".
+        if contents and contents[-1].role == "model":
+            contents.append(
+                types.Content(role="user", parts=[types.Part.from_text(text="")])
+            )
+
         return contents, system_instruction
 
     def _validate_and_emit_structured_output(

--- a/lib/crewai/tests/llms/google/test_google.py
+++ b/lib/crewai/tests/llms/google/test_google.py
@@ -1223,3 +1223,85 @@ def test_gemini_no_thinking_tokens_defaults_to_zero():
     usage = llm._extract_token_usage(mock_response)
     assert usage["reasoning_tokens"] == 0
     assert usage["cached_prompt_tokens"] == 0
+
+
+def test_gemini_appends_trailing_user_turn_when_last_message_is_assistant():
+    """Test that _format_messages_for_gemini appends a synthetic user turn
+    when the conversation ends with an assistant/model message.
+
+    Gemini API rejects requests ending with a model turn (HTTP 400).
+    Agent loops (max_iterations exceeded, guardrail retries) can leave
+    an assistant message as the last entry, so the provider must guard
+    against this.
+    """
+    from crewai.llms.providers.gemini.completion import GeminiCompletion
+
+    llm = GeminiCompletion(model="gemini-2.0-flash-001", api_key="test-key")
+
+    # Simulate a conversation that ends with an assistant message
+    # (e.g., after max_iterations exceeded re-invokes the LLM)
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "The answer is 4."},
+    ]
+
+    contents, _ = llm._format_messages_for_gemini(messages)
+
+    # The last content should be a synthetic user turn
+    assert contents[-1].role == "user", (
+        "Expected trailing user turn after assistant message, "
+        f"got role={contents[-1].role}"
+    )
+
+
+def test_gemini_does_not_append_extra_user_turn_when_last_message_is_user():
+    """Test that _format_messages_for_gemini does NOT append a trailing user
+    turn when the conversation already ends with a user message.
+    """
+    from crewai.llms.providers.gemini.completion import GeminiCompletion
+
+    llm = GeminiCompletion(model="gemini-2.0-flash-001", api_key="test-key")
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "How are you?"},
+    ]
+
+    contents, _ = llm._format_messages_for_gemini(messages)
+
+    # The last content should remain the original user message, not a synthetic one
+    assert contents[-1].role == "user"
+    # Verify it's the original message, not an empty synthetic one
+    last_text = contents[-1].parts[0].text
+    assert last_text == "How are you?", (
+        f"Expected original user message, got: {last_text}"
+    )
+
+
+def test_gemini_appends_trailing_user_turn_after_tool_call():
+    """Test that _format_messages_for_gemini handles the case where
+    the last message is an assistant message with tool_calls (model role in Gemini).
+    """
+    from crewai.llms.providers.gemini.completion import GeminiCompletion
+
+    llm = GeminiCompletion(model="gemini-2.0-flash-001", api_key="test-key")
+
+    # Simulate a conversation ending with an assistant tool call
+    messages = [
+        {"role": "user", "content": "Search for something"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "search", "arguments": "{}"}}],
+        },
+    ]
+
+    contents, _ = llm._format_messages_for_gemini(messages)
+
+    # After the tool call (which becomes a model turn), a trailing user turn
+    # should be appended
+    assert contents[-1].role == "user", (
+        "Expected trailing user turn after assistant tool call, "
+        f"got role={contents[-1].role}"
+    )


### PR DESCRIPTION
## What

Add a guard in `GeminiCompletion._format_messages_for_gemini` that appends a synthetic empty user turn when the conversation ends with a model message.

Fixes #6984

## Why

Gemini API requires conversations to end with a user turn. When CrewAI agent loops re-invoke the LLM after:
- `handle_max_iterations_exceeded`
- Guardrail retries (`guardrail_max_retries`)

...the conversation history can end with an assistant (model) message, causing Gemini to return HTTP 400: *"Requests ending with a model turn are not supported"*.

The LiteLLM fallback path already handles this for Mistral and Ollama in `LLM._format_messages_for_provider` (lines 2347-2360), but the native Gemini provider had no equivalent guard.

## How

At the end of `_format_messages_for_gemini`, check if the last content has `role="model"` and append a synthetic empty user turn:

```python
if contents and contents[-1].role == "model":
    contents.append(
        types.Content(role="user", parts=[types.Part.from_text(text="")] )
    )
```

## Tests

Three new test cases in `test_google.py`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_gemini_appends_trailing_user_turn_when_last_message_is_assistant` | Conversation ends with assistant | Append user turn |
| `test_gemini_does_not_append_extra_user_turn_when_last_message_is_user` | Conversation ends with user | No extra turn |
| `test_gemini_appends_trailing_user_turn_after_tool_call` | Conversation ends with assistant tool call | Append user turn |