### PR TITLE
docs: fix CONTRIBUTING license link, sync reset-memories docs with CLI, fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,4 +170,4 @@ Use the [GitHub issue templates](https://github.com/crewAIInc/crewAI/issues/new/
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [MIT License](../LICENSE).

--- a/docs/edge/en/concepts/cli.mdx
+++ b/docs/edge/en/concepts/cli.mdx
@@ -173,24 +173,22 @@ crewai log-tasks-outputs
 
 ### 6. Reset-memories
 
-Reset the crew memories (long, short, entity, latest_crew_kickoff_outputs).
+Reset the crew memories (memory, knowledge, agent_knowledge, kickoff_outputs).
 
 ```shell Terminal
 crewai reset-memories [OPTIONS]
 ```
 
-- `-l, --long`: Reset LONG TERM memory
-- `-s, --short`: Reset SHORT TERM memory
-- `-e, --entities`: Reset ENTITIES memory
-- `-k, --kickoff-outputs`: Reset LATEST KICKOFF TASK OUTPUTS
+- `-m, --memory`: Reset MEMORY
 - `-kn, --knowledge`: Reset KNOWLEDGE storage
 - `-akn, --agent-knowledge`: Reset AGENT KNOWLEDGE storage
+- `-k, --kickoff-outputs`: Reset LATEST KICKOFF TASK OUTPUTS
 - `-a, --all`: Reset ALL memories
 
 Example:
 
 ```shell Terminal
-crewai reset-memories --long --short
+crewai reset-memories --memory
 crewai reset-memories --all
 ```
 
@@ -203,7 +201,7 @@ crewai test [OPTIONS]
 ```
 
 - `-n, --n-iterations INTEGER`: Number of iterations to test the crew (default: 3)
-- `-m, --model TEXT`: LLM Model to run the tests on the Crew (default: "gpt-4o-mini")
+- `-m, --model TEXT`: LLM Model to run the tests on the Crew (default: "gpt-5.4-mini")
 
 Example:
 

--- a/docs/edge/en/learn/human-feedback-in-flows.mdx
+++ b/docs/edge/en/learn/human-feedback-in-flows.mdx
@@ -701,7 +701,7 @@ class ArticleReviewFlow(Flow):
 
 - [Flows Overview](/en/concepts/flows) - Learn about CrewAI Flows
 - [Flow State Management](/en/guides/flows/mastering-flow-state) - Managing state in flows
-- [Flow Persistence](/en/concepts/flows#persistence) - Persisting flow state
+- [Flow Persistence](/en/concepts/flows#flow-persistence) - Persisting flow state
 - [Routing with @router](/en/concepts/flows#router) - More about conditional routing
 - [Human Input on Execution](/en/learn/human-input-on-execution) - Task-level human input
 - [Memory](/en/concepts/memory) - The unified memory system used by HITL learning

--- a/lib/cli/src/crewai_cli/cli.py
+++ b/lib/cli/src/crewai_cli/cli.py
@@ -582,7 +582,7 @@ def memory(
     "--model",
     type=str,
     default="gpt-5.4-mini",
-    help="LLM Model to run the tests on the Crew. For now only accepting only OpenAI models.",
+    help="LLM Model to run the tests on the Crew. For now only accepting OpenAI models.",
 )
 @click.option(
     "-f",

--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -2177,7 +2177,7 @@ class Crew(FlowTrackable, BaseModel):
         )
 
     def _set_tasks_callbacks(self) -> None:
-        """Sets callback for every task suing task_callback"""
+        """Sets callback for every task using task_callback"""
         for task in self.tasks:
             if not task.callback:
                 task.callback = self.task_callback


### PR DESCRIPTION
## Summary
All verified at HEAD:

- **CONTRIBUTING.md**: linked `(LICENSE)` relative to `.github/`, which 404s — the file lives at the repo root → `../LICENSE`.
- **cli.mdx `reset-memories`**: documented the `-l/--long`, `-s/--short`, `-e/--entities` flags, but in `cli.py` these are `hidden=True` deprecated aliases that all map to unified memory; replaced with the current `-m, --memory` flag and updated the example (`--long --short` → `--memory`).
- **cli.mdx `test`**: documented default model `gpt-4o-mini`, but `cli.py` defaults to `gpt-5.4-mini`.
- **cli.py**: duplicated "only" in the `test --help` string ("For now only accepting only OpenAI models").
- **human-feedback-in-flows.mdx**: `#persistence` anchor → `#flow-persistence` (target heading is `## Flow Persistence`; the sibling `#router` link already matches its heading).
- **crew.py** docstring: "suing" → "using".