### PR TITLE
docs: add DeepKeep guardrails integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -397,6 +397,7 @@
                         "group": "Execution Hooks",
                         "pages": [
                           "edge/en/learn/execution-hooks",
+                          "edge/en/learn/deepkeep-guardrails",
                           "edge/en/learn/llm-hooks",
                           "edge/en/learn/tool-hooks",
                           "edge/en/learn/execution-boundary-hooks",
@@ -13614,6 +13615,7 @@
                       "edge/pt-BR/learn/sequential-process",
                       "edge/pt-BR/learn/using-annotations",
                       "edge/pt-BR/learn/execution-hooks",
+                      "edge/pt-BR/learn/deepkeep-guardrails",
                       "edge/pt-BR/learn/llm-hooks",
                       "edge/pt-BR/learn/tool-hooks",
                       "edge/pt-BR/learn/execution-boundary-hooks"
@@ -25976,6 +25978,7 @@
                       "edge/ko/learn/sequential-process",
                       "edge/ko/learn/using-annotations",
                       "edge/ko/learn/execution-hooks",
+                      "edge/ko/learn/deepkeep-guardrails",
                       "edge/ko/learn/llm-hooks",
                       "edge/ko/learn/tool-hooks",
                       "edge/ko/learn/execution-boundary-hooks"
@@ -38746,6 +38749,7 @@
                       "edge/ar/learn/sequential-process",
                       "edge/ar/learn/using-annotations",
                       "edge/ar/learn/execution-hooks",
+                      "edge/ar/learn/deepkeep-guardrails",
                       "edge/ar/learn/llm-hooks",
                       "edge/ar/learn/tool-hooks",
                       "edge/ar/learn/execution-boundary-hooks"

--- a/docs/edge/ar/learn/deepkeep-guardrails.mdx
+++ b/docs/edge/ar/learn/deepkeep-guardrails.mdx
@@ -1,0 +1,101 @@
+---
+title: حواجز DeepKeep
+description: فرض سياسات DeepKeep AI Firewall باستخدام حواجز مهام CrewAI وhooks التنفيذ
+mode: "wide"
+---
+
+يتكامل DeepKeep AI Firewall مع CrewAI من خلال الحواجز الأصلية وhooks التنفيذ.
+استخدمه للتحقق من مخرجات المهام، واعتراض استدعاءات النماذج، وفرض السياسة حول
+استخدام الأدوات من دون إضافة كود خاص بالمورد إلى CrewAI.
+
+## التثبيت
+
+```bash
+pip install crewai-tools-deepkeep
+```
+
+قم بتكوين بيانات اعتماد DeepKeep:
+
+```bash
+export DEEPKEEP_API_KEY="dk_..."
+export DEEPKEEP_BASE_URL="https://your-deepkeep-base-url"
+```
+
+## حواجز المهام
+
+استخدم حاجز مهمة عندما تريد من CrewAI التحقق من نتيجة المهمة وإعادة محاولة
+المهمة إذا حظر DeepKeep المخرج.
+
+```python
+from crewai import Agent, Task
+from crewai_deepkeep import DeepKeepGuardrail
+
+agent = Agent(
+    role="Support Agent",
+    goal="Answer user questions safely",
+    backstory="You provide concise and policy-compliant responses.",
+)
+
+deepkeep = DeepKeepGuardrail(post_model="output-firewall-id")
+
+task = Task(
+    description="Answer the user's question.",
+    expected_output="A safe answer.",
+    agent=agent,
+    guardrail=deepkeep.check_output,
+    guardrail_max_retries=3,
+)
+```
+
+يعيد `DeepKeepGuardrail.check_output` صيغة الحواجز القياسية في CrewAI:
+
+```python
+(True, validated_or_modified_output)
+(False, "feedback for the agent retry")
+```
+
+## Hooks التنفيذ
+
+استخدم hooks عندما تريد فحوصات سياسة عند حدود وقت التشغيل، بما في ذلك مدخلات
+LLM ومخرجات LLM ومدخلات الأدوات ومخرجات الأدوات.
+
+```python
+from crewai_deepkeep import DeepKeepHooks, install_deepkeep_hooks
+
+install_deepkeep_hooks(
+    DeepKeepHooks(
+        pre_model="input-firewall-id",
+        post_model="output-firewall-id",
+    )
+)
+```
+
+يسجل هذا المساعد فحوصات لنقاط اعتراض النماذج والأدوات في CrewAI. تؤدي قرارات
+الحظر إلى إيقاف العملية المعترضة. وتستبدل قرارات الحجب أو التعديل الحمولة
+المعترضة حيث يدعم CrewAI الاستبدال.
+
+## أدوات Agent الاختيارية
+
+يوفر DeepKeep أيضا أدوات يمكن للـ Agent استدعاؤها لسير العمل الذي تكون فيه
+المراجعة إجراء صريحا من Agent:
+
+```python
+from crewai_deepkeep.tools import DeepKeepModerateInputTool
+
+agent = Agent(
+    role="AI Security Reviewer",
+    goal="Review content before it is used by another agent.",
+    backstory="You call policy tools before approving content.",
+    tools=[DeepKeepModerateInputTool(model="input-firewall-id")],
+)
+```
+
+للفرض في الإنتاج، فضل حواجز المهام وhooks التنفيذ لأنها تعمل كجزء من تدفق
+التحكم في CrewAI بدلا من الاعتماد على Agent لاستدعاء أداة.
+
+## وثائق ذات صلة
+
+- [Tasks](/edge/ar/concepts/tasks)
+- [Execution Hooks](/edge/ar/learn/execution-hooks)
+- [LLM Call Hooks](/edge/ar/learn/llm-hooks)
+- [Tool Call Hooks](/edge/ar/learn/tool-hooks)

--- a/docs/edge/en/learn/deepkeep-guardrails.mdx
+++ b/docs/edge/en/learn/deepkeep-guardrails.mdx
@@ -1,0 +1,102 @@
+---
+title: DeepKeep Guardrails
+description: Enforce DeepKeep AI Firewall policies with CrewAI task guardrails and execution hooks
+mode: "wide"
+---
+
+DeepKeep AI Firewall integrates with CrewAI through native guardrails and
+execution hooks. Use it to validate task outputs, intercept model calls, and
+enforce policy around tool usage without adding vendor-specific code to CrewAI.
+
+## Installation
+
+```bash
+pip install crewai-tools-deepkeep
+```
+
+Configure your DeepKeep credentials:
+
+```bash
+export DEEPKEEP_API_KEY="dk_..."
+export DEEPKEEP_BASE_URL="https://your-deepkeep-base-url"
+```
+
+## Task Guardrails
+
+Use a task guardrail when you want CrewAI to validate a task result and retry
+the task if DeepKeep blocks the output.
+
+```python
+from crewai import Agent, Task
+from crewai_deepkeep import DeepKeepGuardrail
+
+agent = Agent(
+    role="Support Agent",
+    goal="Answer user questions safely",
+    backstory="You provide concise and policy-compliant responses.",
+)
+
+deepkeep = DeepKeepGuardrail(post_model="output-firewall-id")
+
+task = Task(
+    description="Answer the user's question.",
+    expected_output="A safe answer.",
+    agent=agent,
+    guardrail=deepkeep.check_output,
+    guardrail_max_retries=3,
+)
+```
+
+`DeepKeepGuardrail.check_output` returns CrewAI's standard guardrail tuple:
+
+```python
+(True, validated_or_modified_output)
+(False, "feedback for the agent retry")
+```
+
+## Execution Hooks
+
+Use hooks when you want policy checks at runtime boundaries, including LLM input,
+LLM output, tool input, and tool output.
+
+```python
+from crewai_deepkeep import DeepKeepHooks, install_deepkeep_hooks
+
+install_deepkeep_hooks(
+    DeepKeepHooks(
+        pre_model="input-firewall-id",
+        post_model="output-firewall-id",
+    )
+)
+```
+
+The helper registers checks for CrewAI's model and tool interception points.
+Blocking decisions abort the intercepted operation. Redaction or modification
+decisions replace the intercepted payload where CrewAI supports replacement.
+
+## Optional Agent Tools
+
+DeepKeep also provides agent-callable tools for workflows where moderation is an
+explicit agent action:
+
+```python
+from crewai_deepkeep.tools import DeepKeepModerateInputTool
+
+agent = Agent(
+    role="AI Security Reviewer",
+    goal="Review content before it is used by another agent.",
+    backstory="You call policy tools before approving content.",
+    tools=[DeepKeepModerateInputTool(model="input-firewall-id")],
+)
+```
+
+For production enforcement, prefer task guardrails and execution hooks because
+they run as part of CrewAI's control flow instead of relying on the agent to call
+a tool.
+
+## Related Documentation
+
+- [Tasks](/edge/en/concepts/tasks)
+- [Execution Hooks](/edge/en/learn/execution-hooks)
+- [LLM Call Hooks](/edge/en/learn/llm-hooks)
+- [Tool Call Hooks](/edge/en/learn/tool-hooks)

--- a/docs/edge/ko/learn/deepkeep-guardrails.mdx
+++ b/docs/edge/ko/learn/deepkeep-guardrails.mdx
@@ -1,0 +1,103 @@
+---
+title: DeepKeep Guardrails
+description: CrewAI Task guardrails와 execution hooks로 DeepKeep AI Firewall 정책을 적용합니다
+mode: "wide"
+---
+
+DeepKeep AI Firewall은 CrewAI의 기본 guardrails와 execution hooks를 통해
+통합됩니다. CrewAI에 벤더별 코드를 추가하지 않고 Task 출력 검증, 모델
+호출 차단, 도구 사용 주변의 정책 적용에 사용할 수 있습니다.
+
+## 설치
+
+```bash
+pip install crewai-tools-deepkeep
+```
+
+DeepKeep 자격 증명을 설정합니다:
+
+```bash
+export DEEPKEEP_API_KEY="dk_..."
+export DEEPKEEP_BASE_URL="https://your-deepkeep-base-url"
+```
+
+## Task Guardrails
+
+CrewAI가 Task 결과를 검증하고 DeepKeep이 출력을 차단하면 Task를 다시
+시도하게 하려면 Task guardrail을 사용합니다.
+
+```python
+from crewai import Agent, Task
+from crewai_deepkeep import DeepKeepGuardrail
+
+agent = Agent(
+    role="Support Agent",
+    goal="Answer user questions safely",
+    backstory="You provide concise and policy-compliant responses.",
+)
+
+deepkeep = DeepKeepGuardrail(post_model="output-firewall-id")
+
+task = Task(
+    description="Answer the user's question.",
+    expected_output="A safe answer.",
+    agent=agent,
+    guardrail=deepkeep.check_output,
+    guardrail_max_retries=3,
+)
+```
+
+`DeepKeepGuardrail.check_output`은 CrewAI의 표준 guardrail tuple을 반환합니다:
+
+```python
+(True, validated_or_modified_output)
+(False, "feedback for the agent retry")
+```
+
+## Execution Hooks
+
+LLM 입력, LLM 출력, 도구 입력, 도구 출력 등 런타임 경계에서 정책 검사를
+수행하려면 hooks를 사용합니다.
+
+```python
+from crewai_deepkeep import DeepKeepHooks, install_deepkeep_hooks
+
+install_deepkeep_hooks(
+    DeepKeepHooks(
+        pre_model="input-firewall-id",
+        post_model="output-firewall-id",
+    )
+)
+```
+
+이 helper는 CrewAI의 모델 및 도구 interception points에 대한 검사를
+등록합니다. 차단 결정은 intercept된 작업을 중단합니다. redaction 또는
+modification 결정은 CrewAI가 replacement를 지원하는 위치에서 intercept된
+payload를 교체합니다.
+
+## 선택적 Agent Tools
+
+DeepKeep은 moderation이 명시적인 Agent 작업인 워크플로를 위해 Agent가
+호출할 수 있는 tools도 제공합니다:
+
+```python
+from crewai_deepkeep.tools import DeepKeepModerateInputTool
+
+agent = Agent(
+    role="AI Security Reviewer",
+    goal="Review content before it is used by another agent.",
+    backstory="You call policy tools before approving content.",
+    tools=[DeepKeepModerateInputTool(model="input-firewall-id")],
+)
+```
+
+프로덕션 강제 적용에는 Task guardrails와 execution hooks를 선호하세요.
+이들은 Agent가 도구를 호출하는 것에 의존하지 않고 CrewAI의 제어 흐름의
+일부로 실행됩니다.
+
+## 관련 문서
+
+- [Tasks](/edge/ko/concepts/tasks)
+- [Execution Hooks](/edge/ko/learn/execution-hooks)
+- [LLM Call Hooks](/edge/ko/learn/llm-hooks)
+- [Tool Call Hooks](/edge/ko/learn/tool-hooks)

--- a/docs/edge/pt-BR/learn/deepkeep-guardrails.mdx
+++ b/docs/edge/pt-BR/learn/deepkeep-guardrails.mdx
@@ -74,7 +74,7 @@ install_deepkeep_hooks(
 
 O helper registra verificações para os pontos de interceptação de modelos e
 ferramentas do CrewAI. Decisões de bloqueio abortam a operação interceptada.
-Decisões de redação ou modificação substituem o payload interceptado onde o
+Decisões de ocultação ou modificação substituem o payload interceptado onde o
 CrewAI oferece suporte a substituição.
 
 ## Ferramentas Opcionais para Agent

--- a/docs/edge/pt-BR/learn/deepkeep-guardrails.mdx
+++ b/docs/edge/pt-BR/learn/deepkeep-guardrails.mdx
@@ -1,0 +1,105 @@
+---
+title: Guardrails DeepKeep
+description: Aplique políticas do DeepKeep AI Firewall com guardrails de tarefas e hooks de execução do CrewAI
+mode: "wide"
+---
+
+O DeepKeep AI Firewall integra-se ao CrewAI por meio de guardrails nativos e
+hooks de execução. Use-o para validar saídas de tarefas, interceptar chamadas de
+modelo e aplicar políticas ao redor do uso de ferramentas sem adicionar código
+específico de fornecedor ao CrewAI.
+
+## Instalação
+
+```bash
+pip install crewai-tools-deepkeep
+```
+
+Configure suas credenciais do DeepKeep:
+
+```bash
+export DEEPKEEP_API_KEY="dk_..."
+export DEEPKEEP_BASE_URL="https://your-deepkeep-base-url"
+```
+
+## Guardrails de Tarefas
+
+Use um guardrail de tarefa quando quiser que o CrewAI valide o resultado de uma
+tarefa e tente novamente se o DeepKeep bloquear a saída.
+
+```python
+from crewai import Agent, Task
+from crewai_deepkeep import DeepKeepGuardrail
+
+agent = Agent(
+    role="Support Agent",
+    goal="Answer user questions safely",
+    backstory="You provide concise and policy-compliant responses.",
+)
+
+deepkeep = DeepKeepGuardrail(post_model="output-firewall-id")
+
+task = Task(
+    description="Answer the user's question.",
+    expected_output="A safe answer.",
+    agent=agent,
+    guardrail=deepkeep.check_output,
+    guardrail_max_retries=3,
+)
+```
+
+`DeepKeepGuardrail.check_output` retorna a tupla padrão de guardrail do CrewAI:
+
+```python
+(True, validated_or_modified_output)
+(False, "feedback for the agent retry")
+```
+
+## Hooks de Execução
+
+Use hooks quando quiser verificações de política nas fronteiras de execução,
+incluindo entrada de LLM, saída de LLM, entrada de ferramenta e saída de
+ferramenta.
+
+```python
+from crewai_deepkeep import DeepKeepHooks, install_deepkeep_hooks
+
+install_deepkeep_hooks(
+    DeepKeepHooks(
+        pre_model="input-firewall-id",
+        post_model="output-firewall-id",
+    )
+)
+```
+
+O helper registra verificações para os pontos de interceptação de modelos e
+ferramentas do CrewAI. Decisões de bloqueio abortam a operação interceptada.
+Decisões de redação ou modificação substituem o payload interceptado onde o
+CrewAI oferece suporte a substituição.
+
+## Ferramentas Opcionais para Agent
+
+O DeepKeep também fornece ferramentas chamáveis pelo Agent para fluxos de
+trabalho em que a moderação é uma ação explícita do Agent:
+
+```python
+from crewai_deepkeep.tools import DeepKeepModerateInputTool
+
+agent = Agent(
+    role="AI Security Reviewer",
+    goal="Review content before it is used by another agent.",
+    backstory="You call policy tools before approving content.",
+    tools=[DeepKeepModerateInputTool(model="input-firewall-id")],
+)
+```
+
+Para aplicação em produção, prefira guardrails de tarefas e hooks de execução,
+porque eles rodam como parte do fluxo de controle do CrewAI em vez de dependerem
+do Agent chamar uma ferramenta.
+
+## Documentação Relacionada
+
+- [Tasks](/edge/pt-BR/concepts/tasks)
+- [Execution Hooks](/edge/pt-BR/learn/execution-hooks)
+- [LLM Call Hooks](/edge/pt-BR/learn/llm-hooks)
+- [Tool Call Hooks](/edge/pt-BR/learn/tool-hooks)


### PR DESCRIPTION
Summary: Add a DeepKeep Guardrails docs page for CrewAI task guardrails and execution hooks, link it from edge docs navigation, and include ar, ko, and pt-BR locale pages. Package: https://pypi.org/project/crewai-tools-deepkeep/. Repository: https://github.com/Deepkeepai/crewai-tools-deepkeep. Testing: python -m json.tool docs/docs.json; git diff --check.