### PR TITLE
fix(tools): handle nested event loops when running async tools in sync context

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -339,13 +339,14 @@ class BaseTool(BaseModel, ABC):
         if asyncio.iscoroutine(result):
             try:
                 asyncio.get_running_loop()
-                import contextvars
-                from concurrent.futures import ThreadPoolExecutor
-                ctx = contextvars.copy_context()
-                with ThreadPoolExecutor(max_workers=1) as executor:
-                    return executor.submit(ctx.run, asyncio.run, result).result()
             except RuntimeError:
-                result = asyncio.run(result)
+                return asyncio.run(result)
+
+            import contextvars
+            from concurrent.futures import ThreadPoolExecutor
+            ctx = contextvars.copy_context()
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(ctx.run, asyncio.run, result).result()
         return result
 
     async def arun(

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -338,15 +338,12 @@ class BaseTool(BaseModel, ABC):
         result = self._run(*args, **kwargs)
         if asyncio.iscoroutine(result):
             try:
-                loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    # If we're already in a running loop, we should ideally await this.
-                    # But run() is a sync method. The best we can do is run it in a thread
-                    # with a new loop, or use nest_asyncio if available.
-                    # CrewAI seems to prefer running in a thread pool for these cases.
-                    from concurrent.futures import ThreadPoolExecutor
-                    with ThreadPoolExecutor() as executor:
-                        return executor.submit(asyncio.run, result).result()
+                asyncio.get_running_loop()
+                import contextvars
+                from concurrent.futures import ThreadPoolExecutor
+                ctx = contextvars.copy_context()
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    return executor.submit(ctx.run, asyncio.run, result).result()
             except RuntimeError:
                 result = asyncio.run(result)
         return result

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -93,6 +93,27 @@ def _is_awaitable(value: R | Awaitable[R]) -> TypeIs[Awaitable[R]]:
     return asyncio.iscoroutine(value) or asyncio.isfuture(value)
 
 
+def _run_coroutine_safely(coro: Awaitable[R]) -> R:
+    """Execute a coroutine safely from both sync and async contexts.
+
+    If an event loop is already running, the coroutine is executed in a
+    separate thread with its own loop to avoid 'RuntimeError: asyncio.run()
+    cannot be called from a running event loop'. Context variables are
+    propagated to the new thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)  # type: ignore[arg-type]
+
+    import contextvars
+    from concurrent.futures import ThreadPoolExecutor
+
+    ctx = contextvars.copy_context()
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(ctx.run, asyncio.run, coro).result()  # type: ignore[arg-type]
+
+
 class EnvVar(BaseModel):
     name: str
     description: str
@@ -337,16 +358,7 @@ class BaseTool(BaseModel, ABC):
 
         result = self._run(*args, **kwargs)
         if asyncio.iscoroutine(result):
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                return asyncio.run(result)
-
-            import contextvars
-            from concurrent.futures import ThreadPoolExecutor
-            ctx = contextvars.copy_context()
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                return executor.submit(ctx.run, asyncio.run, result).result()
+            return _run_coroutine_safely(result)
         return result
 
     async def arun(
@@ -556,7 +568,7 @@ class Tool(BaseTool, Generic[P, R]):
         result = self.func(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = _run_coroutine_safely(result)
 
         return result  # type: ignore[return-value]
 

--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -336,10 +336,19 @@ class BaseTool(BaseModel, ABC):
             return limit_error
 
         result = self._run(*args, **kwargs)
-
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
-
+            try:
+                loop = asyncio.get_running_loop()
+                if loop.is_running():
+                    # If we're already in a running loop, we should ideally await this.
+                    # But run() is a sync method. The best we can do is run it in a thread
+                    # with a new loop, or use nest_asyncio if available.
+                    # CrewAI seems to prefer running in a thread pool for these cases.
+                    from concurrent.futures import ThreadPoolExecutor
+                    with ThreadPoolExecutor() as executor:
+                        return executor.submit(asyncio.run, result).result()
+            except RuntimeError:
+                result = asyncio.run(result)
         return result
 
     async def arun(

--- a/lib/crewai/src/crewai/tools/mcp_native_tool.py
+++ b/lib/crewai/src/crewai/tools/mcp_native_tool.py
@@ -94,13 +94,14 @@ class MCPNativeTool(BaseTool):
         try:
             try:
                 asyncio.get_running_loop()
-                import contextvars
-                from concurrent.futures import ThreadPoolExecutor
-                ctx = contextvars.copy_context()
-                with ThreadPoolExecutor(max_workers=1) as executor:
-                    return executor.submit(ctx.run, asyncio.run, coro).result()
             except RuntimeError:
                 return asyncio.run(coro)
+
+            import contextvars
+            from concurrent.futures import ThreadPoolExecutor
+            ctx = contextvars.copy_context()
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(ctx.run, asyncio.run, coro).result()
 
         except Exception as e:
             raise RuntimeError(

--- a/lib/crewai/src/crewai/tools/mcp_native_tool.py
+++ b/lib/crewai/src/crewai/tools/mcp_native_tool.py
@@ -90,19 +90,16 @@ class MCPNativeTool(BaseTool):
             The tool's text result, or a :class:`ToolFailure` when the server
             answered with ``isError: true``.
         """
+        coro = self._run_async(**kwargs)
         try:
             try:
-                asyncio.get_running_loop()
-
-                import concurrent.futures
-
-                ctx = contextvars.copy_context()
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    coro = self._run_async(**kwargs)
-                    future = executor.submit(ctx.run, asyncio.run, coro)
-                    return future.result()
+                loop = asyncio.get_running_loop()
+                if loop.is_running():
+                    from concurrent.futures import ThreadPoolExecutor
+                    with ThreadPoolExecutor() as executor:
+                        return executor.submit(asyncio.run, coro).result()
             except RuntimeError:
-                return asyncio.run(self._run_async(**kwargs))
+                return asyncio.run(coro)
 
         except Exception as e:
             raise RuntimeError(

--- a/lib/crewai/src/crewai/tools/mcp_native_tool.py
+++ b/lib/crewai/src/crewai/tools/mcp_native_tool.py
@@ -93,11 +93,12 @@ class MCPNativeTool(BaseTool):
         coro = self._run_async(**kwargs)
         try:
             try:
-                loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    from concurrent.futures import ThreadPoolExecutor
-                    with ThreadPoolExecutor() as executor:
-                        return executor.submit(asyncio.run, coro).result()
+                asyncio.get_running_loop()
+                import contextvars
+                from concurrent.futures import ThreadPoolExecutor
+                ctx = contextvars.copy_context()
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    return executor.submit(ctx.run, asyncio.run, coro).result()
             except RuntimeError:
                 return asyncio.run(coro)
 

--- a/lib/crewai/src/crewai/tools/mcp_native_tool.py
+++ b/lib/crewai/src/crewai/tools/mcp_native_tool.py
@@ -90,19 +90,11 @@ class MCPNativeTool(BaseTool):
             The tool's text result, or a :class:`ToolFailure` when the server
             answered with ``isError: true``.
         """
+        from crewai.tools.base_tool import _run_coroutine_safely
+
         coro = self._run_async(**kwargs)
         try:
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                return asyncio.run(coro)
-
-            import contextvars
-            from concurrent.futures import ThreadPoolExecutor
-            ctx = contextvars.copy_context()
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                return executor.submit(ctx.run, asyncio.run, coro).result()
-
+            return _run_coroutine_safely(coro)
         except Exception as e:
             raise RuntimeError(
                 f"Error executing MCP tool {self.original_tool_name}: {e!s}"

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -438,12 +438,27 @@ class CrewStructuredTool(BaseModel):
         self._increment_usage_count()
 
         if inspect.iscoroutinefunction(self.func):
-            return asyncio.run(self.func(**parsed_args, **kwargs))
+            coro = self.func(**parsed_args, **kwargs)
+            try:
+                loop = asyncio.get_running_loop()
+                if loop.is_running():
+                    from concurrent.futures import ThreadPoolExecutor
+                    with ThreadPoolExecutor() as executor:
+                        return executor.submit(asyncio.run, coro).result()
+            except RuntimeError:
+                return asyncio.run(coro)
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            return asyncio.run(result)
+            try:
+                loop = asyncio.get_running_loop()
+                if loop.is_running():
+                    from concurrent.futures import ThreadPoolExecutor
+                    with ThreadPoolExecutor() as executor:
+                        return executor.submit(asyncio.run, result).result()
+            except RuntimeError:
+                return asyncio.run(result)
 
         return result
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -440,11 +440,12 @@ class CrewStructuredTool(BaseModel):
         if inspect.iscoroutinefunction(self.func):
             coro = self.func(**parsed_args, **kwargs)
             try:
-                loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    from concurrent.futures import ThreadPoolExecutor
-                    with ThreadPoolExecutor() as executor:
-                        return executor.submit(asyncio.run, coro).result()
+                asyncio.get_running_loop()
+                import contextvars
+                from concurrent.futures import ThreadPoolExecutor
+                ctx = contextvars.copy_context()
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    return executor.submit(ctx.run, asyncio.run, coro).result()
             except RuntimeError:
                 return asyncio.run(coro)
 
@@ -452,11 +453,12 @@ class CrewStructuredTool(BaseModel):
 
         if asyncio.iscoroutine(result):
             try:
-                loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    from concurrent.futures import ThreadPoolExecutor
-                    with ThreadPoolExecutor() as executor:
-                        return executor.submit(asyncio.run, result).result()
+                asyncio.get_running_loop()
+                import contextvars
+                from concurrent.futures import ThreadPoolExecutor
+                ctx = contextvars.copy_context()
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    return executor.submit(ctx.run, asyncio.run, result).result()
             except RuntimeError:
                 return asyncio.run(result)
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -437,32 +437,15 @@ class CrewStructuredTool(BaseModel):
 
         self._increment_usage_count()
 
-        if inspect.iscoroutinefunction(self.func):
-            coro = self.func(**parsed_args, **kwargs)
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                return asyncio.run(coro)
+        from crewai.tools.base_tool import _run_coroutine_safely
 
-            import contextvars
-            from concurrent.futures import ThreadPoolExecutor
-            ctx = contextvars.copy_context()
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                return executor.submit(ctx.run, asyncio.run, coro).result()
+        if inspect.iscoroutinefunction(self.func):
+            return _run_coroutine_safely(self.func(**parsed_args, **kwargs))
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                return asyncio.run(result)
-
-            import contextvars
-            from concurrent.futures import ThreadPoolExecutor
-            ctx = contextvars.copy_context()
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                return executor.submit(ctx.run, asyncio.run, result).result()
+            return _run_coroutine_safely(result)
 
         return result
 

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -441,26 +441,28 @@ class CrewStructuredTool(BaseModel):
             coro = self.func(**parsed_args, **kwargs)
             try:
                 asyncio.get_running_loop()
-                import contextvars
-                from concurrent.futures import ThreadPoolExecutor
-                ctx = contextvars.copy_context()
-                with ThreadPoolExecutor(max_workers=1) as executor:
-                    return executor.submit(ctx.run, asyncio.run, coro).result()
             except RuntimeError:
                 return asyncio.run(coro)
+
+            import contextvars
+            from concurrent.futures import ThreadPoolExecutor
+            ctx = contextvars.copy_context()
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(ctx.run, asyncio.run, coro).result()
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
             try:
                 asyncio.get_running_loop()
-                import contextvars
-                from concurrent.futures import ThreadPoolExecutor
-                ctx = contextvars.copy_context()
-                with ThreadPoolExecutor(max_workers=1) as executor:
-                    return executor.submit(ctx.run, asyncio.run, result).result()
             except RuntimeError:
                 return asyncio.run(result)
+
+            import contextvars
+            from concurrent.futures import ThreadPoolExecutor
+            ctx = contextvars.copy_context()
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(ctx.run, asyncio.run, result).result()
 
         return result
 


### PR DESCRIPTION
This PR fixes issue #6611 where async tools were failing when executed from within a running event loop (e.g., when using native function calling).

### Changes
- Updated `BaseTool.run`, `CrewStructuredTool.invoke`, and `MCPNativeTool._run` to detect if an event loop is already running.
- If a loop is running, the coroutine is executed in a separate thread using `ThreadPoolExecutor` to avoid `RuntimeError: asyncio.run() cannot be called from a running event loop`.
- Preserved existing behavior for non-running loop contexts.

### Validation
- Verified with a reproduction script covering `BaseTool` and `CrewStructuredTool` with async implementations.
- Local tests pass.