### PR TITLE
docs(hooks): add HOL Guard tool policy example

### DIFF
--- a/docs/edge/ar/learn/tool-hooks.mdx
+++ b/docs/edge/ar/learn/tool-hooks.mdx
@@ -173,6 +173,47 @@ def safety_check(context: ToolCallHookContext) -> bool | None:
     return None
 ```
 
+### 1.1 فحص أمان الأوامر باستخدام HOL Guard
+
+بالنسبة للأدوات التي تنفذ أوامر، يمكن لفاحص سياسة خارجي وحتمي اتخاذ قرار
+السماح أو الحظر قبل تشغيل الأداة. اعتبر النتائج المفقودة أو غير الصحيحة أو
+التي انتهت مهلتها أو التي أعادت رمز خروج غير صفري حظراً، حتى يفشل الخطاف
+بشكل آمن:
+
+```python
+import json
+import subprocess
+
+@on(InterceptionPoint.PRE_TOOL_CALL, tools=["run_shell_command"])
+def check_command_with_hol_guard(ctx: ToolCallHookContext) -> None:
+    command = ctx.tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise HookAborted(reason="command is missing", source="hol-guard")
+
+    returncode = 1
+    try:
+        result = subprocess.run(
+            ["hol-guard", "command", "test", command, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        returncode = result.returncode
+        decision = json.loads(result.stdout).get("decision")
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        decision = None
+
+    if returncode != 0 or decision != "allow":
+        raise HookAborted(
+            reason=f"HOL Guard rejected {ctx.tool_name}",
+            source="hol-guard",
+        )
+```
+
+يُمرر الأمر كقائمة معاملات وليس عبر shell. اجعل فاحص السياسة اختيارياً، لكن
+افشل بشكل آمن عند عدم توفره؛ يجب ألا تعمل الأداة المحمية عند وجود قرار غير معروف.
+
 ### 2. بوابة الموافقة البشرية
 
 ```python

--- a/docs/edge/en/learn/tool-hooks.mdx
+++ b/docs/edge/en/learn/tool-hooks.mdx
@@ -149,6 +149,47 @@ def safety_check(ctx: ToolCallHookContext) -> None:
         raise HookAborted(reason=f"{ctx.tool_name} is destructive", source="safety-policy")
 ```
 
+### 1.1. Command Safety with HOL Guard
+
+For command-executing tools, an external deterministic policy checker can make
+the allow/block decision before the tool runs. Treat missing, malformed, timed
+out, or non-zero checker results as a block so the hook fails closed:
+
+```python
+import json
+import subprocess
+
+@on(InterceptionPoint.PRE_TOOL_CALL, tools=["run_shell_command"])
+def check_command_with_hol_guard(ctx: ToolCallHookContext) -> None:
+    command = ctx.tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise HookAborted(reason="command is missing", source="hol-guard")
+
+    returncode = 1
+    try:
+        result = subprocess.run(
+            ["hol-guard", "command", "test", command, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        returncode = result.returncode
+        decision = json.loads(result.stdout).get("decision")
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        decision = None
+
+    if returncode != 0 or decision != "allow":
+        raise HookAborted(
+            reason=f"HOL Guard rejected {ctx.tool_name}",
+            source="hol-guard",
+        )
+```
+
+The command is passed as an argument list rather than through a shell. Keep the
+policy checker optional and fail closed when it is unavailable; the protected
+tool should never run on an unknown decision.
+
 ### 2. Human Approval Gate
 
 ```python

--- a/docs/edge/ko/learn/tool-hooks.mdx
+++ b/docs/edge/ko/learn/tool-hooks.mdx
@@ -166,6 +166,47 @@ def safety_check(context: ToolCallHookContext) -> bool | None:
     return None
 ```
 
+### 1.1 HOL Guard를 사용한 명령 안전성 검사
+
+명령을 실행하는 도구는 도구가 실행되기 전에 외부의 결정론적 정책 검사기로
+허용 또는 차단을 판단할 수 있습니다. 검사 결과가 없거나 잘못되었거나
+시간 초과 또는 0이 아닌 종료 코드인 경우 안전하게 차단하여 훅이 fail-closed
+방식으로 동작하도록 합니다.
+
+```python
+import json
+import subprocess
+
+@on(InterceptionPoint.PRE_TOOL_CALL, tools=["run_shell_command"])
+def check_command_with_hol_guard(ctx: ToolCallHookContext) -> None:
+    command = ctx.tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise HookAborted(reason="command is missing", source="hol-guard")
+
+    returncode = 1
+    try:
+        result = subprocess.run(
+            ["hol-guard", "command", "test", command, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        returncode = result.returncode
+        decision = json.loads(result.stdout).get("decision")
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        decision = None
+
+    if returncode != 0 or decision != "allow":
+        raise HookAborted(
+            reason=f"HOL Guard rejected {ctx.tool_name}",
+            source="hol-guard",
+        )
+```
+
+명령은 셸을 거치지 않고 인자 목록으로 전달합니다. 정책 검사기가 없으면
+fail-closed로 처리하여, 결정이 불명확할 때 보호된 도구가 실행되지 않도록 합니다.
+
 ### 2. 사람의 승인 게이트
 
 ```python

--- a/docs/edge/pt-BR/learn/tool-hooks.mdx
+++ b/docs/edge/pt-BR/learn/tool-hooks.mdx
@@ -166,6 +166,48 @@ def safety_check(context: ToolCallHookContext) -> bool | None:
     return None
 ```
 
+### 1.1 Segurança de comandos com HOL Guard
+
+Para ferramentas que executam comandos, um verificador de política determinístico
+externo pode decidir permitir ou bloquear antes da execução. Trate resultados
+ausentes, inválidos, expirados ou com código de saída diferente de zero como
+bloqueio para que o hook falhe de forma segura:
+
+```python
+import json
+import subprocess
+
+@on(InterceptionPoint.PRE_TOOL_CALL, tools=["run_shell_command"])
+def check_command_with_hol_guard(ctx: ToolCallHookContext) -> None:
+    command = ctx.tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise HookAborted(reason="command is missing", source="hol-guard")
+
+    returncode = 1
+    try:
+        result = subprocess.run(
+            ["hol-guard", "command", "test", command, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        returncode = result.returncode
+        decision = json.loads(result.stdout).get("decision")
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        decision = None
+
+    if returncode != 0 or decision != "allow":
+        raise HookAborted(
+            reason=f"HOL Guard rejected {ctx.tool_name}",
+            source="hol-guard",
+        )
+```
+
+O comando é passado como uma lista de argumentos, e não por um shell. Mantenha
+o verificador opcional, mas falhe de forma segura quando ele não estiver
+disponível; a ferramenta protegida nunca deve executar diante de uma decisão desconhecida.
+
 ### 2. Gate de Aprovação Humana
 
 ```python


### PR DESCRIPTION
## Problem

CrewAI documents the generic `PRE_TOOL_CALL` hook, but does not show how to connect that existing hook surface to an external deterministic command-safety policy such as HOL Guard.

## Root Cause

There is no focused, official example that demonstrates a fail-closed policy decision before a command-executing tool runs.

## Solution

Add a documentation-only example that invokes `hol-guard command test ... --json` from a `PRE_TOOL_CALL` hook and aborts on missing, malformed, timed-out, failed, or non-allow decisions.

## Changes

- Added a HOL Guard command-policy example to the English tool-hooks guide.
- Added semantically equivalent Arabic, Korean, and Brazilian Portuguese translations.
- Kept the example on CrewAI's existing hook API; no runtime code or dependency was added.

## Testing

- `git diff --check` — passed.
- Verified the same code block and fail-closed `returncode` guard are present in all four locale pages.
- Prettier was attempted on all four changed MDX files; it reports existing repository formatting differences and would require unrelated whole-file reformatting. No unrelated formatting was applied.
- No runtime test is needed for this documentation-only change.

## Compatibility/Risk

No Python package or runtime behavior changes. The example invokes an optional external CLI as an argument list, never through a shell; an unavailable checker blocks the protected tool rather than allowing an unknown decision.

## Notes for Reviewer

Please review the example's fail-closed behavior and the synchronization of the four locale pages. No screenshot/video is applicable because this is a documentation-only example.

## Linked Issue

Fixes #7091
