### PR TITLE
fix(a2a): use constant-time comparison for server token/API-key auth

### DIFF
--- a/lib/crewai/src/crewai/a2a/auth/server_schemes.py
+++ b/lib/crewai/src/crewai/a2a/auth/server_schemes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import hmac
 import logging
 import os
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal
@@ -174,7 +175,7 @@ class SimpleTokenAuth(ServerAuthScheme):
                 detail="Authentication not configured",
             )
 
-        if token != expected:
+        if not hmac.compare_digest(token, expected):
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,
                 detail="Invalid or missing authentication credentials",
@@ -713,7 +714,7 @@ class APIKeyServerAuth(ServerAuthScheme):
         Raises:
             HTTPException: If authentication fails.
         """
-        if token != self.api_key.get_secret_value():
+        if not hmac.compare_digest(token, self.api_key.get_secret_value()):
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,
                 detail="Invalid API key",

--- a/lib/crewai/tests/a2a/auth/test_server_schemes_constant_time.py
+++ b/lib/crewai/tests/a2a/auth/test_server_schemes_constant_time.py
@@ -1,0 +1,48 @@
+"""Tests that server-side token/API-key auth uses constant-time comparison.
+
+Regression tests for a timing side-channel: server auth schemes validate
+attacker-controlled bearer tokens/API keys from incoming A2A requests. Using a
+plain ``!=`` comparison leaks secret length/prefix via response timing.
+"""
+
+import hmac
+
+import pytest
+
+from crewai.a2a.auth.server_schemes import APIKeyServerAuth, SimpleTokenAuth
+
+
+@pytest.mark.asyncio
+async def test_simple_token_uses_constant_time_compare(monkeypatch):
+    auth = SimpleTokenAuth(token="s3cret-token")
+
+    calls = {"n": 0}
+    real = hmac.compare_digest
+
+    def spy(a, b):
+        calls["n"] += 1
+        return real(a, b)
+
+    monkeypatch.setattr(hmac, "compare_digest", spy)
+
+    user = await auth.authenticate("s3cret-token")
+    assert user.token == "s3cret-token"
+    assert calls["n"] >= 1, "expected constant-time hmac.compare_digest to be used"
+
+
+@pytest.mark.asyncio
+async def test_api_key_uses_constant_time_compare(monkeypatch):
+    auth = APIKeyServerAuth(api_key="my-api-key")
+
+    calls = {"n": 0}
+    real = hmac.compare_digest
+
+    def spy(a, b):
+        calls["n"] += 1
+        return real(a, b)
+
+    monkeypatch.setattr(hmac, "compare_digest", spy)
+
+    user = await auth.authenticate("my-api-key")
+    assert user.token == "my-api-key"
+    assert calls["n"] >= 1, "expected constant-time hmac.compare_digest to be used"


### PR DESCRIPTION
`SimpleTokenAuth` and `APIKeyServerAuth` in `lib/crewai/src/crewai/a2a/auth/server_schemes.py` validate attacker-controlled bearer tokens / API keys from incoming A2A requests. Both used a plain `!=` string comparison, which short-circuits on the first differing byte and leaks the secret's length and matching prefix through response timing — a classic timing side-channel against authentication. `A2AConfig.auth` defaults to `SimpleTokenAuth`.

This replaces the comparisons with `hmac.compare_digest`, the standard constant-time primitive. Behavior is unchanged for valid/invalid inputs; only the timing profile is fixed.

Added `tests/a2a/auth/test_server_schemes_constant_time.py` covering both schemes. Full `tests/a2a` suite passes (103).

_Note: this PR was authored with AI assistance; applying the `llm-generated` label per CONTRIBUTING.md._