### PR TITLE
fix(deps): widen opentelemetry pins so protobuf 7 resolves

### DIFF
--- a/lib/crewai-core/pyproject.toml
+++ b/lib/crewai-core/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "pyjwt>=2.13.0,<3",
     "pydantic>=2.11.9,<2.13",
     "rich>=13.7.1",
-    "opentelemetry-api~=1.42.0",
-    "opentelemetry-sdk~=1.42.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.42.0",
+    "opentelemetry-api~=1.42",
+    "opentelemetry-sdk~=1.42",
+    "opentelemetry-exporter-otlp-proto-http~=1.42",
     "tomli~=2.0.2",
 ]
 

--- a/lib/crewai/pyproject.toml
+++ b/lib/crewai/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "pdfplumber~=0.11.4",
     "regex~=2026.1.15",
     # Telemetry and Monitoring
-    "opentelemetry-api~=1.42.0",
-    "opentelemetry-sdk~=1.42.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.42.0",
+    "opentelemetry-api~=1.42",
+    "opentelemetry-sdk~=1.42",
+    "opentelemetry-exporter-otlp-proto-http~=1.42",
     # Data Handling
     "chromadb~=1.1.0",
     "tokenizers>=0.21,<1",


### PR DESCRIPTION
> **`llm-generated`** — authored with Claude Code, per `.github/CONTRIBUTING.md`. I don't have
> permission to apply labels on this repo; **please add the `llm-generated` label.** Flagging it
> here so the requirement is met in substance even though I can't set it myself.

## The problem

`~=1.42.0` is a **patch-level** pin — `>=1.42.0,<1.43` — so it cannot reach
`opentelemetry-proto` **1.43.0**, which is the release that lifted its own `protobuf<7.0` cap.

Because `opentelemetry-exporter-otlp-proto-http` pins `opentelemetry-proto` **exactly**
(`==1.42.0`, `==1.43.0`), there is no resolving around it. The cap propagates into every `crewai`
install, so `crewai` cannot share an environment with anything requiring `protobuf>=7`.

## The change

Three pins, in two packages: `~=1.42.0` → `~=1.42`.

Per PEP 440 that moves from patch- to minor-level compatible-release:

| | admits | refuses |
|---|---|---|
| `~=1.42.0` | `>=1.42.0,<1.43` | 1.43+ |
| `~=1.42` | `>=1.42,<2` | 2.x |

So it **still refuses 2.x** and **still admits 1.42.x** — nothing that resolves today stops
resolving. It keeps the existing operator style rather than switching to `>=`.

**Both packages change together** because `crewai` pins `crewai-core` exactly; widening one alone
leaves the constraint in place via the other. `crewai-cli` inherits it from `crewai-core`, so no
change is needed there.

## Verification

Resolved the entire workspace — all six members, 52 external requirements after dropping
intra-workspace pins — against a `protobuf>=7.36,<8` floor:

- **before:** unsatisfiable — *"opentelemetry-proto==1.42.1 depends on protobuf>=5.0,<7.0 … your
  requirements are unsatisfiable"*
- **after:** resolves, selecting `opentelemetry-{api,sdk,exporter-otlp-proto-http,proto}==1.44.0`
  and `protobuf==7.36.0`

The two runs differ **only** in these three pins, so the change is isolated as the cause.

**What I have not verified:** that the test suite passes against OpenTelemetry 1.44. I checked the
constraint resolves, not the runtime behaviour — your CI is the right place to establish that, and
it's a fair thing to ask before merging.

## Why this keeps coming back

The same conflict has been reported here at least three times and closed each time without the pin
changing: #4511 asked for precisely this relaxation and was auto-closed as stale after five days;
#4474 (google-adk) and #5845 (OpenLIT) are the same root cause wearing different clothes.

Those were requests to *support a newer version*, which reads as a feature ask. This is narrower: the
upstream fix already shipped in `opentelemetry-proto` 1.43.0, so the only thing standing between
users and it is a pin that is one granularity level tighter than it needs to be.

## Where I hit it

Building an SDK whose generated protobuf stubs require `protobuf>=7.36`. Downstream users currently
need two virtualenvs to run it alongside CrewAI. Happy to adjust the constraint style if you'd prefer
something else — the specific form matters much less than being able to reach 1.43+.

<!-- crewai-require-issue-check -->