### PR TITLE
fix(schema): accept list-form JSON schema types like ["string", "null"]

### DIFF
--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -1215,6 +1215,27 @@ def _json_schema_to_pydantic_type(
 
     type_ = json_schema.get("type")
 
+    if isinstance(type_, list):
+        # JSON Schema draft-07 allows ``type`` to be a list, e.g.
+        # ``{"type": ["string", "null"]}`` for a nullable string. Resolve each
+        # member against a copy of the schema and union the results, instead of
+        # falling through to the "unsupported type" error.
+        member_types = tuple(
+            _json_schema_to_pydantic_type(
+                {**json_schema, "type": member},
+                root_schema,
+                name_=name_,
+                enrich_descriptions=enrich_descriptions,
+                in_progress=in_progress,
+            )
+            for member in type_
+        )
+        if not member_types:
+            return Any
+        if len(member_types) == 1:
+            return member_types[0]
+        return Union[member_types]  # type: ignore[valid-type]
+
     if type_ == "string":
         return str
     if type_ == "integer":

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 import datetime
 from copy import deepcopy
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from pydantic import BaseModel
 
 from crewai.utilities.pydantic_schema_utils import (
+    _json_schema_to_pydantic_type,
     build_rich_field_description,
     convert_oneof_to_anyof,
     create_model_from_schema,
@@ -41,6 +42,18 @@ class TestSimpleTypes:
         Model = create_model_from_schema(schema)
         obj = Model(name="Alice")
         assert obj.name == "Alice"
+
+    def test_list_form_nullable_type(self) -> None:
+        """A draft-07 list-form type (e.g. ["string", "null"]) resolves to a
+        Union instead of raising "Unsupported JSON schema type".
+
+        MCP tool schemas commonly express a nullable field this way, which
+        previously crashed the schema conversion.
+        """
+        assert (
+            _json_schema_to_pydantic_type({"type": ["string", "null"]}, {})
+            == Optional[str]
+        )
 
     def test_integer_field(self) -> None:
         schema = {


### PR DESCRIPTION
## What

`_json_schema_to_pydantic_type` (in `crewai/utilities/pydantic_schema_utils.py`) matches `json_schema["type"]` against string literals (`"string"`, `"integer"`, …) and raises `ValueError: Unsupported JSON schema type` for anything else. JSON Schema draft-07 also allows `type` to be a **list**, e.g. `{"type": ["string", "null"]}` for a nullable field — a form MCP tool schemas commonly use. That list never matches any `==` branch, so it falls through to the error and crashes schema conversion (and, in turn, the `MCPServerAdapter` connection that triggered it).

## Change

- Handle `isinstance(type_, list)` before the scalar-type checks: resolve each member type against a copy of the schema and return their `Union` (a single member returns that type directly; an empty list returns `Any`).
- `["string", "null"]` now resolves to `Optional[str]`, `["string", "integer"]` to `Union[str, int]`.

```python
    type_ = json_schema.get("type")

    if isinstance(type_, list):
        member_types = tuple(
            _json_schema_to_pydantic_type({**json_schema, "type": member}, ...)
            for member in type_
        )
        ...
        return Union[member_types]
```

## Testing

Added `test_list_form_nullable_type` to `lib/crewai/tests/utilities/test_pydantic_schema_utils.py`, asserting `_json_schema_to_pydantic_type({"type": ["string", "null"]}, {}) == Optional[str]`. Before the change the call raises `ValueError`; after, it returns the union.

![before: ValueError / after: resolves to Union](https://github.com/user-attachments/assets/6eb157fe-ea25-4916-9ee0-8c0abbe78dbf)
