### PR TITLE
chore(ci): ignore unpatched chromadb HTTP-server GHSAs

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -86,11 +86,20 @@ jobs:
             --skip-editable
             --format json
             --output pip-audit-report.json
-            # chromadb <=1.5.9 (CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c): pre-auth RCE in
-            # the Python HTTP server. Fix merged upstream in chroma-core/chroma#7237
-            # but no PyPI release beyond 1.5.9 yet. CrewAI only uses PersistentClient
-            # (embedded), not the HTTP server.
+            # chromadb <=1.5.9: Python HTTP server issues. No PyPI release beyond
+            # 1.5.9 yet. CrewAI only uses PersistentClient (embedded), not the
+            # HTTP server.
+            # GHSA-f4j7-r4q5-qw2c (CVE-2026-45829): pre-auth RCE. Fix merged in
+            # chroma-core/chroma#7237.
             --ignore-vuln GHSA-f4j7-r4q5-qw2c
+            # GHSA-2wm9-hf6c-p5cr (CVE-2026-45830): authenticated cross-tenant IDOR.
+            --ignore-vuln GHSA-2wm9-hf6c-p5cr
+            # GHSA-36p7-vc44-83pf (CVE-2026-45833): authenticated trust_remote_code
+            # injection on the collection-update endpoint.
+            --ignore-vuln GHSA-36p7-vc44-83pf
+            # GHSA-xph7-9rjv-w5fr (CVE-2026-45831): SimpleRBACAuthorizationProvider
+            # ignores tenant/database/collection scope.
+            --ignore-vuln GHSA-xph7-9rjv-w5fr
           )
           uv run pip-audit "${pip_audit_args[@]}"
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,10 @@ repos:
           --ignore-vuln PYSEC-2025-216
           --ignore-vuln PYSEC-2025-217
           --ignore-vuln PYSEC-2025-218
-          --ignore-vuln GHSA-f4j7-r4q5-qw2c' --
+          --ignore-vuln GHSA-f4j7-r4q5-qw2c
+          --ignore-vuln GHSA-2wm9-hf6c-p5cr
+          --ignore-vuln GHSA-36p7-vc44-83pf
+          --ignore-vuln GHSA-xph7-9rjv-w5fr' --
         language: system
         pass_filenames: false
         stages: [pre-push, manual]


### PR DESCRIPTION
- Ignore GHSA-2wm9-hf6c-p5cr, GHSA-36p7-vc44-83pf, and GHSA-xph7-9rjv-w5fr in pip-audit (workflow + pre-commit).
- These are Chroma Python HTTP server issues; CrewAI only uses embedded PersistentClient.
- No patched PyPI release exists yet (latest is 1.5.9). Drop the ignores when a fixed version ships.