### PR TITLE
fix(llm): auto-convert BaseTool instances to schemas in call and acall

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import datetime
 import json
 import logging
@@ -45,7 +45,10 @@ from crewai.llms.constants import (
     GEMINI_MODELS,
     OPENAI_MODELS,
 )
+from crewai.tools.base_tool import BaseTool
+from crewai.tools.structured_tool import CrewStructuredTool
 from crewai.utilities import InternalInstructor
+from crewai.utilities.agent_utils import convert_tools_to_openai_schema
 from crewai.utilities.exceptions.context_window_exceeding_exception import (
     LLMContextLengthExceededError,
 )
@@ -65,7 +68,6 @@ except ImportError:
 if TYPE_CHECKING:
     from crewai.agents.agent_builder.base_agent import BaseAgent
     from crewai.task import Task
-    from crewai.tools.base_tool import BaseTool
     from crewai.utilities.types import LLMMessage
 
 load_dotenv()
@@ -1818,10 +1820,51 @@ class LLM(BaseLLM):
                 )
         return None
 
+    def _process_tools(
+        self,
+        tools: Sequence[Any] | None,
+        available_functions: dict[str, Any] | None,
+    ) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | None]:
+        """Convert BaseTool or CrewStructuredTool instances to OpenAI schemas and functions.
+
+        If tools contains BaseTool or CrewStructuredTool objects, convert them
+        to OpenAI function schemas and populate available_functions. Existing
+        dict schemas and available_functions are preserved.
+        """
+        if not tools:
+            return tools, available_functions  # type: ignore[return-value]
+
+        has_tool_instances = any(
+            isinstance(t, (BaseTool, CrewStructuredTool)) for t in tools
+        )
+        if not has_tool_instances:
+            return list(tools), available_functions  # type: ignore[return-value]
+
+        tool_instances: list[BaseTool | CrewStructuredTool] = []
+        dict_tools: list[dict[str, Any]] = []
+
+        for t in tools:
+            if isinstance(t, (BaseTool, CrewStructuredTool)):
+                tool_instances.append(t)
+            elif isinstance(t, dict):
+                dict_tools.append(t)
+            else:
+                tool_instances.append(t)
+
+        converted_schemas, converted_funcs, _ = convert_tools_to_openai_schema(
+            tool_instances
+        )
+
+        merged_tools = dict_tools + converted_schemas
+        merged_functions = dict(available_functions or {})
+        merged_functions.update(converted_funcs)
+
+        return merged_tools, merged_functions
+
     def call(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,
@@ -1835,8 +1878,8 @@ class LLM(BaseLLM):
                      Can be a string or list of message dictionaries.
                      If string, it will be converted to a single user message.
                      If list, each dict must have 'role' and 'content' keys.
-            tools: Optional list of tool schemas for function calling.
-                  Each tool should define its name, description, and parameters.
+            tools: Optional list of tool schemas or tool instances for function calling.
+                  Can be tool schema dicts or BaseTool/CrewStructuredTool instances.
             callbacks: Optional list of callback functions to be executed
                       during and after the LLM call.
             available_functions: Optional dict mapping function names to callables
@@ -1855,6 +1898,8 @@ class LLM(BaseLLM):
             LLMContextLengthExceededError: If input exceeds model's context limit
         """
         with llm_call_context():
+            tools, available_functions = self._process_tools(tools, available_functions)
+
             self._emit_call_started_event(
                 messages=messages,
                 tools=tools,
@@ -1960,7 +2005,7 @@ class LLM(BaseLLM):
     async def acall(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,
@@ -1974,8 +2019,8 @@ class LLM(BaseLLM):
                      Can be a string or list of message dictionaries.
                      If string, it will be converted to a single user message.
                      If list, each dict must have 'role' and 'content' keys.
-            tools: Optional list of tool schemas for function calling.
-                  Each tool should define its name, description, and parameters.
+            tools: Optional list of tool schemas or tool instances for function calling.
+                  Can be tool schema dicts or BaseTool/CrewStructuredTool instances.
             callbacks: Optional list of callback functions to be executed
                       during and after the LLM call.
             available_functions: Optional dict mapping function names to callables
@@ -1994,6 +2039,8 @@ class LLM(BaseLLM):
             LLMContextLengthExceededError: If input exceeds model's context limit
         """
         with llm_call_context():
+            tools, available_functions = self._process_tools(tools, available_functions)
+
             self._emit_call_started_event(
                 messages=messages,
                 tools=tools,

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -7,7 +7,7 @@ in CrewAI, including common functionality for native SDK implementations.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 import contextvars
 from datetime import datetime
@@ -315,7 +315,7 @@ class BaseLLM(BaseModel, ABC):
     def call(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,
@@ -329,7 +329,7 @@ class BaseLLM(BaseModel, ABC):
                      Can be a string or list of message dictionaries.
                      If string, it will be converted to a single user message.
                      If list, each dict must have 'role' and 'content' keys.
-            tools: Optional list of tool schemas for function calling.
+            tools: Optional list of tool schemas or tool instances for function calling.
                   Each tool should define its name, description, and parameters.
             callbacks: Optional list of callback functions to be executed
                       during and after the LLM call.
@@ -352,7 +352,7 @@ class BaseLLM(BaseModel, ABC):
     def stream_events(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,
@@ -385,7 +385,7 @@ class BaseLLM(BaseModel, ABC):
     async def acall(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,
@@ -421,8 +421,8 @@ class BaseLLM(BaseModel, ABC):
         raise NotImplementedError
 
     def _convert_tools_for_interference(
-        self, tools: list[dict[str, BaseTool]]
-    ) -> list[dict[str, BaseTool]]:
+        self, tools: Sequence[Any]
+    ) -> Sequence[Any]:
         """Convert tools to a format that can be used for interference.
 
         Args:
@@ -552,7 +552,7 @@ class BaseLLM(BaseModel, ABC):
     def _emit_call_started_event(
         self,
         messages: str | list[LLMMessage],
-        tools: list[dict[str, BaseTool]] | None = None,
+        tools: Sequence[Any] | None = None,
         callbacks: list[Any] | None = None,
         available_functions: dict[str, Any] | None = None,
         from_task: Task | None = None,

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from time import sleep
@@ -1250,3 +1251,85 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+def test_llm_call_accepts_basetool_instances():
+    """Verify that passing BaseTool instances to LLM.call() converts them
+    to tool schemas and executes available functions properly.
+    """
+    from crewai.tools import BaseTool
+
+    class MultiplyTool(BaseTool):
+        name: str = "multiply"
+        description: str = "Multiplies two numbers."
+
+        def _run(self, a: int, b: int) -> int:
+            return a * b
+
+    llm = LLM(model="gpt-4o-mini", is_litellm=True)
+    tool = MultiplyTool()
+
+    with patch("crewai.llm.litellm.completion") as mock_completion:
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "multiply"
+        mock_tool_call.function.arguments = json.dumps({"a": 6, "b": 7})
+
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = [mock_tool_call]
+
+        mock_choice = MagicMock(message=mock_message)
+        mock_response = MagicMock(choices=[mock_choice], usage={"total_tokens": 10})
+        mock_completion.return_value = mock_response
+
+        result = llm.call("What is 6 times 7?", tools=[tool])
+
+        assert result == 42
+        _, kwargs = mock_completion.call_args
+        assert "tools" in kwargs
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["name"] == "multiply"
+
+
+@pytest.mark.asyncio
+async def test_llm_acall_accepts_basetool_instances():
+    """Verify that passing BaseTool instances to LLM.acall() converts them
+    to tool schemas and executes available functions properly.
+    """
+    from crewai.tools import BaseTool
+
+    class AddTool(BaseTool):
+        name: str = "add"
+        description: str = "Adds two numbers."
+
+        def _run(self, a: int, b: int) -> int:
+            return a + b
+
+    llm = LLM(model="gpt-4o-mini", is_litellm=True)
+    tool = AddTool()
+
+    with patch("crewai.llm.litellm.acompletion") as mock_acompletion:
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "add"
+        mock_tool_call.function.arguments = json.dumps({"a": 10, "b": 20})
+
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = [mock_tool_call]
+
+        mock_choice = MagicMock(message=mock_message)
+        mock_response = MagicMock(choices=[mock_choice], usage={"total_tokens": 10})
+
+        async def _mock_acompletion(*args, **kwargs):
+            return mock_response
+
+        mock_acompletion.side_effect = _mock_acompletion
+
+        result = await llm.acall("What is 10 + 20?", tools=[tool])
+
+        assert result == 30
+        _, kwargs = mock_acompletion.call_args
+        assert "tools" in kwargs
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["name"] == "add"
+


### PR DESCRIPTION
Fixes #7004

### Changes
- Automatically convert `BaseTool` or `CrewStructuredTool` instances passed in the `tools` sequence to schemas in `LLM.call` and `LLM.acall`.
- Populate `available_functions` when tool instances are passed without manually pre-processing schemas.
- Update `BaseLLM` type annotations for `tools` parameter to accept `Sequence[Any]`.
- Add unit tests for synchronous and asynchronous `LLM.call`/`LLM.acall` accepting `BaseTool` instances.