### PR TITLE
fix(llm): raise on response_model conversion failure in streaming

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -71,6 +71,16 @@ if TYPE_CHECKING:
 load_dotenv()
 logger = logging.getLogger(__name__)
 
+
+class _ResponseModelConversionError(Exception):
+    """Raised when a completed stream's content fails response_model conversion.
+
+    Kept distinct from the streaming except-block's generic salvage path: a
+    conversion failure means the stream finished fine and the content just
+    doesn't match the schema, not that the stream broke mid-flight.
+    """
+
+
 # litellm is lazy-loaded to avoid its module-level dotenv.load_dotenv()
 # from polluting env vars (e.g. MODEL= overriding embedder model_name).
 # The TYPE_CHECKING imports give mypy the real types; at runtime the names
@@ -1044,7 +1054,13 @@ class LLM(BaseLLM):
                         model=response_model,
                         llm=self,
                     )
-                    result = instructor_instance.to_pydantic()
+                    try:
+                        result = instructor_instance.to_pydantic()
+                    except Exception as e:
+                        raise _ResponseModelConversionError(
+                            f"Failed to convert streaming response to "
+                            f"{response_model.__name__}: {e!s}"
+                        ) from e
                     structured_response = result.model_dump_json()
                     usage_dict = self._usage_to_dict(usage_info)
                     self._handle_emit_call_events(
@@ -1090,6 +1106,8 @@ class LLM(BaseLLM):
             return full_response
 
         except LLMContextLengthExceededError:
+            raise
+        except _ResponseModelConversionError:
             raise
         except Exception as e:
             error_msg = str(e)

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1099,6 +1099,39 @@ def test_usage_info_streaming_with_call():
     assert llm._token_usage["successful_requests"] == 1
 
 
+def test_streaming_response_model_conversion_failure_raises():
+    """A completed stream that fails response_model conversion must raise,
+    not silently fall back to returning the raw prose (issue #6735)."""
+
+    class Answer(BaseModel):
+        city: str
+        population: int
+
+    llm = LLM(model="gpt-4o-mini", is_litellm=True, stream=True)
+
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "choices": [{"delta": {"content": "Paris has 2.1M residents."}}],
+        },
+        {
+            "id": "chatcmpl-test",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+        },
+    ]
+
+    with (
+        patch("litellm.completion", return_value=iter(chunks)),
+        patch(
+            "crewai.utilities.internal_instructor.InternalInstructor.to_pydantic",
+            side_effect=ValueError("model output did not match schema"),
+        ),
+        pytest.raises(Exception, match="Failed to convert streaming response"),
+    ):
+        llm.call("What is the capital of France?", response_model=Answer)
+
+
 @pytest.mark.asyncio
 @pytest.mark.vcr(record_mode="once",decode_compressed_response=True,match_on=["method", "scheme", "host", "path", "body"])
 async def test_usage_info_non_streaming_with_acall():


### PR DESCRIPTION
Fixes #6735

## What's going wrong

When you pass a `response_model` and turn on streaming, I found that if the model's output doesn't match your schema, `_handle_streaming_response` just quietly hands you back the raw text instead of telling you conversion failed. That's because the conversion call (`to_pydantic()`) sits inside the same `try` block that's meant to rescue partial output if the stream itself breaks mid-way. So a totally different kind of failure - "stream finished fine but the output is the wrong shape" - gets treated the same as "the connection dropped," and you silently get a string back when you asked for a structured object.

I checked the non-streaming paths and they already raise properly in this situation, so this is only a streaming problem. I also noticed async streaming doesn't even attempt `response_model` conversion right now - that looks like a separate bug (#6733), so I left it alone here.

## What I changed

I pulled the conversion call out into its own `try`, and if it fails I re-raise it as a new `_ResponseModelConversionError`. Then, just like the code already does for `LLMContextLengthExceededError`, I added a line to let that error pass straight through instead of getting swallowed by the generic handler below it. So now: real stream breakage still salvages whatever partial text it got, but a schema mismatch actually raises like you'd expect.

## How I tested it

- Wrote a test (`test_streaming_response_model_conversion_failure_raises`) that fakes a completed stream where the conversion step fails, and checks that it raises instead of returning text. It passes.
- Ran the full `test_llm.py` file: 73 passed, 3 skipped, 2 failures - but I checked and those 2 fail the same way on unmodified `main` too, so they're pre-existing (looks like a Windows asyncio cleanup quirk, nothing to do with my change).
- `ruff check` and `ruff format --check` both pass clean on the files I touched.
- `mypy` on llm.py shows 22 errors, but same count and same lines as on `main` before my change (missing litellm type stubs) - none of them are in code I wrote.

## Scope

Just the one function, `_handle_streaming_response`. Didn't touch the non-streaming paths since they were already fine, and didn't touch async streaming since that's a different bug.

<!-- crewai-require-issue-check -->