### PR TITLE
fix(tools): validate snowflake database and schema identifiers

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/snowflake_search_tool/snowflake_search_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/snowflake_search_tool/snowflake_search_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import logging
+import re
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,35 @@ logger = logging.getLogger(__name__)
 # Cache for query results
 _query_cache: dict[str, list[dict[str, Any]]] = {}
 _cache_lock = threading.Lock()
+
+# Unquoted Snowflake identifiers: letter/underscore start, then letters, digits, $, _.
+# Keep these unquoted after validation so Snowflake can still case-fold them.
+_SNOWFLAKE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+def _validate_snowflake_identifier(name: str, *, allow_qualified: bool = False) -> str:
+    """Return *name* if it is a safe Snowflake identifier, else raise ValueError.
+
+    ``database`` is a single identifier. ``snowflake_schema`` may be
+    ``schema`` or ``database.schema``. Anything else (spaces, semicolons,
+    comments, extra dots) is rejected so it cannot be interpolated into
+    ``USE DATABASE`` / ``USE SCHEMA``.
+    """
+    parts = name.split(".")
+    max_parts = 2 if allow_qualified else 1
+    if (
+        not name
+        or not parts
+        or len(parts) > max_parts
+        or any(not _SNOWFLAKE_IDENTIFIER_PATTERN.fullmatch(part) for part in parts)
+    ):
+        kind = (
+            "identifier or database.schema identifier"
+            if allow_qualified
+            else "identifier"
+        )
+        raise ValueError(f"Snowflake database/schema must be a valid {kind}")
+    return name
 
 
 class SnowflakeConfig(BaseModel):
@@ -256,9 +286,13 @@ class SnowflakeSearchTool(BaseTool):
         """Execute the search query."""
         try:
             if database:
-                await self._execute_query(f"USE DATABASE {database}")
+                safe_database = _validate_snowflake_identifier(database)
+                await self._execute_query(f"USE DATABASE {safe_database}")
             if snowflake_schema:
-                await self._execute_query(f"USE SCHEMA {snowflake_schema}")
+                safe_schema = _validate_snowflake_identifier(
+                    snowflake_schema, allow_qualified=True
+                )
+                await self._execute_query(f"USE SCHEMA {safe_schema}")
 
             return await self._execute_query(query, timeout)
         except Exception as e:

--- a/lib/crewai-tools/tests/tools/snowflake_search_tool_test.py
+++ b/lib/crewai-tools/tests/tools/snowflake_search_tool_test.py
@@ -1,7 +1,10 @@
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from crewai_tools import SnowflakeConfig, SnowflakeSearchTool
+from crewai_tools.tools.snowflake_search_tool.snowflake_search_tool import (
+    _validate_snowflake_identifier,
+)
 import pytest
 
 
@@ -95,3 +98,109 @@ def test_config_validation():
 
     with pytest.raises(ValueError):
         SnowflakeConfig(account="test_account", user="test_user")
+
+
+@pytest.mark.parametrize(
+    ("name", "allow_qualified"),
+    [
+        ("analytics", False),
+        ("ANALYTICS", False),
+        ("_tmp", False),
+        ("db_1$", False),
+        ("analytics", True),
+        ("analytics.public", True),
+        ("DB1.SCHEMA_1", True),
+    ],
+)
+def test_validate_snowflake_identifier_accepts_safe_names(
+    name: str, allow_qualified: bool
+) -> None:
+    assert (
+        _validate_snowflake_identifier(name, allow_qualified=allow_qualified) == name
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "analytics; DROP DATABASE prod",
+        "analytics;DROP DATABASE prod",
+        "analytics --",
+        "analytics/*comment*/",
+        "analytics public",
+        "1analytics",
+        "",
+        ".",
+        "analytics.public.extra",
+        'analytics"',
+        "analytics'",
+    ],
+)
+def test_validate_snowflake_identifier_rejects_injection(name: str) -> None:
+    with pytest.raises(ValueError, match="valid identifier"):
+        _validate_snowflake_identifier(name)
+
+
+def test_validate_snowflake_identifier_rejects_qualified_when_disallowed() -> None:
+    with pytest.raises(ValueError, match="valid identifier"):
+        _validate_snowflake_identifier("analytics.public")
+
+
+def _fake_snowflake_tool() -> MagicMock:
+    """Bind SnowflakeSearchTool._run without constructing a real connection."""
+    tool = MagicMock()
+    tool._execute_query = AsyncMock(return_value=[])
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_run_uses_validated_database_and_schema() -> None:
+    tool = _fake_snowflake_tool()
+    await SnowflakeSearchTool._run(
+        tool,
+        query="SELECT 1",
+        database="analytics",
+        snowflake_schema="public",
+    )
+
+    assert tool._execute_query.await_args_list[0].args[0] == "USE DATABASE analytics"
+    assert tool._execute_query.await_args_list[1].args[0] == "USE SCHEMA public"
+    assert tool._execute_query.await_args_list[2].args == ("SELECT 1", 300)
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_qualified_schema() -> None:
+    tool = _fake_snowflake_tool()
+    await SnowflakeSearchTool._run(
+        tool,
+        query="SELECT 1",
+        snowflake_schema="analytics.public",
+    )
+
+    assert (
+        tool._execute_query.await_args_list[0].args[0] == "USE SCHEMA analytics.public"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("database", "snowflake_schema"),
+    [
+        ("analytics; DROP DATABASE prod", None),
+        ("analytics--comment", None),
+        (None, "public; DROP SCHEMA secret"),
+        (None, "public.extra.evil"),
+    ],
+)
+async def test_run_rejects_injected_database_or_schema(
+    database: str | None, snowflake_schema: str | None
+) -> None:
+    tool = _fake_snowflake_tool()
+    with pytest.raises(ValueError, match="valid identifier"):
+        await SnowflakeSearchTool._run(
+            tool,
+            query="SELECT 1",
+            database=database,
+            snowflake_schema=snowflake_schema,
+        )
+    tool._execute_query.assert_not_called()


### PR DESCRIPTION
**AI disclosure:** authored with AI assistance. CONTRIBUTING requires the `llm-generated` label; this account cannot add labels on `crewAIInc/crewAI` (REST 403). Please apply `llm-generated`.

## Problem

`SnowflakeSearchTool._run` interpolates the agent-supplied `database` and `snowflake_schema` values directly into SQL:

```python
await self._execute_query(f"USE DATABASE {database}")
await self._execute_query(f"USE SCHEMA {snowflake_schema}")
```

A value such as `analytics; DROP DATABASE prod` becomes a second statement. This is the same class of identifier interpolation that #6341 closed for MySQL table names, and the same stacked-write class as #6987 (SingleStore), on a different tool.

Self-sourced. #4993 reported this and was stale-closed; #4994 / #4997 bundled Snowflake + NL2SQL and closed unmerged. NL2SQL was later hardened in #5311. This PR is Snowflake-only.

## Triage / Root cause

`_run` treats `database` / `snowflake_schema` as identifiers but never checks that they are identifiers. The connection config already pattern-checks `account`; these two runtime overrides were not checked.

## Fix

- Add `_validate_snowflake_identifier` (unquoted Snowflake identifier: `[A-Za-z_][A-Za-z0-9_$]*`; schema may be `database.schema`).
- Reject spaces, semicolons, comments, extra dots, and other SQL metacharacters before interpolation.
- Leave validated names **unquoted** so Snowflake can still case-fold them (`USE DATABASE analytics` → `ANALYTICS`). Quoting would change that lookup.

## Verification

```
uv run pytest lib/crewai-tools/tests/tools/snowflake_search_tool_test.py -q
```

28 passed. 1 pre-existing failure: `test_cleanup_on_deletion` uses `async with` on a `threading.Lock` and is unrelated to this change.

New tests cover safe names, qualified schema, and injection payloads (`analytics; DROP DATABASE prod`, comment forms) without a Snowflake server.

## Notes / Risks

- Identifiers that only exist as quoted Snowflake names (spaces, reserved words) are rejected. Same tradeoff as #6341.
- Raw `query` is unchanged; this tool still executes the SQL the caller passes. Only the `USE DATABASE` / `USE SCHEMA` overrides are validated.
- Does not touch SingleStore (#6987) or NL2SQL.