### PR TITLE
feat: add Volcengine Ark as an OpenAI-compatible provider

### DIFF
--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -959,6 +959,39 @@ mode: "wide"
     ```
   </Accordion>
 
+  <Accordion title="Volcengine Ark">
+    عيّن متغيرات البيئة التالية في ملف `.env`:
+    ```toml Code
+    # Required
+    ARK_API_KEY=<your-api-key>
+
+    # Optional: القيمة الافتراضية هي نقطة النهاية في الصين
+    ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+    ```
+
+    مثال على الاستخدام في مشروع CrewAI:
+    ```python Code
+    llm = LLM(
+        model="volcengine/doubao-seed-2-1-pro-260628",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      يوفّر Volcengine Ark نماذج Doubao من ByteDance إضافةً إلى نماذج DeepSeek و GLM
+      المستضافة، عبر واجهة برمجة تطبيقات متوافقة مع OpenAI.
+
+      يجب أن تتضمّن معرّفات النماذج رقم الإصدار الكامل. الأسماء المختصرة الظاهرة في
+      وحدة تحكم Ark (مثل `doubao-seed-2.1-pro`) تُرجع
+      `InvalidEndpointOrModel.NotFound`. و`doubao-seed-evolving` هو الاسم المستعار
+      المتجدد الوحيد الذي يعمل بدون لاحقة تاريخ. راجع
+      [قائمة النماذج](https://www.volcengine.com/docs/82379/1330310) للاطلاع على المعرّفات الحالية.
+
+      اضبط `ARK_BASE_URL` على `https://ark.ap-southeast.bytepluses.com/api/v3`
+      لاستخدام BytePlus خارج الصين.
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     عيّن متغيرات البيئة التالية في ملف `.env`:
     ```toml Code

--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -978,7 +978,7 @@ mode: "wide"
     ```
 
     <Info>
-      يوفّر Volcengine Ark نماذج Doubao من ByteDance إضافةً إلى نماذج DeepSeek و GLM
+      يوفّر Volcengine Ark نماذج Doubao من ByteDance إضافةً إلى نماذج DeepSeek و GLM و Kimi
       المستضافة، عبر واجهة برمجة تطبيقات متوافقة مع OpenAI.
 
       يجب أن تتضمّن معرّفات النماذج رقم الإصدار الكامل. الأسماء المختصرة الظاهرة في

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1121,8 +1121,8 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
 
     <Info>
-      Volcengine Ark serves ByteDance's Doubao models alongside hosted DeepSeek
-      and GLM models through an OpenAI-compatible API.
+      Volcengine Ark serves ByteDance's Doubao models alongside hosted DeepSeek,
+      GLM and Kimi models through an OpenAI-compatible API.
 
       Model IDs must be fully versioned. The short names shown in the Ark console
       (for example `doubao-seed-2.1-pro`) return `InvalidEndpointOrModel.NotFound`;

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1102,6 +1102,39 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="Volcengine Ark">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    # Required
+    ARK_API_KEY=<your-api-key>
+
+    # Optional: defaults to the China Mainland endpoint
+    ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="volcengine/doubao-seed-2-1-pro-260628",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      Volcengine Ark serves ByteDance's Doubao models alongside hosted DeepSeek
+      and GLM models through an OpenAI-compatible API.
+
+      Model IDs must be fully versioned. The short names shown in the Ark console
+      (for example `doubao-seed-2.1-pro`) return `InvalidEndpointOrModel.NotFound`;
+      `doubao-seed-evolving` is the one rolling alias that resolves without a date
+      suffix. See the [model list](https://www.volcengine.com/docs/82379/1330310)
+      for current IDs.
+
+      Set `ARK_BASE_URL` to `https://ark.ap-southeast.bytepluses.com/api/v3` to use
+      BytePlus from outside China Mainland.
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     Set the following environment variables in your `.env` file:
     ```toml Code

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -721,8 +721,8 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     ```
 
     <Info>
-      Volcengine Ark는 ByteDance의 Doubao 모델과 함께 호스팅되는 DeepSeek 및 GLM
-      모델을 OpenAI 호환 API로 제공합니다.
+      Volcengine Ark는 ByteDance의 Doubao 모델과 함께 호스팅되는 DeepSeek, GLM 및
+      Kimi 모델을 OpenAI 호환 API로 제공합니다.
 
       모델 ID는 전체 버전을 포함해야 합니다. Ark 콘솔에 표시되는 짧은 이름(예:
       `doubao-seed-2.1-pro`)은 `InvalidEndpointOrModel.NotFound`를 반환합니다.

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -702,6 +702,39 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     ```
   </Accordion>
 
+  <Accordion title="Volcengine Ark">
+    `.env` 파일에 다음 환경 변수를 설정하십시오:
+    ```toml Code
+    # Required
+    ARK_API_KEY=<your-api-key>
+
+    # Optional: 기본값은 중국 본토 엔드포인트입니다
+    ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+    ```
+
+    CrewAI 프로젝트에서의 예시 사용법:
+    ```python Code
+    llm = LLM(
+        model="volcengine/doubao-seed-2-1-pro-260628",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      Volcengine Ark는 ByteDance의 Doubao 모델과 함께 호스팅되는 DeepSeek 및 GLM
+      모델을 OpenAI 호환 API로 제공합니다.
+
+      모델 ID는 전체 버전을 포함해야 합니다. Ark 콘솔에 표시되는 짧은 이름(예:
+      `doubao-seed-2.1-pro`)은 `InvalidEndpointOrModel.NotFound`를 반환합니다.
+      `doubao-seed-evolving`은 날짜 접미사 없이 사용할 수 있는 유일한 롤링
+      별칭입니다. 현재 ID는 [모델 목록](https://www.volcengine.com/docs/82379/1330310)을
+      확인하세요.
+
+      중국 본토 외부에서 BytePlus를 사용하려면 `ARK_BASE_URL`을
+      `https://ark.ap-southeast.bytepluses.com/api/v3`로 설정하세요.
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     `.env` 파일에 다음 환경 변수를 설정하십시오:
     ```toml Code

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -722,7 +722,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     <Info>
       O Volcengine Ark oferece os modelos Doubao da ByteDance junto com modelos
-      DeepSeek e GLM hospedados, por meio de uma API compatível com OpenAI.
+      DeepSeek, GLM e Kimi hospedados, por meio de uma API compatível com OpenAI.
 
       Os IDs de modelo precisam incluir a versão completa. Os nomes curtos exibidos
       no console do Ark (por exemplo, `doubao-seed-2.1-pro`) retornam

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -702,6 +702,39 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     ```
   </Accordion>
 
+  <Accordion title="Volcengine Ark">
+    Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
+    ```toml Code
+    # Required
+    ARK_API_KEY=<your-api-key>
+
+    # Optional: o padrão é o endpoint da China continental
+    ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+    ```
+
+    Exemplo de uso no seu projeto CrewAI:
+    ```python Code
+    llm = LLM(
+        model="volcengine/doubao-seed-2-1-pro-260628",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      O Volcengine Ark oferece os modelos Doubao da ByteDance junto com modelos
+      DeepSeek e GLM hospedados, por meio de uma API compatível com OpenAI.
+
+      Os IDs de modelo precisam incluir a versão completa. Os nomes curtos exibidos
+      no console do Ark (por exemplo, `doubao-seed-2.1-pro`) retornam
+      `InvalidEndpointOrModel.NotFound`. `doubao-seed-evolving` é o único alias
+      contínuo que funciona sem sufixo de data. Consulte a
+      [lista de modelos](https://www.volcengine.com/docs/82379/1330310) para os IDs atuais.
+
+      Defina `ARK_BASE_URL` como `https://ark.ap-southeast.bytepluses.com/api/v3`
+      para usar o BytePlus fora da China continental.
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
     ```toml Code

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -342,6 +342,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "hosted_vllm",
     "cerebras",
     "dashscope",
+    "volcengine",
     "snowflake",
 ]
 
@@ -447,6 +448,7 @@ class LLM(BaseLLM):
                 "hosted_vllm": "hosted_vllm",
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
+                "volcengine": "volcengine",
                 "snowflake": "snowflake",
             }
 
@@ -572,6 +574,10 @@ class LLM(BaseLLM):
 
         if provider == "dashscope":
             return model_lower.startswith("qwen")
+
+        if provider == "volcengine":
+            # Ark serves Doubao plus hosted DeepSeek and GLM models
+            return model_lower.startswith(("doubao", "deepseek", "glm", "kimi"))
 
         if provider == "openrouter":
             # OpenRouter uses org/model format but accepts anything
@@ -705,6 +711,7 @@ class LLM(BaseLLM):
             "hosted_vllm",
             "cerebras",
             "dashscope",
+            "volcengine",
         }
         if provider in openai_compatible_providers:
             from crewai.llms.providers.openai_compatible.completion import (

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -89,6 +89,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         base_url_env="DASHSCOPE_BASE_URL",
         api_key_required=True,
     ),
+    "volcengine": ProviderConfig(
+        base_url="https://ark.cn-beijing.volces.com/api/v3",
+        api_key_env="ARK_API_KEY",
+        base_url_env="ARK_BASE_URL",
+        api_key_required=True,
+    ),
 }
 
 
@@ -125,6 +131,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         - hosted_vllm: vLLM server (https://github.com/vllm-project/vllm)
         - cerebras: Cerebras (https://cerebras.ai)
         - dashscope: Alibaba Dashscope/Qwen (https://dashscope.aliyun.com)
+        - volcengine: Volcengine Ark/Doubao (https://www.volcengine.com/product/ark)
 
     Example:
         # Using provider prefix

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -95,6 +95,14 @@ class TestProviderRegistry:
         assert config.api_key_env == "DASHSCOPE_API_KEY"
         assert config.api_key_required is True
 
+    def test_volcengine_config(self):
+        """Test Volcengine Ark provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["volcengine"]
+        assert config.base_url == "https://ark.cn-beijing.volces.com/api/v3"
+        assert config.api_key_env == "ARK_API_KEY"
+        assert config.base_url_env == "ARK_BASE_URL"
+        assert config.api_key_required is True
+
 
 class TestNormalizeOllamaBaseUrl:
     """Tests for _normalize_ollama_base_url helper."""
@@ -270,6 +278,21 @@ class TestLLMIntegration:
             llm = LLM(model="dashscope/qwen-turbo")
             assert isinstance(llm, OpenAICompatibleCompletion)
             assert llm.provider == "dashscope"
+
+    def test_llm_creates_openai_compatible_for_volcengine(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for Volcengine Ark."""
+        with patch.dict(os.environ, {"ARK_API_KEY": "test-key"}):
+            llm = LLM(model="volcengine/doubao-seed-2-1-pro-260628")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "volcengine"
+
+    def test_llm_creates_openai_compatible_for_volcengine_hosted_models(self):
+        """Ark also serves hosted DeepSeek and GLM models."""
+        with patch.dict(os.environ, {"ARK_API_KEY": "test-key"}):
+            for model in ("deepseek-v4-pro-ga-260813", "glm-5-2-260617"):
+                llm = LLM(model=f"volcengine/{model}")
+                assert isinstance(llm, OpenAICompatibleCompletion)
+                assert llm.provider == "volcengine"
 
     def test_llm_with_explicit_provider(self):
         """Test LLM with explicit provider parameter."""

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -287,9 +287,13 @@ class TestLLMIntegration:
             assert llm.provider == "volcengine"
 
     def test_llm_creates_openai_compatible_for_volcengine_hosted_models(self):
-        """Ark also serves hosted DeepSeek and GLM models."""
+        """Ark also serves hosted DeepSeek, GLM and Kimi models."""
         with patch.dict(os.environ, {"ARK_API_KEY": "test-key"}):
-            for model in ("deepseek-v4-pro-ga-260813", "glm-5-2-260617"):
+            for model in (
+                "deepseek-v4-pro-ga-260813",
+                "glm-5-2-260617",
+                "kimi-k3-260727",
+            ):
                 llm = LLM(model=f"volcengine/{model}")
                 assert isinstance(llm, OpenAICompatibleCompletion)
                 assert llm.provider == "volcengine"


### PR DESCRIPTION
## Summary

Adds Volcengine Ark (火山方舟) as an OpenAI-compatible provider. Ark is ByteDance's model platform — it serves the Doubao family plus hosted DeepSeek and GLM models over an OpenAI-compatible API, so it slots into the existing `OPENAI_COMPATIBLE_PROVIDERS` registry rather than needing its own module like Snowflake did.

```python
from crewai import LLM

llm = LLM(model="volcengine/doubao-seed-2-1-pro-260628")
```

`ARK_API_KEY` for auth, `ARK_BASE_URL` to override the endpoint (BytePlus is `https://ark.ap-southeast.bytepluses.com/api/v3` for use outside China Mainland).

crewAI already ships `dashscope` and `deepseek`; Ark was the remaining gap among the major Chinese providers.

## Changes

- `openai_compatible/completion.py` — one `ProviderConfig` entry
- `llm.py` — four registration points, matching how `dashscope` is wired
- model-name validation accepts `doubao` / `deepseek` / `glm` / `kimi` prefixes, since Ark hosts more than just its own family
- tests + a docs accordion

## Model IDs

Worth flagging: Ark only resolves **fully versioned** IDs. The short names in the Ark console (`doubao-seed-2.1-pro`) come back as `InvalidEndpointOrModel.NotFound`; `doubao-seed-evolving` is the one rolling alias that works without a date suffix. The docs section says so, and the examples use versioned IDs.

## Testing

- `pytest tests/llms/openai_compatible/` — 38 passed
- `ruff check` / `ruff format --check` — no new findings (the 31 pre-existing errors in these files are unchanged; none mention volcengine)

Also exercised against the live Ark API through `LLM.call()` rather than only mocks — `doubao-seed-2-1-pro-260628`, `deepseek-v4-pro-ga-260813` and `glm-5-2-260617` all round-trip.
