### PR TITLE
fix(llms): map default Claude Sonnet 4.6 to its 1M context window

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1953,17 +1953,18 @@ class AnthropicCompletion(BaseLLM):
         """Get the context window size for the model."""
         from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
 
+        # Current offered models. Unknown and retired IDs fall back to 200k.
         context_windows = {
+            "claude-fable-5": 1000000,
+            "claude-opus-5": 1000000,
+            "claude-sonnet-5": 1000000,
+            "claude-opus-4-8": 1000000,
+            "claude-opus-4-7": 1000000,
+            "claude-opus-4-6": 1000000,
             "claude-sonnet-4-6": 1000000,
-            "claude-3-5-sonnet": 200000,
-            "claude-3-5-haiku": 200000,
-            "claude-3-opus": 200000,
-            "claude-3-sonnet": 200000,
-            "claude-3-haiku": 200000,
-            "claude-3-7-sonnet": 200000,
-            "claude-2.1": 200000,
-            "claude-2": 100000,
-            "claude-instant": 100000,
+            "claude-opus-4-5": 200000,
+            "claude-sonnet-4-5": 200000,
+            "claude-haiku-4-5": 200000,
         }
 
         for model_prefix, size in context_windows.items():

--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1954,6 +1954,7 @@ class AnthropicCompletion(BaseLLM):
         from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
 
         context_windows = {
+            "claude-sonnet-4-6": 1000000,
             "claude-3-5-sonnet": 200000,
             "claude-3-5-haiku": 200000,
             "claude-3-opus": 200000,

--- a/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/anthropic/completion.py
@@ -1956,6 +1956,7 @@ class AnthropicCompletion(BaseLLM):
         # Current offered models. Unknown and retired IDs fall back to 200k.
         context_windows = {
             "claude-fable-5": 1000000,
+            "claude-mythos-5": 1000000,
             "claude-opus-5": 1000000,
             "claude-sonnet-5": 1000000,
             "claude-opus-4-8": 1000000,

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -127,6 +127,7 @@ def test_default_anthropic_completion_uses_sonnet_4_6_context_window():
     "model",
     [
         "claude-fable-5",
+        "claude-mythos-5",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-opus-4-8",

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -4,7 +4,7 @@ import types
 from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 
-from crewai.llm import LLM
+from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO, LLM
 from crewai.crew import Crew
 from crewai.agent import Agent
 from crewai.task import Task
@@ -114,6 +114,13 @@ def test_anthropic_completion_defaults_to_sonnet_4_6():
     assert llm.model == DEFAULT_MODEL
     assert llm.model == "claude-sonnet-4-6"
     assert llm.max_tokens == 128000
+
+
+def test_default_anthropic_completion_uses_sonnet_4_6_context_window():
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion()
+    assert llm.get_context_window_size() == int(1_000_000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
 def test_anthropic_defaults_max_tokens_to_model_limit():

--- a/lib/crewai/tests/llms/anthropic/test_anthropic.py
+++ b/lib/crewai/tests/llms/anthropic/test_anthropic.py
@@ -123,6 +123,36 @@ def test_default_anthropic_completion_uses_sonnet_4_6_context_window():
     assert llm.get_context_window_size() == int(1_000_000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-fable-5",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+    ],
+)
+def test_current_1m_anthropic_models_use_1m_context_window(model: str) -> None:
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model=model)
+    assert llm.get_context_window_size() == int(1_000_000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"],
+)
+def test_claude_4_5_family_uses_200k_context_window(model: str) -> None:
+    from crewai.llms.providers.anthropic.completion import AnthropicCompletion
+
+    llm = AnthropicCompletion(model=model)
+    assert llm.get_context_window_size() == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
 def test_anthropic_defaults_max_tokens_to_model_limit():
     """Native Anthropic used to default to 4096, which truncates large tool calls."""
     llm = LLM(model="anthropic/claude-unknown-future")
@@ -507,11 +537,10 @@ def test_anthropic_context_window_size():
     """
     Test that Anthropic models return correct context window sizes
     """
-    llm = LLM(model="anthropic/claude-3-5-sonnet-20241022")
+    llm = LLM(model="anthropic/claude-haiku-4-5")
     context_size = llm.get_context_window_size()
 
-    assert context_size > 100000
-    assert context_size <= 200000  # But not exceed the actual limit
+    assert context_size == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
 def test_anthropic_message_formatting():


### PR DESCRIPTION
- Map native AnthropicCompletion context windows to the current Claude API lineup instead of retired Claude 3 / 2 / Instant IDs
- Default `claude-sonnet-4-6` now uses the documented 1,000,000-token window instead of the 200k fallback
- Include `claude-mythos-5` in the 1M mapping
- Add regression tests for the 1M family, the 4.5 200k family, and the default AnthropicCompletion instance

Verified against Anthropic's [model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations), [models overview](https://platform.claude.com/docs/en/about-claude/models/overview), and [context windows](https://platform.claude.com/docs/en/build-with-claude/context-windows) (Claude API lifecycle as of 2026-08-27). Bedrock and Vertex set their own dates.

**Active (still on the Claude API)**

| Model | Context window |
| --- | --- |
| `claude-fable-5` | 1M |
| `claude-mythos-5` | 1M |
| `claude-opus-5` | 1M |
| `claude-sonnet-5` | 1M |
| `claude-opus-4-8` | 1M |
| `claude-opus-4-7` | 1M |
| `claude-opus-4-6` | 1M |
| `claude-sonnet-4-6` | 1M |
| `claude-opus-4-5` | 200k |
| `claude-sonnet-4-5` | 200k |
| `claude-haiku-4-5` | 200k |

**Retired (Claude API requests fail)**

| Model | Retired |
| --- | --- |
| Claude Instant / Claude 1 | Nov 6, 2024 |
| Claude 2, 2.1, Sonnet 3 | Jul 21, 2025 |
| Sonnet 3.5 | Oct 28, 2025 |
| Opus 3 | Jan 5, 2026 |
| Sonnet 3.7, Haiku 3.5 | Feb 19, 2026 |
| Haiku 3 | Apr 20, 2026 |
| Opus 4, Sonnet 4 | Jun 15, 2026 |
| Opus 4.1 | Aug 5, 2026 |

Unknown and retired IDs fall back to 200k.