### PR TITLE
fix(gemini): use longest-prefix match for context window lookup

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -1370,9 +1370,16 @@ class GeminiCompletion(BaseLLM):
             "gemma-3-27b": 128000,
         }
 
-        for model_prefix, size in context_windows.items():
-            if self.model.startswith(model_prefix):
-                return int(size * CONTEXT_WINDOW_USAGE_RATIO)
+        # Longest matching prefix wins, so a specific entry (e.g.
+        # "gemini-2.0-flash-thinking") is never shadowed by a shorter one
+        # (e.g. "gemini-2.0-flash") listed earlier in the table.
+        matched_prefix = max(
+            (prefix for prefix in context_windows if self.model.startswith(prefix)),
+            key=len,
+            default=None,
+        )
+        if matched_prefix is not None:
+            return int(context_windows[matched_prefix] * CONTEXT_WINDOW_USAGE_RATIO)
 
         return int(1048576 * CONTEXT_WINDOW_USAGE_RATIO)  # 1M tokens default
 

--- a/lib/crewai/tests/llms/google/test_google.py
+++ b/lib/crewai/tests/llms/google/test_google.py
@@ -475,6 +475,20 @@ def test_gemini_context_window_size():
     assert context_size_1_5 > 1000000
 
 
+def test_gemini_context_window_size_prefers_longest_matching_prefix():
+    """
+    "gemini-2.0-flash-thinking" must win over the shorter "gemini-2.0-flash"
+    prefix that appears earlier in the lookup table, regardless of table order.
+    """
+    llm_thinking = LLM(model="google/gemini-2.0-flash-thinking-exp-01-21")
+    context_size_thinking = llm_thinking.get_context_window_size()
+    assert context_size_thinking == int(32768 * 0.85)
+
+    llm_flash = LLM(model="google/gemini-2.0-flash-001")
+    context_size_flash = llm_flash.get_context_window_size()
+    assert context_size_flash > context_size_thinking
+
+
 def test_gemini_message_formatting():
     """
     Test that messages are properly formatted for Gemini API


### PR DESCRIPTION
## Summary
- `GeminiCompletion.get_context_window_size()` returned the first matching prefix in its lookup table via `startswith`, so the more specific `"gemini-2.0-flash-thinking"` entry was always shadowed by the shorter `"gemini-2.0-flash"` entry listed above it — that row was dead code.
- Replaced the first-match loop with a longest-matching-prefix selection, so entry order in the table no longer matters and a more specific prefix always wins over a shorter one.

## Validation
- Added `test_gemini_context_window_size_prefers_longest_matching_prefix` in `lib/crewai/tests/llms/google/test_google.py`, asserting `gemini-2.0-flash-thinking-exp-01-21` resolves to the `32768`-token window rather than the `1048576`-token `gemini-2.0-flash` window.
- Ran the full `lib/crewai/tests/llms/google/` suite: 52 passed, 2 skipped (1 pre-existing unrelated failure due to a missing `litellm` extra in the local dev env, reproduced identically on `main`).
- `ruff check` / `ruff format --check` pass on both changed files.

Fixes #7129