### PR TITLE
fix(agents): preserve tool results when final answer is empty

### DIFF
--- a/lib/crewai/src/crewai/agents/step_executor.py
+++ b/lib/crewai/src/crewai/agents/step_executor.py
@@ -577,6 +577,8 @@ class StepExecutor:
             )
 
             if not answer:
+                if accumulated_results:
+                    return accumulated_results[-1]
                 raise ValueError("Empty response from LLM")
 
             if isinstance(answer, BaseModel):

--- a/lib/crewai/src/crewai/agents/step_executor.py
+++ b/lib/crewai/src/crewai/agents/step_executor.py
@@ -363,7 +363,12 @@ class StepExecutor:
             formatted = process_llm_response(answer_str, use_stop_words)
 
             if isinstance(formatted, AgentFinish):
-                return str(formatted.output)
+                output = str(formatted.output)
+                return (
+                    output
+                    if output.strip() or not last_tool_result
+                    else last_tool_result
+                )
 
             if isinstance(formatted, AgentAction):
                 tool_calls_made.append(formatted.tool)
@@ -584,7 +589,12 @@ class StepExecutor:
                 accumulated_results.append(result)
                 continue
 
-            return str(answer)
+            output = str(answer)
+            return (
+                output
+                if output.strip() or not accumulated_results
+                else accumulated_results[-1]
+            )
 
         return "\n".join(filter(None, accumulated_results))
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -892,7 +892,7 @@ class TestStepExecutorCriticalFixes:
         self, step_executor
     ):
         """The planner should receive evidence from a successful native tool call."""
-        step_executor.llm.call.side_effect = [[Mock()], "  "]
+        step_executor.llm.call.side_effect = [[Mock()], ""]
 
         with (
             patch("crewai.agents.step_executor.is_tool_call_list", return_value=True),

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -855,6 +855,62 @@ class TestStepExecutorCriticalFixes:
         assert finished_events[-1].plan_step_number == 2
         assert finished_events[-1].plan_step_description == "Count words"
 
+    def test_text_step_preserves_tool_result_when_final_answer_is_empty(
+        self, step_executor
+    ):
+        """The planner should receive evidence from a successful text tool call."""
+        action = AgentAction(
+            thought="Need a tool",
+            tool="count_words",
+            tool_input='{"text":"hello world"}',
+            text="Action: count_words",
+        )
+        finish = AgentFinish(thought="", output="", text="Final Answer:")
+        step_executor.llm.call.side_effect = ["tool call", "final answer"]
+
+        with (
+            patch(
+                "crewai.agents.step_executor.process_llm_response",
+                side_effect=[action, finish],
+            ),
+            patch.object(
+                step_executor,
+                "_execute_text_tool_with_events",
+                return_value="2 words",
+            ),
+        ):
+            result = step_executor._execute_text_parsed(
+                [],
+                TodoItem(step_number=1, description="Count words"),
+                [],
+                max_step_iterations=2,
+            )
+
+        assert result == "2 words"
+
+    def test_native_step_preserves_tool_result_when_final_answer_is_empty(
+        self, step_executor
+    ):
+        """The planner should receive evidence from a successful native tool call."""
+        step_executor.llm.call.side_effect = [[Mock()], "  "]
+
+        with (
+            patch("crewai.agents.step_executor.is_tool_call_list", return_value=True),
+            patch.object(
+                step_executor,
+                "_execute_native_tool_calls",
+                return_value="2 words",
+            ),
+        ):
+            result = step_executor._execute_native(
+                [],
+                TodoItem(step_number=1, description="Count words"),
+                [],
+                max_step_iterations=2,
+            )
+
+        assert result == "2 words"
+
     def test_step_executor_falls_back_when_native_tools_are_rejected(
         self, step_executor
     ):


### PR DESCRIPTION
Updated the StepExecutor to ensure that if the final answer from a tool call is empty, the last valid tool result is returned instead. This change enhances the reliability of the output in scenarios where the final answer may not provide useful information. Added tests to verify that both text and native steps correctly preserve tool results under these conditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fallback logic in plan-step execution with new unit tests; behavior only changes when final LLM output would have been empty after tools succeeded.
> 
> **Overview**
> **StepExecutor** no longer returns blank step output when the model finishes with an empty final answer after a successful tool call.
> 
> In **text-parsed** execution, an `AgentFinish` with whitespace-only `output` now falls back to **`last_tool_result`** from the prior tool round. In **native** tool calling, empty final text or an empty LLM response similarly returns the **last accumulated tool result** instead of `""` or raising on empty response (when tools already ran).
> 
> Regression tests cover both paths so planners still get tool evidence when the model omits a final summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d76f9f1c9a922c5e0651d902e38fb674112a5ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->