### PR TITLE
docs(llms): add AI/ML API provider configuration example

### DIFF
--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1015,7 +1015,7 @@ mode: "wide"
 
   <Accordion title="AI/ML API">
     عيّن متغيرات البيئة التالية في ملف `.env`:
-    ```toml Code
+    ```bash Code
     AIML_API_KEY=<your-api-key>
     ```
 

--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1012,6 +1012,39 @@ mode: "wide"
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="AI/ML API">
+    عيّن متغيرات البيئة التالية في ملف `.env`:
+    ```toml Code
+    AIML_API_KEY=<your-api-key>
+    ```
+
+    مثال الاستخدام في مشروع CrewAI:
+    ```python Code
+    llm = LLM(
+        model="aiml/openai/gpt-5-5",
+        temperature=0.7,
+        extra_headers={"X-AIMLAPI-Source": "agent/crewai"}
+    )
+    ```
+
+    `extra_headers` اختياري — فهو يُعلّم الطلبات بأنها قادمة من CrewAI لأغراض تحليلات AI/ML API الخاصة ولا يغيّر السلوك.
+
+    <Info>
+      نماذج AI/ML API:
+      - aiml/openai/gpt-5-5
+      - aiml/anthropic/claude-opus-5
+      - aiml/google/gemini-3-7-flash
+      - aiml/deepseek/deepseek-v4-pro-0813
+
+      مفتاح API واحد لأكثر من 300 نموذج للمحادثة والصور والفيديو والصوت والتضمينات من مزودين متعددين. راجع [كتالوج النماذج](https://docs.aimlapi.com) للاطلاع على القائمة الكاملة والمحدّثة للمعرّفات.
+    </Info>
+
+    **ملاحظة:** يستخدم هذا المزود LiteLLM. أضفه كتبعية لمشروعك:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## بث الاستجابات

--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -1021,6 +1021,8 @@ mode: "wide"
 
     مثال الاستخدام في مشروع CrewAI:
     ```python Code
+    from crewai import LLM
+
     llm = LLM(
         model="aiml/openai/gpt-5-5",
         temperature=0.7,

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1155,6 +1155,38 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="AI/ML API">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    AIML_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="aiml/openai/gpt-5-5",
+        temperature=0.7
+    )
+    ```
+
+    <Info>
+      AI/ML API models:
+      - aiml/openai/gpt-5-5
+      - aiml/anthropic/claude-opus-5
+      - aiml/google/gemini-3-7-flash
+      - aiml/deepseek/deepseek-v4-pro-0813
+
+      One API key for 300+ chat, image, video, audio, and embedding models
+      from many providers. See the [model catalog](https://docs.aimlapi.com)
+      for the full, current list of ids.
+    </Info>
+
+    **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1164,6 +1164,8 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     Example usage in your CrewAI project:
     ```python Code
+    from crewai import LLM
+
     llm = LLM(
         model="aiml/openai/gpt-5-5",
         temperature=0.7,

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1166,9 +1166,13 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```python Code
     llm = LLM(
         model="aiml/openai/gpt-5-5",
-        temperature=0.7
+        temperature=0.7,
+        extra_headers={"X-AIMLAPI-Source": "agent/crewai"}
     )
     ```
+
+    `extra_headers` is optional — it tags requests as coming from CrewAI for
+    AI/ML API's own analytics and doesn't change behavior.
 
     <Info>
       AI/ML API models:

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1158,7 +1158,7 @@ In this section, you'll find detailed examples that help you select, configure, 
 
   <Accordion title="AI/ML API">
     Set the following environment variables in your `.env` file:
-    ```toml Code
+    ```bash Code
     AIML_API_KEY=<your-api-key>
     ```
 

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -758,7 +758,7 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
   <Accordion title="AI/ML API">
     `.env` 파일에 다음 환경 변수를 설정하십시오:
-    ```toml Code
+    ```bash Code
     AIML_API_KEY=<your-api-key>
     ```
 

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -764,6 +764,8 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
 
     CrewAI 프로젝트에서의 예시 사용법:
     ```python Code
+    from crewai import LLM
+
     llm = LLM(
         model="aiml/openai/gpt-5-5",
         temperature=0.7,

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -755,6 +755,39 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="AI/ML API">
+    `.env` 파일에 다음 환경 변수를 설정하십시오:
+    ```toml Code
+    AIML_API_KEY=<your-api-key>
+    ```
+
+    CrewAI 프로젝트에서의 예시 사용법:
+    ```python Code
+    llm = LLM(
+        model="aiml/openai/gpt-5-5",
+        temperature=0.7,
+        extra_headers={"X-AIMLAPI-Source": "agent/crewai"}
+    )
+    ```
+
+    `extra_headers`는 선택 사항입니다 — 요청이 CrewAI에서 온 것임을 AI/ML API 자체 분석용으로 표시할 뿐 동작을 변경하지 않습니다.
+
+    <Info>
+      AI/ML API 모델:
+      - aiml/openai/gpt-5-5
+      - aiml/anthropic/claude-opus-5
+      - aiml/google/gemini-3-7-flash
+      - aiml/deepseek/deepseek-v4-pro-0813
+
+      하나의 API 키로 여러 제공자의 채팅, 이미지, 비디오, 오디오, 임베딩 모델 300개 이상을 사용할 수 있습니다. 전체 최신 모델 ID 목록은 [모델 카탈로그](https://docs.aimlapi.com)를 참조하세요.
+    </Info>
+
+    **참고:** 이 제공자는 LiteLLM을 사용합니다. 프로젝트에 의존성으로 추가하세요:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## 스트리밍 응답

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -737,6 +737,8 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
     Exemplo de uso em seu projeto CrewAI:
     ```python Code
+    from crewai import LLM
+
     llm = LLM(
         model="aiml/openai/gpt-5-5",
         temperature=0.7,

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -728,6 +728,39 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="AI/ML API">
+    Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
+    ```toml Code
+    AIML_API_KEY=<your-api-key>
+    ```
+
+    Exemplo de uso em seu projeto CrewAI:
+    ```python Code
+    llm = LLM(
+        model="aiml/openai/gpt-5-5",
+        temperature=0.7,
+        extra_headers={"X-AIMLAPI-Source": "agent/crewai"}
+    )
+    ```
+
+    `extra_headers` é opcional — ele marca as requisições como vindas do CrewAI para a análise interna da AI/ML API e não altera o comportamento.
+
+    <Info>
+      Modelos da AI/ML API:
+      - aiml/openai/gpt-5-5
+      - aiml/anthropic/claude-opus-5
+      - aiml/google/gemini-3-7-flash
+      - aiml/deepseek/deepseek-v4-pro-0813
+
+      Uma única chave de API para mais de 300 modelos de chat, imagem, vídeo, áudio e embeddings de diversos provedores. Consulte o [catálogo de modelos](https://docs.aimlapi.com) para a lista completa e atualizada de ids.
+    </Info>
+
+    **Nota:** Este provedor usa o LiteLLM. Adicione-o como dependência ao seu projeto:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Respostas em streaming

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -731,7 +731,7 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
 
   <Accordion title="AI/ML API">
     Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
-    ```toml Code
+    ```bash Code
     AIML_API_KEY=<your-api-key>
     ```
 


### PR DESCRIPTION
## Related issue

Fixes #7321

## Summary

AI/ML API (aimlapi.com) already works with CrewAI: LiteLLM ships it as the `aiml` provider, and CrewAI sends any provider outside `SUPPORTED_NATIVE_PROVIDERS` to LiteLLM. It is just not documented, so users have to guess the `aiml/` prefix and the `AIML_API_KEY` variable.

This PR adds an "AI/ML API" accordion to the LLM provider examples in `docs/edge/en/concepts/llms.mdx`, right after Nebius AI Studio, in the same shape as the other LiteLLM-backed providers:

- the `AIML_API_KEY` env var
- an `LLM(...)` example with `model="aiml/openai/gpt-5-5"`
- a few current model ids and a link to the full list
- the usual `uv add 'crewai[litellm]'` note

The same block is added to the `ar`, `ko` and `pt-BR` docs, as AGENTS.md asks.

Docs only. No code, no `docs.json`, no new dependency, nothing changes for current users.

## Verification

- [ ] Tests added or updated for the changed behavior — N/A, docs only
- [ ] Relevant tests and quality checks pass locally — nothing to run for a docs-only change; relying on CI here

Manual checks:
- `aiml` is not a native provider, so it goes to LiteLLM. The model string is never rewritten, so LiteLLM gets `aiml/openai/gpt-5-5` and calls AI/ML API.
- `extra_headers` needs no code: unknown `LLM(...)` kwargs land in `additional_params` in `BaseLLM` and are passed to the completion call.
- Every model id in the example was checked against the live catalog.
- CodeRabbit comments from the first round are addressed: bash fence for `.env`, `from crewai import LLM` import, `ar` fix.

## Additional context

- The `extra_headers={"X-AIMLAPI-Source": "agent/crewai"}` line is optional. It only tags requests for our own analytics and changes no behavior. Happy to drop it.
- An AI assistant helped write this PR. CONTRIBUTING.md asks for the `llm-generated` label; I cannot add labels here, so could a maintainer add it?