### PR TITLE
fix(events): track sync handler futures for mixed event types

### DIFF
--- a/lib/crewai/src/crewai/events/event_bus.py
+++ b/lib/crewai/src/crewai/events/event_bus.py
@@ -633,8 +633,9 @@ class CrewAIEventsBus:
                 sync_future = self._sync_executor.submit(
                     ctx.run, self._call_handlers, source, event, sync_handlers, state
                 )
+                self._track_future(sync_future)
                 if not async_handlers:
-                    return self._track_future(sync_future)
+                    return sync_future
 
         if async_handlers:
             return self._track_future(

--- a/lib/crewai/tests/events/test_event_bus_flush.py
+++ b/lib/crewai/tests/events/test_event_bus_flush.py
@@ -1,0 +1,78 @@
+"""Tests for event bus flush() coverage of sync handlers with mixed handler types."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from crewai.events.base_events import BaseEvent
+from crewai.events.event_bus import crewai_event_bus
+
+
+class _FlushProbeEvent(BaseEvent):
+    """Minimal event type used to probe flush() behavior."""
+
+
+class TestFlushWithMixedHandlers:
+    """flush() must wait for sync handlers even when async handlers are registered."""
+
+    def test_flush_waits_for_sync_handler_when_async_handler_registered(self) -> None:
+        """A slow sync handler must finish before flush() returns (regression #6745)."""
+        sync_done = threading.Event()
+
+        with crewai_event_bus.scoped_handlers():
+
+            @crewai_event_bus.on(_FlushProbeEvent)
+            def slow_sync(_: Any, event: _FlushProbeEvent) -> None:
+                time.sleep(0.4)
+                sync_done.set()
+
+            @crewai_event_bus.on(_FlushProbeEvent)
+            async def quick_async(_: Any, event: _FlushProbeEvent) -> None:
+                pass
+
+            crewai_event_bus.emit("source", _FlushProbeEvent(type="flush-probe"))
+
+            ok = crewai_event_bus.flush(timeout=5.0)
+
+        assert ok is True
+        assert sync_done.is_set(), (
+            "flush() returned before the sync handler finished for a mixed event type"
+        )
+
+    def test_flush_waits_for_sync_only_handlers(self) -> None:
+        """The sync-only path still blocks flush() until the handler finishes."""
+        sync_done = threading.Event()
+
+        with crewai_event_bus.scoped_handlers():
+
+            @crewai_event_bus.on(_FlushProbeEvent)
+            def slow_sync(_: Any, event: _FlushProbeEvent) -> None:
+                time.sleep(0.4)
+                sync_done.set()
+
+            crewai_event_bus.emit("source", _FlushProbeEvent(type="flush-probe"))
+
+            ok = crewai_event_bus.flush(timeout=5.0)
+
+        assert ok is True
+        assert sync_done.is_set()
+
+    def test_emit_returns_future_for_mixed_handlers(self) -> None:
+        """emit() still returns the async future for mixed handler types (contract)."""
+        with crewai_event_bus.scoped_handlers():
+
+            @crewai_event_bus.on(_FlushProbeEvent)
+            def slow_sync(_: Any, event: _FlushProbeEvent) -> None:
+                time.sleep(0.4)
+
+            @crewai_event_bus.on(_FlushProbeEvent)
+            async def quick_async(_: Any, event: _FlushProbeEvent) -> None:
+                pass
+
+            future = crewai_event_bus.emit("source", _FlushProbeEvent(type="flush-probe"))
+
+            assert future is not None
+            assert future.result(timeout=2.0) is None
+            assert crewai_event_bus.flush(timeout=5.0) is True

--- a/lib/crewai/tests/events/test_event_bus_flush.py
+++ b/lib/crewai/tests/events/test_event_bus_flush.py
@@ -61,11 +61,13 @@ class TestFlushWithMixedHandlers:
 
     def test_emit_returns_future_for_mixed_handlers(self) -> None:
         """emit() still returns the async future for mixed handler types (contract)."""
+        release_sync = threading.Event()
+
         with crewai_event_bus.scoped_handlers():
 
             @crewai_event_bus.on(_FlushProbeEvent)
             def slow_sync(_: Any, event: _FlushProbeEvent) -> None:
-                time.sleep(0.4)
+                release_sync.wait(timeout=5.0)
 
             @crewai_event_bus.on(_FlushProbeEvent)
             async def quick_async(_: Any, event: _FlushProbeEvent) -> None:
@@ -73,6 +75,13 @@ class TestFlushWithMixedHandlers:
 
             future = crewai_event_bus.emit("source", _FlushProbeEvent(type="flush-probe"))
 
-            assert future is not None
-            assert future.result(timeout=2.0) is None
+            # The async handler is instantaneous, so the returned future must
+            # complete without waiting for the gated sync handler. If emit()
+            # regressed to returning the sync future, this would time out.
+            try:
+                assert future is not None
+                assert future.result(timeout=1.0) is None
+            finally:
+                release_sync.set()
+
             assert crewai_event_bus.flush(timeout=5.0) is True


### PR DESCRIPTION
## Summary

`crewai_event_bus.flush()` returns `True` while a sync handler is still running whenever the event type also has async handlers registered. `emit()` only registered the sync-handler future with `_track_future` in the sync-only branch, so the sync half of a mixed event type was invisible to `flush()` — callers (e.g. crew kickoff finalization, `shutdown(wait=True)`) could proceed or exit with sync handlers unfinished.

Track the sync future unconditionally and return it only in the sync-only case, matching the shape `replay()` already uses. The documented return-value contract is unchanged (sync-only → sync future, mixed/async → async future).

Fixes #6745

## Validation

- Regression test `test_flush_waits_for_sync_handler_when_async_handler_registered`: fails on `main` (`flush()` returns immediately, sync handler unfinished) and passes with the fix
- Sync-only path guarded by `test_flush_waits_for_sync_only_handlers`; mixed-case return contract guarded by `test_emit_returns_future_for_mixed_handlers`
- `pytest lib/crewai/tests/events/ lib/crewai/tests/utilities/events/` → 232 passed
- `ruff check`, `ruff format --check`, `mypy` on changed files → clean

<!-- crewai-require-issue-check -->