### PR TITLE
docs: correct behavior typo in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Follow these guidelines when contributing:
 
 1. Follow Python best practices and idiomatic patterns.
 2. Maintain existing code structure and organization.
-3. Write unit tests for new functionality focusing on behaivor and not
+3. Write unit tests for new functionality focusing on behavior and not
    implementation.
 4. Document public APIs and complex logic.
 5. Suggest changes to the `docs/` folder when appropriate


### PR DESCRIPTION
Corrects a spelling mistake in the contributor guidance.

Documentation-only change; no runtime behavior is affected.

AI-assisted with Codex; I reviewed the diff and confirmed it is documentation-only.