### PR TITLE
fix(brightdata): correct exception message typo

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -590,10 +590,10 @@ class BrightDataDatasetTool(BaseTool):
                 )
             )
         except TimeoutError as e:
-            return f"Timeout Exception occured in method : get_dataset_data_async. Details - {e!s}"
+            return f"Timeout Exception occurred in method : get_dataset_data_async. Details - {e!s}"
         except BrightDataDatasetToolException as e:
             return (
-                f"Exception occured in method : get_dataset_data_async. Details - {e!s}"
+                f"Exception occurred in method : get_dataset_data_async. Details - {e!s}"
             )
         except Exception as e:
             return f"Bright Data API error: {e!s}"


### PR DESCRIPTION
Corrects two misspellings in Bright Data dataset tool exception messages.

This does not change behavior or API surface.

AI-assisted with Codex; I reviewed the diff and ran Ruff on the touched file.