### PR TITLE
fix(guardrails): distinguish execution failure from invalid verdict

### DIFF
--- a/lib/crewai/src/crewai/tasks/llm_guardrail.py
+++ b/lib/crewai/src/crewai/tasks/llm_guardrail.py
@@ -103,13 +103,18 @@ class LLMGuardrail:
 
         Returns:
             Tuple[bool, Any]: A tuple containing:
-                - bool: True if validation passed, False otherwise
-                - Any: The validation result or error message
+                - bool: True if validation passed, False if the guardrail ran
+                  and judged the output invalid
+                - Any: The raw output when valid, the guardrail's feedback
+                  when invalid
 
         Raises:
             HookAborted: A `pre_model_call` hook denied the validation call.
+            GuardrailExecutionError: The guardrail could not run (e.g. the
+                LLM call failed). Not a statement about the output.
         """
         from crewai.hooks.dispatch import HookAborted
+        from crewai.utilities.guardrail_types import GuardrailExecutionError
 
         try:
             result = self._validate_output(task_output)
@@ -122,4 +127,6 @@ class LLMGuardrail:
         except HookAborted:
             raise
         except Exception as e:
-            return False, f"Error while validating the task output: {e!s}"
+            raise GuardrailExecutionError(
+                f"The LLM guardrail could not run: {e!s}"
+            ) from e

--- a/lib/crewai/src/crewai/utilities/guardrail.py
+++ b/lib/crewai/src/crewai/utilities/guardrail.py
@@ -6,7 +6,7 @@ import warnings
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Self
 
-from crewai.utilities.guardrail_types import GuardrailCallable
+from crewai.utilities.guardrail_types import GuardrailCallable, GuardrailExecutionError
 
 
 def serialize_guardrail_for_json(
@@ -145,6 +145,8 @@ def process_guardrail(
         TypeError: If output is not a TaskOutput or LiteAgentOutput
         ValueError: If guardrail is None
         HookAborted: A `pre_model_call` hook denied an LLM-backed guardrail.
+        GuardrailExecutionError: The guardrail could not run; propagated so
+            callers do not mistake it for a validation verdict.
     """
     from crewai.lite_agent_output import LiteAgentOutput
     from crewai.tasks.task_output import TaskOutput
@@ -174,6 +176,23 @@ def process_guardrail(
     except HookAborted as e:
         # a deny ends the validation, so the started event above still needs a
         # terminal one before it leaves
+        crewai_event_bus.emit(
+            event_source,
+            LLMGuardrailCompletedEvent(
+                success=False,
+                result=None,
+                error=str(e),
+                retry_count=retry_count,
+                guardrail_type=started_event.guardrail_type,
+                guardrail_name=started_event.guardrail_name,
+                from_agent=from_agent,
+                from_task=from_task,
+            ),
+        )
+        raise
+    except GuardrailExecutionError as e:
+        # the guardrail could not run at all; the started event still needs a
+        # terminal one, and the error must not become a validation verdict
         crewai_event_bus.emit(
             event_source,
             LLMGuardrailCompletedEvent(

--- a/lib/crewai/src/crewai/utilities/guardrail_types.py
+++ b/lib/crewai/src/crewai/utilities/guardrail_types.py
@@ -16,3 +16,14 @@ GuardrailCallable: TypeAlias = Callable[
 GuardrailType: TypeAlias = GuardrailCallable | str
 
 GuardrailsType: TypeAlias = Sequence[GuardrailType] | GuardrailType
+
+
+class GuardrailExecutionError(Exception):
+    """The guardrail could not run. Not a statement about the output.
+
+    Raised when the validation itself fails (e.g. the LLM call behind an
+    ``LLMGuardrail`` raises), as opposed to the guardrail running and judging
+    the output invalid. Callers must not treat it as a validation verdict:
+    it does not count against ``guardrail_max_retries`` and the error text
+    must not be fed back into the agent's conversation.
+    """

--- a/lib/crewai/tests/test_task_guardrails.py
+++ b/lib/crewai/tests/test_task_guardrails.py
@@ -10,8 +10,10 @@ from crewai.events.event_types import (
 )
 from crewai.llm import LLM
 from crewai.tasks.hallucination_guardrail import HallucinationGuardrail
-from crewai.tasks.llm_guardrail import LLMGuardrail
+from crewai.tasks.llm_guardrail import LLMGuardrail, LLMGuardrailResult
 from crewai.tasks.task_output import TaskOutput
+from crewai.utilities.guardrail import process_guardrail
+from crewai.utilities.guardrail_types import GuardrailExecutionError
 
 
 def create_smart_task(**kwargs):
@@ -309,8 +311,8 @@ def test_guardrail_when_an_error_occurs(sample_agent, task_output):
             side_effect=Exception("Unexpected error"),
         ),
         pytest.raises(
-            Exception,
-            match="Error while validating the task output: Unexpected error",
+            GuardrailExecutionError,
+            match="The LLM guardrail could not run: Unexpected error",
         ),
     ):
         task = create_smart_task(
@@ -321,6 +323,64 @@ def test_guardrail_when_an_error_occurs(sample_agent, task_output):
             guardrail_max_retries=0,
         )
         task.execute_sync(agent=sample_agent)
+
+
+def test_llm_guardrail_outage_raises_execution_error():
+    """An infrastructure failure must not read as a validation verdict.
+
+    The LLM call behind the guardrail raising (provider outage, expired key,
+    rate limit) used to come back as ``(False, "Error while validating...")``,
+    the same shape as a genuine violation, so callers retried the agent on it
+    and finally reported a validation failure that never happened.
+    """
+    guardrail = LLMGuardrail(description="must be under 100 words", llm=Mock(spec=LLM))
+    out = TaskOutput(description="d", agent="a", raw="the agent's answer")
+    outage = RuntimeError("litellm.APIConnectionError: provider unavailable")
+
+    with patch.object(LLMGuardrail, "_validate_output", side_effect=outage):
+        with pytest.raises(GuardrailExecutionError) as exc_info:
+            guardrail(out)
+
+    assert "provider unavailable" in str(exc_info.value)
+    assert exc_info.value.__cause__ is outage
+
+
+def test_llm_guardrail_violation_still_returns_verdict():
+    """A guardrail that runs and judges the output invalid keeps its shape."""
+    guardrail = LLMGuardrail(description="must be under 100 words", llm=Mock(spec=LLM))
+    out = TaskOutput(description="d", agent="a", raw="the agent's answer")
+
+    class FakeOut:
+        pydantic = LLMGuardrailResult(valid=False, feedback="too long by 40 words")
+
+    with patch.object(LLMGuardrail, "_validate_output", return_value=FakeOut()):
+        assert guardrail(out) == (False, "too long by 40 words")
+
+
+def test_process_guardrail_propagates_execution_error_with_terminal_event():
+    """process_guardrail re-raises GuardrailExecutionError and still closes the
+    started event, the same way it does for a hook abort."""
+    out = TaskOutput(description="d", agent="a", raw="the agent's answer")
+    completed: list[LLMGuardrailCompletedEvent] = []
+
+    @crewai_event_bus.on(LLMGuardrailCompletedEvent)
+    def handle_completed(source, event):
+        completed.append(event)
+
+    def failing_guardrail(output):
+        raise GuardrailExecutionError("boom")
+
+    task = Task(description="d", expected_output="o")
+
+    with pytest.raises(GuardrailExecutionError):
+        process_guardrail(
+            output=out, guardrail=failing_guardrail, retry_count=0, event_source=task
+        )
+
+    crewai_event_bus.flush(timeout=10.0)
+    assert len(completed) == 1
+    assert completed[0].success is False
+    assert completed[0].error == "boom"
 
 
 def test_hallucination_guardrail_integration():


### PR DESCRIPTION
> **Note to maintainers:** this PR was authored with AI assistance. Per `.github/CONTRIBUTING.md` it should carry the `llm-generated` label — I cannot apply labels myself, could a maintainer add it? (happy to retitle/annotate as preferred)

## Summary

- `LLMGuardrail.__call__` returned `(False, "Error while validating the task output: ...")` for **any** exception, the exact shape of a genuine guardrail violation
- A provider outage, expired key or rate limit was therefore reported as a verdict about the agent's output: callers retried the agent on it (`guardrail_max_retries`) and finally raised "guardrail failed validation" for a failure that never judged anything
- An LLM failure now raises `GuardrailExecutionError` (new, in `crewai.utilities.guardrail_types`), which propagates out of the retry loops without spending a retry or appending the error to the conversation
- `process_guardrail` emits the terminal `LLMGuardrailCompletedEvent` for it before re-raising, mirroring the existing `HookAborted` handling, so the started event is always closed
- A guardrail that runs and judges the output invalid still returns `(False, feedback)` — that path is unchanged

## Problem

Before, an infrastructure error and a validation verdict were indistinguishable:

```python
# provider outage during the guardrail's own LLM call
guardrail(out)  # (False, 'Error while validating the task output: litellm.APIConnectionError: provider unavailable')

# genuine violation
guardrail(out)  # (False, 'too long by 40 words')
```

Both feed `GuardrailResult(success=False)`, so `Task._process_output` / `Agent._process_kickoff_guardrail` append the text to the conversation, spend retries re-running the agent, and after `guardrail_max_retries` raise a *validation* failure naming feedback that was really an outage.

## Root cause

`LLMGuardrail.__call__`'s blanket `except Exception` mapped "couldn't check" onto "check says it's bad". Plain callable guardrails already propagate exceptions through `process_guardrail` (which only catches `HookAborted`); `LLMGuardrail` was the odd one swallowing them.

## Changes

- `utilities/guardrail_types.py`: new `GuardrailExecutionError` documenting the contract ("the guardrail could not run; not a statement about the output")
- `tasks/llm_guardrail.py`: the blanket except now raises `GuardrailExecutionError("The LLM guardrail could not run: ...") from e` instead of returning a false verdict; `HookAborted` still re-raises untouched
- `utilities/guardrail.py`: `process_guardrail` catches `GuardrailExecutionError`, emits the terminal completed event (`success=False`, real error), re-raises; docstring updated
- `tests/test_task_guardrails.py`:
  - `test_llm_guardrail_outage_raises_execution_error` — outage raises `GuardrailExecutionError` with the cause chained
  - `test_llm_guardrail_violation_still_returns_verdict` — a real violation still returns `(False, feedback)`
  - `test_process_guardrail_propagates_execution_error_with_terminal_event` — re-raise plus terminal event
  - updated `test_guardrail_when_an_error_occurs` (which pinned the old conflation) to expect `GuardrailExecutionError`

## Testing

- [x] `uv run pytest lib/crewai/tests/test_task_guardrails.py -q` — 25 passed (3 new + updated test included)
- [x] New tests fail at the merge base (cannot even import `GuardrailExecutionError`) and pass at the PR tip
- [x] `uv run pytest lib/crewai/tests/hooks/` — 41 passed (2 Windows-only teardown errors from `TemporaryDirectory` SQLite file locks, also present on clean checkout)
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy` on the changed files — clean

Tests not run: the full `uv run pytest lib/crewai/tests/ -x -q` suite (left to CI per time); locally on Windows the repo's default `--block-network` addopt breaks asyncio's socketpair fallback, so async-event tests were run with `-o addopts` overriding it.

## Related issue

Fixes #7150