### PR TITLE
fix(gemini): append synthetic user turn when history ends on model role (#6984)

### DIFF
--- a/lib/crewai/src/crewai/llms/providers/gemini/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/gemini/completion.py
@@ -680,6 +680,15 @@ class GeminiCompletion(BaseLLM):
                 gemini_content = types.Content(role=gemini_role, parts=parts)
                 contents.append(gemini_content)
 
+        # Gemini API rejects requests ending on a model turn (e.g. guardrail retries)
+        if contents and contents[-1].role == "model":
+            contents.append(
+                types.Content(
+                    role="user",
+                    parts=[types.Part.from_text(text="Please continue.")],
+                )
+            )
+
         return contents, system_instruction
 
     def _validate_and_emit_structured_output(

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -1248,3 +1248,18 @@ async def test_non_streaming_async_returns_tool_calls_when_text_also_present():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].function.name == "search"
+
+
+def test_gemini_format_messages_trailing_model_turn_appends_user_turn():
+    from crewai.llms.providers.gemini.completion import GeminiCompletion
+
+    llm = GeminiCompletion(model="gemini/gemini-2.0-flash", api_key="dummy-key")
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Let me think..."},
+    ]
+    contents, system_instruction = llm._format_messages_for_gemini(messages)
+    assert len(contents) == 3
+    assert contents[-1].role == "user"
+    assert contents[-1].parts[0].text == "Please continue."
+


### PR DESCRIPTION
### Summary

Fixes #6984: Ensures message histories formatted for the native Gemini provider (`GeminiCompletion._format_messages_for_gemini`) never end on a `model` turn.

### Problem
When an agent loop triggers a task guardrail retry (`guardrail_max_retries > 0`) or reaches max iterations, the conversation history can end with an assistant message. Gemini's `generate_content` API strictly rejects requests where the final turn has `role="model"`, returning `400 INVALID_ARGUMENT: Requests ending with a model turn are not supported`.

### Solution
Mirrored the existing Mistral/Ollama guard in `LLM._format_messages_for_provider`: if `contents[-1].role == "model"`, append a synthetic trailing user turn (`types.Content(role="user", parts=[types.Part.from_text("Please continue.")])`).

### Testing
- Added unit test `test_gemini_format_messages_trailing_model_turn_appends_user_turn` in `lib/crewai/tests/test_llm.py`.
- Verified message histories ending on assistant turn have the synthetic user turn appended.
