### PR TITLE
fix: bump nltk to 3.10.3 for PYSEC-2026-3726

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -121,11 +121,11 @@ rag = [
 ]
 xml = [
     "unstructured[local-inference, all-docs]>=0.17.2",
-    # unstructured allows nltk>=3.9.2, but <3.10.0 has GHSA-qvv7-cg9c-w4x3
-    # (DNS-rebinding SSRF bypass), GHSA-fg7f-2386-8897 (ReDoS) and
-    # GHSA-xh95-f55m-82fw (path traversal). Declared here, not only as a uv
-    # override, so consumers installing crewai-tools[xml] get the fixed version.
-    "nltk>=3.10.0",
+    # unstructured allows nltk>=3.9.2, but <3.10.3 still has PYSEC-2026-3726
+    # (symlink file read in IPIPANCorpusReader; 3.10.0-3.10.1) plus later
+    # 3.10.2 findings. Declared here, not only as a uv override, so consumers
+    # installing crewai-tools[xml] get the fixed version.
+    "nltk>=3.10.3",
 ]
 oxylabs = [
     "oxylabs==2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,10 @@ exclude-newer-package = { pypdf = "2026-08-07T00:00:00Z", msgpack = "2026-06-20T
 # nltk.pathsec.urlopen), GHSA-fg7f-2386-8897 (ReDoS in ReviewsCorpusReader), and
 # GHSA-xh95-f55m-82fw (path traversal in FramenetCorpusReader.frame); all fixed
 # in 3.10.0. 3.10.0 also clears PYSEC-2026-597, whose last affected version is
-# 3.9.4, so that ignore is no longer needed. Transitive via
+# 3.9.4, so that ignore is no longer needed. 3.10.0-3.10.1 have PYSEC-2026-3726
+# (symlink-based arbitrary file read in IPIPANCorpusReader); fixed in 3.10.2.
+# 3.10.3 also clears later 3.10.2 findings (proxy SSRF, pickle allowlist RCE,
+# JVM option injection, XML entity expansion). Transitive via
 # crewai-tools[xml] -> unstructured.
 # pydantic-settings <2.14.2 has GHSA-4xgf-cpjx-pc3j.
 # h2 <=4.4.0 has GHSA-6hr6-w5qg-qmwg (CVE-2026-71554): duplicate Host headers
@@ -257,7 +260,7 @@ override-dependencies = [
     "msgpack>=1.2.1",
     "pydantic-settings>=2.14.2",
     "setuptools>=83.0.0", # PYSEC-2026-3447
-    "nltk>=3.10.0",
+    "nltk>=3.10.3",
     "h2>=4.4.1",
     "torch>=2.13.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ overrides = [
     { name = "langchain-text-splitters", specifier = ">=1.1.2,<2" },
     { name = "langsmith", specifier = ">=0.8.18,<1" },
     { name = "msgpack", specifier = ">=1.2.1" },
-    { name = "nltk", specifier = ">=3.10.0" },
+    { name = "nltk", specifier = ">=3.10.3" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "openai", specifier = ">=2.30.0,<3" },
     { name = "paramiko", specifier = ">=5.0.0" },
@@ -1772,7 +1772,7 @@ requires-dist = [
     { name = "multion", marker = "extra == 'multion'", specifier = ">=1.1.0" },
     { name = "nest-asyncio", marker = "extra == 'bedrock'", specifier = ">=1.6.0" },
     { name = "nest-asyncio", marker = "extra == 'contextual'", specifier = ">=1.6.0" },
-    { name = "nltk", marker = "extra == 'xml'", specifier = ">=3.10.0" },
+    { name = "nltk", marker = "extra == 'xml'", specifier = ">=3.10.3" },
     { name = "oxylabs", marker = "extra == 'oxylabs'", specifier = "==2.0.0" },
     { name = "patronus", marker = "extra == 'patronus'", specifier = ">=0.0.16" },
     { name = "playwright", marker = "extra == 'bedrock'", specifier = ">=1.52.0" },
@@ -5037,7 +5037,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -5046,9 +5046,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Raise the nltk floor from 3.10.0 to 3.10.3 in the workspace override and `crewai-tools[xml]` extra
- Refresh `uv.lock` so pip-audit no longer reports PYSEC-2026-3726 (symlink file read in IPIPANCorpusReader on 3.10.0–3.10.1)
- Take 3.10.3 rather than 3.10.2 so later 3.10.2 advisories stay cleared as well

## Test plan
- [ ] Vulnerability Scan / pip-audit no longer reports `nltk==3.10.0: PYSEC-2026-3726`
- [ ] `uv.lock` resolves `nltk` 3.10.3