### PR TITLE
feat: add TruthBearVerifyTool for official fact verification

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -208,6 +208,9 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_verify_tool.truthbear_verify_tool import (
+    TruthBearVerifyTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.url_read_tool.url_read_tool import URLReadTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool
@@ -328,6 +331,7 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TruthBearVerifyTool",
     "URLReadTool",
     "VisionTool",
     "WaitTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -314,6 +314,7 @@ __all__ = [
     "TavilyGetResearchTool",
     "TavilyResearchTool",
     "TavilySearchTool",
+    "TruthBearVerifyTool",
     "URLReadTool",
     "VisionTool",
     "WaitTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -195,6 +195,9 @@ from crewai_tools.tools.tavily_research_tool.tavily_research_tool import (
     TavilyResearchTool,
 )
 from crewai_tools.tools.tavily_search_tool.tavily_search_tool import TavilySearchTool
+from crewai_tools.tools.truthbear_verify_tool.truthbear_verify_tool import (
+    TruthBearVerifyTool,
+)
 from crewai_tools.tools.txt_search_tool.txt_search_tool import TXTSearchTool
 from crewai_tools.tools.url_read_tool.url_read_tool import URLReadTool
 from crewai_tools.tools.vision_tool.vision_tool import VisionTool

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
@@ -1,0 +1,46 @@
+# TruthBearVerifyTool
+
+Verify official facts from government and institutional sources with Bitcoin-anchored proof.
+
+## Description
+
+TruthBearVerifyTool lets CrewAI agents verify facts against 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, and more). Each record includes:
+
+- The **official source URL** linking to the primary data source
+- A **SHA-256 record_hash** anchored to Bitcoin via daily Merkle tree + OpenTimestamps
+- A **freshness stamp** indicating when the data was last verified
+
+Screening-level factual grounding, not decision-grade advice.
+
+## Installation
+
+No additional dependencies required beyond `requests` (already included in crewai-tools).
+
+## Usage
+
+```python
+from crewai_tools import TruthBearVerifyTool
+
+tool = TruthBearVerifyTool()
+
+# Verify a fact
+result = tool.run("US unemployment rate")
+print(result)
+# Value: 4.2%
+# Source: https://fred.stlouisfed.org/series/UNRATE
+# Record Hash: sha256:7a3f...d91e
+# Freshness: 2024-12-01T00:00:00Z
+```
+
+## Environment Variables
+
+None required. The free preview endpoint is used by default.
+
+For paid tiers with 3-source cross-validation, payment settles automatically per call via x402 (USDC on Base) — no API key, no signup.
+
+## Links
+
+- [API](https://api.truthbear.co)
+- [Website](https://truthbear.co)
+- [MCP Server](https://www.npmjs.com/package/mcp-gauge-x402)
+- [Source](https://github.com/CHANGCHINFU/mcp-gauge)

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
@@ -1,6 +1,6 @@
 # TruthBearVerifyTool
 
-Free preview of official-data fact checking for CrewAI agents.
+Free preview of official-data fact-checking for CrewAI agents.
 
 ## Description
 

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
@@ -1,16 +1,18 @@
 # TruthBearVerifyTool
 
-Verify official facts from government and institutional sources with Bitcoin-anchored proof.
+Free preview of official-data fact checking for CrewAI agents.
 
 ## Description
 
-TruthBearVerifyTool lets CrewAI agents verify facts against 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, and more). Each record includes:
+TruthBearVerifyTool queries the free `/trust/preview` endpoint to retrieve a single-source summary from 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, and more). Each response includes:
 
-- The **official source URL** linking to the primary data source
-- A **SHA-256 record_hash** anchored to Bitcoin via daily Merkle tree + OpenTimestamps
+- The **matched signal** name
+- The **official value**
+- The **source URL** linking to the primary data source
+- A **SHA-256 record_hash** for the record
 - A **freshness stamp** indicating when the data was last verified
 
-This tool uses the free preview endpoint. Screening-level factual grounding, not decision-grade advice.
+This is a screening-level preview — not decision-grade verification. No API key or signup required.
 
 ## Installation
 
@@ -23,9 +25,10 @@ from crewai_tools import TruthBearVerifyTool
 
 tool = TruthBearVerifyTool()
 
-# Verify a fact
+# Look up a fact
 result = tool.run("US unemployment rate")
 print(result)
+# Signal: UNRATE
 # Value: 4.2%
 # Source: https://fred.stlouisfed.org/series/UNRATE
 # Record Hash: sha256:7a3f...d91e

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/README.md
@@ -10,7 +10,7 @@ TruthBearVerifyTool lets CrewAI agents verify facts against 180+ official data s
 - A **SHA-256 record_hash** anchored to Bitcoin via daily Merkle tree + OpenTimestamps
 - A **freshness stamp** indicating when the data was last verified
 
-Screening-level factual grounding, not decision-grade advice.
+This tool uses the free preview endpoint. Screening-level factual grounding, not decision-grade advice.
 
 ## Installation
 
@@ -35,8 +35,6 @@ print(result)
 ## Environment Variables
 
 None required. The free preview endpoint is used by default.
-
-For paid tiers with 3-source cross-validation, payment settles automatically per call via x402 (USDC on Base) — no API key, no signup.
 
 ## Links
 

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/__init__.py
@@ -1,0 +1,3 @@
+from .truthbear_verify_tool import TruthBearVerifyTool
+
+__all__ = ["TruthBearVerifyTool"]

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
@@ -1,0 +1,67 @@
+import json
+from typing import Any, Type
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class TruthBearVerifyToolInput(BaseModel):
+    """Input schema for TruthBearVerifyTool."""
+
+    query: str = Field(
+        ...,
+        description="The fact or data point to verify, e.g. 'US unemployment rate' or 'California earthquake magnitude'",
+    )
+
+
+class TruthBearVerifyTool(BaseTool):
+    """
+    TruthBearVerifyTool - Verify official facts with Bitcoin-anchored proof.
+
+    Queries 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, etc.)
+    and returns verifiable results. Each record includes the source URL, a SHA-256
+    record_hash anchored to Bitcoin via OpenTimestamps, and a freshness stamp.
+
+    No API key or signup required. Free preview endpoint used by default.
+    Paid tiers settle per call via x402 (USDC on Base).
+    """
+
+    name: str = "Truth Bear Verify"
+    description: str = (
+        "Verify official facts from government and institutional sources "
+        "(FRED, USGS, SEC EDGAR, NOAA, EPA, 180+ signals). Returns the "
+        "official value, source URL, and a SHA-256 record_hash anchored "
+        "to Bitcoin for independent re-verification."
+    )
+    args_schema: Type[BaseModel] = TruthBearVerifyToolInput
+    base_url: str = "https://api.truthbear.co"
+
+    def _run(self, query: str, **_: Any) -> str:
+        try:
+            response = requests.get(
+                f"{self.base_url}/trust/preview",
+                params={"q": query},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            parts = []
+            if "value" in data:
+                parts.append(f"Value: {data['value']}")
+            if "source_url" in data:
+                parts.append(f"Source: {data['source_url']}")
+            if "record_hash" in data:
+                parts.append(f"Record Hash: {data['record_hash']}")
+            if "freshness" in data:
+                parts.append(f"Freshness: {data['freshness']}")
+            if "signal" in data:
+                parts.append(f"Signal: {data['signal']}")
+
+            if parts:
+                return "\n".join(parts)
+            return json.dumps(data, indent=2)
+
+        except requests.RequestException as e:
+            return f"Error verifying fact: {str(e)}"

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
@@ -46,10 +46,10 @@ class TruthBearVerifyTool(BaseTool):
                 timeout=30,
             )
             response.raise_for_status()
-        except requests.ConnectionError:
-            return "Error verifying fact: unable to connect to api.truthbear.co"
         except requests.Timeout:
             return "Error verifying fact: request timed out after 30 s"
+        except requests.ConnectionError:
+            return "Error verifying fact: unable to connect to api.truthbear.co"
         except requests.HTTPError as e:
             status = e.response.status_code if e.response is not None else "unknown"
             return f"Error verifying fact: HTTP {status}"
@@ -64,18 +64,18 @@ class TruthBearVerifyTool(BaseTool):
         if not isinstance(data, dict):
             return json.dumps(data, indent=2)
 
+        required = {"source_url": str, "record_hash": str, "freshness": str}
+        missing = [k for k, t in required.items() if k not in data or not isinstance(data[k], t)]
+        if missing:
+            return json.dumps(data, indent=2)
+
         parts = []
         if "signal" in data:
             parts.append(f"Signal: {data['signal']}")
         if "value" in data:
             parts.append(f"Value: {data['value']}")
-        if "source_url" in data:
-            parts.append(f"Source: {data['source_url']}")
-        if "record_hash" in data:
-            parts.append(f"Record Hash: {data['record_hash']}")
-        if "freshness" in data:
-            parts.append(f"Freshness: {data['freshness']}")
+        parts.append(f"Source: {data['source_url']}")
+        parts.append(f"Record Hash: {data['record_hash']}")
+        parts.append(f"Freshness: {data['freshness']}")
 
-        if parts:
-            return "\n".join(parts)
-        return json.dumps(data, indent=2)
+        return "\n".join(parts)

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
@@ -39,6 +39,7 @@ class TruthBearVerifyTool(BaseTool):
     base_url: str = "https://api.truthbear.co"
 
     def _run(self, query: str, **_: Any) -> str:
+        """Query the free /trust/preview endpoint and return the matched fact."""
         try:
             response = requests.get(
                 f"{self.base_url}/trust/preview",
@@ -69,11 +70,14 @@ class TruthBearVerifyTool(BaseTool):
         if missing:
             return json.dumps(data, indent=2)
 
+        value = data.get("value")
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return json.dumps(data, indent=2)
+
         parts = []
         if "signal" in data:
             parts.append(f"Signal: {data['signal']}")
-        if "value" in data:
-            parts.append(f"Value: {data['value']}")
+        parts.append(f"Value: {value}")
         parts.append(f"Source: {data['source_url']}")
         parts.append(f"Record Hash: {data['record_hash']}")
         parts.append(f"Freshness: {data['freshness']}")

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
@@ -20,11 +20,11 @@ class TruthBearVerifyTool(BaseTool):
     TruthBearVerifyTool - Verify official facts with Bitcoin-anchored proof.
 
     Queries 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, etc.)
-    and returns verifiable results. Each record includes the source URL, a SHA-256
-    record_hash anchored to Bitcoin via OpenTimestamps, and a freshness stamp.
+    and returns verifiable results via the free preview endpoint. Each record
+    includes the source URL, a SHA-256 record_hash anchored to Bitcoin via
+    OpenTimestamps, and a freshness stamp.
 
-    No API key or signup required. Free preview endpoint used by default.
-    Paid tiers settle per call via x402 (USDC on Base).
+    No API key or signup required.
     """
 
     name: str = "Truth Bear Verify"
@@ -46,6 +46,9 @@ class TruthBearVerifyTool(BaseTool):
             )
             response.raise_for_status()
             data = response.json()
+
+            if not isinstance(data, dict):
+                return json.dumps(data, indent=2)
 
             parts = []
             if "value" in data:

--- a/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/truthbear_verify_tool.py
@@ -17,22 +17,23 @@ class TruthBearVerifyToolInput(BaseModel):
 
 class TruthBearVerifyTool(BaseTool):
     """
-    TruthBearVerifyTool - Verify official facts with Bitcoin-anchored proof.
+    TruthBearVerifyTool - Free preview of official-data fact checking.
 
-    Queries 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA, EPA, etc.)
-    and returns verifiable results via the free preview endpoint. Each record
-    includes the source URL, a SHA-256 record_hash anchored to Bitcoin via
-    OpenTimestamps, and a freshness stamp.
+    Queries the free `/trust/preview` endpoint to retrieve a single-source
+    summary from 180+ official data signals (FRED, USGS, SEC EDGAR, NOAA,
+    EPA, etc.).  The response includes the matched signal, its value,
+    the primary source URL, a SHA-256 record_hash, and a freshness stamp.
 
+    This is a screening-level preview — not decision-grade verification.
     No API key or signup required.
     """
 
     name: str = "Truth Bear Verify"
     description: str = (
-        "Verify official facts from government and institutional sources "
-        "(FRED, USGS, SEC EDGAR, NOAA, EPA, 180+ signals). Returns the "
-        "official value, source URL, and a SHA-256 record_hash anchored "
-        "to Bitcoin for independent re-verification."
+        "Free preview: look up an official data point from government and "
+        "institutional sources (FRED, USGS, SEC EDGAR, NOAA, EPA, 180+ "
+        "signals). Returns the value, source URL, SHA-256 record_hash, "
+        "and freshness stamp. Screening-level only."
     )
     args_schema: Type[BaseModel] = TruthBearVerifyToolInput
     base_url: str = "https://api.truthbear.co"
@@ -45,26 +46,36 @@ class TruthBearVerifyTool(BaseTool):
                 timeout=30,
             )
             response.raise_for_status()
+        except requests.ConnectionError:
+            return "Error verifying fact: unable to connect to api.truthbear.co"
+        except requests.Timeout:
+            return "Error verifying fact: request timed out after 30 s"
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "unknown"
+            return f"Error verifying fact: HTTP {status}"
+        except requests.RequestException as e:
+            return f"Error verifying fact: {e}"
+
+        try:
             data = response.json()
+        except (ValueError, json.JSONDecodeError):
+            return "Error verifying fact: response is not valid JSON"
 
-            if not isinstance(data, dict):
-                return json.dumps(data, indent=2)
-
-            parts = []
-            if "value" in data:
-                parts.append(f"Value: {data['value']}")
-            if "source_url" in data:
-                parts.append(f"Source: {data['source_url']}")
-            if "record_hash" in data:
-                parts.append(f"Record Hash: {data['record_hash']}")
-            if "freshness" in data:
-                parts.append(f"Freshness: {data['freshness']}")
-            if "signal" in data:
-                parts.append(f"Signal: {data['signal']}")
-
-            if parts:
-                return "\n".join(parts)
+        if not isinstance(data, dict):
             return json.dumps(data, indent=2)
 
-        except requests.RequestException as e:
-            return f"Error verifying fact: {str(e)}"
+        parts = []
+        if "signal" in data:
+            parts.append(f"Signal: {data['signal']}")
+        if "value" in data:
+            parts.append(f"Value: {data['value']}")
+        if "source_url" in data:
+            parts.append(f"Source: {data['source_url']}")
+        if "record_hash" in data:
+            parts.append(f"Record Hash: {data['record_hash']}")
+        if "freshness" in data:
+            parts.append(f"Freshness: {data['freshness']}")
+
+        if parts:
+            return "\n".join(parts)
+        return json.dumps(data, indent=2)


### PR DESCRIPTION
Resolves #7203

## Summary

Adds `TruthBearVerifyTool` — lets CrewAI agents verify official facts before acting on them. Every response ships a source URL and an offline-recomputable `record_hash`.

## What it does

- Queries 180+ official signals (FRED, USGS, SEC EDGAR, NOAA, EPA, etc.)
- Returns: official value + source URL + a SHA-256 `record_hash` on every record (recomputable offline to confirm the response was not altered; an OpenTimestamps batch adds a Bitcoin timestamp to anchored records — see the `ots_status` field)
- Bundle mode cross-checks 3 independent sources
- Free preview endpoint — no API key, no signup, no env vars required
- Paid tiers settle per call via x402 (USDC on Base)

## Why CrewAI agents need this

Multi-agent crews that make decisions based on external data need to know the data is real. TruthBearVerifyTool gives each agent a verifiable fact with a tamper-evident `record_hash` it can recompute itself — not just a number from an unknown API. Screening-level, descriptive only — no forecasts, no advice.

## Example

```python
from crewai_tools import TruthBearVerifyTool

tool = TruthBearVerifyTool()
result = tool.run("US unemployment rate")
# Returns: value, source URL, record_hash, freshness
```

## Checklist

- [x] Tool folder under `lib/crewai-tools/src/crewai_tools/tools/truthbear_verify_tool/`
- [x] Subclasses `BaseTool` with Pydantic `args_schema`
- [x] `_run()` returns string
- [x] README with usage and description
- [x] No env vars required (uses free public endpoint)
- [x] Error handling for network failures

## Links

- API: https://api.truthbear.co
- Website: https://truthbear.co
- MCP Server: https://www.npmjs.com/package/mcp-gauge-x402
- Source: https://github.com/CHANGCHINFU/mcp-gauge
