### PR TITLE
Fix summarization chunk token overhead

### DIFF
--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -948,6 +948,11 @@ def _estimate_message_summary_tokens(msg: LLMMessage) -> int:
     return _estimate_token_count(_format_messages_for_summary([msg]))
 
 
+def _estimate_chunk_summary_tokens(chunk: list[LLMMessage]) -> int:
+    """Estimate tokens for a complete rendered summary chunk."""
+    return _estimate_token_count(_format_messages_for_summary(chunk))
+
+
 def _split_text_by_token_limit(text: str, max_tokens: int) -> list[str]:
     """Split text into parts each estimated to fit within max_tokens."""
     if not text:
@@ -962,24 +967,31 @@ def _split_text_by_token_limit(text: str, max_tokens: int) -> list[str]:
 
 def _expand_oversized_message(msg: LLMMessage, max_tokens: int) -> list[LLMMessage]:
     """Split a message whose content alone exceeds max_tokens into sub-messages."""
-    msg_text = message_content_text(msg)
-    if _estimate_token_count(msg_text) <= max_tokens:
+    if _estimate_message_summary_tokens(msg) <= max_tokens:
         return [msg]
 
-    # Reserve budget for the [Part i/n] prefix and summary role label.
-    summary_label_tokens = _estimate_message_summary_tokens({**msg, "content": ""})
-    body_max_tokens = max(1, max_tokens - 5 - summary_label_tokens)
-    parts = _split_text_by_token_limit(msg_text, body_max_tokens)
-    total_parts = len(parts)
-    expanded: list[LLMMessage] = []
+    msg_text = message_content_text(msg)
+    if not msg_text:
+        return [msg]
 
-    for index, part in enumerate(parts, start=1):
-        part_content = (
-            f"[Part {index}/{total_parts}]\n{part}" if total_parts > 1 else part
-        )
-        expanded.append({**msg, "content": part_content})
+    body_max_tokens = max_tokens
+    while body_max_tokens > 0:
+        parts = _split_text_by_token_limit(msg_text, body_max_tokens)
+        total_parts = len(parts)
+        expanded: list[LLMMessage] = []
 
-    return expanded
+        for index, part in enumerate(parts, start=1):
+            part_content = (
+                f"[Part {index}/{total_parts}]\n{part}" if total_parts > 1 else part
+            )
+            expanded.append({**msg, "content": part_content})
+
+        if all(_estimate_message_summary_tokens(part) <= max_tokens for part in expanded):
+            return expanded
+
+        body_max_tokens -= 1
+
+    return [msg]
 
 
 def _normalize_messages_for_chunking(
@@ -1015,18 +1027,16 @@ def _split_messages_into_chunks(
 
     chunks: list[list[LLMMessage]] = []
     current_chunk: list[LLMMessage] = []
-    current_tokens = 0
 
     for msg in normalized:
-        msg_tokens = _estimate_message_summary_tokens(msg)
+        candidate_chunk = [*current_chunk, msg]
+        candidate_tokens = _estimate_chunk_summary_tokens(candidate_chunk)
 
-        if current_chunk and (current_tokens + msg_tokens) > max_tokens:
+        if current_chunk and candidate_tokens > max_tokens:
             chunks.append(current_chunk)
             current_chunk = []
-            current_tokens = 0
 
         current_chunk.append(msg)
-        current_tokens += msg_tokens
 
     if current_chunk:
         chunks.append(current_chunk)
@@ -1058,6 +1068,9 @@ def _summarization_prompt_overhead_tokens() -> int:
         + _estimate_token_count(
             I18N_DEFAULT.slice("summarize_instruction").format(conversation="")
         )
+        # Estimating the empty wrapper and conversation separately can lose
+        # one token to integer-division rounding when they are joined.
+        + 1
     )
 
 
@@ -1129,10 +1142,14 @@ def summarize_messages(
     if not non_system_messages:
         return
 
-    max_tokens = max(
-        1, llm.get_context_window_size() - _summarization_prompt_overhead_tokens()
+    available_content_tokens = (
+        llm.get_context_window_size() - _summarization_prompt_overhead_tokens()
     )
-    chunks = _split_messages_into_chunks(non_system_messages, max_tokens)
+    chunks = (
+        _split_messages_into_chunks(non_system_messages, available_content_tokens)
+        if available_content_tokens > 0
+        else [non_system_messages]
+    )
 
     total_chunks = len(chunks)
 

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -893,51 +893,6 @@ def message_content_text(msg: LLMMessage) -> str:
     return str(content)
 
 
-def _split_text_by_token_limit(text: str, max_tokens: int) -> list[str]:
-    """Split text into parts each estimated to fit within max_tokens."""
-    if not text:
-        return []
-    if _estimate_token_count(text) <= max_tokens:
-        return [text]
-
-    # Inverse of _estimate_token_count (len // 4): each slice is at most max_tokens.
-    max_chars = max(1, max_tokens * 4)
-    return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
-
-
-def _expand_oversized_message(msg: LLMMessage, max_tokens: int) -> list[LLMMessage]:
-    """Split a message whose content alone exceeds max_tokens into sub-messages."""
-    msg_text = message_content_text(msg)
-    if _estimate_token_count(msg_text) <= max_tokens:
-        return [msg]
-
-    # Reserve budget for the [Part i/n] prefix added to each sub-message.
-    body_max_tokens = max(1, max_tokens - 5)
-    parts = _split_text_by_token_limit(msg_text, body_max_tokens)
-    total_parts = len(parts)
-    expanded: list[LLMMessage] = []
-
-    for index, part in enumerate(parts, start=1):
-        part_content = (
-            f"[Part {index}/{total_parts}]\n{part}" if total_parts > 1 else part
-        )
-        expanded.append({**msg, "content": part_content})
-
-    return expanded
-
-
-def _normalize_messages_for_chunking(
-    messages: list[LLMMessage], max_tokens: int
-) -> list[LLMMessage]:
-    """Return non-system messages with oversized entries split to fit max_tokens."""
-    normalized: list[LLMMessage] = []
-    for msg in messages:
-        if msg.get("role") == "system":
-            continue
-        normalized.extend(_expand_oversized_message(msg, max_tokens))
-    return normalized
-
-
 def _format_messages_for_summary(messages: list[LLMMessage]) -> str:
     """Format messages with role labels for summarization.
 
@@ -988,6 +943,57 @@ def _format_messages_for_summary(messages: list[LLMMessage]) -> str:
     return "\n\n".join(lines)
 
 
+def _estimate_message_summary_tokens(msg: LLMMessage) -> int:
+    """Estimate tokens for a message after summary formatting."""
+    return _estimate_token_count(_format_messages_for_summary([msg]))
+
+
+def _split_text_by_token_limit(text: str, max_tokens: int) -> list[str]:
+    """Split text into parts each estimated to fit within max_tokens."""
+    if not text:
+        return []
+    if _estimate_token_count(text) <= max_tokens:
+        return [text]
+
+    # Inverse of _estimate_token_count (len // 4): each slice is at most max_tokens.
+    max_chars = max(1, max_tokens * 4)
+    return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+
+
+def _expand_oversized_message(msg: LLMMessage, max_tokens: int) -> list[LLMMessage]:
+    """Split a message whose content alone exceeds max_tokens into sub-messages."""
+    msg_text = message_content_text(msg)
+    if _estimate_token_count(msg_text) <= max_tokens:
+        return [msg]
+
+    # Reserve budget for the [Part i/n] prefix and summary role label.
+    summary_label_tokens = _estimate_message_summary_tokens({**msg, "content": ""})
+    body_max_tokens = max(1, max_tokens - 5 - summary_label_tokens)
+    parts = _split_text_by_token_limit(msg_text, body_max_tokens)
+    total_parts = len(parts)
+    expanded: list[LLMMessage] = []
+
+    for index, part in enumerate(parts, start=1):
+        part_content = (
+            f"[Part {index}/{total_parts}]\n{part}" if total_parts > 1 else part
+        )
+        expanded.append({**msg, "content": part_content})
+
+    return expanded
+
+
+def _normalize_messages_for_chunking(
+    messages: list[LLMMessage], max_tokens: int
+) -> list[LLMMessage]:
+    """Return non-system messages with oversized entries split to fit max_tokens."""
+    normalized: list[LLMMessage] = []
+    for msg in messages:
+        if msg.get("role") == "system":
+            continue
+        normalized.extend(_expand_oversized_message(msg, max_tokens))
+    return normalized
+
+
 def _split_messages_into_chunks(
     messages: list[LLMMessage], max_tokens: int
 ) -> list[list[LLMMessage]]:
@@ -1012,7 +1018,7 @@ def _split_messages_into_chunks(
     current_tokens = 0
 
     for msg in normalized:
-        msg_tokens = _estimate_token_count(message_content_text(msg))
+        msg_tokens = _estimate_message_summary_tokens(msg)
 
         if current_chunk and (current_tokens + msg_tokens) > max_tokens:
             chunks.append(current_chunk)
@@ -1043,6 +1049,16 @@ def _extract_summary_tags(text: str) -> str:
     if match:
         return match.group(1).strip()
     return text.strip()
+
+
+def _summarization_prompt_overhead_tokens() -> int:
+    """Estimate fixed tokens added around each chunk during summarization."""
+    return (
+        _estimate_token_count(I18N_DEFAULT.slice("summarizer_system_message"))
+        + _estimate_token_count(
+            I18N_DEFAULT.slice("summarize_instruction").format(conversation="")
+        )
+    )
 
 
 async def _asummarize_chunks(
@@ -1113,7 +1129,9 @@ def summarize_messages(
     if not non_system_messages:
         return
 
-    max_tokens = llm.get_context_window_size()
+    max_tokens = max(
+        1, llm.get_context_window_size() - _summarization_prompt_overhead_tokens()
+    )
     chunks = _split_messages_into_chunks(non_system_messages, max_tokens)
 
     total_chunks = len(chunks)

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -20,6 +20,7 @@ from crewai.tools.base_tool import BaseTool
 from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
 from crewai.utilities.agent_utils import (
     _asummarize_chunks,
+    _estimate_chunk_summary_tokens,
     _estimate_token_count,
     _expand_oversized_message,
     _extract_summary_tags,
@@ -708,10 +709,7 @@ class TestSplitMessagesIntoChunks:
         chunks = _split_messages_into_chunks(messages, max_tokens=max_tokens)
         assert len(chunks) > 1
         for chunk in chunks:
-            chunk_tokens = sum(
-                _estimate_token_count(message_content_text(msg)) for msg in chunk
-            )
-            assert chunk_tokens <= max_tokens
+            assert _estimate_chunk_summary_tokens(chunk) <= max_tokens
 
     def test_oversized_tool_in_conversation(self) -> None:
         messages: list[dict[str, Any]] = [
@@ -723,10 +721,36 @@ class TestSplitMessagesIntoChunks:
         chunks = _split_messages_into_chunks(messages, max_tokens=max_tokens)
         assert len(chunks) > 1
         for chunk in chunks:
-            chunk_tokens = sum(
-                _estimate_token_count(message_content_text(msg)) for msg in chunk
-            )
-            assert chunk_tokens <= max_tokens
+            assert _estimate_chunk_summary_tokens(chunk) <= max_tokens
+
+    def test_chunk_budget_includes_rendered_separators(self) -> None:
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "a" * 4},
+            {"role": "user", "content": "b" * 4},
+        ]
+
+        chunks = _split_messages_into_chunks(messages, max_tokens=4)
+
+        assert len(chunks) == 2
+        assert all(_estimate_chunk_summary_tokens(chunk) <= 4 for chunk in chunks)
+
+    def test_tool_call_rendering_counts_toward_chunk_budget(self) -> None:
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"function": {"name": "x" * 80, "arguments": "{}"}},
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+
+        chunks = _split_messages_into_chunks(messages, max_tokens=10)
+
+        assert len(chunks) == 2
+        assert _estimate_chunk_summary_tokens(chunks[0]) > 10
+        assert _estimate_chunk_summary_tokens(chunks[1]) <= 10
 
     def test_rendered_summarization_request_within_raw_context_window(self) -> None:
         """Chunked payloads plus summarization prompt fit in the raw model limit.
@@ -779,6 +803,23 @@ class TestSplitMessagesIntoChunks:
         assert request_token_counts
         assert max(request_token_counts) <= context_window
         assert min(request_token_counts) > _summarization_prompt_overhead_tokens()
+
+    def test_summarize_messages_uses_single_attempt_when_no_content_budget(
+        self,
+    ) -> None:
+        context_window = _summarization_prompt_overhead_tokens()
+        messages: list[dict[str, Any]] = [
+            {"role": "tool", "content": "Z" * 400, "name": "search"},
+        ]
+
+        mock_llm = MagicMock()
+        mock_llm.get_context_window_size.return_value = context_window
+        mock_llm.call.return_value = "<summary>chunk summary</summary>"
+
+        summarize_messages(messages=messages, llm=mock_llm, callbacks=[], verbose=False)
+
+        mock_llm.call.assert_called_once()
+        mock_llm.acall.assert_not_called()
 
 
 class TestMessageContentText:

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -28,6 +28,7 @@ from crewai.utilities.agent_utils import (
     _normalize_messages_for_chunking,
     _split_messages_into_chunks,
     _split_text_by_token_limit,
+    _summarization_prompt_overhead_tokens,
     format_message_for_llm,
     convert_tools_to_openai_schema,
     execute_single_native_tool_call,
@@ -748,6 +749,37 @@ class TestSplitMessagesIntoChunks:
             request_tokens = _estimate_summarization_request_tokens(chunk)
             assert request_tokens <= raw_context_limit
 
+    def test_summarize_messages_subtracts_prompt_overhead_from_chunk_budget(
+        self,
+    ) -> None:
+        context_window = 850
+        messages: list[dict[str, Any]] = [
+            {"role": "tool", "content": "Z" * (context_window * 4), "name": "search"},
+        ]
+        request_token_counts: list[int] = []
+
+        async def _assert_request_fits_context_window(
+            summarization_messages: list[dict[str, Any]], **kwargs: Any
+        ) -> str:
+            request_tokens = sum(
+                _estimate_token_count(str(message.get("content", "")))
+                for message in summarization_messages
+            )
+            request_token_counts.append(request_tokens)
+            assert request_tokens <= context_window
+            return "<summary>chunk summary</summary>"
+
+        mock_llm = MagicMock()
+        mock_llm.get_context_window_size.return_value = context_window
+        mock_llm.acall = AsyncMock(side_effect=_assert_request_fits_context_window)
+
+        summarize_messages(messages=messages, llm=mock_llm, callbacks=[], verbose=False)
+
+        assert mock_llm.acall.await_count > 1
+        assert request_token_counts
+        assert max(request_token_counts) <= context_window
+        assert min(request_token_counts) > _summarization_prompt_overhead_tokens()
+
 
 class TestMessageContentText:
     """Tests for message_content_text helper."""
@@ -925,8 +957,9 @@ class TestParallelSummarization:
     def _make_messages_for_n_chunks(self, n: int) -> list[dict[str, Any]]:
         """Build a message list that will produce exactly *n* chunks.
 
-        Each message has 400 chars (~100 tokens). With max_tokens=100 returned
-        by the mock LLM, each message lands in its own chunk.
+        Each message has 400 chars (~100 tokens). With the mock LLM's
+        context window leaving just over 100 content tokens after
+        summarization overhead, each message lands in its own chunk.
         """
         msgs: list[dict[str, Any]] = []
         for i in range(n):
@@ -941,7 +974,9 @@ class TestParallelSummarization:
         messages = self._make_messages_for_n_chunks(3)
 
         mock_llm = MagicMock()
-        mock_llm.get_context_window_size.return_value = 100
+        mock_llm.get_context_window_size.return_value = (
+            _summarization_prompt_overhead_tokens() + 125
+        )
         mock_llm.acall = AsyncMock(
             side_effect=[
                 "<summary>Summary chunk 1</summary>",
@@ -989,7 +1024,9 @@ class TestParallelSummarization:
         messages = self._make_messages_for_n_chunks(3)
 
         mock_llm = MagicMock()
-        mock_llm.get_context_window_size.return_value = 100
+        mock_llm.get_context_window_size.return_value = (
+            _summarization_prompt_overhead_tokens() + 125
+        )
 
         # Simulate varying latencies — chunk 2 finishes before chunk 0
         async def _delayed_acall(msgs: Any, **kwargs: Any) -> str:
@@ -1051,7 +1088,9 @@ class TestParallelSummarization:
         messages = self._make_messages_for_n_chunks(2)
 
         mock_llm = MagicMock()
-        mock_llm.get_context_window_size.return_value = 100
+        mock_llm.get_context_window_size.return_value = (
+            _summarization_prompt_overhead_tokens() + 125
+        )
         mock_llm.acall = AsyncMock(
             side_effect=[
                 "<summary>Flow summary 1</summary>",


### PR DESCRIPTION
## Summary
- subtract fixed summarizer prompt overhead from the chunk budget before splitting messages
- estimate chunk sizes using the formatted summary text, including role labels
- add a regression test that asserts every chunked summarization request stays within the LLM context budget

Fixes #7170

## Tests
- uv run pytest lib/crewai/tests/utilities/test_agent_utils.py::TestSplitMessagesIntoChunks lib/crewai/tests/utilities/test_agent_utils.py::TestExpandOversizedMessage lib/crewai/tests/utilities/test_agent_utils.py::TestNormalizeMessagesForChunking lib/crewai/tests/utilities/test_agent_utils.py::TestParallelSummarization -q -o addopts=
- uv run ruff check lib/crewai/src/crewai/utilities/agent_utils.py lib/crewai/tests/utilities/test_agent_utils.py