### PR TITLE
feat: add MadeOnSol tools (Solana KOL tracking, deployer intel, token risk)

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -68,6 +68,9 @@ scrapegraph-py = [
 linkup-sdk = [
     "linkup-sdk>=0.2.2",
 ]
+madeonsol-x402 = [
+    "madeonsol-x402>=1.28.1",
+]
 tavily-python = [
     "tavily-python~=0.7.14",
 ]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -111,6 +111,13 @@ from crewai_tools.tools.jina_scrape_website_tool.jina_scrape_website_tool import
 from crewai_tools.tools.json_search_tool.json_search_tool import JSONSearchTool
 from crewai_tools.tools.linkup.linkup_search_tool import LinkupSearchTool
 from crewai_tools.tools.llamaindex_tool.llamaindex_tool import LlamaIndexTool
+from crewai_tools.tools.madeonsol_tool.madeonsol_tool import (
+    MadeOnSolDeployerAlertsTool,
+    MadeOnSolKolCoordinationTool,
+    MadeOnSolKolFeedTool,
+    MadeOnSolKolLeaderboardTool,
+    MadeOnSolTokenRiskTool,
+)
 from crewai_tools.tools.mdx_search_tool.mdx_search_tool import MDXSearchTool
 from crewai_tools.tools.merge_agent_handler_tool.merge_agent_handler_tool import (
     MergeAgentHandlerTool,
@@ -283,6 +290,11 @@ __all__ = [
     "LlamaIndexTool",
     "MCPServerAdapter",
     "MDXSearchTool",
+    "MadeOnSolDeployerAlertsTool",
+    "MadeOnSolKolCoordinationTool",
+    "MadeOnSolKolFeedTool",
+    "MadeOnSolKolLeaderboardTool",
+    "MadeOnSolTokenRiskTool",
     "MergeAgentHandlerTool",
     "MongoDBVectorSearchConfig",
     "MongoDBVectorSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -100,6 +100,13 @@ from crewai_tools.tools.jina_scrape_website_tool.jina_scrape_website_tool import
 from crewai_tools.tools.json_search_tool.json_search_tool import JSONSearchTool
 from crewai_tools.tools.linkup.linkup_search_tool import LinkupSearchTool
 from crewai_tools.tools.llamaindex_tool.llamaindex_tool import LlamaIndexTool
+from crewai_tools.tools.madeonsol_tool.madeonsol_tool import (
+    MadeOnSolDeployerAlertsTool,
+    MadeOnSolKolCoordinationTool,
+    MadeOnSolKolFeedTool,
+    MadeOnSolKolLeaderboardTool,
+    MadeOnSolTokenRiskTool,
+)
 from crewai_tools.tools.mdx_search_tool.mdx_search_tool import MDXSearchTool
 from crewai_tools.tools.merge_agent_handler_tool.merge_agent_handler_tool import (
     MergeAgentHandlerTool,
@@ -266,6 +273,11 @@ __all__ = [
     "LinkupSearchTool",
     "LlamaIndexTool",
     "MDXSearchTool",
+    "MadeOnSolDeployerAlertsTool",
+    "MadeOnSolKolCoordinationTool",
+    "MadeOnSolKolFeedTool",
+    "MadeOnSolKolLeaderboardTool",
+    "MadeOnSolTokenRiskTool",
     "MergeAgentHandlerTool",
     "MongoDBToolSchema",
     "MongoDBVectorSearchConfig",

--- a/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/README.md
@@ -1,0 +1,46 @@
+# MadeOnSol Tools
+
+## Description
+
+Tools for Solana trading intelligence via the [MadeOnSol API](https://madeonsol.com/api-docs):
+
+- **MadeOnSolKolFeedTool** — latest trades from 2,000+ tracked Solana KOL (influencer) wallets.
+- **MadeOnSolKolLeaderboardTool** — KOL performance rankings by realized PnL and win rate.
+- **MadeOnSolKolCoordinationTool** — convergence signals: tokens multiple KOLs are buying in the same window.
+- **MadeOnSolDeployerAlertsTool** — Pump.fun launch alerts enriched with the deployer's historical track record.
+- **MadeOnSolTokenRiskTool** — token risk assessment (deployer reputation, sniper/bundler concentration, holder distribution).
+
+## Installation
+
+```shell
+uv add crewai-tools madeonsol-x402
+```
+
+## Authentication
+
+Either of:
+
+- `MADEONSOL_API_KEY` — an `msk_` API key. A free tier (200 requests/day) is available at [madeonsol.com/pricing](https://madeonsol.com/pricing); free-tier live feeds are delayed 5 minutes, paid tiers are real-time.
+- `SVM_PRIVATE_KEY` — a Solana private key for keyless [x402](https://madeonsol.com/x402) pay-per-call micropayments in USDC ($0.005–$0.02 per request, always real-time). No signup needed.
+
+## Example
+
+```python
+from crewai import Agent
+from crewai_tools import (
+    MadeOnSolKolFeedTool,
+    MadeOnSolKolCoordinationTool,
+    MadeOnSolTokenRiskTool,
+)
+
+analyst = Agent(
+    role="Solana Market Analyst",
+    goal="Find tokens that profitable KOLs are converging on and assess their risk",
+    backstory="An on-chain analyst tracking smart-money wallets on Solana.",
+    tools=[
+        MadeOnSolKolFeedTool(),
+        MadeOnSolKolCoordinationTool(),
+        MadeOnSolTokenRiskTool(),
+    ],
+)
+```

--- a/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/__init__.py
@@ -1,0 +1,15 @@
+from crewai_tools.tools.madeonsol_tool.madeonsol_tool import (
+    MadeOnSolDeployerAlertsTool,
+    MadeOnSolKolCoordinationTool,
+    MadeOnSolKolFeedTool,
+    MadeOnSolKolLeaderboardTool,
+    MadeOnSolTokenRiskTool,
+)
+
+__all__ = [
+    "MadeOnSolDeployerAlertsTool",
+    "MadeOnSolKolCoordinationTool",
+    "MadeOnSolKolFeedTool",
+    "MadeOnSolKolLeaderboardTool",
+    "MadeOnSolTokenRiskTool",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/madeonsol_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/madeonsol_tool/madeonsol_tool.py
@@ -1,0 +1,193 @@
+"""MadeOnSol tools — Solana & Robinhood Chain trading intelligence.
+
+Wraps the `madeonsol-x402` SDK (https://pypi.org/project/madeonsol-x402/) to
+give agents access to MadeOnSol's KOL wallet tracking (2,000+ tracked wallets),
+Pump.fun deployer intelligence, and token risk scoring.
+
+Auth is either of:
+- ``MADEONSOL_API_KEY`` — an ``msk_`` API key (free tier available at
+  https://madeonsol.com/pricing; free-tier live feeds are delayed 5 minutes,
+  paid tiers are real-time).
+- ``SVM_PRIVATE_KEY`` — a Solana private key for keyless x402 pay-per-call
+  micropayments in USDC ($0.005-$0.02 per request, always real-time).
+"""
+
+import json
+import os
+from typing import Any, List, Optional, Type
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+
+try:
+    from madeonsol_x402 import MadeOnSolClient
+
+    MADEONSOL_AVAILABLE = True
+except ImportError:
+    MADEONSOL_AVAILABLE = False
+    MadeOnSolClient = Any
+
+
+def _make_client() -> "MadeOnSolClient":
+    """Build a client from env vars. Priority: MADEONSOL_API_KEY > SVM_PRIVATE_KEY."""
+    if not MADEONSOL_AVAILABLE:
+        raise ImportError(
+            "madeonsol-x402 is not installed. Install it with: "
+            "uv add madeonsol-x402  (or pip install madeonsol-x402)"
+        )
+    api_key = os.environ.get("MADEONSOL_API_KEY", "")
+    private_key = os.environ.get("SVM_PRIVATE_KEY", "")
+    if api_key:
+        return MadeOnSolClient(api_key=api_key)
+    if private_key:
+        return MadeOnSolClient(private_key=private_key)
+    raise ValueError(
+        "Set MADEONSOL_API_KEY (free key at https://madeonsol.com/pricing) or "
+        "SVM_PRIVATE_KEY (x402 pay-per-call) to use the MadeOnSol tools."
+    )
+
+
+_MADEONSOL_ENV_VARS: List[EnvVar] = [
+    EnvVar(
+        name="MADEONSOL_API_KEY",
+        description="MadeOnSol API key (msk_...). Free tier at https://madeonsol.com/pricing.",
+        required=False,
+    ),
+    EnvVar(
+        name="SVM_PRIVATE_KEY",
+        description="Solana private key for keyless x402 pay-per-call (USDC micropayments). Alternative to MADEONSOL_API_KEY.",
+        required=False,
+    ),
+]
+
+
+class MadeOnSolKolFeedToolSchema(BaseModel):
+    """Input for MadeOnSolKolFeedTool."""
+
+    limit: int = Field(default=10, description="Number of trades to return (1-100).")
+    action: Optional[str] = Field(
+        default=None, description="Optional filter: 'buy' or 'sell'."
+    )
+
+
+class MadeOnSolKolFeedTool(BaseTool):
+    """Live Solana KOL (key opinion leader) trade feed from MadeOnSol."""
+
+    name: str = "MadeOnSol KOL Feed"
+    description: str = (
+        "Get the latest Solana KOL trades from 2,000+ tracked influencer wallets. "
+        "Returns token, side, SOL amount, price, and the KOL's identity per trade."
+    )
+    args_schema: Type[BaseModel] = MadeOnSolKolFeedToolSchema
+    env_vars: List[EnvVar] = _MADEONSOL_ENV_VARS
+    package_dependencies: List[str] = Field(default_factory=lambda: ["madeonsol-x402"])
+
+    def _run(self, limit: int = 10, action: Optional[str] = None) -> str:
+        data = _make_client().kol_feed(limit=limit, action=action)
+        return json.dumps(data, indent=2)
+
+
+class MadeOnSolKolLeaderboardToolSchema(BaseModel):
+    """Input for MadeOnSolKolLeaderboardTool."""
+
+    period: str = Field(
+        default="7d", description="Time period: today, 7d, 30d, 90d, or 180d."
+    )
+    limit: int = Field(default=10, description="Number of KOLs to return (1-50).")
+
+
+class MadeOnSolKolLeaderboardTool(BaseTool):
+    """Solana KOL performance rankings from MadeOnSol."""
+
+    name: str = "MadeOnSol KOL Leaderboard"
+    description: str = (
+        "Get Solana KOL performance rankings by realized PnL and win rate over a "
+        "chosen period. Useful for finding which influencer wallets are actually profitable."
+    )
+    args_schema: Type[BaseModel] = MadeOnSolKolLeaderboardToolSchema
+    env_vars: List[EnvVar] = _MADEONSOL_ENV_VARS
+    package_dependencies: List[str] = Field(default_factory=lambda: ["madeonsol-x402"])
+
+    def _run(self, period: str = "7d", limit: int = 10) -> str:
+        data = _make_client().kol_leaderboard(period=period, limit=limit)
+        return json.dumps(data, indent=2)
+
+
+class MadeOnSolKolCoordinationToolSchema(BaseModel):
+    """Input for MadeOnSolKolCoordinationTool."""
+
+    period: str = Field(default="24h", description="Time period: 1h, 6h, 24h, or 7d.")
+    min_kols: int = Field(
+        default=3, description="Minimum number of KOLs converging on a token (2-50)."
+    )
+
+
+class MadeOnSolKolCoordinationTool(BaseTool):
+    """KOL convergence signals — tokens multiple KOLs are accumulating."""
+
+    name: str = "MadeOnSol KOL Coordination"
+    description: str = (
+        "Get KOL convergence signals: tokens that multiple tracked KOL wallets are "
+        "buying in the same window, with per-token KOL lists and buy totals."
+    )
+    args_schema: Type[BaseModel] = MadeOnSolKolCoordinationToolSchema
+    env_vars: List[EnvVar] = _MADEONSOL_ENV_VARS
+    package_dependencies: List[str] = Field(default_factory=lambda: ["madeonsol-x402"])
+
+    def _run(self, period: str = "24h", min_kols: int = 3) -> str:
+        data = _make_client().kol_coordination(period=period, min_kols=min_kols)
+        return json.dumps(data, indent=2)
+
+
+class MadeOnSolDeployerAlertsToolSchema(BaseModel):
+    """Input for MadeOnSolDeployerAlertsTool."""
+
+    limit: int = Field(default=10, description="Number of alerts to return (1-100).")
+    tier: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional deployer-tier filter: elite, good, moderate, rising, or cold "
+            "(paid MadeOnSol tiers only)."
+        ),
+    )
+
+
+class MadeOnSolDeployerAlertsTool(BaseTool):
+    """Pump.fun deployer launch alerts with deployer track records."""
+
+    name: str = "MadeOnSol Deployer Alerts"
+    description: str = (
+        "Get Pump.fun token-launch alerts enriched with the deployer's historical "
+        "track record (prior launches, bond rate, rug history) and early KOL buys."
+    )
+    args_schema: Type[BaseModel] = MadeOnSolDeployerAlertsToolSchema
+    env_vars: List[EnvVar] = _MADEONSOL_ENV_VARS
+    package_dependencies: List[str] = Field(default_factory=lambda: ["madeonsol-x402"])
+
+    def _run(self, limit: int = 10, tier: Optional[str] = None) -> str:
+        data = _make_client().deployer_alerts(limit=limit, tier=tier)
+        return json.dumps(data, indent=2)
+
+
+class MadeOnSolTokenRiskToolSchema(BaseModel):
+    """Input for MadeOnSolTokenRiskTool."""
+
+    mint: str = Field(description="Solana token mint address (base58).")
+
+
+class MadeOnSolTokenRiskTool(BaseTool):
+    """Risk assessment for a Solana token."""
+
+    name: str = "MadeOnSol Token Risk"
+    description: str = (
+        "Get a risk assessment for a Solana token by mint address: deployer "
+        "reputation, sniper/bundler concentration, holder distribution, and "
+        "dump-cluster signals."
+    )
+    args_schema: Type[BaseModel] = MadeOnSolTokenRiskToolSchema
+    env_vars: List[EnvVar] = _MADEONSOL_ENV_VARS
+    package_dependencies: List[str] = Field(default_factory=lambda: ["madeonsol-x402"])
+
+    def _run(self, mint: str) -> str:
+        data = _make_client().token_risk(mint)
+        return json.dumps(data, indent=2)

--- a/lib/crewai-tools/tests/tools/madeonsol_tool_test.py
+++ b/lib/crewai-tools/tests/tools/madeonsol_tool_test.py
@@ -1,0 +1,73 @@
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# madeonsol-x402 is an optional dependency — mock the module so the tools are
+# importable and testable without it installed (same pattern as couchbase).
+mock_madeonsol = MagicMock()
+sys.modules.setdefault("madeonsol_x402", mock_madeonsol)
+
+from crewai_tools.tools.madeonsol_tool.madeonsol_tool import (  # noqa: E402
+    MadeOnSolDeployerAlertsTool,
+    MadeOnSolKolCoordinationTool,
+    MadeOnSolKolFeedTool,
+    MadeOnSolKolLeaderboardTool,
+    MadeOnSolTokenRiskTool,
+)
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    with patch(
+        "crewai_tools.tools.madeonsol_tool.madeonsol_tool._make_client",
+        return_value=client,
+    ):
+        yield client
+
+
+def test_kol_feed_tool(mock_client):
+    mock_client.kol_feed.return_value = {"trades": [{"mint": "abc", "action": "buy"}]}
+    result = MadeOnSolKolFeedTool().run(limit=5, action="buy")
+    mock_client.kol_feed.assert_called_once_with(limit=5, action="buy")
+    assert json.loads(result) == {"trades": [{"mint": "abc", "action": "buy"}]}
+
+
+def test_kol_leaderboard_tool(mock_client):
+    mock_client.kol_leaderboard.return_value = {"leaderboard": []}
+    result = MadeOnSolKolLeaderboardTool().run(period="30d", limit=20)
+    mock_client.kol_leaderboard.assert_called_once_with(period="30d", limit=20)
+    assert json.loads(result) == {"leaderboard": []}
+
+
+def test_kol_coordination_tool(mock_client):
+    mock_client.kol_coordination.return_value = {"signals": []}
+    result = MadeOnSolKolCoordinationTool().run(period="6h", min_kols=4)
+    mock_client.kol_coordination.assert_called_once_with(period="6h", min_kols=4)
+    assert json.loads(result) == {"signals": []}
+
+
+def test_deployer_alerts_tool(mock_client):
+    mock_client.deployer_alerts.return_value = {"alerts": []}
+    result = MadeOnSolDeployerAlertsTool().run(limit=10, tier="elite")
+    mock_client.deployer_alerts.assert_called_once_with(limit=10, tier="elite")
+    assert json.loads(result) == {"alerts": []}
+
+
+def test_token_risk_tool(mock_client):
+    mint = "So11111111111111111111111111111111111111112"
+    mock_client.token_risk.return_value = {"risk_score": 12}
+    result = MadeOnSolTokenRiskTool().run(mint=mint)
+    mock_client.token_risk.assert_called_once_with(mint)
+    assert json.loads(result) == {"risk_score": 12}
+
+
+def test_missing_credentials_raises(monkeypatch):
+    from crewai_tools.tools.madeonsol_tool import madeonsol_tool as module
+
+    monkeypatch.delenv("MADEONSOL_API_KEY", raising=False)
+    monkeypatch.delenv("SVM_PRIVATE_KEY", raising=False)
+    with pytest.raises(ValueError, match="MADEONSOL_API_KEY"):
+        module._make_client()


### PR DESCRIPTION
## What

Adds five tools for on-chain Solana trading intelligence via the [MadeOnSol API](https://madeonsol.com/api-docs), wrapping the [`madeonsol-x402`](https://pypi.org/project/madeonsol-x402/) SDK as an optional dependency:

- **MadeOnSolKolFeedTool** — latest trades from 2,000+ tracked Solana KOL (influencer) wallets
- **MadeOnSolKolLeaderboardTool** — KOL performance rankings by realized PnL and win rate
- **MadeOnSolKolCoordinationTool** — convergence signals: tokens multiple KOLs are buying in the same window
- **MadeOnSolDeployerAlertsTool** — Pump.fun launch alerts enriched with the deployer's historical track record
- **MadeOnSolTokenRiskTool** — per-token risk assessment (deployer reputation, sniper/bundler concentration, holder distribution)

## Auth

Either `MADEONSOL_API_KEY` (free tier available, no card) or `SVM_PRIVATE_KEY` for keyless [x402](https://www.x402.org/) pay-per-call USDC micropayments — the SDK handles the 402 → sign → retry loop, so agents can pay per request without any signup.

## Implementation notes

- Lazy `try/except` import of the SDK + `madeonsol-x402` pyproject extra, following the tavily/linkup pattern.
- `env_vars` and `package_dependencies` declared on every tool.
- Tests mock the `madeonsol_x402` module in `sys.modules` (same pattern as the couchbase tests), so they pass without the optional dependency installed; the credential-error path is tested too.
- Tool directory includes a README with a usage example.
- `tool.specs.json` not regenerated here (the generator needs every optional dep installed) — happy to run it if you prefer it included in the PR.

## Disclosure

I'm the maintainer of MadeOnSol and the `madeonsol-x402` SDK. The same SDK already ships LangChain tools listed in the official LangChain integrations docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3J7DzXMvfCE5o5hCszPiU