### PR TITLE
Add injectable client for CrewAI platform tools

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/__init__.py
@@ -13,10 +13,18 @@ from crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder impor
 from crewai_tools.tools.crewai_platform_tools.crewai_platform_tools import (
     CrewaiPlatformTools,
 )
+from crewai_tools.tools.crewai_platform_tools.integrations_client import (
+    IntegrationsClient,
+    IntegrationsResponse,
+    LegacyClient,
+)
 
 
 __all__ = [
     "CrewAIPlatformActionTool",
     "CrewaiPlatformToolBuilder",
     "CrewaiPlatformTools",
+    "IntegrationsClient",
+    "IntegrationsResponse",
+    "LegacyClient",
 ]

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_action_tool.py
@@ -1,22 +1,21 @@
 """Crewai Enterprise Tools."""
 
 import json
-import os
 from typing import Any
 
 from crewai.tools import BaseTool
 from crewai.tools.tool_failure import ToolFailure
 from crewai.utilities.pydantic_schema_utils import create_model_from_schema
-from pydantic import Field, create_model
-import requests
+from pydantic import Field, PrivateAttr, create_model
 
-from crewai_tools.tools.crewai_platform_tools.misc import (
-    get_platform_api_base_url,
-    get_platform_integration_token,
+from crewai_tools.tools.crewai_platform_tools.integrations_client import (
+    IntegrationsClient,
+    LegacyClient,
 )
 
 
 class CrewAIPlatformActionTool(BaseTool):
+    _integrations_client: IntegrationsClient = PrivateAttr()
     app: str = Field(description="The integration slug for this action")
     action_name: str = Field(default="", description="The name of the action")
     action_schema: dict[str, Any] = Field(
@@ -29,7 +28,8 @@ class CrewAIPlatformActionTool(BaseTool):
         app: str,
         action_name: str,
         action_schema: dict[str, Any],
-    ):
+        integrations_client: IntegrationsClient | None = None,
+    ) -> None:
         parameters = action_schema.get("function", {}).get("parameters", {})
 
         if parameters and parameters.get("properties"):
@@ -52,6 +52,9 @@ class CrewAIPlatformActionTool(BaseTool):
         )
         self.action_name = action_name
         self.action_schema = action_schema
+        self._integrations_client = (
+            integrations_client if integrations_client is not None else LegacyClient()
+        )
 
     def _run(self, **kwargs: Any) -> Any:
         try:
@@ -59,24 +62,8 @@ class CrewAIPlatformActionTool(BaseTool):
                 key: value for key, value in kwargs.items() if value is not None
             }
 
-            api_url = (
-                f"{get_platform_api_base_url()}/actions/{self.action_name}/execute"
-            )
-            token = get_platform_integration_token()
-            headers = {
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-            }
-            payload = {
-                "integration": cleaned_kwargs if cleaned_kwargs else {"_noop": True}
-            }
-
-            response = requests.post(
-                url=api_url,
-                headers=headers,
-                json=payload,
-                timeout=60,
-                verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
+            response = self._integrations_client.execute_action(
+                self.action_name, cleaned_kwargs
             )
 
             data = response.json()

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tool_builder.py
@@ -1,12 +1,10 @@
 """CrewAI platform tool builder for fetching and creating action tools."""
 
 import logging
-import os
 from types import TracebackType
 from typing import Any
 
 from crewai.tools import BaseTool
-import requests
 
 from crewai_tools.tools.crewai_platform_tools.application_selector import (
     ApplicationSelector,
@@ -14,9 +12,9 @@ from crewai_tools.tools.crewai_platform_tools.application_selector import (
 from crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool import (
     CrewAIPlatformActionTool,
 )
-from crewai_tools.tools.crewai_platform_tools.misc import (
-    get_platform_api_base_url,
-    get_platform_integration_token,
+from crewai_tools.tools.crewai_platform_tools.integrations_client import (
+    IntegrationsClient,
+    LegacyClient,
 )
 
 
@@ -29,8 +27,12 @@ class CrewaiPlatformToolBuilder:
     def __init__(
         self,
         apps: list[str],
+        integrations_client: IntegrationsClient | None = None,
     ) -> None:
         self._apps = [ApplicationSelector(app) for app in apps]
+        self._integrations_client = (
+            integrations_client if integrations_client is not None else LegacyClient()
+        )
         self._actions_schema: dict[str, dict[str, Any]] = {}
         self._tools: list[BaseTool] | None = None
 
@@ -43,22 +45,16 @@ class CrewaiPlatformToolBuilder:
 
     def _fetch_actions(self) -> None:
         """Fetch action schemas from the platform API."""
-        actions_url = f"{get_platform_api_base_url()}/actions"
-        headers = {"Authorization": f"Bearer {get_platform_integration_token()}"}
         apps = [
             f"{app.name}/{app.action}" if app.action is not None else app.name
             for app in self._apps
         ]
 
         try:
-            response = requests.get(
-                actions_url,
-                headers=headers,
-                timeout=30,
-                params={"apps": ",".join(apps)},
-                verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
-            )
+            response = self._integrations_client.get_actions(apps)
             response.raise_for_status()
+        except ValueError:
+            raise
         except Exception as e:
             logger.error(f"Failed to fetch platform tools for apps {apps}: {e}")
             return
@@ -99,6 +95,7 @@ class CrewaiPlatformToolBuilder:
                 app=function_details["app"],
                 action_name=action_name,
                 action_schema=action_schema,
+                integrations_client=self._integrations_client,
             )
 
             tools.append(tool)

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tools.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/crewai_platform_tools.py
@@ -6,6 +6,9 @@ from crewai_tools.adapters.tool_collection import ToolCollection
 from crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder import (
     CrewaiPlatformToolBuilder,
 )
+from crewai_tools.tools.crewai_platform_tools.integrations_client import (
+    IntegrationsClient,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -13,15 +16,19 @@ logger = logging.getLogger(__name__)
 
 def CrewaiPlatformTools(  # noqa: N802
     apps: list[str],
+    integrations_client: IntegrationsClient | None = None,
 ) -> ToolCollection[BaseTool]:
     """Factory function that returns crewai platform tools.
 
     Args:
         apps: List of platform apps to get tools that are available on the platform.
+        integrations_client: Client used to get and execute actions.
 
     Returns:
         A list of BaseTool instances for platform actions
     """
-    builder = CrewaiPlatformToolBuilder(apps=apps)
+    builder = CrewaiPlatformToolBuilder(
+        apps=apps, integrations_client=integrations_client
+    )
 
     return builder.tools()  # type: ignore

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/integrations_client.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/integrations_client.py
@@ -17,20 +17,16 @@ class IntegrationsResponse(Protocol):
     @property
     def ok(self) -> bool:
         """Return whether the request succeeded."""
-        ...
 
     @property
     def status_code(self) -> int:
         """Return the HTTP response status code."""
-        ...
 
     def json(self) -> Any:
         """Decode the response body as JSON."""
-        ...
 
     def raise_for_status(self) -> None:
         """Raise an error when the request failed."""
-        ...
 
 
 class IntegrationsClient(Protocol):
@@ -38,13 +34,11 @@ class IntegrationsClient(Protocol):
 
     def get_actions(self, apps: list[str]) -> IntegrationsResponse:
         """Get the actions available for the selected applications."""
-        ...
 
     def execute_action(
         self, action_name: str, arguments: dict[str, Any]
     ) -> IntegrationsResponse:
         """Execute an action with the given arguments."""
-        ...
 
 
 class LegacyClient:

--- a/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/integrations_client.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/crewai_platform_tools/integrations_client.py
@@ -1,0 +1,76 @@
+"""Contract and default client for platform integrations."""
+
+import os
+from typing import Any, Protocol
+
+import requests
+
+from crewai_tools.tools.crewai_platform_tools.misc import (
+    get_platform_api_base_url,
+    get_platform_integration_token,
+)
+
+
+class IntegrationsResponse(Protocol):
+    """Define the response operations used by platform tools."""
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the request succeeded."""
+        ...
+
+    @property
+    def status_code(self) -> int:
+        """Return the HTTP response status code."""
+        ...
+
+    def json(self) -> Any:
+        """Decode the response body as JSON."""
+        ...
+
+    def raise_for_status(self) -> None:
+        """Raise an error when the request failed."""
+        ...
+
+
+class IntegrationsClient(Protocol):
+    """Define the client operations required by CrewAI platform tools."""
+
+    def get_actions(self, apps: list[str]) -> IntegrationsResponse:
+        """Get the actions available for the selected applications."""
+        ...
+
+    def execute_action(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> IntegrationsResponse:
+        """Execute an action with the given arguments."""
+        ...
+
+
+class LegacyClient:
+    """Use the existing CrewAI platform integrations API."""
+
+    def get_actions(self, apps: list[str]) -> requests.Response:
+        """Get the actions available for the selected applications."""
+        return requests.get(
+            f"{get_platform_api_base_url()}/actions",
+            headers={"Authorization": f"Bearer {get_platform_integration_token()}"},
+            timeout=30,
+            params={"apps": ",".join(apps)},
+            verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
+        )
+
+    def execute_action(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> requests.Response:
+        """Execute an action with the given arguments."""
+        return requests.post(
+            url=f"{get_platform_api_base_url()}/actions/{action_name}/execute",
+            headers={
+                "Authorization": f"Bearer {get_platform_integration_token()}",
+                "Content-Type": "application/json",
+            },
+            json={"integration": arguments if arguments else {"_noop": True}},
+            timeout=60,
+            verify=os.environ.get("CREWAI_FACTORY", "false").lower() != "true",
+        )

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_action_tool.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_action_tool.py
@@ -34,7 +34,7 @@ class TestCrewAIPlatformActionToolVerify:
         )
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"}, clear=True)
-    @patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
+    @patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
     def test_run_with_ssl_verification_default(self, mock_post):
         """Test that _run uses SSL verification by default when CREWAI_FACTORY is not set"""
         mock_response = Mock()
@@ -50,7 +50,7 @@ class TestCrewAIPlatformActionToolVerify:
         assert call_args.kwargs["verify"] is True
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "false"}, clear=True)
-    @patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
+    @patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
     def test_run_with_ssl_verification_factory_false(self, mock_post):
         """Test that _run uses SSL verification when CREWAI_FACTORY is 'false'"""
         mock_response = Mock()
@@ -66,7 +66,7 @@ class TestCrewAIPlatformActionToolVerify:
         assert call_args.kwargs["verify"] is True
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "FALSE"}, clear=True)
-    @patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
+    @patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
     def test_run_with_ssl_verification_factory_false_uppercase(self, mock_post):
         """Test that _run uses SSL verification when CREWAI_FACTORY is 'FALSE' (case-insensitive)"""
         mock_response = Mock()
@@ -82,7 +82,7 @@ class TestCrewAIPlatformActionToolVerify:
         assert call_args.kwargs["verify"] is True
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "true"}, clear=True)
-    @patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
+    @patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
     def test_run_without_ssl_verification_factory_true(self, mock_post):
         """Test that _run disables SSL verification when CREWAI_FACTORY is 'true'"""
         mock_response = Mock()
@@ -98,7 +98,7 @@ class TestCrewAIPlatformActionToolVerify:
         assert call_args.kwargs["verify"] is False
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "TRUE"}, clear=True)
-    @patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
+    @patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
     def test_run_without_ssl_verification_factory_true_uppercase(self, mock_post):
         """Test that _run disables SSL verification when CREWAI_FACTORY is 'TRUE' (case-insensitive)"""
         mock_response = Mock()

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tool_builder.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tool_builder.py
@@ -60,7 +60,7 @@ class TestCrewaiPlatformToolBuilder(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_success(self, mock_get):
         mock_api_response = {
@@ -120,7 +120,7 @@ class TestCrewaiPlatformToolBuilder(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_create_tools(self, mock_get):
         mock_api_response = {
@@ -217,7 +217,7 @@ class TestCrewaiPlatformToolBuilder(unittest.TestCase):
         builder = CrewaiPlatformToolBuilder(apps=[])
 
         with patch(
-            "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+            "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
         ) as mock_get:
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
@@ -237,7 +237,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"}, clear=True)
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_with_ssl_verification_default(self, mock_get):
         """Test that _fetch_actions uses SSL verification by default when CREWAI_FACTORY is not set"""
@@ -255,7 +255,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "false"}, clear=True)
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_with_ssl_verification_factory_false(self, mock_get):
         """Test that _fetch_actions uses SSL verification when CREWAI_FACTORY is 'false'"""
@@ -273,7 +273,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "FALSE"}, clear=True)
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_with_ssl_verification_factory_false_uppercase(self, mock_get):
         """Test that _fetch_actions uses SSL verification when CREWAI_FACTORY is 'FALSE' (case-insensitive)"""
@@ -291,7 +291,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "true"}, clear=True)
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_without_ssl_verification_factory_true(self, mock_get):
         """Test that _fetch_actions disables SSL verification when CREWAI_FACTORY is 'true'"""
@@ -309,7 +309,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token", "CREWAI_FACTORY": "TRUE"}, clear=True)
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_fetch_actions_without_ssl_verification_factory_true_uppercase(self, mock_get):
         """Test that _fetch_actions disables SSL verification when CREWAI_FACTORY is 'TRUE' (case-insensitive)"""
@@ -328,7 +328,7 @@ class TestCrewaiPlatformToolBuilderVerify(unittest.TestCase):
 
 @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
 @patch(
-    "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+    "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
 )
 def test_connection_ids_are_parsed_but_not_sent(mock_get):
     mock_response = Mock()

--- a/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tools.py
+++ b/lib/crewai-tools/tests/tools/crewai_platform_tools/test_crewai_platform_tools.py
@@ -7,7 +7,7 @@ from crewai_tools.tools.crewai_platform_tools import CrewaiPlatformTools
 class TestCrewaiPlatformTools(unittest.TestCase):
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_crewai_platform_tools_basic(self, mock_get):
         mock_response = Mock()
@@ -21,7 +21,7 @@ class TestCrewaiPlatformTools(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_crewai_platform_tools_multiple_apps(self, mock_get):
         mock_response = Mock()
@@ -84,7 +84,7 @@ class TestCrewaiPlatformTools(unittest.TestCase):
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     def test_crewai_platform_tools_empty_apps(self):
         with patch(
-            "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+            "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
         ) as mock_get:
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
@@ -98,7 +98,7 @@ class TestCrewaiPlatformTools(unittest.TestCase):
 
     @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
     @patch(
-        "crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get"
+        "crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get"
     )
     def test_crewai_platform_tools_api_error_handling(self, mock_get):
         mock_get.side_effect = Exception("API Error")
@@ -113,3 +113,38 @@ class TestCrewaiPlatformTools(unittest.TestCase):
             with self.assertRaises(ValueError) as context:
                 CrewaiPlatformTools(apps=["github"])
             assert "No platform integration token found" in str(context.exception)
+
+    def test_crewai_platform_tools_accepts_an_integrations_client(self):
+        integrations_client = Mock()
+        actions_response = Mock()
+        actions_response.raise_for_status.return_value = None
+        actions_response.json.return_value = {
+            "actions": {
+                "github": [
+                    {
+                        "name": "create_issue",
+                        "description": "Create a GitHub issue",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"title": {"type": "string"}},
+                            "required": ["title"],
+                        },
+                    }
+                ]
+            }
+        }
+        integrations_client.get_actions.return_value = actions_response
+        execution_response = Mock(ok=True, status_code=200)
+        execution_response.json.return_value = {"issue": 42}
+        integrations_client.execute_action.return_value = execution_response
+
+        tools = CrewaiPlatformTools(
+            apps=["github"], integrations_client=integrations_client
+        )
+        result = tools[0].run(title="Contract test")
+
+        integrations_client.get_actions.assert_called_once_with(["github"])
+        integrations_client.execute_action.assert_called_once_with(
+            "create_issue", {"title": "Contract test"}
+        )
+        assert result == '{\n  "issue": 42\n}'

--- a/lib/crewai/tests/agents/test_lite_agent.py
+++ b/lib/crewai/tests/agents/test_lite_agent.py
@@ -612,8 +612,8 @@ def test_lite_agent_with_invalid_llm():
 
 
 @patch.dict("os.environ", {"CREWAI_PLATFORM_INTEGRATION_TOKEN": "test_token"})
-@patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool.requests.post")
-@patch("crewai_tools.tools.crewai_platform_tools.crewai_platform_tool_builder.requests.get")
+@patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.post")
+@patch("crewai_tools.tools.crewai_platform_tools.integrations_client.requests.get")
 @pytest.mark.vcr()
 def test_agent_kickoff_with_platform_tools(mock_get, mock_post):
     """Test that Agent.kickoff() properly integrates platform tools with LiteAgent"""

--- a/lib/crewai/tests/tools/test_tool_failure.py
+++ b/lib/crewai/tests/tools/test_tool_failure.py
@@ -1693,7 +1693,7 @@ class TestPlatformActionTool:
     """CrewAI AMP agentic-app actions -- the Slack case from the bug report."""
 
     @staticmethod
-    def _tool() -> Any:
+    def _tool(response: Any) -> Any:
         import crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool as mod
 
         return mod.CrewAIPlatformActionTool(
@@ -1709,12 +1709,13 @@ class TestPlatformActionTool:
                     },
                 }
             },
+            integrations_client=SimpleNamespace(
+                execute_action=lambda _action_name, _arguments: response
+            ),
         )
 
-    def test_non_ok_response_becomes_a_tool_failure(self, monkeypatch) -> None:  # noqa: ANN001
+    def test_non_ok_response_becomes_a_tool_failure(self) -> None:
         from unittest.mock import Mock
-
-        import crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool as mod
 
         response = Mock()
         response.ok = False
@@ -1722,27 +1723,21 @@ class TestPlatformActionTool:
         response.json.return_value = {
             "error": "Failed to execute action: Slack API error: channel_not_found"
         }
-        monkeypatch.setattr(mod.requests, "post", Mock(return_value=response))
-        monkeypatch.setenv("CREWAI_PLATFORM_INTEGRATION_TOKEN", "t")
 
-        result = self._tool()._run(channel="#joao-message")
+        result = self._tool(response)._run(channel="#joao-message")
 
         assert isinstance(result, ToolFailure)
         assert "channel_not_found" in result.message
         assert result.retryable is True
 
-    def test_ok_response_still_returns_json(self, monkeypatch) -> None:  # noqa: ANN001
+    def test_ok_response_still_returns_json(self) -> None:
         from unittest.mock import Mock
-
-        import crewai_tools.tools.crewai_platform_tools.crewai_platform_action_tool as mod
 
         response = Mock()
         response.ok = True
         response.json.return_value = {"ts": "1234.5678"}
-        monkeypatch.setattr(mod.requests, "post", Mock(return_value=response))
-        monkeypatch.setenv("CREWAI_PLATFORM_INTEGRATION_TOKEN", "t")
 
-        result = self._tool()._run(channel="#general")
+        result = self._tool(response)._run(channel="#general")
 
         assert not isinstance(result, ToolFailure)
         assert "1234.5678" in result


### PR DESCRIPTION
Define an integrations client contract for action discovery and execution. Keep the existing platform API as the default client to preserve current behavior.

Allow callers to provide a custom client through CrewaiPlatformTools.
