### PR TITLE
feat(conversation): implement a FIFO queue for handling conversationa…

### DIFF
--- a/lib/cli/src/crewai_cli/crew_run_tui.py
+++ b/lib/cli/src/crewai_cli/crew_run_tui.py
@@ -4,6 +4,7 @@ Two-column layout: left sidebar (tasks/agents/tokens) + main content
 (task header, plan checklist, activity timeline, streaming output).
 """
 
+from concurrent.futures import Future
 import json as _json
 import re
 import threading
@@ -395,6 +396,16 @@ Screen {
     border-top: hkey #1F7982;
 }
 
+#conversation-queue {
+    display: none;
+    height: auto;
+    max-height: 5;
+    padding: 0 2;
+    background: #1c1c1c;
+    border-top: hkey #333333;
+    color: #AAAAAA;
+}
+
 Header {
     background: #1c1c1c;
     color: #FF5A50;
@@ -563,6 +574,11 @@ FooterKey .footer-key--key {
         self._conversation_messages: list[tuple[str, str]] = []
         self._conversation_turns = 0
         self._conversation_turn_in_progress = False
+        self._conversation_queued_turns = 0
+        self._conversation_turn_queue: Any = None
+        self._conversation_turn_futures: list[tuple[str, Future[Any]]] = []
+        self._conversation_displayed_turns: set[Future[Any]] = set()
+        self._conversation_result_timer: Any = None
         self._conversation_previous_defer_trace_finalization: bool | None = None
         self._conversation_exit_commands = {"exit", "quit"}
         self._default_inputs: dict[str, Any] | None = None
@@ -612,6 +628,7 @@ FooterKey .footer-key--key {
                     placeholder="Message the flow...",
                     id="conversation-input",
                 )
+                yield Static(id="conversation-queue")
                 with VerticalScroll(id="log-panel"):
                     yield Static(id="log-content")
         yield Footer()
@@ -847,6 +864,13 @@ FooterKey .footer-key--key {
             )
             self._flow.defer_trace_finalization = True
 
+        from crewai.flow._conversation_queue import ConversationTurnQueue
+
+        self._conversation_turn_queue = ConversationTurnQueue(self._flow)
+        self._conversation_result_timer = self.set_interval(
+            1 / 20, self._drain_queued_conversation_results
+        )
+
         try:
             input_widget = self.query_one("#conversation-input", Input)
             input_widget.display = True
@@ -857,6 +881,16 @@ FooterKey .footer-key--key {
     def _finalize_conversational_session(self) -> None:
         if not (self._is_conversational and self._flow):
             return
+        if self._conversation_turn_queue is not None:
+            try:
+                self._conversation_turn_queue.close()
+            except Exception:  # noqa: S110
+                pass
+            self._drain_queued_conversation_results()
+            self._conversation_turn_queue = None
+        if self._conversation_result_timer is not None:
+            self._conversation_result_timer.stop()
+            self._conversation_result_timer = None
         try:
             self._flow.finalize_session_traces()
         except Exception:  # noqa: S110
@@ -883,13 +917,28 @@ FooterKey .footer-key--key {
             self._unsubscribe()
             self.exit(self._crew_result)
             return
-        if self._conversation_turn_in_progress:
+        if (
+            self._conversation_turn_in_progress
+            and self._conversation_turn_queue is None
+        ):
             return
 
+        queued_future: Future[Any] | None = None
+        if self._conversation_turn_queue is not None:
+            try:
+                queued_future = self._conversation_turn_queue.submit(message)
+            except Exception as exc:
+                self._on_conversation_turn_failed(str(exc))
+                return
+
         with self._lock:
-            self._conversation_messages.append(("user", message))
             self._conversation_turn_in_progress = True
-            self._conversation_turns += 1
+            if queued_future is not None:
+                self._conversation_queued_turns += 1
+                self._conversation_turn_futures.append((message, queued_future))
+            else:
+                self._conversation_messages.append(("user", message))
+                self._conversation_turns += 1
             self._status = "working"
             self._current_step = ("yellow", "Thinking…", "")
             self._is_streaming = False
@@ -897,8 +946,52 @@ FooterKey .footer-key--key {
             self._task_full_output = ""
             self._current_llm_text = ""
 
+        if queued_future is not None:
+            self._tick()
+            return
+
         event.input.disabled = True
         self._run_conversation_turn_worker(message)
+
+    def _drain_queued_conversation_results(self) -> None:
+        while (
+            self._conversation_turn_futures
+            and self._conversation_turn_futures[0][1].done()
+        ):
+            message, future = self._conversation_turn_futures.pop(0)
+            try:
+                result = future.result()
+            except BaseException as exc:
+                from crewai.flow._conversation_queue import (
+                    ConversationTurnQueueStoppedError,
+                )
+
+                if not isinstance(exc, ConversationTurnQueueStoppedError):
+                    self._display_queued_user_message(message, future)
+                self._on_conversation_turn_failed(str(exc))
+            else:
+                self._display_queued_user_message(message, future)
+                self._on_conversation_turn_done(result)
+            self._conversation_displayed_turns.discard(future)
+
+        for message, future in self._conversation_turn_futures:
+            if future.running():
+                self._display_queued_user_message(message, future)
+
+    def _display_queued_user_message(self, message: str, future: Future[Any]) -> None:
+        if future in self._conversation_displayed_turns:
+            return
+        self._conversation_displayed_turns.add(future)
+        self._conversation_messages.append(("user", message))
+        self._conversation_turns += 1
+
+    def _queued_conversation_entries(self) -> list[tuple[str, str]]:
+        """Return outstanding messages with active or queued display status."""
+        return [
+            (message, "active" if future.running() else "queued")
+            for message, future in self._conversation_turn_futures
+            if not future.done()
+        ]
 
     @work(thread=True, exclusive=True, group="conversation")
     def _run_conversation_turn_worker(self, message: str) -> None:
@@ -924,23 +1017,39 @@ FooterKey .footer-key--key {
             output = self._stringify_output(result)
             self._conversation_messages.append(("assistant", output))
             self._crew_result = result
-            self._conversation_turn_in_progress = False
-            self._status = "chatting"
+            if self._conversation_turn_queue is not None:
+                self._conversation_queued_turns = max(
+                    0, self._conversation_queued_turns - 1
+                )
+            self._conversation_turn_in_progress = self._conversation_queued_turns > 0
+            self._status = (
+                "working" if self._conversation_turn_in_progress else "chatting"
+            )
             self._is_streaming = False
             self._streaming_text = ""
-            self._current_step = None
-        self._enable_conversation_input()
+            self._current_step = (
+                ("yellow", "Thinking…", "")
+                if self._conversation_turn_in_progress
+                else None
+            )
+        if self._conversation_turn_queue is None:
+            self._enable_conversation_input()
         self._tick()
         self._scroll_to_result()
 
     def _on_conversation_turn_failed(self, error: str) -> None:
         with self._lock:
+            if self._conversation_turn_queue is not None:
+                self._conversation_queued_turns = max(
+                    0, self._conversation_queued_turns - 1
+                )
             self._status = "failed"
             self._error = error
-            self._conversation_turn_in_progress = False
+            self._conversation_turn_in_progress = self._conversation_queued_turns > 0
             self._is_streaming = False
             self._current_step = None
-        self._enable_conversation_input()
+        if self._conversation_turn_queue is None:
+            self._enable_conversation_input()
         self._tick()
 
     def _enable_conversation_input(self) -> None:
@@ -1196,6 +1305,7 @@ FooterKey .footer-key--key {
                 self._render_sidebar()
                 self._render_task_header()
                 self._render_main_content()
+                self._render_conversation_queue()
                 if self.query_one("#log-panel").display:
                     self._render_log_panel()
         except NoMatches:
@@ -1222,6 +1332,11 @@ FooterKey .footer-key--key {
             else:
                 t.append("  ● Ready\n", style=_C_GREEN)
             t.append(f"  Turns {self._conversation_turns}\n", style=_C_DIM)
+            queued = sum(
+                status == "queued" for _, status in self._queued_conversation_entries()
+            )
+            if queued:
+                t.append(f"  Queue {queued} waiting\n", style=_C_TEAL)
             t.append("\n")
             t.append("  TOKENS\n", style=f"bold {_C_PRIMARY}")
             t.append("\n")
@@ -1336,6 +1451,12 @@ FooterKey .footer-key--key {
             elif self._conversation_turn_in_progress:
                 t.append(f"{self._spinner()} ", style=_C_PRIMARY)
                 t.append("Flow is responding", style=f"bold {_C_PRIMARY}")
+                queued = sum(
+                    status == "queued"
+                    for _, status in self._queued_conversation_entries()
+                )
+                if queued:
+                    t.append(f"  {queued} queued", style=_C_TEAL)
             else:
                 t.append("● ", style=f"bold {_C_GREEN}")
                 t.append("Conversational flow ready", style=f"bold {_C_GREEN}")
@@ -1437,6 +1558,29 @@ FooterKey .footer-key--key {
         widget.update(t)
 
     # ── Main content rendering ──────────────────────────────
+
+    def _render_conversation_queue(self) -> None:
+        widget = self.query_one("#conversation-queue", Static)
+        waiting = [
+            message
+            for message, status in self._queued_conversation_entries()
+            if status == "queued"
+        ]
+        widget.display = bool(waiting)
+        if not waiting:
+            widget.update("")
+            return
+
+        t = Text()
+        t.append(f"QUEUED ({len(waiting)})\n", style=f"bold {_C_TEAL}")
+        for message in waiting[:3]:
+            summary = " ".join(message.split())
+            if len(summary) > 72:
+                summary = summary[:71] + "…"
+            t.append(f"○ {summary}\n", style=_C_DIM)
+        if len(waiting) > 3:
+            t.append(f"+ {len(waiting) - 3} more\n", style=_C_DIM)
+        widget.update(t)
 
     def _render_main_content(self) -> None:
         widget = self.query_one("#main-content", Static)

--- a/lib/cli/tests/test_crew_run_tui.py
+++ b/lib/cli/tests/test_crew_run_tui.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from threading import Event
 import time
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -207,10 +208,89 @@ async def test_conversation_input_submits_turn() -> None:
             if app._conversation_messages[-1:] == [("assistant", "reply: hi")]:
                 break
 
+        await pilot.press("q")
+
     assert app._conversation_messages == [
         ("user", "hi"),
         ("assistant", "reply: hi"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_conversation_queue_accepts_input_during_turn() -> None:
+    first_started = Event()
+    release_first = Event()
+
+    class FakeFlow:
+        defer_trace_finalization = False
+
+        def handle_turn(
+            self, message: str, *, session_id: str | None = None
+        ) -> str:
+            if message == "first":
+                first_started.set()
+                assert release_first.wait(timeout=5)
+            return f"reply: {message}"
+
+        def finalize_session_traces(self) -> None:
+            pass
+
+    app = CrewRunApp(crew_name="Demo", conversational=True)
+    app._flow = FakeFlow()
+
+    async with app.run_test() as pilot:
+        await pilot.click("#conversation-input")
+        await pilot.press("f", "i", "r", "s", "t", "enter")
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if first_started.is_set():
+                break
+
+        assert first_started.is_set()
+        assert not app.query_one("#conversation-input").disabled
+
+        await pilot.press("s", "e", "c", "o", "n", "d", "enter")
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if app._conversation_messages == [("user", "first")] and (
+                app._queued_conversation_entries()
+                == [("first", "active"), ("second", "queued")]
+            ):
+                break
+
+        assert app._conversation_messages == [("user", "first")]
+        assert app._queued_conversation_entries() == [
+            ("first", "active"),
+            ("second", "queued"),
+        ]
+        app._tick()
+        queue_widget = app.query_one("#conversation-queue")
+        queue_display = str(queue_widget.render())
+        assert queue_widget.display is True
+        assert "QUEUED (1)" in queue_display
+        assert "second" in queue_display
+        assert "first" not in queue_display
+
+        release_first.set()
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if app._conversation_messages[-2:] == [
+                ("assistant", "reply: first"),
+                ("assistant", "reply: second"),
+            ]:
+                break
+
+        app._tick()
+        assert app.query_one("#conversation-queue").display is False
+        await pilot.press("q")
+
+    assert app._conversation_messages == [
+        ("user", "first"),
+        ("assistant", "reply: first"),
+        ("user", "second"),
+        ("assistant", "reply: second"),
+    ]
+    assert app._queued_conversation_entries() == []
 
 
 def test_plan_step_status_updates_only_the_explicit_step() -> None:

--- a/lib/crewai/src/crewai/flow/_conversation_queue.py
+++ b/lib/crewai/src/crewai/flow/_conversation_queue.py
@@ -1,0 +1,244 @@
+"""Internal FIFO queue for conversational Flow turns."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from contextvars import Context, copy_context
+from dataclasses import dataclass
+from queue import Empty, Full, Queue
+from threading import Lock, Thread, current_thread
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from crewai.flow.flow import Flow
+
+
+_FLOW_QUEUE_ATTR = "_conversation_turn_queue"
+_FLOW_QUEUE_LOCK = Lock()
+_STOP = object()
+
+
+def _track_feature(feature: str) -> None:
+    """Count a queue feature without letting telemetry break the session."""
+    try:
+        from crewai.telemetry.telemetry import Telemetry
+
+        Telemetry().feature_usage_span(feature)
+    except Exception:
+        return
+
+
+class ConversationTurnQueueError(RuntimeError):
+    """Base error raised by the conversation turn queue."""
+
+
+class ConversationTurnQueueFullError(ConversationTurnQueueError):
+    """Raised when a queue has reached its pending-turn limit."""
+
+
+class ConversationTurnQueueStoppedError(ConversationTurnQueueError):
+    """Raised when work is submitted to a closed or failed queue."""
+
+
+@dataclass(frozen=True)
+class _QueuedTurn:
+    message: str
+    kwargs: dict[str, Any]
+    future: Future[Any]
+    context: Context
+
+
+class ConversationTurnQueue:
+    """Run submitted conversational turns in FIFO order on one worker.
+
+    The queue is runtime-only. It serializes calls to ``Flow.handle_turn``
+    without adding pending messages to persisted conversation history before
+    their turn begins.
+    """
+
+    def __init__(
+        self,
+        flow: Flow[Any],
+        *,
+        session_id: str | None = None,
+        max_pending: int = 32,
+        handle_turn_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if max_pending < 1:
+            raise ValueError("max_pending must be at least 1")
+
+        self._flow = flow
+        self._session_id = session_id
+        self._max_pending = max_pending
+        self._handle_turn_kwargs = dict(handle_turn_kwargs or {})
+        self._items: Queue[_QueuedTurn | object] = Queue(maxsize=max_pending)
+        self._state_lock = Lock()
+        self._closed = False
+        self._active = False
+        self._pending = 0
+        self._failure: BaseException | None = None
+        self._worker = Thread(
+            target=self._run,
+            name=f"{type(flow).__name__}-conversation-turns",
+        )
+
+        self._claim_flow()
+        try:
+            self._worker.start()
+        except BaseException:
+            self._release_flow()
+            raise
+
+    @property
+    def active(self) -> bool:
+        """Whether one turn is currently executing."""
+        with self._state_lock:
+            return self._active
+
+    @property
+    def pending_count(self) -> int:
+        """Number of accepted turns waiting behind the active turn."""
+        with self._state_lock:
+            return self._pending
+
+    @property
+    def closed(self) -> bool:
+        """Whether the queue has stopped accepting submissions."""
+        with self._state_lock:
+            return self._closed
+
+    @property
+    def failure(self) -> BaseException | None:
+        """The turn error that stopped the queue, if any."""
+        with self._state_lock:
+            return self._failure
+
+    def submit(self, message: str, **handle_turn_kwargs: Any) -> Future[Any]:
+        """Queue one message and immediately return its result future."""
+        future: Future[Any] = Future()
+        item = _QueuedTurn(
+            message=message,
+            kwargs={**self._handle_turn_kwargs, **handle_turn_kwargs},
+            future=future,
+            context=copy_context(),
+        )
+
+        with self._state_lock:
+            if self._closed:
+                raise ConversationTurnQueueStoppedError(
+                    "Conversation turn queue is closed"
+                )
+            backed_up = self._active or self._pending > 0
+            try:
+                self._items.put_nowait(item)
+            except Full as exc:
+                _track_feature("flow:conversation_queue_full")
+                raise ConversationTurnQueueFullError(
+                    f"Conversation turn queue already has {self._max_pending} "
+                    "pending turns"
+                ) from exc
+            self._pending += 1
+        if backed_up:
+            _track_feature("flow:conversation_queued")
+        return future
+
+    def close(self, *, wait: bool = True) -> None:
+        """Stop accepting submissions and drain accepted turns."""
+        if wait and current_thread() is self._worker:
+            raise ConversationTurnQueueError(
+                "Cannot wait for the conversation queue from its worker thread"
+            )
+
+        with self._state_lock:
+            should_signal = not self._closed
+            self._closed = True
+        if should_signal:
+            self._items.put(_STOP)
+        if wait:
+            self._worker.join()
+
+    def __enter__(self) -> ConversationTurnQueue:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def _claim_flow(self) -> None:
+        with _FLOW_QUEUE_LOCK:
+            existing = getattr(self._flow, _FLOW_QUEUE_ATTR, None)
+            if existing is not None:
+                raise ConversationTurnQueueError(
+                    "This Flow already has an active conversation turn queue"
+                )
+            object.__setattr__(self._flow, _FLOW_QUEUE_ATTR, self)
+
+    def _release_flow(self) -> None:
+        with _FLOW_QUEUE_LOCK:
+            if getattr(self._flow, _FLOW_QUEUE_ATTR, None) is self:
+                object.__setattr__(self._flow, _FLOW_QUEUE_ATTR, None)
+
+    def _run(self) -> None:
+        try:
+            while True:
+                queued = self._items.get()
+                if not isinstance(queued, _QueuedTurn):
+                    return
+
+                turn = queued
+                with self._state_lock:
+                    self._pending -= 1
+                    self._active = True
+                try:
+                    if turn.future.set_running_or_notify_cancel():
+                        kwargs = dict(turn.kwargs)
+                        if self._session_id is not None:
+                            kwargs["session_id"] = self._session_id
+                        result = turn.context.run(
+                            self._flow.handle_turn,
+                            turn.message,
+                            **kwargs,
+                        )
+                        turn.future.set_result(result)
+                except BaseException as exc:
+                    turn.future.set_exception(exc)
+                    self._stop_after_failure(exc)
+                    return
+                finally:
+                    with self._state_lock:
+                        self._active = False
+        finally:
+            self._release_flow()
+
+    def _stop_after_failure(self, failure: BaseException) -> None:
+        with self._state_lock:
+            self._failure = failure
+            self._closed = True
+
+        dropped = False
+        while True:
+            try:
+                queued = self._items.get_nowait()
+            except Empty:
+                break
+            if not isinstance(queued, _QueuedTurn):
+                continue
+            dropped = True
+            with self._state_lock:
+                self._pending -= 1
+            if not queued.future.cancelled():
+                queued.future.set_exception(
+                    ConversationTurnQueueStoppedError(
+                        "Conversation turn queue stopped after an earlier turn failed"
+                    )
+                )
+        if dropped:
+            _track_feature("flow:conversation_queue_dropped")
+
+
+__all__ = [
+    "ConversationTurnQueue",
+    "ConversationTurnQueueError",
+    "ConversationTurnQueueFullError",
+    "ConversationTurnQueueStoppedError",
+]

--- a/lib/crewai/src/crewai/flow/conversational_mixin.py
+++ b/lib/crewai/src/crewai/flow/conversational_mixin.py
@@ -18,6 +18,7 @@ Import surface:
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import Future
 from contextlib import contextmanager
 from enum import Enum
 import json
@@ -641,8 +642,25 @@ class _ConversationalMixin:
         previous_defer = getattr(self, "defer_trace_finalization", False)
         if defer_trace_finalization:
             self.defer_trace_finalization = True
+        uses_human_feedback = any(
+            method.human_feedback is not None
+            for method in self._definition.methods.values()
+        )
 
         try:
+            if not uses_human_feedback:
+                self._chat_with_message_queue(
+                    session_id=session_id,
+                    prompt=prompt,
+                    assistant_prefix=assistant_prefix,
+                    exit_set=exit_set,
+                    input_fn=input_fn,
+                    output_fn=output_fn,
+                    skip_empty=skip_empty,
+                    handle_turn_kwargs=handle_turn_kwargs,
+                )
+                return
+
             while True:
                 try:
                     message = input_fn(prompt).strip()
@@ -665,6 +683,53 @@ class _ConversationalMixin:
             self.finalize_session_traces()
             if defer_trace_finalization:
                 self.defer_trace_finalization = previous_defer
+
+    def _chat_with_message_queue(
+        self,
+        *,
+        session_id: str | None,
+        prompt: str,
+        assistant_prefix: str,
+        exit_set: set[str],
+        input_fn: Callable[[str], str],
+        output_fn: Callable[[str], None],
+        skip_empty: bool,
+        handle_turn_kwargs: dict[str, Any],
+    ) -> None:
+        """Run the terminal REPL with queued turn execution."""
+        from crewai.flow._conversation_queue import ConversationTurnQueue
+
+        failures: list[BaseException] = []
+
+        def render(future: Future[Any]) -> None:
+            try:
+                result = future.result()
+            except BaseException as exc:
+                failures.append(exc)
+                return
+            output_fn(f"{assistant_prefix}{self._stringify_result(result)}")
+
+        with ConversationTurnQueue(
+            cast(Any, self),
+            session_id=session_id,
+            handle_turn_kwargs=handle_turn_kwargs,
+        ) as turns:
+            while True:
+                try:
+                    message = input_fn(prompt).strip()
+                except (EOFError, KeyboardInterrupt):
+                    output_fn("")
+                    break
+
+                if message.lower() in exit_set:
+                    break
+                if skip_empty and not message:
+                    continue
+
+                turns.submit(message).add_done_callback(render)
+
+        if failures:
+            raise failures[0]
 
     def build_router_context(self) -> dict[str, Any]:
         """Build context used by the routing policy for the current turn."""

--- a/lib/crewai/tests/test_flow_conversation.py
+++ b/lib/crewai/tests/test_flow_conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from threading import Event
 from typing import Any, ClassVar, Literal
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -1123,6 +1124,54 @@ class TestConversationalFlow:
             )
 
         assert outputs == ["\nAssistant: raw assistant output"]
+
+    def test_queued_chat_accepts_input_while_turn_runs(self) -> None:
+        first_started = Event()
+        second_read = Event()
+        release_first = Event()
+
+        @ConversationConfig(defer_trace_finalization=False)
+        class MyChat(ConversationalFlow):
+            def route_turn(self, context: dict[str, Any]) -> str | None:
+                return "work"
+
+            @listen("work")
+            def do_work(self) -> str:
+                message = self.state.current_user_message or ""
+                if message == "first":
+                    first_started.set()
+                    assert release_first.wait(timeout=5)
+                return f"worked: {message}"
+
+        flow = MyChat()
+        inputs = iter(["first", "second", "quit"])
+        calls = 0
+        outputs: list[str] = []
+
+        def input_fn(_: str) -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                assert first_started.wait(timeout=5)
+                second_read.set()
+            elif calls == 3:
+                assert second_read.is_set()
+                release_first.set()
+            return next(inputs)
+
+        with patch.object(flow, "finalize_session_traces"):
+            flow.chat(input_fn=input_fn, output_fn=outputs.append)
+
+        assert outputs == [
+            "\nAssistant: worked: first",
+            "\nAssistant: worked: second",
+        ]
+        assert [message.content for message in flow.state.messages] == [
+            "first",
+            "worked: first",
+            "second",
+            "worked: second",
+        ]
 
     def test_chat_rejects_non_conversational_flows(self) -> None:
         class PlainFlow(Flow):

--- a/lib/crewai/tests/test_flow_conversation_queue.py
+++ b/lib/crewai/tests/test_flow_conversation_queue.py
@@ -1,0 +1,191 @@
+"""Tests for the internal conversational turn queue."""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from crewai.flow._conversation_queue import (
+    ConversationTurnQueue,
+    ConversationTurnQueueError,
+    ConversationTurnQueueFullError,
+    ConversationTurnQueueStoppedError,
+)
+
+
+class BlockingFlow:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.history: list[str] = []
+        self.first_started = Event()
+        self.release_first = Event()
+        self._lock = Lock()
+        self._active = 0
+        self.max_active = 0
+
+    def handle_turn(
+        self,
+        message: str,
+        *,
+        session_id: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        with self._lock:
+            self._active += 1
+            self.max_active = max(self.max_active, self._active)
+            self.calls.append(message)
+            self.history.append(message)
+        try:
+            if message == "first":
+                self.first_started.set()
+                assert self.release_first.wait(timeout=5)
+            return f"{session_id}:{message}"
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+def test_turns_run_fifo_without_overlapping() -> None:
+    flow = BlockingFlow()
+    with ConversationTurnQueue(flow, session_id="session-1") as turns:  # type: ignore[arg-type]
+        first = turns.submit("first")
+        assert flow.first_started.wait(timeout=5)
+
+        second = turns.submit("second")
+        third = turns.submit("third")
+        assert flow.history == ["first"]
+        assert turns.active is True
+        assert turns.pending_count == 2
+
+        flow.release_first.set()
+
+    assert first.result() == "session-1:first"
+    assert second.result() == "session-1:second"
+    assert third.result() == "session-1:third"
+    assert flow.calls == ["first", "second", "third"]
+    assert flow.max_active == 1
+
+
+def test_queue_rejects_submissions_over_capacity() -> None:
+    flow = BlockingFlow()
+    with ConversationTurnQueue(flow, max_pending=1) as turns:  # type: ignore[arg-type]
+        turns.submit("first")
+        assert flow.first_started.wait(timeout=5)
+        turns.submit("second")
+
+        with pytest.raises(ConversationTurnQueueFullError):
+            turns.submit("third")
+
+        flow.release_first.set()
+
+
+def test_turn_failure_stops_pending_work() -> None:
+    started = Event()
+    release = Event()
+    calls: list[str] = []
+
+    class FailingFlow:
+        def handle_turn(self, message: str, **_: Any) -> str:
+            calls.append(message)
+            if message == "bad":
+                started.set()
+                assert release.wait(timeout=5)
+                raise ValueError("broken turn")
+            return message
+
+    turns = ConversationTurnQueue(FailingFlow())  # type: ignore[arg-type]
+    bad = turns.submit("bad")
+    assert started.wait(timeout=5)
+    pending = turns.submit("never")
+    release.set()
+    turns.close()
+
+    with pytest.raises(ValueError, match="broken turn"):
+        bad.result()
+    with pytest.raises(ConversationTurnQueueStoppedError):
+        pending.result()
+    assert calls == ["bad"]
+    assert isinstance(turns.failure, ValueError)
+
+
+def test_only_one_queue_can_own_a_flow() -> None:
+    flow = BlockingFlow()
+    turns = ConversationTurnQueue(flow)  # type: ignore[arg-type]
+    with pytest.raises(ConversationTurnQueueError, match="already has"):
+        ConversationTurnQueue(flow)  # type: ignore[arg-type]
+
+    turns.close()
+    replacement = ConversationTurnQueue(flow)  # type: ignore[arg-type]
+    replacement.close()
+
+    with pytest.raises(ConversationTurnQueueStoppedError):
+        replacement.submit("too late")
+
+
+def test_max_pending_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        ConversationTurnQueue(BlockingFlow(), max_pending=0)  # type: ignore[arg-type]
+
+
+def test_typed_ahead_submit_counts_as_queued() -> None:
+    flow = BlockingFlow()
+    with (
+        patch("crewai.telemetry.telemetry.Telemetry.feature_usage_span") as track,
+        ConversationTurnQueue(flow) as turns,  # type: ignore[arg-type]
+    ):
+        turns.submit("first")
+        assert flow.first_started.wait(timeout=5)
+        turns.submit("second")
+        flow.release_first.set()
+
+    assert [call.args[0] for call in track.call_args_list] == [
+        "flow:conversation_queued",
+    ]
+
+
+def test_capacity_reject_counts_as_queue_full() -> None:
+    flow = BlockingFlow()
+    with (
+        patch("crewai.telemetry.telemetry.Telemetry.feature_usage_span") as track,
+        ConversationTurnQueue(flow, max_pending=1) as turns,  # type: ignore[arg-type]
+    ):
+        turns.submit("first")
+        assert flow.first_started.wait(timeout=5)
+        turns.submit("second")
+        with pytest.raises(ConversationTurnQueueFullError):
+            turns.submit("third")
+        flow.release_first.set()
+
+    assert [call.args[0] for call in track.call_args_list] == [
+        "flow:conversation_queued",
+        "flow:conversation_queue_full",
+    ]
+
+
+def test_failed_turn_counts_dropped_pending_work() -> None:
+    started = Event()
+    release = Event()
+
+    class FailingFlow:
+        def handle_turn(self, message: str, **_: Any) -> str:
+            if message == "bad":
+                started.set()
+                assert release.wait(timeout=5)
+                raise ValueError("broken turn")
+            return message
+
+    with patch("crewai.telemetry.telemetry.Telemetry.feature_usage_span") as track:
+        turns = ConversationTurnQueue(FailingFlow())  # type: ignore[arg-type]
+        turns.submit("bad")
+        assert started.wait(timeout=5)
+        turns.submit("never")
+        release.set()
+        turns.close()
+
+    assert "flow:conversation_queued" in [call.args[0] for call in track.call_args_list]
+    assert "flow:conversation_queue_dropped" in [
+        call.args[0] for call in track.call_args_list
+    ]


### PR DESCRIPTION
will unlock steering prompting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversational turn ordering and threading for `handle_turn` in CLI/TUI and `chat()`; failures now abort queued turns, but flows with human feedback are unchanged.
> 
> **Overview**
> Adds a **FIFO conversation turn queue** so users can submit the next message while a flow is still responding, instead of blocking until each `handle_turn` finishes.
> 
> A new internal `ConversationTurnQueue` runs turns on one worker thread (default up to 32 pending), preserves submitter `contextvars`, enforces single-queue-per-flow, and stops pending work with explicit errors after a failed turn (with telemetry for queue/full/dropped cases).
> 
> **Terminal `Flow.chat()`** routes through the queue when the flow has no `@human_feedback` methods; otherwise it keeps the previous synchronous read/process loop.
> 
> The **crew run TUI** wires the same queue into conversational sessions: the input stays enabled during work, queued messages appear in a `#conversation-queue` strip and sidebar/header counts, user lines enter the transcript when their turn starts, and a timer drains completed futures into assistant replies. Session teardown closes the queue and drains remaining results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be46127b814ce6ca7bd19789d366a8e70e61f19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->