### PR TITLE
fix(cli): preserve tool config during Poetry migration

### DIFF
--- a/lib/cli/src/crewai_cli/update_crew.py
+++ b/lib/cli/src/crewai_cli/update_crew.py
@@ -21,7 +21,7 @@ def migrate_pyproject(input_file: str, output_file: str) -> None:
     When the time comes that uv supports the new format, this function will be deprecated.
     """
     poetry_data = {}
-    pyproject_data = read_toml()
+    pyproject_data = read_toml(input_file)
 
     new_pyproject: dict[str, Any] = {
         "project": {},
@@ -41,6 +41,13 @@ def migrate_pyproject(input_file: str, output_file: str) -> None:
             for author in poetry_data.get("authors", [])
         ]
         new_pyproject["project"]["requires-python"] = poetry_data.get("python")
+        preserved_tool_config = {
+            name: config
+            for name, config in pyproject_data["tool"].items()
+            if name != "poetry"
+        }
+        if preserved_tool_config:
+            new_pyproject["tool"] = preserved_tool_config
     else:
         new_pyproject["project"] = pyproject_data.get("project", {})
         new_pyproject["tool"] = pyproject_data.get("tool", {})

--- a/lib/cli/tests/test_update_crew.py
+++ b/lib/cli/tests/test_update_crew.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import tomli
+from pytest import MonkeyPatch
+
+from crewai_cli.update_crew import migrate_pyproject
+
+
+def test_migrate_poetry_project_preserves_non_poetry_tool_config(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    input_file = tmp_path / "legacy.toml"
+    output_file = tmp_path / "migrated.toml"
+    input_file.write_text(
+        """
+[tool.poetry]
+name = "example-crew"
+version = "0.1.0"
+description = "An example crew"
+authors = ["Ada Lovelace <ada@example.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.14"
+crewai = "^1.0.0"
+
+[tool.crewai]
+type = "crew"
+
+[tool.ruff]
+line-length = 88
+""".strip(),
+        encoding="utf-8",
+    )
+
+    migrate_pyproject(str(input_file), str(output_file))
+
+    migrated = tomli.loads(output_file.read_text(encoding="utf-8"))
+    assert migrated["project"]["name"] == "example-crew"
+    assert migrated["tool"]["crewai"] == {"type": "crew"}
+    assert migrated["tool"]["ruff"] == {"line-length": 88}
+    assert "poetry" not in migrated["tool"]


### PR DESCRIPTION
## Summary
- preserve `[tool.crewai]` and other non-Poetry tool tables during migration
- read the TOML from the supplied migration input path
- add focused regression coverage for both behaviors

Closes #7190

## Test plan
- [x] `uv run pytest lib/cli/tests/test_update_crew.py`
- [x] Ruff on the modified source and test files

> Maintainers: please apply the required `llm-generated` label. GitHub does not
> grant external contributors permission to manage repository labels.