### PR TITLE
fix(cli): fail when flow destination exists

### DIFF
--- a/lib/cli/src/crewai_cli/create_flow.py
+++ b/lib/cli/src/crewai_cli/create_flow.py
@@ -17,12 +17,11 @@ def create_flow(name: str, *, declarative: bool = False) -> None:
     folder_name = name.replace(" ", "_").replace("-", "_").lower()
     class_name = name.replace("_", " ").replace("-", " ").title().replace(" ", "")
 
-    click.secho(f"Creating flow {folder_name}...", fg="green", bold=True)
-
     project_root = Path(folder_name)
     if project_root.exists():
-        click.secho(f"Error: Folder {folder_name} already exists.", fg="red")
-        return
+        raise click.ClickException(f"Folder {folder_name} already exists.")
+
+    click.secho(f"Creating flow {folder_name}...", fg="green", bold=True)
 
     telemetry = Telemetry()
     telemetry.flow_creation_span(class_name)

--- a/lib/cli/tests/test_create_flow.py
+++ b/lib/cli/tests/test_create_flow.py
@@ -10,6 +10,23 @@ from crewai_cli.cli import crewai
 from crewai_cli.create_flow import create_flow
 
 
+def test_create_flow_existing_folder_exits_nonzero(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    project_root = tmp_path / "research_flow"
+    project_root.mkdir()
+    sentinel = project_root / "existing.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+
+    result = CliRunner().invoke(crewai, ["create", "flow", "Research Flow"])
+
+    assert result.exit_code != 0
+    assert "Error: Folder research_flow already exists." in result.output
+    assert "Creating flow research_flow" not in result.output
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+
 def test_create_flow_declarative_project_can_run(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ):


### PR DESCRIPTION
## Summary
- return a non-zero status when the flow destination already exists
- check the destination before printing the creation-start message
- verify the existing directory remains unchanged

Closes #7192

## Test plan
- [x] `uv run pytest lib/cli/tests/test_create_flow.py -k existing_folder`
- [x] Complete `test_create_flow.py` module (2 passed)
- [x] Ruff on the modified source and test files

> Maintainers: please apply the required `llm-generated` label. GitHub does not
> grant external contributors permission to manage repository labels.