### PR TITLE
chore(ci): ignore unpatched nltk GHSA-8mgp-746c-j5xp

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -104,6 +104,8 @@ jobs:
             # APIs bypass pathsec and read/write outside allowed roots. No patched
             # PyPI release yet (fixes are on nltk develop only). Transitive via
             # crewai-tools[xml] -> unstructured; CrewAI does not call those APIs.
+            # TODO: drop this ignore when bumping nltk past 3.10.3 to a patched
+            # release; keep the ignore list in sync with .pre-commit-config.yaml.
             --ignore-vuln GHSA-8mgp-746c-j5xp
           )
           uv run pip-audit "${pip_audit_args[@]}"

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -100,6 +100,11 @@ jobs:
             # GHSA-xph7-9rjv-w5fr (CVE-2026-45831): SimpleRBACAuthorizationProvider
             # ignores tenant/database/collection scope.
             --ignore-vuln GHSA-xph7-9rjv-w5fr
+            # nltk <=3.10.3: GHSA-8mgp-746c-j5xp (CVE-2026-81726): model-artifact
+            # APIs bypass pathsec and read/write outside allowed roots. No patched
+            # PyPI release yet (fixes are on nltk develop only). Transitive via
+            # crewai-tools[xml] -> unstructured; CrewAI does not call those APIs.
+            --ignore-vuln GHSA-8mgp-746c-j5xp
           )
           uv run pip-audit "${pip_audit_args[@]}"
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,8 @@ repos:
           --ignore-vuln GHSA-f4j7-r4q5-qw2c
           --ignore-vuln GHSA-2wm9-hf6c-p5cr
           --ignore-vuln GHSA-36p7-vc44-83pf
-          --ignore-vuln GHSA-xph7-9rjv-w5fr' --
+          --ignore-vuln GHSA-xph7-9rjv-w5fr
+          --ignore-vuln GHSA-8mgp-746c-j5xp' --
         language: system
         pass_filenames: false
         stages: [pre-push, manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: pip-audit
         name: pip-audit
         # Keep this ignore list in sync with .github/workflows/vulnerability-scan.yml.
+        # TODO: drop --ignore-vuln GHSA-8mgp-746c-j5xp when bumping nltk past 3.10.3.
         entry: >-
           bash -c 'source .venv/bin/activate && uv run pip-audit --skip-editable
           --ignore-vuln PYSEC-2024-277

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -123,8 +123,10 @@ xml = [
     "unstructured[local-inference, all-docs]>=0.17.2",
     # unstructured allows nltk>=3.9.2, but <3.10.3 still has PYSEC-2026-3726
     # (symlink file read in IPIPANCorpusReader; 3.10.0-3.10.1) plus later
-    # 3.10.2 findings. Declared here, not only as a uv override, so consumers
-    # installing crewai-tools[xml] get the fixed version.
+    # 3.10.2 findings. 3.10.3 still has unpatched GHSA-8mgp-746c-j5xp
+    # (ignored in pip-audit until a release ships). Declared here, not only
+    # as a uv override, so consumers installing crewai-tools[xml] get this
+    # floor.
     "nltk>=3.10.3",
 ]
 oxylabs = [

--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -124,9 +124,9 @@ xml = [
     # unstructured allows nltk>=3.9.2, but <3.10.3 still has PYSEC-2026-3726
     # (symlink file read in IPIPANCorpusReader; 3.10.0-3.10.1) plus later
     # 3.10.2 findings. 3.10.3 still has unpatched GHSA-8mgp-746c-j5xp
-    # (ignored in pip-audit until a release ships). Declared here, not only
-    # as a uv override, so consumers installing crewai-tools[xml] get this
-    # floor.
+    # (ignored in pip-audit until a release ships). TODO: drop that ignore
+    # when bumping nltk past 3.10.3. Declared here, not only as a uv
+    # override, so consumers installing crewai-tools[xml] get this floor.
     "nltk>=3.10.3",
 ]
 oxylabs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,10 @@ exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = 
 # 3.9.4, so that ignore is no longer needed. 3.10.0-3.10.1 have PYSEC-2026-3726
 # (symlink-based arbitrary file read in IPIPANCorpusReader); fixed in 3.10.2.
 # 3.10.3 also clears later 3.10.2 findings (proxy SSRF, pickle allowlist RCE,
-# JVM option injection, XML entity expansion). Transitive via
+# JVM option injection, XML entity expansion). 3.10.3 still has
+# GHSA-8mgp-746c-j5xp (CVE-2026-81726; model-artifact pathsec bypass); no
+# patched PyPI release yet, so that GHSA is ignored in pip-audit until one
+# ships. Transitive via
 # crewai-tools[xml] -> unstructured.
 # pydantic-settings <2.14.2 has GHSA-4xgf-cpjx-pc3j.
 # h2 <=4.4.0 has GHSA-6hr6-w5qg-qmwg (CVE-2026-71554): duplicate Host headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,8 @@ exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = 
 # JVM option injection, XML entity expansion). 3.10.3 still has
 # GHSA-8mgp-746c-j5xp (CVE-2026-81726; model-artifact pathsec bypass); no
 # patched PyPI release yet, so that GHSA is ignored in pip-audit until one
-# ships. Transitive via
+# ships. TODO: drop --ignore-vuln GHSA-8mgp-746c-j5xp when bumping nltk
+# past 3.10.3. Transitive via
 # crewai-tools[xml] -> unstructured.
 # pydantic-settings <2.14.2 has GHSA-4xgf-cpjx-pc3j.
 # h2 <=4.4.0 has GHSA-6hr6-w5qg-qmwg (CVE-2026-71554): duplicate Host headers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related issue

No linked issue. Unblocks Vulnerability Scan after [GHSA-8mgp-746c-j5xp](https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp) (CVE-2026-81726) was published against nltk 3.10.3.

## Summary

- Ignore `GHSA-8mgp-746c-j5xp` in pip-audit (CI + pre-commit) until NLTK ships a patched PyPI release. 3.10.3 is still the latest.
- Document the unpatched model-artifact pathsec bypass on the existing nltk 3.10.3 floor. CrewAI does not call those APIs; nltk is transitive via `crewai-tools[xml]` → unstructured.

## Verification

- [ ] Reproduce pip-audit failure on `nltk==3.10.3: GHSA-8mgp-746c-j5xp`
- [ ] Same command with `--ignore-vuln GHSA-8mgp-746c-j5xp` reports no remaining vulns

## Additional context

Same approach as the unpatched chromadb HTTP-server GHSAs. Fixes live on nltk `develop` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66698968-fcb5-402d-87b7-58f51a949f48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66698968-fcb5-402d-87b7-58f51a949f48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

