### PR TITLE
feat: add llmman as an OpenAI-compatible provider

### DIFF
--- a/lib/cli/src/crewai_cli/constants.py
+++ b/lib/cli/src/crewai_cli/constants.py
@@ -58,6 +58,12 @@ ENV_VARS: dict[str, list[dict[str, Any]]] = {
             "API_BASE": "http://localhost:11434",
         }
     ],
+    "llmman": [
+        {
+            "default": True,
+            "API_BASE": "http://localhost:17434",
+        }
+    ],
     "bedrock": [
         {
             "prompt": "Enter your AWS Access Key ID (press Enter to skip)",
@@ -123,6 +129,7 @@ PROVIDERS: list[str] = [
     "groq",
     "huggingface",
     "ollama",
+    "llmman",
     "watson",
     "bedrock",
     "azure",
@@ -269,6 +276,7 @@ MODELS: dict[str, list[str]] = {
         "groq/gemma-7b-it",
     ],
     "ollama": ["ollama/llama3.1", "ollama/mixtral"],
+    "llmman": ["llmman/qwen3.8", "llmman/gemma4"],
     "watson": [
         "watsonx/meta-llama/llama-3-1-70b-instruct",
         "watsonx/meta-llama/llama-3-1-8b-instruct",

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -341,6 +341,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "deepseek",
     "ollama",
     "ollama_chat",
+    "llmman",
     "hosted_vllm",
     "cerebras",
     "dashscope",
@@ -446,6 +447,7 @@ class LLM(BaseLLM):
                 "deepseek": "deepseek",
                 "ollama": "ollama",
                 "ollama_chat": "ollama_chat",
+                "llmman": "llmman",
                 "hosted_vllm": "hosted_vllm",
                 "cerebras": "cerebras",
                 "dashscope": "dashscope",
@@ -561,8 +563,8 @@ class LLM(BaseLLM):
         if provider == "deepseek":
             return model_lower.startswith("deepseek")
 
-        if provider == "ollama" or provider == "ollama_chat":
-            # Ollama accepts any local model name
+        if provider in ("ollama", "ollama_chat", "llmman"):
+            # Local servers accept any model name they can resolve
             return True
 
         if provider == "hosted_vllm":
@@ -704,6 +706,7 @@ class LLM(BaseLLM):
             "deepseek",
             "ollama",
             "ollama_chat",
+            "llmman",
             "hosted_vllm",
             "cerebras",
             "dashscope",

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -70,6 +70,13 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         api_key_required=False,
         default_api_key="ollama",
     ),
+    "llmman": ProviderConfig(
+        base_url="http://localhost:17434/v1",
+        api_key_env="LLMMAN_API_KEY",
+        base_url_env="LLMMAN_HOST",
+        api_key_required=False,
+        default_api_key="llmman",
+    ),
     "hosted_vllm": ProviderConfig(
         base_url="http://localhost:8000/v1",
         api_key_env="VLLM_API_KEY",
@@ -92,11 +99,11 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
 }
 
 
-def _normalize_ollama_base_url(base_url: str) -> str:
-    """Normalize Ollama base URL to ensure it ends with /v1.
+def _normalize_local_base_url(base_url: str) -> str:
+    """Ensure a local server base URL ends with /v1.
 
-    Ollama uses OLLAMA_HOST which may not include the /v1 suffix,
-    but the OpenAI-compatible endpoint requires it.
+    Hosts configured via OLLAMA_HOST or LLMMAN_HOST are bare host:port values,
+    but the OpenAI-compatible endpoint requires the /v1 suffix.
 
     Args:
         base_url: The base URL, potentially without /v1 suffix.
@@ -122,6 +129,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         - deepseek: DeepSeek (https://deepseek.com)
         - ollama: Ollama local server (https://ollama.ai)
         - ollama_chat: Alias for ollama
+        - llmman: llmman local server (https://github.com/llmmanorg/llmman)
         - hosted_vllm: vLLM server (https://github.com/vllm-project/vllm)
         - cerebras: Cerebras (https://cerebras.ai)
         - dashscope: Alibaba Dashscope/Qwen (https://dashscope.aliyun.com)
@@ -222,8 +230,8 @@ class OpenAICompatibleCompletion(OpenAICompletion):
         else:
             resolved = config.base_url
 
-        if provider in ("ollama", "ollama_chat"):
-            resolved = _normalize_ollama_base_url(resolved)
+        if provider in ("ollama", "ollama_chat", "llmman"):
+            resolved = _normalize_local_base_url(resolved)
 
         return resolved
 

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -10,7 +10,7 @@ from crewai.llms.providers.openai_compatible.completion import (
     OPENAI_COMPATIBLE_PROVIDERS,
     OpenAICompatibleCompletion,
     ProviderConfig,
-    _normalize_ollama_base_url,
+    _normalize_local_base_url,
 )
 
 
@@ -73,6 +73,24 @@ class TestProviderRegistry:
         assert ollama.base_url == ollama_chat.base_url
         assert ollama.api_key_required == ollama_chat.api_key_required
 
+    def test_llmman_config(self):
+        """Test llmman provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["llmman"]
+        assert config.base_url == "http://localhost:17434/v1"
+        assert config.api_key_env == "LLMMAN_API_KEY"
+        assert config.base_url_env == "LLMMAN_HOST"
+        assert config.api_key_required is False
+        assert config.default_api_key == "llmman"
+
+    def test_llmman_base_url_does_not_collide(self):
+        """llmman must not reuse another provider's default endpoint."""
+        others = [
+            cfg.base_url
+            for name, cfg in OPENAI_COMPATIBLE_PROVIDERS.items()
+            if name != "llmman"
+        ]
+        assert OPENAI_COMPATIBLE_PROVIDERS["llmman"].base_url not in others
+
     def test_hosted_vllm_config(self):
         """Test hosted_vllm provider configuration."""
         config = OPENAI_COMPATIBLE_PROVIDERS["hosted_vllm"]
@@ -96,24 +114,24 @@ class TestProviderRegistry:
         assert config.api_key_required is True
 
 
-class TestNormalizeOllamaBaseUrl:
-    """Tests for _normalize_ollama_base_url helper."""
+class TestNormalizeLocalBaseUrl:
+    """Tests for _normalize_local_base_url helper."""
 
     def test_adds_v1_suffix(self):
         """Test that /v1 is added when missing."""
-        assert _normalize_ollama_base_url("http://localhost:11434") == "http://localhost:11434/v1"
+        assert _normalize_local_base_url("http://localhost:11434") == "http://localhost:11434/v1"
 
     def test_preserves_existing_v1(self):
         """Test that existing /v1 is preserved."""
-        assert _normalize_ollama_base_url("http://localhost:11434/v1") == "http://localhost:11434/v1"
+        assert _normalize_local_base_url("http://localhost:11434/v1") == "http://localhost:11434/v1"
 
     def test_strips_trailing_slash(self):
         """Test that trailing slash is handled."""
-        assert _normalize_ollama_base_url("http://localhost:11434/") == "http://localhost:11434/v1"
+        assert _normalize_local_base_url("http://localhost:11434/") == "http://localhost:11434/v1"
 
     def test_handles_v1_with_trailing_slash(self):
         """Test /v1/ is normalized."""
-        assert _normalize_ollama_base_url("http://localhost:11434/v1/") == "http://localhost:11434/v1"
+        assert _normalize_local_base_url("http://localhost:11434/v1/") == "http://localhost:11434/v1"
 
 
 class TestOpenAICompatibleCompletion:
@@ -197,6 +215,12 @@ class TestOpenAICompatibleCompletion:
             completion = OpenAICompatibleCompletion(model="llama3", provider="ollama")
             assert completion.base_url == "http://custom-ollama:11434/v1"
 
+    def test_llmman_base_url_normalized(self):
+        """Test llmman base URL is normalized to include /v1."""
+        with patch.dict(os.environ, {"LLMMAN_HOST": "http://custom-llmman:17434"}):
+            completion = OpenAICompatibleCompletion(model="qwen3.8", provider="llmman")
+            assert completion.base_url == "http://custom-llmman:17434/v1"
+
     def test_openrouter_headers(self):
         """Test OpenRouter has HTTP-Referer header."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
@@ -241,6 +265,21 @@ class TestLLMIntegration:
         assert isinstance(llm, OpenAICompatibleCompletion)
         assert llm.provider == "ollama"
         assert llm.model == "llama3"
+
+    def test_llm_creates_openai_compatible_for_llmman(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for llmman."""
+        llm = LLM(model="llmman/qwen3.8")
+        assert isinstance(llm, OpenAICompatibleCompletion)
+        assert llm.provider == "llmman"
+        assert llm.model == "qwen3.8"
+        assert llm.base_url == "http://localhost:17434/v1"
+
+    def test_llm_creates_openai_compatible_for_explicit_llmman(self):
+        """Test LLM factory routes an explicit llmman provider without a prefix."""
+        llm = LLM(model="qwen3.8", provider="llmman")
+        assert isinstance(llm, OpenAICompatibleCompletion)
+        assert llm.provider == "llmman"
+        assert llm.model == "qwen3.8"
 
     def test_llm_creates_openai_compatible_for_openrouter(self):
         """Test LLM factory creates OpenAICompatibleCompletion for OpenRouter."""


### PR DESCRIPTION
Closes #7216

Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an OpenAI-compatible API on port 17434.

- **Provider config.** No API key, so it follows the Ollama entry (`api_key_required=False`, a `default_api_key`) rather than the hosted ones. `LLMMAN_HOST` is a bare `host:port` value, so it joins the `/v1` base-URL normalization. That helper is renamed `_normalize_local_base_url` now that it serves two providers.
- **Runtime routing.** Registered in `SUPPORTED_NATIVE_PROVIDERS`, the model-prefix map and `_get_native_provider`, so both `llmman/qwen3.8` and `LLM(model="qwen3.8", provider="llmman")` reach `OpenAICompatibleCompletion` instead of falling back to LiteLLM.
- **CLI.** Added to `PROVIDERS`, `ENV_VARS` and `MODELS`, using bare model names since llmman resolves those to OCI artifacts itself.

### Testing

```
$ pytest lib/crewai/tests/llms/openai_compatible/
40 passed
```

The existing 35 plus 5 new: registry config, base-URL collision, `LLMMAN_HOST` normalization, and factory routing for both the prefixed and explicit-provider forms. The wider `lib/crewai/tests/llms/` suite shows the same 306 pre-existing failures before and after this branch.

Not verified: no request against a live llmman server.

### AI disclosure

This PR was **AI-assisted** (OpenCode); I reviewed the diff before submitting. Per your policy I have applied the `llm-generated` label — if I lack permission to set it, please add it.


<!-- crewai-require-issue-check -->