### PR TITLE
fix(tools): run async tools safely when an event loop is already running

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -40,6 +40,7 @@ from crewai.tools.structured_tool import (
 )
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy, ToolFailureReason
 from crewai.types.callback import SerializableCallable, _resolve_dotted_path
+from crewai.utilities.asyncio_utils import run_sync
 from crewai.utilities.string_utils import sanitize_tool_name
 
 
@@ -338,7 +339,7 @@ class BaseTool(BaseModel, ABC):
         result = self._run(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_sync(result)
 
         return result
 
@@ -549,7 +550,7 @@ class Tool(BaseTool, Generic[P, R]):
         result = self.func(*args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+            result = run_sync(result)
 
         return result  # type: ignore[return-value]
 

--- a/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
+++ b/lib/crewai/src/crewai/tools/mcp_tool_wrapper.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 from crewai.tools import BaseTool
+from crewai.utilities.asyncio_utils import run_sync
 
 
 MCP_CONNECTION_TIMEOUT = 15
@@ -76,7 +77,7 @@ class MCPToolWrapper(BaseTool):
             Result from the MCP tool execution
         """
         try:
-            return asyncio.run(self._run_async(**kwargs))
+            return run_sync(self._run_async(**kwargs))
         except asyncio.TimeoutError:
             return f"MCP tool '{self.original_tool_name}' timed out after {MCP_TOOL_EXECUTION_TIMEOUT} seconds"
         except Exception as e:

--- a/lib/crewai/src/crewai/tools/structured_tool.py
+++ b/lib/crewai/src/crewai/tools/structured_tool.py
@@ -22,6 +22,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy
+from crewai.utilities.asyncio_utils import run_sync
 from crewai.utilities.logger import Logger
 from crewai.utilities.pydantic_schema_utils import (
     create_model_from_schema,
@@ -438,12 +439,12 @@ class CrewStructuredTool(BaseModel):
         self._increment_usage_count()
 
         if inspect.iscoroutinefunction(self.func):
-            return asyncio.run(self.func(**parsed_args, **kwargs))
+            return run_sync(self.func(**parsed_args, **kwargs))
 
         result = self.func(**parsed_args, **kwargs)
 
         if asyncio.iscoroutine(result):
-            return asyncio.run(result)
+            return run_sync(result)
 
         return result
 

--- a/lib/crewai/src/crewai/utilities/asyncio_utils.py
+++ b/lib/crewai/src/crewai/utilities/asyncio_utils.py
@@ -1,0 +1,37 @@
+"""Helpers for bridging coroutines into synchronous call sites."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+import concurrent.futures
+import contextvars
+from typing import Any, TypeVar
+
+
+T = TypeVar("T")
+
+
+def run_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run ``coro`` to completion from synchronous code.
+
+    ``asyncio.run`` raises ``RuntimeError`` when a loop is already running on
+    the current thread, which happens whenever synchronous code is reached from
+    an async caller -- for example a tool invoked from an ``async`` Flow method.
+    In that case run the coroutine on a worker thread, which has no loop of its
+    own, carrying the caller's context variables across.
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        Whatever the coroutine returns.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    ctx = contextvars.copy_context()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(ctx.run, asyncio.run, coro).result()

--- a/lib/crewai/tests/tools/test_async_tools.py
+++ b/lib/crewai/tests/tools/test_async_tools.py
@@ -194,3 +194,69 @@ class TestAsyncToolWithIO:
         assert len(results) == 3
         assert all("done" in r for r in results)
         assert elapsed < 0.25, f"Expected concurrent execution, took {elapsed}s"
+
+class TestAsyncToolInsideRunningLoop:
+    """Tools bridged from async to sync must work when a loop is already running.
+
+    A Flow running an ``async def`` method already owns the thread's event loop,
+    so the sync bridge inside ``run()`` / ``invoke()`` cannot use a bare
+    ``asyncio.run()``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_decorated_async_tool_run_inside_running_loop(self) -> None:
+        """An async decorated tool works through run() with a loop already running."""
+
+        @tool("async_in_loop")
+        async def async_func(value: str) -> str:
+            """An async decorated tool."""
+            await asyncio.sleep(0.01)
+            return f"async: {value}"
+
+        assert async_func.run(value="test") == "async: test"
+
+    @pytest.mark.asyncio
+    async def test_base_tool_coroutine_run_inside_running_loop(self) -> None:
+        """A BaseTool whose _run returns a coroutine works with a loop running."""
+
+        class CoroutineRunTool(BaseTool):
+            name: str = "coroutine_run_tool"
+            description: str = "A tool whose _run returns a coroutine"
+
+            async def _run(self, input_text: str) -> str:
+                await asyncio.sleep(0.01)
+                return f"Coroutine processed: {input_text}"
+
+        assert CoroutineRunTool().run(input_text="test") == "Coroutine processed: test"
+
+    @pytest.mark.asyncio
+    async def test_structured_tool_invoke_inside_running_loop(self) -> None:
+        """CrewStructuredTool.invoke() works with a loop already running."""
+
+        @tool("structured_in_loop")
+        async def async_func(value: str) -> str:
+            """An async decorated tool."""
+            await asyncio.sleep(0.01)
+            return f"async: {value}"
+
+        structured = async_func.to_structured_tool()
+        assert structured.invoke({"value": "test"}) == "async: test"
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_wrapper_run_inside_running_loop(self) -> None:
+        """MCPToolWrapper._run() reaches the server with a loop already running."""
+        from crewai.tools.mcp_tool_wrapper import MCPToolWrapper
+
+        wrapper = MCPToolWrapper(
+            mcp_server_params={"url": "http://127.0.0.1:9/mcp"},
+            tool_name="echo",
+            tool_schema={},
+            server_name="probe",
+        )
+
+        async def fake_run_async(**kwargs: object) -> str:
+            return "mcp ok"
+
+        wrapper._run_async = fake_run_async  # type: ignore[method-assign]
+
+        assert wrapper._run(value="test") == "mcp ok"


### PR DESCRIPTION
Fixes #7235

## Problem

`BaseTool.run()`, `CrewStructuredTool.invoke()` and `MCPToolWrapper._run()` bridge async tools into sync call sites with a bare `asyncio.run()`. That works from ordinary sync code, but `asyncio.run()` raises when a loop is already running on the thread — which is exactly what happens when a tool is called from an `async def` Flow method:

```
sync  @start method -> ok:hi
async @start method -> RuntimeError: asyncio.run() cannot be called from a running event loop
```

For MCP tools the failure was silent. `MCPToolWrapper._run` caught the error and returned it as the tool's result string, so an agent received an error message as though it were the tool's output and never learned the call hadn't happened:

```
MCP sync context  -> MCP tool execution failed after 3 attempts: Connection timed out
MCP async context -> Error executing MCP tool echo: asyncio.run() cannot be called from a running event loop
```

## Fix

Adds `crewai.utilities.asyncio_utils.run_sync`, which checks for a running loop and runs the coroutine on a worker thread when there is one, carrying context variables across. This is the approach already used in `tasks/llm_guardrail.py` and `tools/mcp_native_tool.py` — I lifted it into a shared helper rather than inventing anything.

Applied at the five bare `asyncio.run()` call sites in `base_tool.py`, `structured_tool.py` and `mcp_tool_wrapper.py`.

## Scope

I deliberately left `llm_guardrail.py` and `mcp_native_tool.py` alone even though they now duplicate the helper, to keep the diff focused on the bug. Happy to de-duplicate them in a follow-up if you'd like.

## Trade-off

This stops the crash but doesn't make the path truly async — the worker thread blocks the caller while the tool runs, the same as the existing helpers do today. Awaiting `arun()` on async call paths would be the fuller fix, but that touches the executor and Flow runtime, so I didn't want to make that call unilaterally. Happy to look at it separately if you'd prefer that direction.

## Testing

New `TestAsyncToolInsideRunningLoop` covers an async `@tool`, a `BaseTool` whose `_run` returns a coroutine, `CrewStructuredTool.invoke()`, and `MCPToolWrapper._run()` — each invoked from inside a running event loop. All four fail on `main` and pass here.

Locally: `tests/tools/` + `tests/llms/` 892 passed, 20 skipped; `tests/agents/`, `tests/task/`, `tests/mcp/`, `tests/experimental/` 527 passed, 16 skipped. ruff, ruff-format and mypy clean.

Note: `pip-audit` is currently failing on `main` as well, unrelated to this change.

---

This PR was written with AI assistance and should carry the `llm-generated` label per CONTRIBUTING.md. I can't apply labels myself — could a maintainer add it?
