### PR TITLE
fix: resolve human input result display

### DIFF
--- a/lib/crewai/src/crewai/agents/crew_agent_executor.py
+++ b/lib/crewai/src/crewai/agents/crew_agent_executor.py
@@ -1542,13 +1542,18 @@ class CrewAgentExecutor(BaseAgentExecutor):
         if self.agent is None:
             raise ValueError("Agent cannot be None")
 
+        should_show_output = (
+            self.agent.verbose
+            or (hasattr(self, "crew") and getattr(self.crew, "verbose", False))
+            or self.ask_for_human_input
+        )
+
         future = crewai_event_bus.emit(
             self.agent,
             AgentLogsExecutionEvent(
                 agent_role=self.agent.role,
                 formatted_answer=formatted_answer,
-                verbose=self.agent.verbose
-                or (hasattr(self, "crew") and getattr(self.crew, "verbose", False)),
+                verbose=should_show_output,
             ),
         )
 

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -3128,13 +3128,18 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         if self.agent is None:
             raise ValueError("Agent cannot be None")
 
+        should_show_output = (
+            self.agent.verbose
+            or (hasattr(self, "crew") and getattr(self.crew, "verbose", False))
+            or self.state.ask_for_human_input
+        )
+
         crewai_event_bus.emit(
             self.agent,
             AgentLogsExecutionEvent(
                 agent_role=self.agent.role,
                 formatted_answer=formatted_answer,
-                verbose=self.agent.verbose
-                or (hasattr(self, "crew") and getattr(self.crew, "verbose", False)),
+                verbose=should_show_output,
             ),
         )
 

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from crewai.agents.crew_agent_executor import CrewAgentExecutor
 from crewai.agents.tools_handler import ToolsHandler as _ToolsHandler
 from crewai.core.providers.human_input import SyncHumanInputProvider
 from crewai.agents.step_executor import StepExecutor
@@ -67,6 +68,7 @@ from crewai.experimental.agent_executor import (
 )
 from crewai.agents.parser import AgentAction, AgentFinish
 from crewai.events.event_bus import crewai_event_bus
+from crewai.events.types.logging_events import AgentLogsExecutionEvent
 from crewai.events.types.observation_events import (
     PlanStepCompletedEvent,
     PlanStepStartedEvent,
@@ -238,6 +240,38 @@ class TestAgentExecutor:
         assert executor.state.is_finished is True
         assert executor._finalize_called is True
         assert executor._is_feedback_iteration is False
+
+    def test_show_logs_is_visible_when_human_input_requested(self):
+        """Human review should show the answer even when normal verbose logs are off."""
+        agent = SimpleNamespace(role="Tester", verbose=False)
+        crew = SimpleNamespace(verbose=False)
+        executor = _build_executor(agent=agent, crew=crew)
+        executor.state.ask_for_human_input = True
+        final_answer = AgentFinish(thought="", output="The sky is blue.", text="done")
+
+        with patch.object(crewai_event_bus, "emit") as mock_emit:
+            executor._show_logs(final_answer)
+
+        event = mock_emit.call_args.args[1]
+        assert isinstance(event, AgentLogsExecutionEvent)
+        assert event.formatted_answer is final_answer
+        assert event.verbose is True
+
+    def test_legacy_show_logs_is_visible_when_human_input_requested(self):
+        """Legacy executor should follow the same human review visibility rule."""
+        agent = SimpleNamespace(role="Tester", verbose=False)
+        crew = SimpleNamespace(verbose=False)
+        executor = CrewAgentExecutor.model_construct(agent=agent, crew=crew)
+        executor.ask_for_human_input = True
+        final_answer = AgentFinish(thought="", output="The sky is blue.", text="done")
+
+        with patch.object(crewai_event_bus, "emit") as mock_emit:
+            executor._show_logs(final_answer)
+
+        event = mock_emit.call_args.args[1]
+        assert isinstance(event, AgentLogsExecutionEvent)
+        assert event.formatted_answer is final_answer
+        assert event.verbose is True
 
     @pytest.mark.asyncio
     async def test_async_human_feedback_reruns_flow_with_state_messages(self):


### PR DESCRIPTION
## Related issue

Fixes #6072

## Summary

When `human_input=True` is set on a task, CrewAI asks the operator to review the final answer. Previously, if both the agent and crew were running with `verbose=False`, the feedback prompt appeared but the final answer panel was hidden.

This updates both executor paths so the final answer is shown when human input is pending, even if normal verbose logging is disabled. Non-verbose runs without human review remain quiet.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

Added regression coverage for:
- Default `AgentExecutor`
- Legacy `CrewAgentExecutor`

Ran:

```powershell
.\.venv\Scripts\python.exe -m pytest -n 0 lib/crewai/tests/agents/test_agent_executor.py -k "show_logs_is_visible_when_human_input_requested"

<!-- crewai-require-issue-check -->