### PR TITLE
feat(tools): add AnyAPI catalog search, endpoint schema and run tools

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -93,6 +93,10 @@ apify = [
     "langchain-apify>=0.1.2,<1.0.0",
 ]
 
+getanyapi = [
+    "getanyapi>=0.35.3",
+]
+
 databricks-sdk = [
     "databricks-sdk>=0.46.0",
 ]

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -8,6 +8,9 @@ from crewai_tools.aws.bedrock.knowledge_base.retriever_tool import (
 from crewai_tools.aws.s3.reader_tool import S3ReaderTool
 from crewai_tools.aws.s3.writer_tool import S3WriterTool
 from crewai_tools.tools.ai_mind_tool.ai_mind_tool import AIMindTool
+from crewai_tools.tools.anyapi_tool.anyapi_describe import AnyApiDescribeTool
+from crewai_tools.tools.anyapi_tool.anyapi_run import AnyApiRunTool
+from crewai_tools.tools.anyapi_tool.anyapi_search import AnyApiSearchTool
 from crewai_tools.tools.apify_actors_tool.apify_actors_tool import ApifyActorsTool
 from crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool import ArxivPaperTool
 from crewai_tools.tools.brave_search_tool.brave_image_tool import BraveImageSearchTool
@@ -226,6 +229,9 @@ from crewai_tools.tools.zapier_action_tool.zapier_action_tool import ZapierActio
 
 __all__ = [
     "AIMindTool",
+    "AnyApiDescribeTool",
+    "AnyApiRunTool",
+    "AnyApiSearchTool",
     "ApifyActorsTool",
     "ArxivPaperTool",
     "BedrockInvokeAgentTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -1,4 +1,9 @@
 from crewai_tools.tools.ai_mind_tool.ai_mind_tool import AIMindTool
+from crewai_tools.tools.anyapi_tool import (
+    AnyApiDescribeTool,
+    AnyApiRunTool,
+    AnyApiSearchTool,
+)
 from crewai_tools.tools.apify_actors_tool.apify_actors_tool import ApifyActorsTool
 from crewai_tools.tools.arxiv_paper_tool.arxiv_paper_tool import ArxivPaperTool
 from crewai_tools.tools.brave_search_tool.brave_image_tool import BraveImageSearchTool
@@ -213,6 +218,9 @@ from crewai_tools.tools.zapier_action_tool.zapier_action_tool import ZapierActio
 
 __all__ = [
     "AIMindTool",
+    "AnyApiDescribeTool",
+    "AnyApiRunTool",
+    "AnyApiSearchTool",
     "ApifyActorsTool",
     "ArxivPaperTool",
     "BraveImageSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/README.md
@@ -1,0 +1,106 @@
+# AnyAPI Tools Documentation
+
+## Description
+
+AnyAPI is a unified marketplace for scraping and data APIs: any API, one wallet, USD, no
+subscriptions. Reach hundreds of third-party APIs (social media, search results, web data)
+through one key and one normalized interface; pay per request in real dollars; failed calls
+are never charged - AnyAPI fails over across providers automatically under one price.
+
+These three tools give a CrewAI agent the whole loop, and they are meant to be used in this
+order:
+
+- **AnyApiSearchTool**: search the catalog for an API that returns the data you need
+- **AnyApiDescribeTool**: fetch one endpoint's input schema, output schema and USD price
+- **AnyApiRunTool**: execute an endpoint with a JSON input and get normalized output back
+
+Every AnyAPI input schema is strict, so an agent must read the schema with
+`AnyApiDescribeTool` before its first `AnyApiRunTool` call on a slug. An invented field name
+fails the call.
+
+## Installation
+
+```shell
+pip install crewai[tools] getanyapi
+```
+
+or
+
+```shell
+uv add crewai-tools --extra getanyapi
+```
+
+## Examples
+
+### Search the catalog
+
+```python
+from crewai_tools import AnyApiSearchTool
+
+tool = AnyApiSearchTool()
+result = tool.run(query="instagram profile", platform="instagram", limit=5)
+```
+
+### Read an endpoint's schema and price
+
+```python
+from crewai_tools import AnyApiDescribeTool
+
+tool = AnyApiDescribeTool()
+result = tool.run(slug="instagram.profile")
+```
+
+### Run an endpoint
+
+```python
+from crewai_tools import AnyApiRunTool
+
+tool = AnyApiRunTool()
+result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+```
+
+### Give an agent the full loop
+
+```python
+from crewai import Agent
+from crewai_tools import AnyApiDescribeTool, AnyApiRunTool, AnyApiSearchTool
+
+researcher = Agent(
+    role="Data researcher",
+    goal="Answer questions with live third-party data",
+    backstory="Finds the right API, reads its schema, then calls it.",
+    tools=[AnyApiSearchTool(), AnyApiDescribeTool(), AnyApiRunTool()],
+)
+```
+
+## Steps to Get Started
+
+1. **Package Installation**: install `crewai[tools]` and the `getanyapi` extra.
+
+2. **API Key Acquisition**: create a key at `https://getanyapi.com/dashboard`. New accounts
+   start with free trial credit, so the first calls cost nothing.
+
+3. **Environment Configuration**:
+   ```bash
+   export ANYAPI_API_KEY="aa_live_..."
+   ```
+   Or pass it directly: `AnyApiSearchTool(api_key="aa_live_...")`.
+
+4. **Tool Order**: search for a slug, describe it to get the strict input schema and the
+   USD price, then run it. `AnyApiRunTool` reports what the call cost as `costUsd`.
+
+## Environment Variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `ANYAPI_API_KEY` | Yes | AnyAPI key from `https://getanyapi.com/dashboard`. Can be passed as the `api_key` argument instead. |
+
+## Conclusion
+
+AnyAPI gives AI agents one API key and one USD wallet to call hundreds of scraping and data
+APIs - Instagram, TikTok, YouTube, Reddit, Facebook, Google search results, general web
+scraping, and more - through a single normalized interface. Every API exposes a normalized
+input/output JSON Schema, so an agent discovers, inspects, and runs any of them with the same
+loop. Pricing is real-dollar pay-per-request with no subscriptions; failed calls are never
+charged because AnyAPI fails over across upstream providers automatically under one price
+reservation. The provider is always reported as AnyAPI.

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/__init__.py
@@ -1,0 +1,10 @@
+from crewai_tools.tools.anyapi_tool.anyapi_describe import AnyApiDescribeTool
+from crewai_tools.tools.anyapi_tool.anyapi_run import AnyApiRunTool
+from crewai_tools.tools.anyapi_tool.anyapi_search import AnyApiSearchTool
+
+
+__all__ = [
+    "AnyApiDescribeTool",
+    "AnyApiRunTool",
+    "AnyApiSearchTool",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_base.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_base.py
@@ -1,0 +1,66 @@
+import os
+from typing import Any, cast
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import ConfigDict, Field, PrivateAttr
+
+
+ANYAPI_BASE_URL = "https://api.getanyapi.com"
+
+INSTALL_HINT = (
+    "Missing optional dependency 'getanyapi'. Install it with:\n"
+    "  pip install getanyapi\n"
+    "or\n"
+    "  uv add crewai-tools --extra getanyapi\n"
+)
+
+MISSING_KEY_HINT = (
+    "An AnyAPI key is required. Pass api_key=... or set the ANYAPI_API_KEY environment "
+    "variable. Create a key at https://getanyapi.com/dashboard; new accounts start with "
+    "free trial credit."
+)
+
+
+def import_getanyapi() -> Any:
+    """Import the AnyAPI SDK lazily so the base install stays light."""
+    try:
+        import getanyapi
+    except ImportError as exc:
+        raise ImportError(INSTALL_HINT) from exc
+    return getanyapi
+
+
+class AnyApiToolBase(BaseTool):
+    """Credential handling and client wiring shared by the AnyAPI tools."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    api_key: str | None = None
+    base_url: str = ANYAPI_BASE_URL
+    package_dependencies: list[str] = Field(default=["getanyapi"])
+    env_vars: list[EnvVar] = Field(
+        default=[
+            EnvVar(
+                name="ANYAPI_API_KEY",
+                description="API key for AnyAPI, created at https://getanyapi.com/dashboard",
+                required=True,
+            ),
+        ]
+    )
+
+    _anyapi: Any = PrivateAttr(default=None)
+    _client: Any = PrivateAttr(default=None)
+
+    def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._anyapi = import_getanyapi()
+
+        self.api_key = api_key or os.getenv("ANYAPI_API_KEY")
+        if not self.api_key:
+            raise ValueError(MISSING_KEY_HINT)
+
+        self._client = self._anyapi.AnyAPI(api_key=self.api_key, base_url=self.base_url)
+
+    def _as_json(self, payload: Any) -> str:
+        """Serialize an SDK response the way the AnyAPI wire publishes it."""
+        return cast(str, payload.model_dump_json(by_alias=True, exclude_none=True))

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_base.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_base.py
@@ -35,7 +35,6 @@ class AnyApiToolBase(BaseTool):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    api_key: str | None = None
     base_url: str = ANYAPI_BASE_URL
     package_dependencies: list[str] = Field(default=["getanyapi"])
     env_vars: list[EnvVar] = Field(
@@ -48,6 +47,9 @@ class AnyApiToolBase(BaseTool):
         ]
     )
 
+    # The key is never a model field: CrewAI serializes a tool's fields into
+    # checkpoints and telemetry, and a secret must not travel with them. Only the
+    # SDK client below holds it.
     _anyapi: Any = PrivateAttr(default=None)
     _client: Any = PrivateAttr(default=None)
 
@@ -55,11 +57,11 @@ class AnyApiToolBase(BaseTool):
         super().__init__(**kwargs)
         self._anyapi = import_getanyapi()
 
-        self.api_key = api_key or os.getenv("ANYAPI_API_KEY")
-        if not self.api_key:
+        key = api_key or os.getenv("ANYAPI_API_KEY")
+        if not key:
             raise ValueError(MISSING_KEY_HINT)
 
-        self._client = self._anyapi.AnyAPI(api_key=self.api_key, base_url=self.base_url)
+        self._client = self._anyapi.AnyAPI(api_key=key, base_url=self.base_url)
 
     def _as_json(self, payload: Any) -> str:
         """Serialize an SDK response the way the AnyAPI wire publishes it."""

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_describe.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_describe.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from crewai_tools.tools.anyapi_tool.anyapi_base import AnyApiToolBase
+
+
+class AnyApiDescribeToolSchema(BaseModel):
+    """Input for AnyApiDescribeTool."""
+
+    slug: str = Field(
+        ...,
+        description=(
+            "The slug of the AnyAPI endpoint to describe, as returned by 'AnyAPI "
+            "catalog search', for example 'instagram.profile'."
+        ),
+    )
+
+
+class AnyApiDescribeTool(AnyApiToolBase):
+    """Fetch one AnyAPI endpoint's input schema and price before running it."""
+
+    name: str = "AnyAPI endpoint schema"
+    description: str = (
+        "Fetch the full definition of one AnyAPI endpoint by slug: its input JSON "
+        "Schema, its output JSON Schema and its USD price per request. Call this after "
+        "'AnyAPI catalog search' and before the first 'AnyAPI endpoint run' on a slug. "
+        "Build the run input only from the schema this returns, because every AnyAPI "
+        "input schema is strict and an invented field name fails the call."
+    )
+    args_schema: type[BaseModel] = AnyApiDescribeToolSchema
+
+    def _run(self, slug: str, **_: Any) -> str:
+        try:
+            entry = self._client.describe(slug)
+        except self._anyapi.AnyAPIError as exc:
+            return f"AnyAPI could not describe '{slug}': {exc}"
+
+        return self._as_json(entry)

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_describe.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_describe.py
@@ -33,7 +33,7 @@ class AnyApiDescribeTool(AnyApiToolBase):
     def _run(self, slug: str, **_: Any) -> str:
         try:
             entry = self._client.describe(slug)
-        except self._anyapi.AnyAPIError as exc:
+        except (self._anyapi.AnyAPIError, ValueError) as exc:
             return f"AnyAPI could not describe '{slug}': {exc}"
 
         return self._as_json(entry)

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_run.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_run.py
@@ -5,6 +5,12 @@ from pydantic import BaseModel, Field
 from crewai_tools.tools.anyapi_tool.anyapi_base import AnyApiToolBase
 
 
+# AnyAPI answers 402 with three codes and only one of them is about the wallet:
+# a spend cap on the key or on an authorized connection stops a call whatever the
+# balance is, so adding funds would not help.
+CAP_CODES = frozenset({"key_cap_exceeded", "grant_cap_exceeded"})
+
+
 class AnyApiRunToolSchema(BaseModel):
     """Input for AnyApiRunTool."""
 
@@ -42,17 +48,23 @@ class AnyApiRunTool(AnyApiToolBase):
         try:
             result = self._client.run(slug=slug, input=input)
         except self._anyapi.InsufficientBalanceError as exc:
-            return f"AnyAPI run failed for '{slug}': {exc}{self._balance_hint()}"
-        except self._anyapi.AnyAPIError as exc:
+            return f"AnyAPI run failed for '{slug}': {exc}{self._spend_hint(exc)}"
+        except (self._anyapi.AnyAPIError, ValueError) as exc:
             return f"AnyAPI run failed for '{slug}': {exc}"
 
         return self._as_json(result)
 
-    def _balance_hint(self) -> str:
-        """Report the wallet balance so an agent knows how much is left."""
+    def _spend_hint(self, exc: Any) -> str:
+        """Point at the limit that stopped the call: a spend cap, or the wallet."""
+        if getattr(exc, "code", None) in CAP_CODES:
+            return (
+                " A spend limit on this key, not the wallet balance, stopped the "
+                "call. Raise it at https://getanyapi.com/dashboard."
+            )
+
         try:
             balance = self._client.balance()
-        except self._anyapi.AnyAPIError:
+        except (self._anyapi.AnyAPIError, ValueError):
             return ""
 
         return (

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_run.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_run.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from crewai_tools.tools.anyapi_tool.anyapi_base import AnyApiToolBase
+
+
+class AnyApiRunToolSchema(BaseModel):
+    """Input for AnyApiRunTool."""
+
+    slug: str = Field(
+        ...,
+        description=(
+            "The slug of the AnyAPI endpoint to run, for example 'instagram.profile'."
+        ),
+    )
+    input: dict[str, Any] = Field(
+        ...,
+        description=(
+            "The endpoint input, built from the input schema returned by 'AnyAPI "
+            "endpoint schema'. The schema is strict, so an unknown field fails the "
+            'call. Example for the instagram.profile endpoint: {"handle": "nasa"}.'
+        ),
+    )
+
+
+class AnyApiRunTool(AnyApiToolBase):
+    """Execute one AnyAPI endpoint and return its normalized output."""
+
+    name: str = "AnyAPI endpoint run"
+    description: str = (
+        "Run one AnyAPI endpoint by slug with a JSON input and return its normalized "
+        "output. Use 'AnyAPI catalog search' first to pick a slug, then 'AnyAPI "
+        "endpoint schema' to read that slug's input schema, and only then run it: the "
+        "input schema is strict, so an invented field name fails the call. The response "
+        "reports what the call cost in USD as costUsd. Failed calls are never charged, "
+        "because AnyAPI fails over across sources automatically under one price."
+    )
+    args_schema: type[BaseModel] = AnyApiRunToolSchema
+
+    def _run(self, slug: str, input: dict[str, Any], **_: Any) -> str:
+        try:
+            result = self._client.run(slug=slug, input=input)
+        except self._anyapi.InsufficientBalanceError as exc:
+            return f"AnyAPI run failed for '{slug}': {exc}{self._balance_hint()}"
+        except self._anyapi.AnyAPIError as exc:
+            return f"AnyAPI run failed for '{slug}': {exc}"
+
+        return self._as_json(result)
+
+    def _balance_hint(self) -> str:
+        """Report the wallet balance so an agent knows how much is left."""
+        try:
+            balance = self._client.balance()
+        except self._anyapi.AnyAPIError:
+            return ""
+
+        return (
+            f" The wallet holds ${balance.usd} USD. "
+            "Add funds at https://getanyapi.com/dashboard."
+        )

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_search.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_search.py
@@ -61,7 +61,7 @@ class AnyApiSearchTool(AnyApiToolBase):
                 platform=platform,
                 limit=limit,
             )
-        except self._anyapi.AnyAPIError as exc:
+        except (self._anyapi.AnyAPIError, ValueError) as exc:
             return f"AnyAPI catalog search failed for '{query}': {exc}"
 
         return self._as_json(results)

--- a/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_search.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/anyapi_tool/anyapi_search.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from crewai_tools.tools.anyapi_tool.anyapi_base import AnyApiToolBase
+
+
+class AnyApiSearchToolSchema(BaseModel):
+    """Input for AnyApiSearchTool."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "What the data is, in plain words, for example 'instagram profile' or "
+            "'google maps reviews'."
+        ),
+    )
+    category: str | None = Field(
+        default=None,
+        description="Optional category filter, for example 'social' or 'search'.",
+    )
+    platform: str | None = Field(
+        default=None,
+        description=(
+            "Optional platform filter, matched against the slug prefix, for example "
+            "'instagram', 'tiktok' or 'linkedin'."
+        ),
+    )
+    limit: int | None = Field(
+        default=None,
+        description="Optional cap on how many matching APIs to return.",
+    )
+
+
+class AnyApiSearchTool(AnyApiToolBase):
+    """Search the AnyAPI catalog for the API that answers a question."""
+
+    name: str = "AnyAPI catalog search"
+    description: str = (
+        "Search the AnyAPI catalog for an API that returns the data you need. AnyAPI is "
+        "one gateway to hundreds of scraping and data APIs (social media, search "
+        "results, general web data), reached with one key and paid per request in USD. "
+        "Use this tool first. It returns matching slugs with a short description and the "
+        "USD price per request, but no input schemas. Pick a slug from the results, then "
+        "call 'AnyAPI endpoint schema' on it, and only then 'AnyAPI endpoint run'."
+    )
+    args_schema: type[BaseModel] = AnyApiSearchToolSchema
+
+    def _run(
+        self,
+        query: str,
+        category: str | None = None,
+        platform: str | None = None,
+        limit: int | None = None,
+        **_: Any,
+    ) -> str:
+        try:
+            results = self._client.search(
+                query=query,
+                category=category,
+                platform=platform,
+                limit=limit,
+            )
+        except self._anyapi.AnyAPIError as exc:
+            return f"AnyAPI catalog search failed for '{query}': {exc}"
+
+        return self._as_json(results)

--- a/lib/crewai-tools/tests/tools/anyapi_tool_test.py
+++ b/lib/crewai-tools/tests/tools/anyapi_tool_test.py
@@ -1,0 +1,233 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from getanyapi import (
+    AnyAPIError,
+    Balance,
+    CatalogEntry,
+    CatalogSearchResults,
+    InsufficientBalanceError,
+    RunResult,
+)
+from pydantic import ValidationError
+
+from crewai_tools.tools.anyapi_tool import (
+    AnyApiDescribeTool,
+    AnyApiRunTool,
+    AnyApiSearchTool,
+)
+from crewai_tools.tools.anyapi_tool.anyapi_run import AnyApiRunToolSchema
+
+SEARCH_RESULT = {
+    "slug": "instagram.profile",
+    "platformId": "instagram",
+    "name": "Instagram Profile",
+    "description": "Fetch an Instagram account's public profile by handle.",
+    "category": "social",
+    "method": "POST",
+    "path": "/v1/run/instagram.profile",
+    "execution": {"mode": "sync"},
+    "provider": "AnyAPI",
+    "pricing": {
+        "from": {
+            "model": "flat",
+            "unit": "request",
+            "maxUsd": 0.002,
+            "maxPer1kUsd": 2.0,
+        },
+        "failoverMaxUsd": 0.0024,
+        "failoverMaxPer1kUsd": 2.4,
+    },
+    "failover": True,
+    "relevance": 1.0,
+}
+
+CATALOG_ENTRY = {
+    "id": "instagram.profile",
+    "slug": "instagram.profile",
+    "name": "Instagram Profile",
+    "category": "social",
+    "description": "Fetch an Instagram account's public profile by handle.",
+    "method": "POST",
+    "path": "/v1/run/instagram.profile",
+    "execution": {"mode": "sync"},
+    "provider": "AnyAPI",
+    "pricing": SEARCH_RESULT["pricing"],
+    "lanes": [
+        {
+            "pricing": {
+                "model": "flat",
+                "unit": "request",
+                "maxUsd": 0.002,
+                "maxPer1kUsd": 2.0,
+            },
+            "source": {
+                "id": "anonymous-giraffe",
+                "name": "Giraffe",
+                "kind": "anonymous",
+                "artworkKey": "giraffe",
+            },
+        }
+    ],
+    "tryEligible": True,
+    "inputSchema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {"handle": {"type": "string"}},
+        "required": ["handle"],
+    },
+}
+
+
+@pytest.fixture
+def client():
+    fake = MagicMock()
+    with patch("getanyapi.AnyAPI", return_value=fake) as constructor:
+        fake.constructor = constructor
+        yield fake
+
+
+def test_search_tool_requires_a_key(monkeypatch):
+    monkeypatch.delenv("ANYAPI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match=r"getanyapi\.com/dashboard"):
+        AnyApiSearchTool()
+
+
+def test_describe_tool_requires_a_key(monkeypatch):
+    monkeypatch.delenv("ANYAPI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ANYAPI_API_KEY"):
+        AnyApiDescribeTool()
+
+
+def test_run_tool_requires_a_key(monkeypatch):
+    monkeypatch.delenv("ANYAPI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ANYAPI_API_KEY"):
+        AnyApiRunTool()
+
+
+def test_key_is_read_from_the_environment(client, monkeypatch):
+    monkeypatch.setenv("ANYAPI_API_KEY", "aa_live_from_env")
+    AnyApiSearchTool()
+    client.constructor.assert_called_once_with(
+        api_key="aa_live_from_env", base_url="https://api.getanyapi.com"
+    )
+
+
+def test_search_returns_ranked_catalog_matches(client):
+    client.search.return_value = CatalogSearchResults.model_validate(
+        {"results": [SEARCH_RESULT], "total": 1, "ranking": "semantic"}
+    )
+
+    tool = AnyApiSearchTool(api_key="aa_live_test")
+    payload = json.loads(
+        tool.run(query="instagram profile", platform="instagram", limit=5)
+    )
+
+    client.search.assert_called_once_with(
+        query="instagram profile", category=None, platform="instagram", limit=5
+    )
+    assert payload["total"] == 1
+    assert payload["results"][0]["slug"] == "instagram.profile"
+    assert payload["results"][0]["pricing"]["from"]["maxUsd"] == 0.002
+
+
+def test_search_reports_an_api_error(client):
+    client.search.side_effect = AnyAPIError("gateway unreachable", status=0)
+
+    tool = AnyApiSearchTool(api_key="aa_live_test")
+    result = tool.run(query="instagram profile")
+
+    assert "AnyAPI catalog search failed" in result
+    assert "gateway unreachable" in result
+
+
+def test_describe_returns_the_input_schema(client):
+    client.describe.return_value = CatalogEntry.model_validate(CATALOG_ENTRY)
+
+    tool = AnyApiDescribeTool(api_key="aa_live_test")
+    payload = json.loads(tool.run(slug="instagram.profile"))
+
+    client.describe.assert_called_once_with("instagram.profile")
+    assert payload["inputSchema"]["required"] == ["handle"]
+    assert payload["pricing"]["from"]["maxPer1kUsd"] == 2.0
+
+
+def test_describe_reports_an_api_error(client):
+    client.describe.side_effect = AnyAPIError("no such endpoint", status=404)
+
+    tool = AnyApiDescribeTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.nope")
+
+    assert "AnyAPI could not describe 'instagram.nope'" in result
+    assert "no such endpoint" in result
+
+
+def test_run_returns_output_and_usd_cost(client):
+    client.run.return_value = RunResult.model_validate(
+        {
+            "output": {"found": True, "data": {"handle": "nasa", "followers": 100}},
+            "provider": "AnyAPI",
+            "costUsd": 0.002,
+            "items": 1,
+            "replayed": False,
+        }
+    )
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    payload = json.loads(tool.run(slug="instagram.profile", input={"handle": "nasa"}))
+
+    client.run.assert_called_once_with(
+        slug="instagram.profile", input={"handle": "nasa"}
+    )
+    assert payload["costUsd"] == 0.002
+    assert payload["provider"] == "AnyAPI"
+    assert payload["output"]["data"]["handle"] == "nasa"
+
+
+def test_run_reports_an_api_error(client):
+    client.run.side_effect = AnyAPIError("upstream refused the input", status=400)
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert "AnyAPI run failed for 'instagram.profile'" in result
+    assert "upstream refused the input" in result
+
+
+def test_run_reports_the_wallet_balance_when_funds_run_out(client):
+    client.run.side_effect = InsufficientBalanceError(
+        "insufficient balance", status=402
+    )
+    client.balance.return_value = Balance(usd=0.01)
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert "insufficient balance" in result
+    assert "$0.01 USD" in result
+    assert "https://getanyapi.com/dashboard" in result
+
+
+def test_run_survives_a_failed_balance_lookup(client):
+    client.run.side_effect = InsufficientBalanceError(
+        "insufficient balance", status=402
+    )
+    client.balance.side_effect = AnyAPIError("gateway unreachable", status=0)
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert result.endswith("insufficient balance")
+
+
+def test_run_schema_rejects_an_input_that_is_not_an_object():
+    with pytest.raises(ValidationError):
+        AnyApiRunToolSchema(slug="instagram.profile", input="handle=nasa")
+
+
+def test_tools_declare_their_optional_dependency(client):
+    for tool_class in (AnyApiSearchTool, AnyApiDescribeTool, AnyApiRunTool):
+        tool = tool_class(api_key="aa_live_test")
+        assert tool.package_dependencies == ["getanyapi"]
+        assert [env_var.name for env_var in tool.env_vars] == ["ANYAPI_API_KEY"]

--- a/lib/crewai-tools/tests/tools/anyapi_tool_test.py
+++ b/lib/crewai-tools/tests/tools/anyapi_tool_test.py
@@ -132,6 +132,23 @@ def test_search_returns_ranked_catalog_matches(client):
     assert payload["results"][0]["pricing"]["from"]["maxUsd"] == 0.002
 
 
+def _validation_error() -> ValidationError:
+    """A real pydantic failure, as the SDK raises when a 200 body is malformed."""
+    try:
+        Balance.model_validate({"usd": "plenty"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("a malformed balance body should not validate")
+
+
+def test_the_key_never_reaches_serialized_tool_state(client):
+    tool = AnyApiSearchTool(api_key="aa_live_secret")
+
+    assert "api_key" not in tool.model_dump()
+    assert "aa_live_secret" not in tool.model_dump_json()
+    assert "aa_live_secret" not in repr(tool)
+
+
 def test_search_reports_an_api_error(client):
     client.search.side_effect = AnyAPIError("gateway unreachable", status=0)
 
@@ -140,6 +157,16 @@ def test_search_reports_an_api_error(client):
 
     assert "AnyAPI catalog search failed" in result
     assert "gateway unreachable" in result
+
+
+def test_search_reports_a_malformed_discovery_response(client):
+    client.search.side_effect = ValueError("malformed discovery response: search")
+
+    tool = AnyApiSearchTool(api_key="aa_live_test")
+    result = tool.run(query="instagram profile")
+
+    assert "AnyAPI catalog search failed" in result
+    assert "malformed discovery response" in result
 
 
 def test_describe_returns_the_input_schema(client):
@@ -161,6 +188,18 @@ def test_describe_reports_an_api_error(client):
 
     assert "AnyAPI could not describe 'instagram.nope'" in result
     assert "no such endpoint" in result
+
+
+def test_describe_reports_a_malformed_discovery_response(client):
+    client.describe.side_effect = ValueError(
+        "malformed discovery response: detail latency is required"
+    )
+
+    tool = AnyApiDescribeTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile")
+
+    assert "AnyAPI could not describe 'instagram.profile'" in result
+    assert "detail latency is required" in result
 
 
 def test_run_returns_output_and_usd_cost(client):
@@ -195,6 +234,15 @@ def test_run_reports_an_api_error(client):
     assert "upstream refused the input" in result
 
 
+def test_run_reports_a_malformed_durable_response(client):
+    client.run.side_effect = _validation_error()
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert result.startswith("AnyAPI run failed for 'instagram.profile'")
+
+
 def test_run_reports_the_wallet_balance_when_funds_run_out(client):
     client.run.side_effect = InsufficientBalanceError(
         "insufficient balance", status=402
@@ -214,6 +262,33 @@ def test_run_survives_a_failed_balance_lookup(client):
         "insufficient balance", status=402
     )
     client.balance.side_effect = AnyAPIError("gateway unreachable", status=0)
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert result.endswith("insufficient balance")
+
+
+def test_run_names_the_spend_cap_rather_than_the_wallet(client):
+    client.run.side_effect = InsufficientBalanceError(
+        "this API key has reached its spend limit",
+        status=402,
+        code="key_cap_exceeded",
+    )
+
+    tool = AnyApiRunTool(api_key="aa_live_test")
+    result = tool.run(slug="instagram.profile", input={"handle": "nasa"})
+
+    assert "spend limit" in result
+    assert "Add funds" not in result
+    client.balance.assert_not_called()
+
+
+def test_run_survives_a_malformed_balance_response(client):
+    client.run.side_effect = InsufficientBalanceError(
+        "insufficient balance", status=402
+    )
+    client.balance.side_effect = _validation_error()
 
     tool = AnyApiRunTool(api_key="aa_live_test")
     result = tool.run(slug="instagram.profile", input={"handle": "nasa"})

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -118,6 +118,361 @@
       }
     },
     {
+      "description": "Fetch the full definition of one AnyAPI endpoint by slug: its input JSON Schema, its output JSON Schema and its USD price per request. Call this after 'AnyAPI catalog search' and before the first 'AnyAPI endpoint run' on a slug. Build the run input only from the schema this returns, because every AnyAPI input schema is strict and an invented field name fails the call.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for AnyAPI, created at https://getanyapi.com/dashboard",
+          "name": "ANYAPI_API_KEY",
+          "required": true
+        }
+      ],
+      "humanized_name": "AnyAPI endpoint schema",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Fetch one AnyAPI endpoint's input schema and price before running it.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Key"
+          },
+          "base_url": {
+            "default": "https://api.getanyapi.com",
+            "title": "Base Url",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "title": "AnyApiDescribeTool",
+        "type": "object"
+      },
+      "name": "AnyApiDescribeTool",
+      "package_dependencies": [
+        "getanyapi"
+      ],
+      "run_params_schema": {
+        "description": "Input for AnyApiDescribeTool.",
+        "properties": {
+          "slug": {
+            "description": "The slug of the AnyAPI endpoint to describe, as returned by 'AnyAPI catalog search', for example 'instagram.profile'.",
+            "title": "Slug",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug"
+        ],
+        "title": "AnyApiDescribeToolSchema",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Run one AnyAPI endpoint by slug with a JSON input and return its normalized output. Use 'AnyAPI catalog search' first to pick a slug, then 'AnyAPI endpoint schema' to read that slug's input schema, and only then run it: the input schema is strict, so an invented field name fails the call. The response reports what the call cost in USD as costUsd. Failed calls are never charged, because AnyAPI fails over across sources automatically under one price.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for AnyAPI, created at https://getanyapi.com/dashboard",
+          "name": "ANYAPI_API_KEY",
+          "required": true
+        }
+      ],
+      "humanized_name": "AnyAPI endpoint run",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Execute one AnyAPI endpoint and return its normalized output.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Key"
+          },
+          "base_url": {
+            "default": "https://api.getanyapi.com",
+            "title": "Base Url",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "title": "AnyApiRunTool",
+        "type": "object"
+      },
+      "name": "AnyApiRunTool",
+      "package_dependencies": [
+        "getanyapi"
+      ],
+      "run_params_schema": {
+        "description": "Input for AnyApiRunTool.",
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "description": "The endpoint input, built from the input schema returned by 'AnyAPI endpoint schema'. The schema is strict, so an unknown field fails the call. Example for the instagram.profile endpoint: {\"handle\": \"nasa\"}.",
+            "title": "Input",
+            "type": "object"
+          },
+          "slug": {
+            "description": "The slug of the AnyAPI endpoint to run, for example 'instagram.profile'.",
+            "title": "Slug",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "input"
+        ],
+        "title": "AnyApiRunToolSchema",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Search the AnyAPI catalog for an API that returns the data you need. AnyAPI is one gateway to hundreds of scraping and data APIs (social media, search results, general web data), reached with one key and paid per request in USD. Use this tool first. It returns matching slugs with a short description and the USD price per request, but no input schemas. Pick a slug from the results, then call 'AnyAPI endpoint schema' on it, and only then 'AnyAPI endpoint run'.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "API key for AnyAPI, created at https://getanyapi.com/dashboard",
+          "name": "ANYAPI_API_KEY",
+          "required": true
+        }
+      ],
+      "humanized_name": "AnyAPI catalog search",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Search the AnyAPI catalog for the API that answers a question.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Key"
+          },
+          "base_url": {
+            "default": "https://api.getanyapi.com",
+            "title": "Base Url",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "title": "AnyApiSearchTool",
+        "type": "object"
+      },
+      "name": "AnyApiSearchTool",
+      "package_dependencies": [
+        "getanyapi"
+      ],
+      "run_params_schema": {
+        "description": "Input for AnyApiSearchTool.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional category filter, for example 'social' or 'search'.",
+            "title": "Category"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional cap on how many matching APIs to return.",
+            "title": "Limit"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional platform filter, matched against the slug prefix, for example 'instagram', 'tiktok' or 'linkedin'.",
+            "title": "Platform"
+          },
+          "query": {
+            "description": "What the data is, in plain words, for example 'instagram profile' or 'google maps reviews'.",
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "AnyApiSearchToolSchema",
+        "type": "object"
+      }
+    },
+    {
       "description": "Fetches metadata from Arxiv based on a search query and optionally downloads PDFs.",
       "env_vars": [],
       "humanized_name": "Arxiv Paper Fetcher and Downloader",

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -178,18 +178,6 @@
         },
         "description": "Fetch one AnyAPI endpoint's input schema and price before running it.",
         "properties": {
-          "api_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Api Key"
-          },
           "base_url": {
             "default": "https://api.getanyapi.com",
             "title": "Base Url",
@@ -281,18 +269,6 @@
         },
         "description": "Execute one AnyAPI endpoint and return its normalized output.",
         "properties": {
-          "api_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Api Key"
-          },
           "base_url": {
             "default": "https://api.getanyapi.com",
             "title": "Base Url",
@@ -391,18 +367,6 @@
         },
         "description": "Search the AnyAPI catalog for the API that answers a question.",
         "properties": {
-          "api_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Api Key"
-          },
           "base_url": {
             "default": "https://api.getanyapi.com",
             "title": "Base Url",

--- a/uv.lock
+++ b/uv.lock
@@ -1662,6 +1662,9 @@ exa-py = [
 firecrawl-py = [
     { name = "firecrawl-py" },
 ]
+getanyapi = [
+    { name = "getanyapi" },
+]
 github = [
     { name = "gitpython" },
     { name = "pygithub" },
@@ -1762,6 +1765,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = "~=2.6.0" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
+    { name = "getanyapi", marker = "extra == 'getanyapi'", specifier = ">=0.35.3" },
     { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.58,<4" },
     { name = "hyperbrowser", marker = "extra == 'hyperbrowser'", specifier = ">=0.18.0" },
     { name = "langchain-apify", marker = "extra == 'apify'", specifier = ">=0.1.2,<1.0.0" },
@@ -1803,7 +1807,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate-client'", specifier = ">=4.10.2" },
     { name = "youtube-transcript-api", specifier = "~=1.2.2" },
 ]
-provides-extras = ["apify", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
+provides-extras = ["apify", "beautifulsoup4", "bedrock", "browserbase", "composio-core", "contextual", "couchbase", "databricks-sdk", "daytona", "e2b", "exa-py", "firecrawl-py", "getanyapi", "github", "hyperbrowser", "linkup-sdk", "mcp", "mongodb", "multion", "mysql", "oxylabs", "patronus", "postgresql", "qdrant-client", "rag", "scrapegraph-py", "scrapfly-sdk", "selenium", "serpapi", "singlestore", "snowflake", "spider-client", "sqlalchemy", "stagehand", "tavily-python", "weaviate-client", "xml"]
 
 [[package]]
 name = "cryptography"
@@ -2766,6 +2770,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
+name = "getanyapi"
+version = "0.35.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/ed/d6fa8e55c8d22952cafa3babd51880bde75e3d296819c3b498d13e20a63d/getanyapi-0.35.3.tar.gz", hash = "sha256:26deac93c5ec3c1bd4bd70dd07ef105c11334a4f189653ac4d89c9ccae76cb6e", size = 349760, upload-time = "2026-09-01T06:58:28.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/5a/61394b66c43e2e903f68535e22f23751776b9dacb833da8a7fc01f4e54ea/getanyapi-0.35.3-py3-none-any.whl", hash = "sha256:cf4dccdc97ddffbe9ad09c317a303eed781f1f3c62da73fe8d2602cdfeea928f", size = 383613, upload-time = "2026-09-01T06:58:26.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Fixes #7253

## Summary

Adds three tools for [AnyAPI](https://getanyapi.com), a gateway to hundreds of scraping and data APIs behind one key, billed per request in USD with no subscription. It sits alongside the existing Apify, Bright Data, Exa, Firecrawl, Jina, Oxylabs, Scrapfly, SerpApi, Serper and Tavily tools, but is catalog-shaped rather than single-purpose, so the agent picks the data source at run time instead of the developer picking it at import time.

| Tool | Name shown to the agent | Purpose |
|---|---|---|
| `AnyApiSearchTool` | AnyAPI catalog search | ranked search for the endpoint that returns the needed data |
| `AnyApiDescribeTool` | AnyAPI endpoint schema | that endpoint's input/output JSON Schema and USD price |
| `AnyApiRunTool` | AnyAPI endpoint run | execute the endpoint |

All three sit on a shared `AnyApiToolBase` that owns the lazy `getanyapi` import, the `api_key` / `ANYAPI_API_KEY` fallback and client construction. Each tool's description points at the next one by name and states that the schema is strict, so an agent that skips the describe step is told why its call failed.

Responses are dumped with `by_alias=True`, so the agent sees the published wire names (`costUsd`, `inputSchema`, `maxPer1kUsd`) rather than internal ones. `AnyApiRunTool` catches an insufficient-balance error and appends the remaining USD plus the dashboard URL, so an empty wallet is a readable failure rather than an opaque one.

There is deliberately no hardcoded endpoint list, no per-platform convenience tool and no catalog caching. Routing, pricing and schemas belong to the gateway, so this stays a thin transport layer and needs no release when the catalog changes.

`getanyapi` is declared as an optional extra following the sibling tools, and `ImportError` carries install instructions per `BUILDING_TOOLS.md` rather than prompting interactively, which would be wrong inside an agent run.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

```
$ uv run ruff check lib/
All checks passed!

$ uv run ruff format --check lib/
922 files already formatted

$ uv lock --check
Resolved 477 packages in 11ms

$ cd lib/crewai-tools && uv run pytest tests/tools/anyapi_tool_test.py
14 passed, 18 warnings in 4.68s

$ uv run pytest lib/crewai-tools/tests/test_generate_tool_specs.py
10 passed
```

`mypy` scoped to the new files reports `Success: no issues found`. Repo-wide `mypy lib/` reports 584 errors in 96 files on this branch - identical to `main` checked out in a throwaway worktree with the same interpreter, so none of them are mine.

Beyond the mocked unit tests, I smoke tested the two free catalog paths against the live production API with a real key. `AnyApiSearchTool(query="instagram profile", platform="instagram", limit=3)` returned 27 total matches led by `instagram.basic_profile` at `maxPer1kUsd: 1.5`, and `AnyApiDescribeTool` on that slug returned the real input schema and nested USD pricing. `AnyApiRunTool` was instantiated but not executed, since it bills real money; its behaviour is covered by unit tests.

`tool.specs.json` was regenerated with the repo's own `generate_tool_specs.py`; it added exactly the three new entries with zero existing entries removed or changed. `uv.lock` was hand-spliced rather than regenerated, so the diff is 19 added lines instead of a few thousand.

## Additional context

**Disclosure:** I work on AnyAPI, so this is a vendor-contributed integration, and it was drafted with an AI coding tool and then reviewed by a human against the live API before submitting. Flagging both rather than leaving you to find out.

**One supply-chain note.** `getanyapi>=0.35.3` was published on 2026-09-01, and this repo sets `exclude-newer = "3 days"`. `uv lock --check` passes because it validates the lock against the manifests, but a full re-resolution run before 2026-09-04 would exclude the package. This resolves itself with time; I did not add an `exclude-newer-package` override because that widens the change into your supply-chain policy. Say the word if you would rather have the pin.

**Not included:** a docs page. `AGENTS.md` requires syncing any English docs edit to `ar`, `ko` and `pt-BR`, which would multiply the diff. Happy to follow up with the four MDX files and the `docs.json` entry if you want the tools discoverable there.

<!-- crewai-require-issue-check -->