### PR TITLE
fix(state): persist json checkpoints as utf-8

### DIFF
--- a/lib/crewai/src/crewai/state/provider/json_provider.py
+++ b/lib/crewai/src/crewai/state/provider/json_provider.py
@@ -63,7 +63,7 @@ class JsonProvider(BaseProvider):
         file_path = _build_path(location, branch, parent_id)
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(data)
         return str(file_path)
 
@@ -91,7 +91,7 @@ class JsonProvider(BaseProvider):
         file_path = _build_path(location, branch, parent_id)
         await aiofiles.os.makedirs(str(file_path.parent), exist_ok=True)
 
-        async with aiofiles.open(file_path, "w") as f:
+        async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
             await f.write(data)
         return str(file_path)
 
@@ -129,7 +129,7 @@ class JsonProvider(BaseProvider):
         Returns:
             The raw JSON string.
         """
-        return Path(location).read_text()
+        return Path(location).read_text(encoding="utf-8")
 
     async def afrom_checkpoint(self, location: str) -> str:
         """Read a JSON checkpoint file asynchronously.
@@ -140,7 +140,7 @@ class JsonProvider(BaseProvider):
         Returns:
             The raw JSON string.
         """
-        async with aiofiles.open(location) as f:
+        async with aiofiles.open(location, encoding="utf-8") as f:
             return await f.read()
 
 

--- a/lib/crewai/tests/test_checkpoint.py
+++ b/lib/crewai/tests/test_checkpoint.py
@@ -378,6 +378,25 @@ class TestJsonProviderFork:
             assert path.endswith(".json")
             assert os.path.isfile(path)
 
+    def test_checkpoint_uses_utf8_for_non_ascii_json(self) -> None:
+        provider = JsonProvider()
+        data = '{"message": "olá niño"}'
+        with tempfile.TemporaryDirectory() as d:
+            path = provider.checkpoint(data, d, branch="main")
+
+            assert Path(path).read_bytes() == data.encode("utf-8")
+            assert provider.from_checkpoint(path) == data
+
+    @pytest.mark.asyncio
+    async def test_acheckpoint_uses_utf8_for_non_ascii_json(self) -> None:
+        provider = JsonProvider()
+        data = '{"message": "olá niño"}'
+        with tempfile.TemporaryDirectory() as d:
+            path = await provider.acheckpoint(data, d, branch="main")
+
+            assert Path(path).read_bytes() == data.encode("utf-8")
+            assert await provider.afrom_checkpoint(path) == data
+
     def test_checkpoint_fork_branch_subdir(self) -> None:
         provider = JsonProvider()
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## Problem

`JsonProvider` persists checkpoint JSON with the platform default text encoding in both the sync and async paths. The matching checkpoint readers also rely on the default encoding.

That makes checkpoint round-trips environment-dependent when serialized state contains non-ASCII text on systems whose default encoding is not UTF-8.

## Before / after

Before this change, checkpoint writes and reads used the process/platform default encoding.

After this change, sync and async checkpoint writes/readers use `encoding="utf-8"`, matching JSON's expected interoperable encoding and keeping checkpoint behavior stable across platforms.

## Verification

- `python -m py_compile lib/crewai/src/crewai/state/provider/json_provider.py lib/crewai/tests/test_checkpoint.py`
- `git diff --check`
- direct smoke test of `JsonProvider` sync + async non-ASCII checkpoint round trip via file import: passed

I also attempted:

- `python -m pytest lib/crewai/tests/test_checkpoint.py -k "JsonProviderFork or checkpoint_uses_utf8" -q`

That local run was blocked by environment setup in this bare checkout: first the configured `--timeout=60` option required a missing pytest-timeout plugin, then collection required repo dependencies such as `jsonref`. The added tests are narrow and exercise the same provider paths as the passing direct smoke test.


Closes #7256

