### PR TITLE
docs: replace retired Anthropic model ids in native-provider examples

### DIFF
--- a/docs/edge/ar/concepts/knowledge.mdx
+++ b/docs/edge/ar/concepts/knowledge.mdx
@@ -577,7 +577,7 @@ agent = Agent(
     role="Researcher",
     goal="Research topics",
     backstory="Expert researcher",
-    llm=LLM(provider="anthropic", model="claude-3-sonnet")  # Using Claude
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6")  # Using Claude
 )
 
 # CrewAI will still use OpenAI embeddings by default for knowledge

--- a/docs/edge/ar/concepts/memory.mdx
+++ b/docs/edge/ar/concepts/memory.mdx
@@ -730,7 +730,7 @@ memory = Memory()
 memory = Memory(llm="gpt-4o")
 
 # Use Anthropic
-memory = Memory(llm="anthropic/claude-3-haiku-20240307")
+memory = Memory(llm="anthropic/claude-haiku-4-5")
 
 # Use Ollama for fully local/private analysis
 memory = Memory(llm="ollama/llama3.2")

--- a/docs/edge/ar/guides/agents/crafting-effective-agents.mdx
+++ b/docs/edge/ar/guides/agents/crafting-effective-agents.mdx
@@ -423,7 +423,7 @@ writer:
   role: "Creative Content Writer"
   goal: "..."
   backstory: "..."
-  llm: anthropic/claude-3-opus
+  llm: anthropic/claude-opus-4-6
 ```
 
 ## اختبار تصميم الـ Agent والتكرار عليه

--- a/docs/edge/ar/learn/llm-selection-guide.mdx
+++ b/docs/edge/ar/learn/llm-selection-guide.mdx
@@ -147,7 +147,7 @@ from crewai import Agent, Task, Crew, LLM
 manager_llm = LLM(model="gemini/gemini-3.7-flash", temperature=0.1)
 
 # Creative model for content generation
-content_llm = LLM(model="claude-3-5-sonnet-20241022", temperature=0.7)
+content_llm = LLM(model="claude-sonnet-4-6", temperature=0.7)
 
 # Efficient model for data processing
 processing_llm = LLM(model="gpt-4o-mini", temperature=0)
@@ -320,7 +320,7 @@ domain_expert = Agent(
     You've worked with companies like Salesforce, HubSpot, and emerging unicorns, giving
     you perspective on both established and disruptive go-to-market strategies.
     """,
-    llm=LLM(model="claude-3-5-sonnet", temperature=0.3)  # Balanced creativity with domain knowledge
+    llm=LLM(model="claude-sonnet-4-6", temperature=0.3)  # Balanced creativity with domain knowledge
 )
 
 # This context enables Claude to perform like a domain expert
@@ -352,7 +352,7 @@ tech_writer = Agent(
     and practical use cases. You prioritize accuracy and usability over marketing fluff.
     """,
     llm=LLM(
-        model="claude-3-5-sonnet",  # Excellent for technical writing
+        model="claude-sonnet-4-6",  # Excellent for technical writing
         temperature=0.1  # Low temperature for accuracy
     ),
     tools=[code_analyzer_tool, api_scanner_tool],
@@ -416,7 +416,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
     # Creative or customer-facing agents
     content_agent = Agent(
         role="Content Creator",
-        llm=LLM(model="claude-3-5-sonnet"),  # Best for writing
+        llm=LLM(model="claude-sonnet-4-6"),  # Best for writing
         # ... rest of config
     )
     ```
@@ -511,7 +511,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
     )
 
     # Agents inherit crew LLM unless specifically overridden
-    agent1 = Agent(llm=LLM(model="claude-3-5-sonnet"))  # Override for specific needs
+    agent1 = Agent(llm=LLM(model="claude-sonnet-4-6"))  # Override for specific needs
     ```
 
   </Accordion>
@@ -529,7 +529,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
         tools=[search_tool, api_tool, data_tool],
         llm=LLM(model="gpt-4o"),  # Excellent function calling
         # OR
-        llm=LLM(model="claude-3-5-sonnet")  # Also strong with tools
+        llm=LLM(model="claude-sonnet-4-6")  # Also strong with tools
     )
     ```
 

--- a/docs/edge/en/concepts/knowledge.mdx
+++ b/docs/edge/en/concepts/knowledge.mdx
@@ -577,7 +577,7 @@ agent = Agent(
     role="Researcher",
     goal="Research topics",
     backstory="Expert researcher",
-    llm=LLM(provider="anthropic", model="claude-3-sonnet")  # Using Claude
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6")  # Using Claude
 )
 
 # CrewAI will still use OpenAI embeddings by default for knowledge

--- a/docs/edge/en/concepts/memory.mdx
+++ b/docs/edge/en/concepts/memory.mdx
@@ -734,7 +734,7 @@ memory = Memory()
 memory = Memory(llm="gpt-4o")
 
 # Use Anthropic
-memory = Memory(llm="anthropic/claude-3-haiku-20240307")
+memory = Memory(llm="anthropic/claude-haiku-4-5")
 
 # Use Ollama for fully local/private analysis
 memory = Memory(llm="ollama/llama3.2")

--- a/docs/edge/en/guides/agents/crafting-effective-agents.mdx
+++ b/docs/edge/en/guides/agents/crafting-effective-agents.mdx
@@ -423,7 +423,7 @@ writer:
   role: "Creative Content Writer"
   goal: "..."
   backstory: "..."
-  llm: anthropic/claude-3-opus
+  llm: anthropic/claude-opus-4-6
 ```
 
 ## Testing and Iterating on Agent Design

--- a/docs/edge/en/learn/llm-selection-guide.mdx
+++ b/docs/edge/en/learn/llm-selection-guide.mdx
@@ -150,7 +150,7 @@ from crewai import Agent, Task, Crew, LLM
 manager_llm = LLM(model="gemini/gemini-3.7-flash", temperature=0.1)
 
 # Creative model for content generation
-content_llm = LLM(model="claude-3-5-sonnet-20241022", temperature=0.7)
+content_llm = LLM(model="claude-sonnet-4-6", temperature=0.7)
 
 # Efficient model for data processing
 processing_llm = LLM(model="gpt-4o-mini", temperature=0)
@@ -323,7 +323,7 @@ domain_expert = Agent(
     You've worked with companies like Salesforce, HubSpot, and emerging unicorns, giving
     you perspective on both established and disruptive go-to-market strategies.
     """,
-    llm=LLM(model="claude-3-5-sonnet", temperature=0.3)  # Balanced creativity with domain knowledge
+    llm=LLM(model="claude-sonnet-4-6", temperature=0.3)  # Balanced creativity with domain knowledge
 )
 
 # This context enables Claude to perform like a domain expert
@@ -355,7 +355,7 @@ tech_writer = Agent(
     and practical use cases. You prioritize accuracy and usability over marketing fluff.
     """,
     llm=LLM(
-        model="claude-3-5-sonnet",  # Excellent for technical writing
+        model="claude-sonnet-4-6",  # Excellent for technical writing
         temperature=0.1  # Low temperature for accuracy
     ),
     tools=[code_analyzer_tool, api_scanner_tool],
@@ -419,7 +419,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
     # Creative or customer-facing agents
     content_agent = Agent(
         role="Content Creator",
-        llm=LLM(model="claude-3-5-sonnet"),  # Best for writing
+        llm=LLM(model="claude-sonnet-4-6"),  # Best for writing
         # ... rest of config
     )
     ```
@@ -514,7 +514,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
     )
 
     # Agents inherit crew LLM unless specifically overridden
-    agent1 = Agent(llm=LLM(model="claude-3-5-sonnet"))  # Override for specific needs
+    agent1 = Agent(llm=LLM(model="claude-sonnet-4-6"))  # Override for specific needs
     ```
 
   </Accordion>
@@ -532,7 +532,7 @@ Rather than repeating the strategic framework, here's a tactical checklist for i
         tools=[search_tool, api_tool, data_tool],
         llm=LLM(model="gpt-4o"),  # Excellent function calling
         # OR
-        llm=LLM(model="claude-3-5-sonnet")  # Also strong with tools
+        llm=LLM(model="claude-sonnet-4-6")  # Also strong with tools
     )
     ```
 

--- a/docs/edge/ko/concepts/knowledge.mdx
+++ b/docs/edge/ko/concepts/knowledge.mdx
@@ -544,7 +544,7 @@ agent = Agent(
     role="Researcher",
     goal="Research topics",
     backstory="Expert researcher",
-    llm=LLM(provider="anthropic", model="claude-3-sonnet")  # Using Claude
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6")  # Using Claude
 )
 
 # CrewAI will still use OpenAI embeddings by default for knowledge

--- a/docs/edge/ko/concepts/memory.mdx
+++ b/docs/edge/ko/concepts/memory.mdx
@@ -730,7 +730,7 @@ memory = Memory()
 memory = Memory(llm="gpt-4o")
 
 # Anthropic 사용
-memory = Memory(llm="anthropic/claude-3-haiku-20240307")
+memory = Memory(llm="anthropic/claude-haiku-4-5")
 
 # 완전한 로컬/비공개 분석을 위해 Ollama 사용
 memory = Memory(llm="ollama/llama3.2")

--- a/docs/edge/ko/guides/agents/crafting-effective-agents.mdx
+++ b/docs/edge/ko/guides/agents/crafting-effective-agents.mdx
@@ -424,7 +424,7 @@ writer:
   role: "Creative Content Writer"
   goal: "..."
   backstory: "..."
-  llm: anthropic/claude-3-opus
+  llm: anthropic/claude-opus-4-6
 ```
 
 ## 에이전트 설계 테스트 및 반복

--- a/docs/edge/ko/learn/llm-selection-guide.mdx
+++ b/docs/edge/ko/learn/llm-selection-guide.mdx
@@ -148,7 +148,7 @@ from crewai import Agent, Task, Crew, LLM
 manager_llm = LLM(model="gemini/gemini-3.7-flash", temperature=0.1)
 
 # Creative model for content generation
-content_llm = LLM(model="claude-3-5-sonnet-20241022", temperature=0.7)
+content_llm = LLM(model="claude-sonnet-4-6", temperature=0.7)
 
 # Efficient model for data processing
 processing_llm = LLM(model="gpt-4o-mini", temperature=0)
@@ -322,7 +322,7 @@ domain_expert = Agent(
     You've worked with companies like Salesforce, HubSpot, and emerging unicorns, giving
     you perspective on both established and disruptive go-to-market strategies.
     """,
-    llm=LLM(model="claude-3-5-sonnet", temperature=0.3)  # Balanced creativity with domain knowledge
+    llm=LLM(model="claude-sonnet-4-6", temperature=0.3)  # Balanced creativity with domain knowledge
 )
 
 # This context enables Claude to perform like a domain expert
@@ -354,7 +354,7 @@ tech_writer = Agent(
     and practical use cases. You prioritize accuracy and usability over marketing fluff.
     """,
     llm=LLM(
-        model="claude-3-5-sonnet",  # Excellent for technical writing
+        model="claude-sonnet-4-6",  # Excellent for technical writing
         temperature=0.1  # Low temperature for accuracy
     ),
     tools=[code_analyzer_tool, api_scanner_tool],
@@ -418,7 +418,7 @@ tech_writer = Agent(
     # Creative 또는 고객 대응 agent
     content_agent = Agent(
         role="Content Creator",
-        llm=LLM(model="claude-3-5-sonnet"),  # 글쓰기에 최적
+        llm=LLM(model="claude-sonnet-4-6"),  # 글쓰기에 최적
         # ... 나머지 설정
     )
     ```
@@ -513,7 +513,7 @@ tech_writer = Agent(
     )
 
     # agent는 특별히 지정하지 않으면 crew LLM을 상속받음
-    agent1 = Agent(llm=LLM(model="claude-3-5-sonnet"))  # 특정 요구에 따라 오버라이드
+    agent1 = Agent(llm=LLM(model="claude-sonnet-4-6"))  # 특정 요구에 따라 오버라이드
     ```
 
   </Accordion>
@@ -531,7 +531,7 @@ tech_writer = Agent(
         tools=[search_tool, api_tool, data_tool],
         llm=LLM(model="gpt-4o"),  # 함수 호출에 우수
         # OR
-        llm=LLM(model="claude-3-5-sonnet")  # 도구 사용에 강점
+        llm=LLM(model="claude-sonnet-4-6")  # 도구 사용에 강점
     )
     ```
 

--- a/docs/edge/pt-BR/concepts/knowledge.mdx
+++ b/docs/edge/pt-BR/concepts/knowledge.mdx
@@ -542,7 +542,7 @@ agent = Agent(
     role="Researcher",
     goal="Research topics",
     backstory="Expert researcher",
-    llm=LLM(provider="anthropic", model="claude-3-sonnet")  # Using Claude
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6")  # Using Claude
 )
 
 # CrewAI will still use OpenAI embeddings by default for knowledge

--- a/docs/edge/pt-BR/concepts/memory.mdx
+++ b/docs/edge/pt-BR/concepts/memory.mdx
@@ -730,7 +730,7 @@ memory = Memory()
 memory = Memory(llm="gpt-4o")
 
 # Usar Anthropic
-memory = Memory(llm="anthropic/claude-3-haiku-20240307")
+memory = Memory(llm="anthropic/claude-haiku-4-5")
 
 # Usar Ollama para análise totalmente local/privada
 memory = Memory(llm="ollama/llama3.2")

--- a/docs/edge/pt-BR/guides/agents/crafting-effective-agents.mdx
+++ b/docs/edge/pt-BR/guides/agents/crafting-effective-agents.mdx
@@ -423,7 +423,7 @@ writer:
   role: "Creative Content Writer"
   goal: "..."
   backstory: "..."
-  llm: anthropic/claude-3-opus
+  llm: anthropic/claude-opus-4-6
 ```
 
 ## Testando e Iterando no Design de Agentes

--- a/docs/edge/pt-BR/learn/llm-selection-guide.mdx
+++ b/docs/edge/pt-BR/learn/llm-selection-guide.mdx
@@ -151,7 +151,7 @@ from crewai import Agent, Task, Crew, LLM
 manager_llm = LLM(model="gemini/gemini-3.7-flash", temperature=0.1)
 
 # Modelo criativo para gerar conteúdo
-content_llm = LLM(model="claude-3-5-sonnet-20241022", temperature=0.7)
+content_llm = LLM(model="claude-sonnet-4-6", temperature=0.7)
 
 # Modelo eficiente para processamento de dados
 processing_llm = LLM(model="gpt-4o-mini", temperature=0)
@@ -324,7 +324,7 @@ domain_expert = Agent(
     You've worked with companies like Salesforce, HubSpot, and emerging unicorns, giving
     you perspective on both established and disruptive go-to-market strategies.
     """,
-    llm=LLM(model="claude-3-5-sonnet", temperature=0.3)  # Criatividade balanceada com conhecimento de domínio
+    llm=LLM(model="claude-sonnet-4-6", temperature=0.3)  # Criatividade balanceada com conhecimento de domínio
 )
 
 # Esse contexto faz o Claude agir como especialista do setor
@@ -356,7 +356,7 @@ tech_writer = Agent(
     and practical use cases. You prioritize accuracy and usability over marketing fluff.
     """,
     llm=LLM(
-        model="claude-3-5-sonnet",
+        model="claude-sonnet-4-6",
         temperature=0.1
     ),
     tools=[code_analyzer_tool, api_scanner_tool],
@@ -420,7 +420,7 @@ Em vez de repetir o framework estratégico, segue um checklist tático para impl
     # Agentes criativos ou customer-facing
     content_agent = Agent(
         role="Content Creator",
-        llm=LLM(model="claude-3-5-sonnet"),
+        llm=LLM(model="claude-sonnet-4-6"),
         # ... demais configs
     )
     ```
@@ -515,7 +515,7 @@ Em vez de repetir o framework estratégico, segue um checklist tático para impl
     )
 
     # Agentes herdam o LLM da crew, salvo sobrescrita
-    agent1 = Agent(llm=LLM(model="claude-3-5-sonnet"))
+    agent1 = Agent(llm=LLM(model="claude-sonnet-4-6"))
     ```
 
   </Accordion>
@@ -533,7 +533,7 @@ Em vez de repetir o framework estratégico, segue um checklist tático para impl
         tools=[search_tool, api_tool, data_tool],
         llm=LLM(model="gpt-4o"),
         # OU
-        llm=LLM(model="claude-3-5-sonnet")
+        llm=LLM(model="claude-sonnet-4-6")
     )
     ```
 


### PR DESCRIPTION
> **AI-assisted contribution.** Written with Claude Code and reviewed by me before opening.
> Per `CONTRIBUTING.md` this needs the `llm-generated` label; I do not have triage
> permission here, so could a maintainer please apply it.

Closes #7402.

Reopening after the bot closed this for lacking an associated issue, which was my mistake.
#7402 is now open and describes the problem; this PR is the fix.

Follow-up to the offer I made on #7110. #7003 fixed the retired Gemini ids; the Claude ones
in the same docs are in the same state.

## What this changes

Nine Claude 3 family ids used in the native-provider examples now return 404 from the
Messages API. Checked today:

```
claude-3-5-sonnet-20241022   HTTP 404
claude-3-5-sonnet            HTTP 404
claude-3-haiku-20240307      HTTP 404
claude-3-opus                HTTP 404
claude-3-sonnet              HTTP 404

claude-sonnet-4-6            OK 200
claude-haiku-4-5             OK 200
claude-opus-4-6              OK 200
```

36 occurrences across 4 files and all 4 locales:

- `learn/llm-selection-guide.mdx` (6 per locale)
- `guides/agents/crafting-effective-agents.mdx`
- `concepts/knowledge.mdx`
- `concepts/memory.mdx`

## Replacements keep the tier

`claude-sonnet-4-6` is already used elsewhere in these docs after #7003, so this is
consistent rather than introducing a new id.

Tier matters here because `llm-selection-guide.mdx` is teaching a cost and capability
tradeoff, which is the point you and I discussed on #7002. So sonnet stays sonnet, haiku
stays haiku (`Memory(llm=...)`, the cheap path), and opus stays opus
(`crafting-effective-agents.mdx`, where the prose is about the strongest model). Trailing
comments like `# Best for writing` and their Korean and Portuguese translations are
untouched.

## Deliberately not included

`observability/portkey.mdx` and `observability/langdb.mdx` also contain ids that 404 on the
direct API, but those examples route through a gateway with its own model-id namespace, so
I have left them alone rather than guess. Same reasoning as the Bedrock and Vertex id
formats.

Frozen `docs/v*` snapshots untouched, and the `ar`, `ko` and `pt-BR` translations are synced
as `AGENTS.md` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
