### PR TITLE
fix(deps): bump gitpython to >=3.1.60 for PYSEC-2026-3785–3788

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -107,12 +107,11 @@ stagehand = [
     "stagehand>=0.4.1",
 ]
 github = [
-    # <3.1.58 has GHSA-p538-c434-8v24 (arbitrary file truncation),
-    # GHSA-3f7w-8rr8-f37f (unguarded git option forwarding),
-    # GHSA-9rj7-rf2p-w77r, GHSA-4gmw-gg2m-w46p, GHSA-hh9p-6wh2-4mfc,
-    # GHSA-wvpp-8hx9-p66j and GHSA-jm78-9fvv-mhgr (further unguarded git
-    # option forwarding / arbitrary file read); force 3.1.58+.
-    "gitpython>=3.1.58,<4",
+    # <3.1.59 has PYSEC-2026-3785/GHSA-7833-fr7j-v32q,
+    # PYSEC-2026-3786/GHSA-284h-m62q-gf8w, PYSEC-2026-3787/GHSA-8mcc-hrx5-hvxc,
+    # and PYSEC-2026-3788/GHSA-5xxx-qhh7-9287. 3.1.60 hardens config escapes,
+    # diff/actor parsing, and filesystem diffs; force 3.1.60+.
+    "gitpython>=3.1.60,<4",
     "PyGithub==1.59.1",
 ]
 rag = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ info = "Commits must follow Conventional Commits 1.0.0."
 [tool.uv]
 exclude-newer = "3 days"
 # These security fixes are newer than the global supply-chain cutoff.
-exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = "2026-06-20T00:00:00Z", langsmith = "2026-06-20T00:00:00Z", gitpython = "2026-08-05T00:00:00Z" }
+exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = "2026-06-20T00:00:00Z", langsmith = "2026-06-20T00:00:00Z" }
 
 # composio-core pins rich<14 but textual requires rich>=14.
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it so qdrant[fastembed] resolves on 3.10.
@@ -203,8 +203,14 @@ exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = 
 # TagReference); force 3.1.57+.
 # gitpython <3.1.58 has GHSA-9rj7-rf2p-w77r, GHSA-4gmw-gg2m-w46p, GHSA-hh9p-6wh2-4mfc, GHSA-wvpp-8hx9-p66j and
 # GHSA-jm78-9fvv-mhgr (further unguarded git option forwarding in Repo.init, read-tree and git-config, plus
-# arbitrary file read via --pathspec-from-file); force 3.1.58+. Its exclude-newer-package cutoff is bumped to
-# 2026-08-05 to admit that release.
+# arbitrary file read via --pathspec-from-file).
+# gitpython <3.1.59 has PYSEC-2026-3785/GHSA-7833-fr7j-v32q (.gitmodules [include] file disclosure),
+# PYSEC-2026-3786/GHSA-284h-m62q-gf8w (multi-line git-config re-serialization RCE),
+# PYSEC-2026-3787/GHSA-8mcc-hrx5-hvxc (clone --separate-git-dir omitted from unsafe options),
+# and PYSEC-2026-3788/GHSA-5xxx-qhh7-9287 (Repo.blame --contents/-S arbitrary file read).
+# gitpython 3.1.60 hardens config escape semantics, diff/actor parsing, and
+# filesystem diffs; force 3.1.60+. 3.1.60 is older than the global 3-day cutoff,
+# so no exclude-newer-package override is needed.
 # pyasn1 <0.6.4 has GHSA-8ppf-4f7h-5ppj and GHSA-hm4w-wwcw-mr6r; force 0.6.4+.
 # urllib3 <2.7.0 has GHSA-qccp-gfcp-xxvc (ProxyManager cross-origin redirect leaks Authorization/Cookie) and GHSA-mf9v-mfxr-j63j (streaming decompression-bomb bypass); force 2.7.0+.
 # langsmith <0.8.18 has GHSA-3644-q5cj-c5c7 (public prompt manifest deserialization, SSRF/secret disclosure)
@@ -257,7 +263,7 @@ override-dependencies = [
     "pypdf>=6.16.1,<7",
     "uv>=0.11.15,<1",
     "python-multipart>=0.0.27,<1",
-    "gitpython>=3.1.58,<4",
+    "gitpython>=3.1.60,<4",
     "pyasn1>=0.6.4",
     "langsmith>=0.8.18,<1",
     "authlib>=1.6.12",

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,6 @@ exclude-newer-span = "P3D"
 [options.exclude-newer-package]
 msgpack = "2026-06-20T00:00:00Z"
 langsmith = "2026-06-20T00:00:00Z"
-gitpython = "2026-08-05T00:00:00Z"
 pydantic-settings = "2026-06-20T00:00:00Z"
 
 [manifest]
@@ -36,7 +35,7 @@ overrides = [
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "docling-core", extras = ["chunking"], specifier = ">=2.74.1" },
-    { name = "gitpython", specifier = ">=3.1.58,<4" },
+    { name = "gitpython", specifier = ">=3.1.60,<4" },
     { name = "h2", specifier = ">=4.4.1" },
     { name = "langchain-core", specifier = ">=1.3.3,<2" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2,<2" },
@@ -1762,7 +1761,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = "~=2.6.0" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
-    { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.58,<4" },
+    { name = "gitpython", marker = "extra == 'github'", specifier = ">=3.1.60,<4" },
     { name = "hyperbrowser", marker = "extra == 'hyperbrowser'", specifier = ">=0.18.0" },
     { name = "langchain-apify", marker = "extra == 'apify'", specifier = ">=0.1.2,<1.0.0" },
     { name = "linkup-sdk", marker = "extra == 'linkup-sdk'", specifier = ">=0.2.2" },
@@ -2782,14 +2781,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Raise `gitpython` floor from `>=3.1.58` to `>=3.1.60` in both the workspace override and `crewai-tools[github]` to clear pip-audit findings on PYSEC-2026-3785 through PYSEC-2026-3788:

- **PYSEC-2026-3785** / GHSA-7833-fr7j-v32q — `.gitmodules` `[include]` file disclosure
- **PYSEC-2026-3786** / GHSA-284h-m62q-gf8w — multi-line git-config re-serialization RCE
- **PYSEC-2026-3787** / GHSA-8mcc-hrx5-hvxc — `clone --separate-git-dir` omitted from unsafe options
- **PYSEC-2026-3788** / GHSA-5xxx-qhh7-9287 — `Repo.blame --contents/-S` arbitrary file read

3.1.60 hardens config escape semantics, diff/actor parsing, and filesystem diffs. Lock resolves to 3.1.61.

Drops the `gitpython` `exclude-newer-package` cutoff since 3.1.60+ is older than the global 3-day supply-chain window.

Supersedes #7244.

## Test plan
- [ ] Vulnerability Scan / pip-audit is green (no `gitpython` PYSEC findings)
- [ ] `uv.lock` resolves `gitpython==3.1.61`

Co-authored-by: Vidit Ostwal <viditostwal@gmail.com>