### PR TITLE
docs: add Hubris provider example

### DIFF
--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1164,11 +1164,13 @@ In this section, you'll find detailed examples that help you select, configure, 
 
     Example usage in your CrewAI project:
     ```python Code
+    import os
+
     llm = LLM(
         model="anthropic/claude-sonnet-5",
         custom_openai=True,
         base_url="https://api.hubris.pw/v1",
-        api_key=HUBRIS_API_KEY
+        api_key=os.environ["HUBRIS_API_KEY"]
     )
     ```
 

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1155,6 +1155,29 @@ In this section, you'll find detailed examples that help you select, configure, 
     uv add 'crewai[litellm]'
     ```
   </Accordion>
+
+  <Accordion title="Hubris">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    HUBRIS_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="anthropic/claude-sonnet-5",
+        custom_openai=True,
+        base_url="https://api.hubris.pw/v1",
+        api_key=HUBRIS_API_KEY
+    )
+    ```
+
+    <Info>
+      Hubris is a ruble-billed, OpenAI-compatible LLM gateway giving access to 400+
+      models (OpenAI, Anthropic, Google, and more) behind one API key. See the full
+      model catalog at [hubris.pw/models](https://hubris.pw/models).
+    </Info>
+  </Accordion>
 </AccordionGroup>
 
 ## Streaming Responses


### PR DESCRIPTION
Adds a `Hubris` accordion to the Provider Configuration Examples on the LLMs concepts page, using the native `custom_openai=True` self-hosted-gateway pattern (Hubris isn't a native LiteLLM provider, so this avoids the LiteLLM dependency note used by Open Router/Nebius).

Closes #7276

Docs-only change (`docs/edge/en/concepts/llms.mdx`), no code changes.

<!-- crewai-require-issue-check -->