### PR TITLE
fix(schema): support list-form type arrays in JSON schema conversion

### DIFF
--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -1215,6 +1215,28 @@ def _json_schema_to_pydantic_type(
 
     type_ = json_schema.get("type")
 
+    if isinstance(type_, list):
+        # JSON Schema also allows "type" to be an array, e.g.
+        # {"type": ["string", "null"]} -- the .NET/System.Text.Json-style
+        # way of expressing a nullable field. Pydantic's own schema
+        # generation instead uses anyOf/oneOf for this (handled above), so
+        # external tool schemas (e.g. from a non-Python MCP server) are the
+        # main source of this form. Treat each entry the same way anyOf's
+        # members are handled just above: build a Union of the
+        # corresponding Python types. A single-element list collapses to
+        # that one type, matching typing.Union's own behavior.
+        member_types = [
+            _json_schema_to_pydantic_type(
+                {**json_schema, "type": member},
+                root_schema,
+                name_=f"{name_ or 'Union'}Option{i}",
+                enrich_descriptions=enrich_descriptions,
+                in_progress=in_progress,
+            )
+            for i, member in enumerate(type_)
+        ]
+        return Union[tuple(member_types)]  # noqa: UP007
+
     if type_ == "string":
         return str
     if type_ == "integer":

--- a/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
+++ b/lib/crewai/src/crewai/utilities/pydantic_schema_utils.py
@@ -30,6 +30,8 @@ from typing import (
     TypedDict,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 import uuid
 
@@ -1042,7 +1044,20 @@ def _json_schema_to_pydantic_field(
                 elif len(allowed_schemes) == 1 and allowed_schemes[0] == "file":
                     pydantic_type = FileUrl
 
-        type_ = pydantic_type
+        # `type_` can be a Union built from a list-form `type` (or anyOf/oneOf)
+        # rather than a plain `str`, e.g. `{"type": ["string", "null"],
+        # "format": "date-time"}`. Replacing the whole thing with
+        # `pydantic_type` would silently drop the other members (null,
+        # non-string alternatives) instead of just narrowing the string one.
+        if type_ is str:
+            type_ = pydantic_type
+        elif get_origin(type_) is Union:
+            type_ = Union[  # noqa: UP007
+                tuple(
+                    pydantic_type if member is str else member
+                    for member in get_args(type_)
+                )
+            ]
 
     if isinstance(type_, type) and issubclass(type_, str):
         if "minLength" in json_schema:

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -303,6 +303,68 @@ class TestUnionTypes:
         assert Model(value="hello").value == "hello"
         assert Model(value=3.14).value == pytest.approx(3.14)
 
+    def test_type_array_nullable_string_with_format(self) -> None:
+        """type: ["string", "null"] -- the .NET/System.Text.Json-style way
+        of expressing an optional field, as opposed to Pydantic's own
+        anyOf-based form. Seen in real MCP tool schemas from non-Python
+        servers (e.g. Equibles' ListCompanyDocuments startDate/endDate
+        filters). The format="date-time" here (also straight from that
+        real schema) is applied by the existing FORMAT_TYPE_MAP logic once
+        the list-form type no longer raises, so the field lands as a real
+        datetime rather than str -- that's the pre-existing, correct
+        behavior for any date-time-formatted field, not something this fix
+        changes."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "startDate": {
+                    "description": "Optional start date filter in YYYY-MM-DD format",
+                    "type": ["string", "null"],
+                    "format": "date-time",
+                    "default": None,
+                },
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(startDate="2026-01-01").startDate == datetime.datetime(
+            2026, 1, 1
+        )
+        assert Model(startDate=None).startDate is None
+        assert Model().startDate is None
+
+    def test_type_array_nullable_string_no_format(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "note": {"type": ["string", "null"]},
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(note="hello").note == "hello"
+        assert Model(note=None).note is None
+        assert Model().note is None
+
+    def test_type_array_multiple_non_null(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {"type": ["string", "integer", "null"]},
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value="hello").value == "hello"
+        assert Model(value=42).value == 42
+        assert Model(value=None).value is None
+
+    def test_type_array_single_element(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"value": {"type": ["string"]}},
+            "required": ["value"],
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value="hello").value == "hello"
+
 
 class TestAllOfMerging:
     def test_allof_merges_properties(self) -> None:

--- a/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
+++ b/lib/crewai/tests/utilities/test_pydantic_schema_utils.py
@@ -365,6 +365,60 @@ class TestUnionTypes:
         Model = create_model_from_schema(schema)
         assert Model(value="hello").value == "hello"
 
+    def test_type_array_required_nullable_string_with_format(self) -> None:
+        """A required-but-nullable formatted field, e.g. `{"type":
+        ["string", "null"], "format": "date-time"}` inside a "required"
+        list -- a valid JSON Schema shape meaning the key must be present
+        but its value may be null. Before this fix, the FORMAT_TYPE_MAP
+        override in `_json_schema_to_pydantic_field` replaced the whole
+        `Union[datetime, None]` with plain `datetime`, so passing `None`
+        would fail validation even though the schema explicitly allows it.
+        The `not is_required` Optional-rewrap at the end of that function
+        doesn't fire for required fields, so this case wasn't masked the
+        way the non-required version (test above) was.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "startDate": {
+                    "type": ["string", "null"],
+                    "format": "date-time",
+                },
+            },
+            "required": ["startDate"],
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(startDate="2026-01-01").startDate == datetime.datetime(
+            2026, 1, 1
+        )
+        assert Model(startDate=None).startDate is None
+        with pytest.raises(Exception):
+            Model()
+
+    def test_type_array_multiple_non_null_with_format(self) -> None:
+        """A list-form type with more than one non-null member plus a
+        recognized format, e.g. `{"type": ["string", "integer", "null"],
+        "format": "date-time"}`. Before this fix, the FORMAT_TYPE_MAP
+        override collapsed the entire Union down to plain `datetime`,
+        silently dropping the `integer` alternative regardless of whether
+        the field was required. The fix narrows only the `str` member of
+        the union to the formatted type, leaving `integer` and `None`
+        alone.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": ["string", "integer", "null"],
+                    "format": "date-time",
+                },
+            },
+        }
+        Model = create_model_from_schema(schema)
+        assert Model(value="2026-01-01").value == datetime.datetime(2026, 1, 1)
+        assert Model(value=42).value == 42
+        assert Model(value=None).value is None
+
 
 class TestAllOfMerging:
     def test_allof_merges_properties(self) -> None:


### PR DESCRIPTION
Fixes #7280. Supersedes #7058 (closed by the first-time-contributor bot for lacking a linked issue -- opening this one instead per its instructions, now with #7280 attached).

Disclosure: I'm not a developer and didn't write this fix by hand -- I found and diagnosed the bug while evaluating crewai + MCP for my own project, then used Claude (Anthropic's AI assistant) to trace the root cause against your source, prepare the fix, and write tests. Per your CONTRIBUTING.md, this should carry the `llm-generated` label -- I don't have permission to add it myself as an external contributor, so flagging it here for a maintainer to apply.

## What

`_json_schema_to_pydantic_type` (in `crewai/utilities/pydantic_schema_utils.py`) already handles `anyOf`/`oneOf` for nullable unions -- the form Pydantic's own schema generation produces for `Optional[T]` fields. But it has no handling for the other, equally valid JSON Schema way of expressing the same thing: a **list-form `type` array**, e.g. `{"type": ["string", "null"]}`. This is what .NET/`System.Text.Json`-based schema generators produce instead of `anyOf`, so any MCP tool schema coming from a non-Python server using this form crashes `create_model_from_schema` outright:

```python
raise ValueError(f"Unsupported JSON schema type: {type_} from {json_schema}")
# ValueError: Unsupported JSON schema type: ['string', 'null'] from
# {'description': 'Optional start date filter in YYYY-MM-DD format',
#  'type': ['string', 'null'], 'format': 'date-time', 'default': None}
```

Since this happens during `MCPServerAdapter`'s initialization (converting every tool's `inputSchema` up front), **one tool with this pattern takes down the entire adapter connection**, not just that one tool -- every other tool on the server becomes unusable too.

## Confirmed against a real server

Found this evaluating [Equibles](https://github.com/daniel3303/Equibles) (a self-hosted SEC-data MCP server) for my own project. Several of its tools (e.g. `ListCompanyDocuments`'s `startDate`/`endDate` filters) use exactly this pattern. `MCPServerAdapter` couldn't connect to it at all as a result -- reproduced identically on both Windows and macOS, with the underlying `mcp` Python SDK confirmed working fine directly (connects and lists all 64 tools in well under a second), isolating the fault specifically to this schema conversion step.

## Fix

Two commits:

1. **List-form type array support** -- mirrors the existing `anyOf`/`oneOf` handling directly above it: treat each entry in a list-form `type` the same way an `anyOf` member is handled, building a `Union` of the corresponding Python types. A single-element list collapses to that one type via `typing.Union`'s own behavior, and a `"null"` entry resolves to `None`.
2. **Format-override fix** (addressing CodeRabbit's review comment on #7058) -- the format-mapping override in `_json_schema_to_pydantic_field` was unconditionally replacing the *entire* resolved type with `FORMAT_TYPE_MAP`'s type, even when that type was a `Union` built from a list-form `type` rather than a plain `str`. For `{"type": ["string", "null"], "format": "date-time"}`, this collapsed `Union[str, None]` down to plain `datetime`, silently dropping the null option -- invisible for most optional fields (masked by the `Optional[...]` rewrap for non-required fields), but a **required**-but-nullable formatted field would wrongly reject `None`. The same override also dropped any non-string members of a multi-type array (e.g. `["string", "integer", "null"]`) regardless of required status. Now the override only replaces the `str` member specifically, leaving `null`/other members untouched.

## Testing

- 6 new tests in `TestUnionTypes` (`test_pydantic_schema_utils.py`): nullable string with a `format` (the exact real-world shape, including confirming the pre-existing `FORMAT_TYPE_MAP` datetime coercion still applies once the crash is gone), nullable string with no format, a 3-member list (`["string", "integer", "null"]`), a single-element list, a **required** nullable formatted field (the case the format-override bug affected), and a multi-type array with a format (verifying the non-string member survives).
- Full existing test suite for this file: **89/89 passing** (83 pre-existing + 6 new).
- `ruff check` / `ruff format --check`: clean.
- Reproduced the exact real-world crashing schema fragment directly against `create_model_from_schema` before the fix (confirmed it raised) and after (confirmed it now builds and validates correctly, including the `format="date-time"` coercion).
- Reproduced the real end-to-end failure through `MCPServerAdapter` against the live Equibles server before this fix, confirming the connection crash.
- Ran a full real crew (researcher + analyst agents, local Ollama LLM) end-to-end against the live Equibles server with this fix applied, on a separate physical machine from where the fix was written: all 64 tools loaded with no crash, the researcher agent made real tool calls against live data, and the crew completed successfully with a final summary.
- Rebased onto current `main` (65 commits) and re-ran the full suite clean.
