### PR TITLE
docs(streaming): fix streaming output docstring examples

### DIFF
--- a/lib/crewai/src/crewai/types/streaming.py
+++ b/lib/crewai/src/crewai/types/streaming.py
@@ -586,9 +586,10 @@ class FlowStreamingOutput(StreamingOutputBase[Any]):
 
     Note:
         Flow-level streaming is exposed to users through
-        :class:`StreamSession` (see ``Flow.kickoff`` with ``stream=True``).
-        ``FlowStreamingOutput`` is retained for consumers that build a
-        streaming wrapper directly from an existing iterator.
+        :class:`StreamSession`; configure the Flow with ``stream=True``
+        before calling ``Flow.kickoff()``. ``FlowStreamingOutput`` is
+        retained for consumers that build a streaming wrapper directly
+        from an existing iterator.
     """
 
     def _set_result(self, result: Any) -> None:

--- a/lib/crewai/src/crewai/types/streaming.py
+++ b/lib/crewai/src/crewai/types/streaming.py
@@ -504,13 +504,15 @@ class CrewStreamingOutput(StreamingOutputBase["CrewOutput"]):
 
     Example:
         ```python
-        # Single crew
+        # Single crew — the crew must be constructed with stream=True
+        crew = Crew(agents=[...], tasks=[...], stream=True)
         streaming = crew.kickoff(inputs={"topic": "AI"})
         for chunk in streaming:
             print(chunk.content, end="", flush=True)
         result = streaming.result
 
-        # Multiple crews (kickoff_for_each_async)
+        # Multiple crews (kickoff_for_each_async) — also requires stream=True
+        crew = Crew(agents=[...], tasks=[...], stream=True)
         streaming = await crew.kickoff_for_each_async(
             [{"topic": "AI"}, {"topic": "ML"}]
         )
@@ -580,22 +582,13 @@ class FlowStreamingOutput(StreamingOutputBase[Any]):
     """Streaming output wrapper for flow execution.
 
     Provides both sync and async iteration over stream chunks,
-    with access to the final flow output via the .result property.
+    with access to the final flow output via the ``.result`` property.
 
-    Example:
-        ```python
-        # Sync usage
-        streaming = flow.kickoff_streaming()
-        for chunk in streaming:
-            print(chunk.content, end="", flush=True)
-        result = streaming.result
-
-        # Async usage
-        streaming = await flow.kickoff_streaming_async()
-        async for chunk in streaming:
-            print(chunk.content, end="", flush=True)
-        result = streaming.result
-        ```
+    Note:
+        Flow-level streaming is exposed to users through
+        :class:`StreamSession` (see ``Flow.kickoff`` with ``stream=True``).
+        ``FlowStreamingOutput`` is retained for consumers that build a
+        streaming wrapper directly from an existing iterator.
     """
 
     def _set_result(self, result: Any) -> None:

--- a/lib/crewai/src/crewai/types/streaming.py
+++ b/lib/crewai/src/crewai/types/streaming.py
@@ -584,6 +584,23 @@ class FlowStreamingOutput(StreamingOutputBase[Any]):
     Provides both sync and async iteration over stream chunks,
     with access to the final flow output via the ``.result`` property.
 
+    Example:
+        ```python
+        # FlowStreamingOutput wraps a chunk-producing iterator directly.
+        # Consumers use it to expose a custom flow-execution generator
+        # through the same iteration + .result API as CrewStreamingOutput.
+        streaming = FlowStreamingOutput(sync_iterator=chunk_generator())
+        for chunk in streaming:
+            print(chunk.content, end="", flush=True)
+        result = streaming.result
+
+        # Async variant:
+        streaming = FlowStreamingOutput(async_iterator=async_chunk_generator())
+        async for chunk in streaming:
+            print(chunk.content, end="", flush=True)
+        result = streaming.result
+        ```
+
     Note:
         Flow-level streaming is exposed to users through
         :class:`StreamSession`; configure the Flow with ``stream=True``

--- a/lib/crewai/src/crewai/types/streaming.py
+++ b/lib/crewai/src/crewai/types/streaming.py
@@ -586,18 +586,22 @@ class FlowStreamingOutput(StreamingOutputBase[Any]):
 
     Example:
         ```python
-        # FlowStreamingOutput wraps a chunk-producing iterator directly.
-        # Consumers use it to expose a custom flow-execution generator
-        # through the same iteration + .result API as CrewStreamingOutput.
-        streaming = FlowStreamingOutput(sync_iterator=chunk_generator())
-        for chunk in streaming:
-            print(chunk.content, end="", flush=True)
+        # Flow-level streaming returns a StreamSession from Flow.kickoff() —
+        # NOT a FlowStreamingOutput. See
+        # docs/edge/en/learn/streaming-flow-execution.mdx for the full guide.
+        flow = MyFlow()
+        flow.stream = True
+        streaming = flow.kickoff()  # -> StreamSession
+        for frame in streaming:
+            print(frame.content, end="", flush=True)
         result = streaming.result
 
         # Async variant:
-        streaming = FlowStreamingOutput(async_iterator=async_chunk_generator())
-        async for chunk in streaming:
-            print(chunk.content, end="", flush=True)
+        flow = MyFlow()
+        flow.stream = True
+        streaming = await flow.kickoff_async()  # -> AsyncStreamSession
+        async for frame in streaming:
+            print(frame.content, end="", flush=True)
         result = streaming.result
         ```
 


### PR DESCRIPTION
## Related issue

Fixes #7285

## Summary

Docstring-only fix for two public streaming wrapper classes in `lib/crewai/src/crewai/types/streaming.py`. The examples showed APIs that either silently do not stream (`CrewStreamingOutput`) or do not exist (`FlowStreamingOutput`).

- **`CrewStreamingOutput`** — the sync and async examples both called `crew.kickoff(...)` / `crew.kickoff_for_each_async(...)` without setting `stream=True` on the crew. `Crew.kickoff` only returns a `CrewStreamingOutput` when the crew is constructed with `stream=True` (`lib/crewai/src/crewai/crew.py:1017`, `docs/edge/en/concepts/streaming.mdx:128`); otherwise it returns a `CrewOutput` and the snippet does not stream. Updated both examples to construct the crew with `stream=True`.
- **`FlowStreamingOutput`** — the example called `flow.kickoff_streaming()` and `flow.kickoff_streaming_async()`; `grep -rn "kickoff_streaming" lib/` confirms neither method exists. Flow-level streaming is actually exposed via `Flow.kickoff` with `stream=True`, which returns a `StreamSession`, not a `FlowStreamingOutput` (see `lib/crewai/tests/test_streaming.py:424-435`). `FlowStreamingOutput` is only referenced in internal type unions and instantiated directly with an iterator in tests. Replaced the misleading example with a note pointing users at `Flow.kickoff` / `StreamSession`.

## Verification

- [ ] Tests added or updated for the changed behavior — **N/A**, docstring-only change; no runtime behavior modified.
- [x] Relevant tests and quality checks pass locally — `uv tool run --from ruff==0.15.1 ruff check` and `ruff format --check` on the touched file both pass.

## Additional context

`lib/crewai/tests/test_streaming.py` continues to exercise `FlowStreamingOutput`'s streaming semantics by constructing it directly with an iterator — this PR does not change that path.