### PR TITLE
fix(agent): await async execution on guardrail retry in kickoff_async (#7252)

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1803,6 +1803,52 @@ class Agent(BaseAgent):
 
         return output
 
+    async def _finalize_kickoff_async(
+        self,
+        output: LiteAgentOutput,
+        executor: AgentExecutor,
+        inputs: dict[str, str],
+        response_format: type[Any] | None,
+        messages: str | list[LLMMessage],
+        agent_info: dict[str, Any],
+        usage_baseline: UsageMetrics | None = None,
+    ) -> LiteAgentOutput:
+        """Apply guardrails, save to memory, and emit completion event asynchronously.
+
+        Args:
+            output: The execution output.
+            executor: The agent executor.
+            inputs: The execution inputs.
+            response_format: Optional response format.
+            messages: The original messages.
+            agent_info: Agent metadata for events.
+            usage_baseline: Usage snapshot taken at kickoff start, so retries
+                report per-call usage relative to it.
+
+        Returns:
+            The finalized output.
+        """
+        if self.guardrail is not None:
+            output = await self._process_kickoff_guardrail_async(
+                output=output,
+                executor=executor,
+                inputs=inputs,
+                response_format=response_format,
+                usage_baseline=usage_baseline,
+            )
+
+        self._save_kickoff_to_memory(messages, output.raw)
+
+        crewai_event_bus.emit(
+            self,
+            event=LiteAgentExecutionCompletedEvent(
+                agent_info=agent_info,
+                output=output.raw,
+            ),
+        )
+
+        return output
+
     def _emit_kickoff_error(self, agent_info: dict[str, Any], e: Exception) -> NoReturn:
         """Emit a kickoff error event and re-raise."""
         crewai_event_bus.emit(
@@ -2056,6 +2102,90 @@ class Agent(BaseAgent):
 
         return output
 
+    async def _process_kickoff_guardrail_async(
+        self,
+        output: LiteAgentOutput,
+        executor: AgentExecutor,
+        inputs: dict[str, str],
+        response_format: type[Any] | None = None,
+        retry_count: int = 0,
+        usage_baseline: UsageMetrics | None = None,
+    ) -> LiteAgentOutput:
+        """Process guardrail for async kickoff execution with retry logic.
+
+        Args:
+            output: Current agent output.
+            executor: The executor instance.
+            inputs: Input dictionary for re-execution.
+            response_format: Optional response format.
+            retry_count: Current retry count.
+            usage_baseline: Usage snapshot taken at kickoff start, so a
+                retried output reports the whole call's usage, not just the
+                last attempt's.
+
+        Returns:
+            Validated/updated output.
+        """
+        guardrail_callable: GuardrailCallable
+        if isinstance(self.guardrail, str):
+            from crewai.tasks.llm_guardrail import LLMGuardrail
+
+            guardrail_callable = cast(
+                GuardrailCallable,
+                LLMGuardrail(description=self.guardrail, llm=cast(BaseLLM, self.llm)),
+            )
+        elif callable(self.guardrail):
+            guardrail_callable = self.guardrail
+        else:
+            return output
+
+        guardrail_result = process_guardrail(
+            output=output,
+            guardrail=guardrail_callable,
+            retry_count=retry_count,
+            event_source=self,
+            from_agent=self,
+        )
+
+        if not guardrail_result.success:
+            if retry_count >= self.guardrail_max_retries:
+                raise ValueError(
+                    f"Agent's guardrail failed validation after {self.guardrail_max_retries} retries. "
+                    f"Last error: {guardrail_result.error}"
+                )
+
+            executor._append_message_to_state(
+                guardrail_result.error or "Guardrail validation failed",
+                role="user",
+            )
+
+            retried = await self._execute_and_build_output_async(
+                executor, inputs, response_format, usage_baseline
+            )
+            # The retry opens its own collector, so carry the blocked attempt's
+            # failures forward or they vanish from the final output.
+            retried.tool_failures = merge_tool_failures(
+                output.tool_failures, retried.tool_failures
+            )
+            output = retried
+
+            return await self._process_kickoff_guardrail_async(
+                output=output,
+                executor=executor,
+                inputs=inputs,
+                response_format=response_format,
+                retry_count=retry_count + 1,
+                usage_baseline=usage_baseline,
+            )
+
+        if guardrail_result.result is not None:
+            if isinstance(guardrail_result.result, str):
+                output.raw = guardrail_result.result
+            elif isinstance(guardrail_result.result, BaseModel):
+                output.pydantic = guardrail_result.result
+
+        return output
+
     async def kickoff_async(
         self,
         messages: str | list[LLMMessage],
@@ -2118,7 +2248,7 @@ class Agent(BaseAgent):
             output = await self._execute_and_build_output_async(
                 executor, inputs, response_format, usage_baseline
             )
-            return self._finalize_kickoff(
+            return await self._finalize_kickoff_async(
                 output,
                 executor,
                 inputs,

--- a/lib/crewai/tests/agents/test_agent_kickoff_guardrail.py
+++ b/lib/crewai/tests/agents/test_agent_kickoff_guardrail.py
@@ -1,0 +1,147 @@
+"""Tests for Agent kickoff and kickoff_async guardrail retry handling."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.block_network(allowed_hosts=["127.0.0.1", "localhost"])
+from pydantic import BaseModel
+
+from crewai import Agent
+from crewai.llms.base_llm import BaseLLM
+
+
+class _CountedLLM(BaseLLM):
+    """Returns responses with sequential call counts."""
+
+    def __init__(self, responses: list[str] | None = None) -> None:
+        super().__init__(model="counted_llm")
+        object.__setattr__(self, "call_count", 0)
+        object.__setattr__(self, "responses", responses or [])
+
+    def call(self, messages: Any, **kwargs: Any) -> str:
+        count = self.call_count
+        object.__setattr__(self, "call_count", count + 1)
+        if self.responses and count < len(self.responses):
+            return self.responses[count]
+        return f"Response {count + 1}"
+
+    async def acall(self, messages: Any, **kwargs: Any) -> str:
+        return self.call(messages, **kwargs)
+
+    def supports_function_calling(self) -> bool:
+        return False
+
+    def supports_stop_words(self) -> bool:
+        return False
+
+    def get_context_window_size(self) -> int:
+        return 8192
+
+
+class _CustomPydanticResult(BaseModel):
+    summary: str
+
+
+@pytest.mark.asyncio
+async def test_agent_kickoff_async_guardrail_retry_success() -> None:
+    """A failing guardrail in kickoff_async retries asynchronously and returns on success."""
+    llm = _CountedLLM(responses=["Initial draft", "Refined draft"])
+    attempts: list[str] = []
+
+    def fail_first_guardrail(output: Any) -> tuple[bool, str]:
+        attempts.append(output.raw)
+        if len(attempts) == 1:
+            return (False, "Draft lacked required detail, please refine.")
+        return (True, output.raw)
+
+    agent = Agent(
+        role="Researcher",
+        goal="Test guardrails",
+        backstory="Tester",
+        llm=llm,
+        guardrail=fail_first_guardrail,
+        guardrail_max_retries=2,
+    )
+
+    result = await agent.kickoff_async("Provide report")
+
+    assert result.raw == "Refined draft"
+    assert len(attempts) == 2
+    assert attempts == ["Initial draft", "Refined draft"]
+
+
+@pytest.mark.asyncio
+async def test_agent_kickoff_async_guardrail_max_retries_exceeded() -> None:
+    """When a guardrail fails repeatedly, kickoff_async raises ValueError after max retries."""
+    llm = _CountedLLM()
+
+    def always_fail_guardrail(output: Any) -> tuple[bool, str]:
+        return (False, "Unconditional guardrail rejection")
+
+    agent = Agent(
+        role="Researcher",
+        goal="Test guardrails",
+        backstory="Tester",
+        llm=llm,
+        guardrail=always_fail_guardrail,
+        guardrail_max_retries=2,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Agent's guardrail failed validation after 2 retries. Last error: Unconditional guardrail rejection",
+    ):
+        await agent.kickoff_async("Provide report")
+
+
+@pytest.mark.asyncio
+async def test_agent_kickoff_async_guardrail_transforms_output() -> None:
+    """A passing guardrail in kickoff_async can transform raw and pydantic outputs."""
+    llm = _CountedLLM()
+
+    def transform_guardrail(output: Any) -> tuple[bool, _CustomPydanticResult]:
+        return (True, _CustomPydanticResult(summary="Transformed Summary"))
+
+    agent = Agent(
+        role="Researcher",
+        goal="Test guardrails",
+        backstory="Tester",
+        llm=llm,
+        guardrail=transform_guardrail,
+        guardrail_max_retries=1,
+    )
+
+    result = await agent.kickoff_async("Provide report")
+
+    assert result.pydantic is not None
+    assert isinstance(result.pydantic, _CustomPydanticResult)
+    assert result.pydantic.summary == "Transformed Summary"
+
+
+def test_agent_kickoff_sync_guardrail_retry_parity() -> None:
+    """Synchronous kickoff continues to process guardrail retries cleanly."""
+    llm = _CountedLLM(responses=["Draft 1", "Draft 2"])
+    attempts: list[str] = []
+
+    def fail_first_guardrail(output: Any) -> tuple[bool, str]:
+        attempts.append(output.raw)
+        if len(attempts) == 1:
+            return (False, "Needs revision.")
+        return (True, "Draft 2 Approved")
+
+    agent = Agent(
+        role="Researcher",
+        goal="Test guardrails",
+        backstory="Tester",
+        llm=llm,
+        guardrail=fail_first_guardrail,
+        guardrail_max_retries=2,
+    )
+
+    result = agent.kickoff("Provide report")
+
+    assert result.raw == "Draft 2 Approved"
+    assert len(attempts) == 2

--- a/lib/crewai/tests/agents/test_agent_kickoff_guardrail.py
+++ b/lib/crewai/tests/agents/test_agent_kickoff_guardrail.py
@@ -17,11 +17,13 @@ class _CountedLLM(BaseLLM):
     """Returns responses with sequential call counts."""
 
     def __init__(self, responses: list[str] | None = None) -> None:
+        """Initialize CountedLLM with optional canned responses."""
         super().__init__(model="counted_llm")
         object.__setattr__(self, "call_count", 0)
         object.__setattr__(self, "responses", responses or [])
 
     def call(self, messages: Any, **kwargs: Any) -> str:
+        """Return next response or default response string."""
         count = self.call_count
         object.__setattr__(self, "call_count", count + 1)
         if self.responses and count < len(self.responses):
@@ -29,19 +31,25 @@ class _CountedLLM(BaseLLM):
         return f"Response {count + 1}"
 
     async def acall(self, messages: Any, **kwargs: Any) -> str:
+        """Async call delegating to synchronous call."""
         return self.call(messages, **kwargs)
 
     def supports_function_calling(self) -> bool:
+        """Return whether function calling is supported."""
         return False
 
     def supports_stop_words(self) -> bool:
+        """Return whether stop words are supported."""
         return False
 
     def get_context_window_size(self) -> int:
+        """Return simulated context window size."""
         return 8192
 
 
 class _CustomPydanticResult(BaseModel):
+    """Sample Pydantic result model for guardrail output transformations."""
+
     summary: str
 
 
@@ -52,6 +60,7 @@ async def test_agent_kickoff_async_guardrail_retry_success() -> None:
     attempts: list[str] = []
 
     def fail_first_guardrail(output: Any) -> tuple[bool, str]:
+        """Fail on first attempt and pass on subsequent attempts."""
         attempts.append(output.raw)
         if len(attempts) == 1:
             return (False, "Draft lacked required detail, please refine.")
@@ -79,6 +88,7 @@ async def test_agent_kickoff_async_guardrail_max_retries_exceeded() -> None:
     llm = _CountedLLM()
 
     def always_fail_guardrail(output: Any) -> tuple[bool, str]:
+        """Always reject output to trigger retry exhaustion."""
         return (False, "Unconditional guardrail rejection")
 
     agent = Agent(
@@ -103,6 +113,7 @@ async def test_agent_kickoff_async_guardrail_transforms_output() -> None:
     llm = _CountedLLM()
 
     def transform_guardrail(output: Any) -> tuple[bool, _CustomPydanticResult]:
+        """Transform output into a structured Pydantic model."""
         return (True, _CustomPydanticResult(summary="Transformed Summary"))
 
     agent = Agent(
@@ -127,6 +138,7 @@ def test_agent_kickoff_sync_guardrail_retry_parity() -> None:
     attempts: list[str] = []
 
     def fail_first_guardrail(output: Any) -> tuple[bool, str]:
+        """Fail on first attempt and pass on second for sync kickoff."""
         attempts.append(output.raw)
         if len(attempts) == 1:
             return (False, "Needs revision.")


### PR DESCRIPTION
## Related issue

Fixes #7252

## Summary

When calling `Agent.kickoff_async()` with a guardrail configured, if the initial execution fails the guardrail check, the retry branch inside `_process_kickoff_guardrail` called the synchronous `self._execute_and_build_output(...)`.

Under an active asyncio event loop, `AgentExecutor.invoke()` delegates to `self.invoke_async()`, returning an unawaited coroutine object instead of a completed output dictionary. `_build_output_from_result` then attempts `result.get("output", "")` on that coroutine, raising:
`AttributeError: 'coroutine' object has no attribute 'get'` and leaving an unawaited coroutine warning.

### Key Changes
1. Added `_finalize_kickoff_async` and `_process_kickoff_guardrail_async` to `Agent` in `lib/crewai/src/crewai/agent/core.py`.
2. On guardrail failure retry during async kickoff, `_process_kickoff_guardrail_async` awaits `self._execute_and_build_output_async(...)`, preserving asynchronous event loop semantics and carrying tool failures forward across attempts with `merge_tool_failures`.
3. Updated `Agent.kickoff_async` to await `_finalize_kickoff_async`.
4. Preserved existing synchronous behavior and signature parity for `kickoff()` and `_finalize_kickoff()`.
5. Added unit tests in `lib/crewai/tests/agents/test_agent_kickoff_guardrail.py` covering:
   - Async guardrail retry recovery after initial failure.
   - Max retries exceeded raising `ValueError`.
   - Async guardrail output transformations (raw strings and Pydantic models).
   - Synchronous kickoff retry parity.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

Verification runs:
- `uv run pytest lib/crewai/tests/agents/test_agent_kickoff_guardrail.py`: 4 passed in 13.01s
- `uv run ruff check lib/crewai/src/crewai/agent/core.py lib/crewai/tests/agents/test_agent_kickoff_guardrail.py`: passed (0 issues)
- `uv run ruff format --check lib/crewai/src/crewai/agent/core.py lib/crewai/tests/agents/test_agent_kickoff_guardrail.py`: passed (0 issues)

## Additional context

None.


<!-- crewai-require-issue-check -->