### PR TITLE
fix(llm): correct gpt-4o-mini context window 200000 -> 128000

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -170,7 +170,7 @@ ANTHROPIC_PREFIXES: Final[tuple[str, str, str]] = ("anthropic/", "claude-", "cla
 LLM_CONTEXT_WINDOW_SIZES: Final[dict[str, int]] = {
     "gpt-4": 8192,
     "gpt-4o": 128000,
-    "gpt-4o-mini": 200000,
+    "gpt-4o-mini": 128000,
     "gpt-5.4-mini": 200000,
     "gpt-5.6": 1050000,  # sol, terra, luna, and the gpt-5.6 alias
     "gpt-4-turbo": 128000,

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -1320,7 +1320,7 @@ class AzureCompletion(BaseLLM):
             "gpt-3.5-turbo": 16385,
             "gpt-5.4-mini": 200000,
             "gpt-35-turbo": 16385,
-            "gpt-4o-mini": 200000,
+            "gpt-4o-mini": 128000,
             "gpt-4-turbo": 128000,
             "gpt-5.6": 1050000,
             "gpt-4o": 128000,

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -2682,7 +2682,7 @@ class OpenAICompletion(BaseLLM):
             "gpt-4.1-nano-2025-04-14": 1047576,
             "gpt-5.4-mini": 200000,
             "gpt-4-turbo": 128000,
-            "gpt-4o-mini": 200000,
+            "gpt-4o-mini": 128000,
             "gpt-5-mini": 1047576,
             "gpt-5-nano": 1047576,
             "o1-preview": 128000,


### PR DESCRIPTION
## Related issue

Fixes #7293

## Summary

`gpt-4o-mini`'s official context window is **128,000 tokens** (OpenAI [announcement](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) and [API docs](https://developers.openai.com/api/docs/models/gpt-4o-mini)); litellm's own model database also reports `max_input_tokens = 128000`. The shared `LLM_CONTEXT_WINDOW_SIZES` table and the OpenAI/Azure provider-local tables list **200000** — apparently copied from the neighboring `o3-mini` / `o4-mini` entries (both 200000). The same tables list `gpt-4o` as 128000, so the smaller `mini` having a larger window is internally inconsistent.

Because `get_context_window_size()` applies `CONTEXT_WINDOW_USAGE_RATIO = 0.85`, crews using `gpt-4o-mini` resolved their usable window to `170000` instead of `108800` on all three provider paths (the litellm-path lookup in `llm.py` iterates without `break`, so `gpt-4o-mini` resolves to its own entry), letting conversation history grow past the model's real 128k limit and failing with API 400s on long-running crews.

This changes only the `gpt-4o-mini` value in three places — no key additions, removals, or reordering, so lookups for any other model are unaffected.

Note for review: open PR #6603 (longest-prefix matching) adds a test asserting `gpt-4o-mini == 200000`; if it merges first, its assertion needs the same correction.

## Verification

- [x] Tests added or updated for the changed behavior → covered by the existing context-window tests (`pytest lib/crewai/tests/test_llm.py -k context_window`, 10 passed); happy to add a dedicated `gpt-4o-mini` regression test if preferred
- [x] Relevant tests and quality checks pass locally

Local checks:

```python
import os
os.environ.setdefault("OPENAI_API_KEY", "test-key")
from crewai.llm import LLM

LLM(model="gpt-4o-mini", is_litellm=True).get_context_window_size()  # 170000 -> 108800
LLM(model="openai/gpt-4o-mini").get_context_window_size()            # 170000 -> 108800
```

- `uv run ruff check <changed files>` and `uv run ruff format --check <changed files>`: clean
- `pytest lib/crewai/tests/test_llm.py -q`: 89 passed, 3 skipped (2 pre-existing environment errors on Windows, reproduced on unmodified `main`)
- Full-repo scan confirms the three changed entries are the only `gpt-4o-mini` window-size occurrences

## Additional context

- No existing issue tracked this value; #7129 is the same class of bug for a different model, which motivated opening #7293 first.
- Disclosure per CONTRIBUTING: this PR was prepared with AI assistance and human-reviewed; please apply the `llm-generated` label (contributors without triage permissions cannot add labels themselves).
