### PR TITLE
feat(tools): add DNS Doctor tools (scan, DMARC upgrade, propagation)

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -74,6 +74,11 @@ from crewai_tools.tools.directory_read_tool.directory_read_tool import (
 from crewai_tools.tools.directory_search_tool.directory_search_tool import (
     DirectorySearchTool,
 )
+from crewai_tools.tools.dns_doctor_tool.dns_doctor_tool import (
+    DnsDoctorDmarcUpgradeTool,
+    DnsDoctorPropagationTool,
+    DnsDoctorScanTool,
+)
 from crewai_tools.tools.docx_search_tool.docx_search_tool import DOCXSearchTool
 from crewai_tools.tools.e2b_sandbox_tool import (
     E2BExecTool,
@@ -261,6 +266,9 @@ __all__ = [
     "DaytonaPythonTool",
     "DirectoryReadTool",
     "DirectorySearchTool",
+    "DnsDoctorDmarcUpgradeTool",
+    "DnsDoctorPropagationTool",
+    "DnsDoctorScanTool",
     "E2BExecTool",
     "E2BFileTool",
     "E2BPythonTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -63,6 +63,11 @@ from crewai_tools.tools.directory_read_tool.directory_read_tool import (
 from crewai_tools.tools.directory_search_tool.directory_search_tool import (
     DirectorySearchTool,
 )
+from crewai_tools.tools.dns_doctor_tool.dns_doctor_tool import (
+    DnsDoctorDmarcUpgradeTool,
+    DnsDoctorPropagationTool,
+    DnsDoctorScanTool,
+)
 from crewai_tools.tools.docx_search_tool.docx_search_tool import DOCXSearchTool
 from crewai_tools.tools.e2b_sandbox_tool import (
     E2BExecTool,
@@ -246,6 +251,9 @@ __all__ = [
     "DaytonaPythonTool",
     "DirectoryReadTool",
     "DirectorySearchTool",
+    "DnsDoctorDmarcUpgradeTool",
+    "DnsDoctorPropagationTool",
+    "DnsDoctorScanTool",
     "E2BExecTool",
     "E2BFileTool",
     "E2BPythonTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/README.md
@@ -1,0 +1,44 @@
+# DNS Doctor Tools Documentation
+
+## Description
+Three tools over the hosted [DNS Doctor](https://dnsdoctor.dev) API that give an agent deterministic DNS and email-authentication checks for a domain:
+
+- `DnsDoctorScanTool`: the full report (SPF, DKIM, DMARC, MX, DNS health, blacklists, domain and TLS expiry) with per-check verdicts and copy-paste fix records from a validating engine, never a model-generated record.
+- `DnsDoctorDmarcUpgradeTool`: the next safe DMARC record for a domain, alignment-gated, with the rationale.
+- `DnsDoctorPropagationTool`: whether a DNS change has propagated, read from six locations on four continents.
+
+No API key is needed. Responses are relayed verbatim as JSON text.
+
+## Installation
+```shell
+pip install 'crewai[tools]'
+```
+
+## Example
+```python
+from crewai_tools import DnsDoctorScanTool, DnsDoctorDmarcUpgradeTool, DnsDoctorPropagationTool
+
+scan = DnsDoctorScanTool()
+upgrade = DnsDoctorDmarcUpgradeTool()
+propagation = DnsDoctorPropagationTool()
+
+print(scan.run(domain="example.com"))
+print(upgrade.run(domain="example.com"))
+print(propagation.run(name="www.example.com", record_type="A", expected_value="203.0.113.10"))
+```
+
+## Arguments
+- `DnsDoctorScanTool`: `domain` (required).
+- `DnsDoctorDmarcUpgradeTool`: `domain` (required).
+- `DnsDoctorPropagationTool`: `name` (required), `record_type` (default `A`), `expected_value` (optional; omit to check consistency only).
+
+## Environment
+- `DNSDOCTOR_API_TOKEN` (optional): raises the anonymous per-caller rate limit and unlocks nothing else. Past the free allowance the API answers `402` with an x402 offer; the tool returns that as text.
+- `DNSDOCTOR_API_BASE` (optional): override the API origin.
+
+## Rules the tools follow
+- Present any returned record verbatim; never rewrite or reformat it.
+- A `temperror` check status is a transient lookup failure, not a failure of the domain. A transport failure (rate limit, 5xx, network) is returned as text that says it is not a verdict.
+- `record` can be `null` in the DMARC upgrade response: the `rationale` is the answer; do not compose a record to fill the gap.
+- SPF is diagnose-only: the scan reports SPF findings but the tools never propose SPF edits.
+- A human must approve every DNS change; nothing is applied automatically.

--- a/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/dns_doctor_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/dns_doctor_tool.py
@@ -1,0 +1,176 @@
+"""DNS Doctor tools: deterministic DNS and email-authentication checks.
+
+Three tools over the hosted DNS Doctor API (https://dnsdoctor.dev): a full
+domain scan, the next safe DMARC record, and a six-location propagation check.
+Every verdict is deterministic and every record comes from a validating
+engine, never from a language model. Responses are relayed verbatim as JSON
+text; nothing is composed here.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+import json
+import os
+from typing import Any, Literal
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
+import requests
+
+
+DEFAULT_API_BASE = "https://dnsdoctor.dev"
+_TIMEOUT_SECONDS = 45
+_NOT_A_VERDICT = "retry later; this is not a verdict about the domain"
+
+_ENV_VARS: list[EnvVar] = [
+    EnvVar(
+        name="DNSDOCTOR_API_TOKEN",
+        description="Optional DNS Doctor API token. Raises the anonymous rate limit; never required.",
+        required=False,
+    ),
+]
+
+
+def _user_agent() -> str:
+    try:
+        tools_version = version("crewai-tools")
+    except PackageNotFoundError:
+        tools_version = "0"
+    return f"dnsdoctor-crewai/{tools_version} (+https://dnsdoctor.dev)"
+
+
+def _call(path: str, body: dict[str, Any]) -> str:
+    """POST one request and return the API body as JSON text, untouched.
+
+    A transport failure (network, 429, 402, 5xx) returns a message that says it
+    is not a verdict about the domain, so an agent never reads it as one.
+    """
+    base = os.environ.get("DNSDOCTOR_API_BASE", DEFAULT_API_BASE).rstrip("/")
+    headers = {"Accept": "application/json", "User-Agent": _user_agent()}
+    token = os.environ.get("DNSDOCTOR_API_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        response = requests.post(
+            f"{base}{path}", json=body, headers=headers, timeout=_TIMEOUT_SECONDS
+        )
+    except requests.RequestException as exc:
+        return f"DNS Doctor could not be reached ({exc}); {_NOT_A_VERDICT}."
+    status = response.status_code
+    if status == 429:
+        return f"DNS Doctor rate-limited this caller; {_NOT_A_VERDICT}."
+    if status == 402:
+        # The body is the x402 payment offer (the v1 document; the v2 document
+        # rides in the PAYMENT-REQUIRED header). Relay both so an x402-capable
+        # caller can pay and retry; the text says it is not a verdict.
+        offer_header = response.headers.get("PAYMENT-REQUIRED", "")
+        return (
+            "DNS Doctor: past the free per-caller allowance. The API offered a paid "
+            "retry over x402 (USDC on Base); wait and retry, or pay with an x402 client. "
+            "This is not a verdict about the domain.\n"
+            f"x402 offer (body): {response.text}\n"
+            f"x402 offer (PAYMENT-REQUIRED header): {offer_header}"
+        )
+    if status >= 500:
+        return f"DNS Doctor returned HTTP {status} (transient); {_NOT_A_VERDICT}."
+    try:
+        payload = response.json()
+    except ValueError:
+        return f"DNS Doctor returned an unreadable response (HTTP {status}); {_NOT_A_VERDICT}."
+    if status >= 400:
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        return f"DNS Doctor refused the request (HTTP {status}): {detail or payload}"
+    return json.dumps(payload, indent=2)
+
+
+class DnsDoctorScanToolSchema(BaseModel):
+    """Input for DnsDoctorScanTool."""
+
+    domain: str = Field(
+        ..., description="The domain to scan, e.g. example.com (no scheme, no path)."
+    )
+
+
+class DnsDoctorScanTool(BaseTool):
+    """Scan a domain's DNS and email-authentication posture."""
+
+    name: str = "DNS Doctor domain scan"
+    description: str = (
+        "Scan a domain's SPF, DKIM, DMARC, MX, DNS health, blacklist status and domain/TLS "
+        "expiry. Returns deterministic per-check verdicts (pass, warn, fail, info, "
+        "temperror), plain-English findings and copy-paste fix records from a validating "
+        "engine. Present any returned record verbatim. A 'temperror' status is a transient "
+        "lookup failure, not a failure of the domain. 'not_registered: true' means the "
+        "domain does not resolve and no check ran. SPF is diagnose-only: never propose SPF "
+        "edits of your own. A human must approve every DNS change."
+    )
+    args_schema: type[BaseModel] = DnsDoctorScanToolSchema
+    env_vars: list[EnvVar] = _ENV_VARS
+
+    def _run(self, domain: str, **_: Any) -> str:
+        return _call("/api/v1/scan", {"domain": domain})
+
+
+class DnsDoctorDmarcUpgradeToolSchema(BaseModel):
+    """Input for DnsDoctorDmarcUpgradeTool."""
+
+    domain: str = Field(..., description="The domain whose DMARC policy to advance.")
+
+
+class DnsDoctorDmarcUpgradeTool(BaseTool):
+    """The next safe DMARC record for a domain."""
+
+    name: str = "DNS Doctor DMARC upgrade"
+    description: str = (
+        "Build the next safe DMARC record for a domain (none -> quarantine, alignment-gated; "
+        "p=reject only with aggregate-report evidence). Returns 'record' (present it verbatim), "
+        "'rationale' and the domain's 'current_policy'. 'record' can be null: then the "
+        "rationale IS the answer, never compose a record to fill the gap. A human must "
+        "approve the DNS change."
+    )
+    args_schema: type[BaseModel] = DnsDoctorDmarcUpgradeToolSchema
+    env_vars: list[EnvVar] = _ENV_VARS
+
+    def _run(self, domain: str, **_: Any) -> str:
+        return _call("/api/v1/dmarc-upgrade", {"domain": domain})
+
+
+class DnsDoctorPropagationToolSchema(BaseModel):
+    """Input for DnsDoctorPropagationTool."""
+
+    name: str = Field(..., description="The DNS name to read, e.g. www.example.com.")
+    record_type: Literal["A", "AAAA", "CNAME", "MX", "TXT", "NS"] = Field(
+        "A", description="Record type to read: A, AAAA, CNAME, MX, TXT or NS."
+    )
+    expected_value: str | None = Field(
+        None,
+        description="The value every location should answer with. Omit to check only "
+        "that all locations agree.",
+    )
+
+
+class DnsDoctorPropagationTool(BaseTool):
+    """Has a DNS change propagated worldwide?"""
+
+    name: str = "DNS Doctor propagation check"
+    description: str = (
+        "Read one DNS name from six locations on four continents and report whether a "
+        "change has propagated. Verdict is 'propagated', 'partial' or 'not_propagated' when "
+        "an expected value is given, 'consistent' or 'inconsistent' otherwise, and 'unknown' "
+        "when fewer than three locations answered. A location that did not answer is "
+        "reported as unreached, never as a negative result. Observation only: no record is "
+        "composed."
+    )
+    args_schema: type[BaseModel] = DnsDoctorPropagationToolSchema
+    env_vars: list[EnvVar] = _ENV_VARS
+
+    def _run(
+        self,
+        name: str,
+        record_type: str = "A",
+        expected_value: str | None = None,
+        **_: Any,
+    ) -> str:
+        body: dict[str, Any] = {"name": name, "record_type": record_type}
+        if expected_value:
+            body["expected_value"] = expected_value
+        return _call("/api/tools/propagation-check", body)

--- a/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/dns_doctor_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/dns_doctor_tool/dns_doctor_tool.py
@@ -8,7 +8,6 @@ text; nothing is composed here.
 """
 
 from importlib.metadata import PackageNotFoundError, version
-import json
 import os
 from typing import Any, Literal
 
@@ -39,7 +38,7 @@ def _user_agent() -> str:
 
 
 def _call(path: str, body: dict[str, Any]) -> str:
-    """POST one request and return the API body as JSON text, untouched.
+    """POST one request and return the API body as the API sent it, untouched.
 
     A transport failure (network, 429, 402, 5xx) returns a message that says it
     is not a verdict about the domain, so an agent never reads it as one.
@@ -79,7 +78,8 @@ def _call(path: str, body: dict[str, Any]) -> str:
     if status >= 400:
         detail = payload.get("detail") if isinstance(payload, dict) else None
         return f"DNS Doctor refused the request (HTTP {status}): {detail or payload}"
-    return json.dumps(payload, indent=2)
+    # Validated above; relayed as the API sent it (no re-serialisation).
+    return response.text
 
 
 class DnsDoctorScanToolSchema(BaseModel):
@@ -171,6 +171,6 @@ class DnsDoctorPropagationTool(BaseTool):
         **_: Any,
     ) -> str:
         body: dict[str, Any] = {"name": name, "record_type": record_type}
-        if expected_value:
+        if expected_value is not None:
             body["expected_value"] = expected_value
         return _call("/api/tools/propagation-check", body)

--- a/lib/crewai-tools/tests/tools/dns_doctor_tool_test.py
+++ b/lib/crewai-tools/tests/tools/dns_doctor_tool_test.py
@@ -1,0 +1,96 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from crewai_tools.tools.dns_doctor_tool.dns_doctor_tool import (
+    DnsDoctorDmarcUpgradeTool,
+    DnsDoctorPropagationTool,
+    DnsDoctorScanTool,
+)
+
+REPORT = {
+    "domain": "example.com",
+    "checks": [{"check": "dmarc", "status": "fail", "title": "No DMARC record found"}],
+    "next_steps": {"report_url": "https://dnsdoctor.dev/scan/example.com"},
+}
+_PATH = "crewai_tools.tools.dns_doctor_tool.dns_doctor_tool.requests.post"
+
+
+def _response(status: int, payload=None):
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = payload
+    return response
+
+
+def test_scan_posts_the_domain_and_relays_the_body_verbatim():
+    with patch(_PATH, return_value=_response(200, REPORT)) as post:
+        out = DnsDoctorScanTool().run(domain="example.com")
+    assert json.loads(out) == REPORT
+    (_url,) = post.call_args.args
+    assert _url == "https://dnsdoctor.dev/api/v1/scan"
+    assert post.call_args.kwargs["json"] == {"domain": "example.com"}
+    assert post.call_args.kwargs["headers"]["User-Agent"].startswith(
+        "dnsdoctor-crewai/"
+    )
+
+
+def test_dmarc_upgrade_uses_its_own_endpoint():
+    body = {"record": None, "rationale": "reporting first", "current_policy": "none"}
+    with patch(_PATH, return_value=_response(200, body)) as post:
+        out = DnsDoctorDmarcUpgradeTool().run(domain="example.com")
+    assert json.loads(out) == body
+    assert post.call_args.args[0] == "https://dnsdoctor.dev/api/v1/dmarc-upgrade"
+
+
+def test_propagation_sends_the_endpoints_field_names_and_omits_an_absent_expectation():
+    with patch(_PATH, return_value=_response(200, {"verdict": "consistent"})) as post:
+        DnsDoctorPropagationTool().run(name="www.example.com", record_type="NS")
+    assert post.call_args.args[0] == "https://dnsdoctor.dev/api/tools/propagation-check"
+    assert post.call_args.kwargs["json"] == {
+        "name": "www.example.com",
+        "record_type": "NS",
+    }
+    with patch(_PATH, return_value=_response(200, {"verdict": "propagated"})) as post:
+        DnsDoctorPropagationTool().run(
+            name="www.example.com", expected_value="203.0.113.10"
+        )
+    assert post.call_args.kwargs["json"] == {
+        "name": "www.example.com",
+        "record_type": "A",
+        "expected_value": "203.0.113.10",
+    }
+
+
+def test_transport_failures_are_messages_that_are_not_verdicts():
+    with patch(_PATH, return_value=_response(429, {"detail": "slow down"})):
+        assert "not a verdict" in DnsDoctorScanTool().run(domain="example.com")
+    with patch(_PATH, return_value=_response(503, {"detail": "unavailable"})):
+        assert "not a verdict" in DnsDoctorScanTool().run(domain="example.com")
+    with patch(_PATH, side_effect=requests.ConnectionError("down")):
+        assert "not a verdict" in DnsDoctorScanTool().run(domain="example.com")
+    paid = _response(402, {"x402Version": 1, "accepts": []})
+    paid.text = '{"x402Version": 1, "accepts": []}'
+    paid.headers = {"PAYMENT-REQUIRED": "eyJ4NDAyVmVyc2lvbiI6Mn0"}
+    with patch(_PATH, return_value=paid):
+        out = DnsDoctorScanTool().run(domain="example.com")
+    assert "x402" in out and "not a verdict" in out
+    # the offer travels with the text, so an x402-capable caller can pay and retry
+    assert '"accepts": []' in out and "eyJ4NDAyVmVyc2lvbiI6Mn0" in out
+
+
+def test_a_refusal_relays_the_apis_own_detail():
+    with patch(_PATH, return_value=_response(422, {"detail": "malformed domain"})):
+        assert "malformed domain" in DnsDoctorScanTool().run(domain="not a domain")
+
+
+def test_token_is_sent_only_when_set(monkeypatch):
+    monkeypatch.setenv("DNSDOCTOR_API_TOKEN", "dnsd_example")
+    with patch(_PATH, return_value=_response(200, {})) as post:
+        DnsDoctorScanTool().run(domain="example.com")
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer dnsd_example"
+    monkeypatch.delenv("DNSDOCTOR_API_TOKEN")
+    with patch(_PATH, return_value=_response(200, {})) as post:
+        DnsDoctorScanTool().run(domain="example.com")
+    assert "Authorization" not in post.call_args.kwargs["headers"]

--- a/lib/crewai-tools/tests/tools/dns_doctor_tool_test.py
+++ b/lib/crewai-tools/tests/tools/dns_doctor_tool_test.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from crewai_tools.tools.dns_doctor_tool.dns_doctor_tool import (
@@ -17,16 +18,27 @@ REPORT = {
 _PATH = "crewai_tools.tools.dns_doctor_tool.dns_doctor_tool.requests.post"
 
 
-def _response(status: int, payload=None):
+def _response(status: int, payload=None, text: str | None = None):
     response = MagicMock()
     response.status_code = status
     response.json.return_value = payload
+    # Deliberately NOT json.dumps(payload): the tool must relay the exact bytes
+    # the API sent, so the tests give the text a shape re-serialisation would change.
+    response.text = text if text is not None else json.dumps(payload, separators=(",", ":"))
+    response.headers = {}
     return response
+
+
+@pytest.fixture(autouse=True)
+def _default_api_base(monkeypatch):
+    """The expected URLs assume the default origin; a developer's env must not leak in."""
+    monkeypatch.delenv("DNSDOCTOR_API_BASE", raising=False)
 
 
 def test_scan_posts_the_domain_and_relays_the_body_verbatim():
     with patch(_PATH, return_value=_response(200, REPORT)) as post:
         out = DnsDoctorScanTool().run(domain="example.com")
+    assert out == post.return_value.text  # relayed verbatim, never re-serialised
     assert json.loads(out) == REPORT
     (_url,) = post.call_args.args
     assert _url == "https://dnsdoctor.dev/api/v1/scan"
@@ -40,7 +52,7 @@ def test_dmarc_upgrade_uses_its_own_endpoint():
     body = {"record": None, "rationale": "reporting first", "current_policy": "none"}
     with patch(_PATH, return_value=_response(200, body)) as post:
         out = DnsDoctorDmarcUpgradeTool().run(domain="example.com")
-    assert json.loads(out) == body
+    assert out == post.return_value.text
     assert post.call_args.args[0] == "https://dnsdoctor.dev/api/v1/dmarc-upgrade"
 
 
@@ -61,6 +73,10 @@ def test_propagation_sends_the_endpoints_field_names_and_omits_an_absent_expecta
         "record_type": "A",
         "expected_value": "203.0.113.10",
     }
+    # An explicit empty string is still an explicit value; only None means "omit".
+    with patch(_PATH, return_value=_response(200, {"verdict": "consistent"})) as post:
+        DnsDoctorPropagationTool().run(name="www.example.com", expected_value="")
+    assert post.call_args.kwargs["json"]["expected_value"] == ""
 
 
 def test_transport_failures_are_messages_that_are_not_verdicts():

--- a/lib/crewai-tools/tool.specs.json
+++ b/lib/crewai-tools/tool.specs.json
@@ -7960,7 +7960,7 @@
         ],
         "properties": {
           "action": {
-            "description": "The filesystem action to perform: 'read' (returns file contents); 'write' (create or replace a file with content); 'append' (append content to an existing file \u2014 use this for writing large files in chunks to avoid hitting tool-call size limits); 'list' (lists a directory); 'delete' (removes a file/dir); 'mkdir' (creates a directory); 'info' (returns file metadata); 'exists' (returns whether a path exists); 'move' (rename or relocate a file/dir; requires 'destination'); 'find' (grep file CONTENTS recursively; requires 'pattern'); 'search' (find files by NAME pattern; requires 'pattern'); 'chmod' (change permissions/owner/group; pass at least one of 'mode', 'owner', 'group'); 'replace' (find-and-replace text across files; requires 'paths', 'pattern', and 'replacement').",
+            "description": "The filesystem action to perform: 'read' (returns file contents); 'write' (create or replace a file with content); 'append' (append content to an existing file — use this for writing large files in chunks to avoid hitting tool-call size limits); 'list' (lists a directory); 'delete' (removes a file/dir); 'mkdir' (creates a directory); 'info' (returns file metadata); 'exists' (returns whether a path exists); 'move' (rename or relocate a file/dir; requires 'destination'); 'find' (grep file CONTENTS recursively; requires 'pattern'); 'search' (find files by NAME pattern; requires 'pattern'); 'chmod' (change permissions/owner/group; pass at least one of 'mode', 'owner', 'group'); 'replace' (find-and-replace text across files; requires 'paths', 'pattern', and 'replacement').",
             "enum": [
               "read",
               "write",
@@ -9487,6 +9487,282 @@
       }
     },
     {
+      "description": "Build the next safe DMARC record for a domain (none -> quarantine, alignment-gated; p=reject only with aggregate-report evidence). Returns 'record' (present it verbatim), 'rationale' and the domain's 'current_policy'. 'record' can be null: then the rationale IS the answer, never compose a record to fill the gap. A human must approve the DNS change.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "Optional DNS Doctor API token. Raises the anonymous rate limit; never required.",
+          "name": "DNSDOCTOR_API_TOKEN",
+          "required": false
+        }
+      ],
+      "humanized_name": "DNS Doctor DMARC upgrade",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "The next safe DMARC record for a domain.",
+        "properties": {},
+        "required": [],
+        "title": "DnsDoctorDmarcUpgradeTool",
+        "type": "object"
+      },
+      "name": "DnsDoctorDmarcUpgradeTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for DnsDoctorDmarcUpgradeTool.",
+        "properties": {
+          "domain": {
+            "description": "The domain whose DMARC policy to advance.",
+            "title": "Domain",
+            "type": "string"
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "title": "DnsDoctorDmarcUpgradeToolSchema",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Read one DNS name from six locations on four continents and report whether a change has propagated. Verdict is 'propagated', 'partial' or 'not_propagated' when an expected value is given, 'consistent' or 'inconsistent' otherwise, and 'unknown' when fewer than three locations answered. A location that did not answer is reported as unreached, never as a negative result. Observation only: no record is composed.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "Optional DNS Doctor API token. Raises the anonymous rate limit; never required.",
+          "name": "DNSDOCTOR_API_TOKEN",
+          "required": false
+        }
+      ],
+      "humanized_name": "DNS Doctor propagation check",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Has a DNS change propagated worldwide?",
+        "properties": {},
+        "required": [],
+        "title": "DnsDoctorPropagationTool",
+        "type": "object"
+      },
+      "name": "DnsDoctorPropagationTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for DnsDoctorPropagationTool.",
+        "properties": {
+          "expected_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The value every location should answer with. Omit to check only that all locations agree.",
+            "title": "Expected Value"
+          },
+          "name": {
+            "description": "The DNS name to read, e.g. www.example.com.",
+            "title": "Name",
+            "type": "string"
+          },
+          "record_type": {
+            "default": "A",
+            "description": "Record type to read: A, AAAA, CNAME, MX, TXT or NS.",
+            "enum": [
+              "A",
+              "AAAA",
+              "CNAME",
+              "MX",
+              "TXT",
+              "NS"
+            ],
+            "title": "Record Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "DnsDoctorPropagationToolSchema",
+        "type": "object"
+      }
+    },
+    {
+      "description": "Scan a domain's SPF, DKIM, DMARC, MX, DNS health, blacklist status and domain/TLS expiry. Returns deterministic per-check verdicts (pass, warn, fail, info, temperror), plain-English findings and copy-paste fix records from a validating engine. Present any returned record verbatim. A 'temperror' status is a transient lookup failure, not a failure of the domain. 'not_registered: true' means the domain does not resolve and no check ran. SPF is diagnose-only: never propose SPF edits of your own. A human must approve every DNS change.",
+      "env_vars": [
+        {
+          "default": null,
+          "description": "Optional DNS Doctor API token. Raises the anonymous rate limit; never required.",
+          "name": "DNSDOCTOR_API_TOKEN",
+          "required": false
+        }
+      ],
+      "humanized_name": "DNS Doctor domain scan",
+      "init_params_schema": {
+        "$defs": {
+          "EnvVar": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Default"
+              },
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "required": {
+                "default": true,
+                "title": "Required",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ],
+            "title": "EnvVar",
+            "type": "object"
+          },
+          "ToolFailurePolicy": {
+            "description": "How an agent reacts when one of its tools reports a failure.",
+            "enum": [
+              "ignore",
+              "warn",
+              "raise"
+            ],
+            "title": "ToolFailurePolicy",
+            "type": "string"
+          }
+        },
+        "description": "Scan a domain's DNS and email-authentication posture.",
+        "properties": {},
+        "required": [],
+        "title": "DnsDoctorScanTool",
+        "type": "object"
+      },
+      "name": "DnsDoctorScanTool",
+      "package_dependencies": [],
+      "run_params_schema": {
+        "description": "Input for DnsDoctorScanTool.",
+        "properties": {
+          "domain": {
+            "description": "The domain to scan, e.g. example.com (no scheme, no path).",
+            "title": "Domain",
+            "type": "string"
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "title": "DnsDoctorScanToolSchema",
+        "type": "object"
+      }
+    },
+    {
       "description": "Execute a shell command inside an E2B sandbox and return the exit code, stdout, and stderr. Use this to run builds, package installs, git operations, or any one-off shell command.",
       "env_vars": [
         {
@@ -9894,7 +10170,7 @@
       "run_params_schema": {
         "properties": {
           "action": {
-            "description": "The filesystem action to perform: 'read' (returns file contents), 'write' (create or replace a file with content), 'append' (append content to an existing file \u2014 use this for writing large files in chunks to avoid hitting tool-call size limits), 'list' (lists a directory), 'delete' (removes a file/dir), 'mkdir' (creates a directory), 'info' (returns file metadata), 'exists' (returns a boolean for whether the path exists).",
+            "description": "The filesystem action to perform: 'read' (returns file contents), 'write' (create or replace a file with content), 'append' (append content to an existing file — use this for writing large files in chunks to avoid hitting tool-call size limits), 'list' (lists a directory), 'delete' (removes a file/dir), 'mkdir' (creates a directory), 'info' (returns file metadata), 'exists' (returns a boolean for whether the path exists).",
             "enum": [
               "read",
               "write",
@@ -16381,7 +16657,7 @@
       }
     },
     {
-      "description": "Converts natural language to SQL queries and executes them against a database. Read-only by default \u2014 only SELECT/SHOW/DESCRIBE/EXPLAIN queries (and read-only CTEs) are allowed unless configured with allow_dml=True.",
+      "description": "Converts natural language to SQL queries and executes them against a database. Read-only by default — only SELECT/SHOW/DESCRIBE/EXPLAIN queries (and read-only CTEs) are allowed unless configured with allow_dml=True.",
       "env_vars": [],
       "humanized_name": "NL2SQLTool",
       "init_params_schema": {
@@ -16432,7 +16708,7 @@
             "type": "string"
           }
         },
-        "description": "Tool that converts natural language to SQL and executes it against a database.\n\nBy default the tool operates in **read-only mode**: only SELECT, SHOW,\nDESCRIBE, EXPLAIN, and read-only CTEs (WITH \u2026 SELECT) are permitted.  Write\noperations (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, \u2026) are\nblocked unless ``allow_dml=True`` is set explicitly or the environment\nvariable ``CREWAI_NL2SQL_ALLOW_DML=true`` is present.\n\nWritable CTEs (``WITH d AS (DELETE \u2026) SELECT \u2026``) and\n``EXPLAIN ANALYZE <write-stmt>`` are treated as write operations and are\nblocked in read-only mode.\n\nThe ``_fetch_all_available_columns`` helper uses parameterised queries so\nthat table names coming from the database catalogue cannot be used as an\ninjection vector.",
+        "description": "Tool that converts natural language to SQL and executes it against a database.\n\nBy default the tool operates in **read-only mode**: only SELECT, SHOW,\nDESCRIBE, EXPLAIN, and read-only CTEs (WITH … SELECT) are permitted.  Write\noperations (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, …) are\nblocked unless ``allow_dml=True`` is set explicitly or the environment\nvariable ``CREWAI_NL2SQL_ALLOW_DML=true`` is present.\n\nWritable CTEs (``WITH d AS (DELETE …) SELECT …``) and\n``EXPLAIN ANALYZE <write-stmt>`` are treated as write operations and are\nblocked in read-only mode.\n\nThe ``_fetch_all_available_columns`` helper uses parameterised queries so\nthat table names coming from the database catalogue cannot be used as an\ninjection vector.",
         "properties": {
           "allow_dml": {
             "default": false,


### PR DESCRIPTION
Closes #7300

## Summary

Adds three tools over the hosted [DNS Doctor](https://dnsdoctor.dev) API to `lib/crewai-tools`, giving agents deterministic DNS and email-authentication checks for a domain:

- `DnsDoctorScanTool`: the full report (SPF, DKIM, DMARC, MX, DNS health, blacklists, domain and TLS expiry) with per-check verdicts and copy-paste fix records from a validating engine, never a model-generated record.
- `DnsDoctorDmarcUpgradeTool`: the next safe DMARC record for a domain, alignment-gated, with the rationale.
- `DnsDoctorPropagationTool`: whether a DNS change has propagated, read from six locations on four continents.

No API key is needed (an optional `DNSDOCTOR_API_TOKEN` raises the rate limit). Uses the existing `requests` dependency, no new extras. Responses are relayed verbatim as JSON text; transport failures (rate limit, 5xx, network) are returned as text that says they are not a verdict about the domain. A `402` relays the x402 payment offer so an x402-capable caller can pay and retry.

## Checklist

- Tool folder with `README.md`; class names end in `Tool`; pydantic `args_schema` with field descriptions (`record_type` is an enum matching the API); `env_vars` declared.
- Exported from `crewai_tools/tools/__init__.py` and `crewai_tools/__init__.py` (imports and `__all__`); `tool.specs.json` carries the three generated entries.
- `tests/tools/dns_doctor_tool_test.py` mocks the network (`uv run --package crewai-tools pytest lib/crewai-tools/tests/tools/dns_doctor_tool_test.py`: 6 passed); pre-commit (ruff, ruff-format, mypy) clean on the changed files.

Authored with an AI coding assistant working from the contributing guide; please apply the `llm-generated` label if the author cannot.


<!-- crewai-require-issue-check -->