### PR TITLE
test(tools): run wait async tests with anyio (#7305)

### DIFF
--- a/lib/crewai-tools/tests/tools/wait_tool_test.py
+++ b/lib/crewai-tools/tests/tools/wait_tool_test.py
@@ -10,6 +10,11 @@ def tool():
     return WaitTool()
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 @patch("crewai_tools.tools.wait_tool.wait_tool.time.sleep")
 def test_waits_requested_duration(mock_sleep, tool):
     result = tool.run(seconds=2)
@@ -65,7 +70,8 @@ def test_negative_seconds_is_rejected_when_passed_positionally(mock_sleep, tool)
     mock_sleep.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.block_network(allowed_hosts=[r"127\.0\.0\.1"])
+@pytest.mark.anyio
 async def test_async_negative_seconds_is_rejected_when_passed_positionally(tool):
     with patch(
         "crewai_tools.tools.wait_tool.wait_tool.asyncio.sleep", new_callable=AsyncMock
@@ -106,7 +112,8 @@ def test_invalid_max_seconds_is_rejected():
         WaitTool(max_seconds=0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.block_network(allowed_hosts=[r"127\.0\.0\.1"])
+@pytest.mark.anyio
 async def test_async_wait_caps_long_waits(tool):
     with patch(
         "crewai_tools.tools.wait_tool.wait_tool.asyncio.sleep", new_callable=AsyncMock


### PR DESCRIPTION
## Related issue

Fixes #7305

## Summary

- run the two asynchronous WaitTool tests with the AnyIO pytest plugin
- pin the AnyIO backend to asyncio because `WaitTool.arun()` uses `asyncio.sleep`
- allow only the IPv4 loopback address so the asyncio event loop can initialize on Windows while the repository-wide network block remains active

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

Commands:

- `uv run pytest --override-ini "addopts=" --disable-plugin-autoload -p anyio.pytest_plugin -p pytest_recording.plugin lib/crewai-tools/tests/tools/wait_tool_test.py -q` (23 passed)
- `uv run pytest lib/crewai-tools/tests/tools/wait_tool_test.py -q` (23 passed)
- `uv run ruff check --isolated lib/crewai-tools/tests/tools/wait_tool_test.py`
- `uv run ruff format --check --isolated lib/crewai-tools/tests/tools/wait_tool_test.py`

## Additional context

This is an AI-assisted contribution. I attempted to apply the required `llm-generated` label, but GitHub does not grant external contributors permission to add labels in the upstream repository. Maintainers: please apply `llm-generated` during triage.