### PR TITLE
docs(events): remove stale params from handle_llm_stream_chunk docstring

### DIFF
--- a/lib/crewai/src/crewai/events/utils/console_formatter.py
+++ b/lib/crewai/src/crewai/events/utils/console_formatter.py
@@ -589,9 +589,7 @@ To enable tracing, do any one of these:
         """Handle LLM stream chunk event - display streaming text in a panel.
 
         Args:
-            chunk: The new chunk of text received.
             accumulated_text: All text accumulated so far.
-            crew_tree: Unused (kept for API compatibility).
             call_type: The type of LLM call (LLM_CALL or TOOL_CALL).
         """
         if not self.verbose:


### PR DESCRIPTION
## Related issue

Fixes #7312

## Summary

Docstring-only fix in `lib/crewai/src/crewai/events/utils/console_formatter.py`. The `Args:` block on `ConsoleFormatter.handle_llm_stream_chunk` listed `chunk` and `crew_tree` parameters that were removed from the signature (which is now `(accumulated_text, call_type)`). The sole caller — `lib/crewai/src/crewai/events/event_listener.py:635` — passes exactly the two real params.

## Verification

- [ ] Tests added or updated for the changed behavior — **N/A**, docstring-only change; no runtime behavior modified.
- [x] Relevant tests and quality checks pass locally — `uv tool run --from ruff==0.15.1 ruff check` and `ruff format --check` on the touched file both pass.

## Additional context

Note for triage: this PR was authored with the assistance of Claude Code. Per CONTRIBUTING.md the `llm-generated` label is required; I don't have permission to apply it from a fork PR, so flagging it here. Issue #7312 already carries the label.