### PR TITLE
docs(crew): document the real _execute_tasks parameters

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -1565,8 +1565,10 @@ class Crew(FlowTrackable, BaseModel):
 
         Args:
             tasks (List[Task]): List of tasks to execute
-            manager (Optional[BaseAgent], optional): Manager agent to use for
-                delegation. Defaults to None.
+            start_index (Optional[int], optional): Index of the task to start
+                execution from. Defaults to 0.
+            was_replayed (bool, optional): Whether the tasks are being replayed
+                from a checkpoint. Defaults to False.
 
         Returns:
             CrewOutput: Final output of the crew


### PR DESCRIPTION
`Crew._execute_tasks`'s Args block documents a `manager (Optional[BaseAgent])` parameter that no longer exists in the signature; the actual `start_index` and `was_replayed` parameters were undocumented. The block now matches the signature.

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)