### PR TITLE
docs(README): update FAQ anchors after the Enterprise → AMP rename

### DIFF
--- a/lib/crewai/README.md
+++ b/lib/crewai/README.md
@@ -677,9 +677,9 @@ CrewAI is released under the [MIT License](https://github.com/crewAIInc/crewAI/b
 
 ### Enterprise Features
 
-- [What additional features does CrewAI AMP offer?](#q-what-additional-features-does-crewai-enterprise-offer)
-- [Is CrewAI AMP available for cloud and on-premise deployments?](#q-is-crewai-enterprise-available-for-cloud-and-on-premise-deployments)
-- [Can I try CrewAI AMP for free?](#q-can-i-try-crewai-enterprise-for-free)
+- [What additional features does CrewAI AMP offer?](#q-what-additional-features-does-crewai-amp-offer)
+- [Is CrewAI AMP available for cloud and on-premise deployments?](#q-is-crewai-amp-available-for-cloud-and-on-premise-deployments)
+- [Can I try CrewAI AMP for free?](#q-can-i-try-crewai-amp-for-free)
 
 ### Q: What exactly is CrewAI?
 


### PR DESCRIPTION
The FAQ table of contents in `lib/crewai/README.md` still uses `...-crewai-enterprise-...` anchor slugs, while the answer headings were renamed to "CrewAI AMP" — all three TOC links land nowhere:

- `#q-what-additional-features-does-crewai-enterprise-offer`
- `#q-is-crewai-enterprise-available-for-cloud-and-on-premise-deployments`
- `#q-can-i-try-crewai-enterprise-for-free`

The anchors now match the AMP headings.

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)