### PR TITLE
fix(brightdata): drop stray $ in f-string search URLs

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
@@ -131,10 +131,10 @@ class BrightDataSearchTool(BaseTool):
 
     def get_search_url(self, engine: str, query: str) -> str:
         if engine == "yandex":
-            return f"https://yandex.com/search/?text=${query}"
+            return f"https://yandex.com/search/?text={query}"
         if engine == "bing":
-            return f"https://www.bing.com/search?q=${query}"
-        return f"https://www.google.com/search?q=${query}"
+            return f"https://www.bing.com/search?q={query}"
+        return f"https://www.google.com/search?q={query}"
 
     def _run(
         self,


### PR DESCRIPTION
`BrightDataSERPTool.get_search_url` built its URLs with `${query}` inside f-strings:

```python
return f"https://www.bing.com/search?q=${query}"
```

In an f-string, `$` is a literal character, so the result is `...?q=$test` — a malformed query string. The URL is passed directly to the SERP request (no template substitution happens later), so every search through the tool carried the stray `$`.

The three URL templates (yandex/bing/google) now interpolate `{query}` normally.

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)