### PR TITLE
docs(pt-BR): fix Galileo observability quickstart links

### DIFF
--- a/docs/edge/pt-BR/observability/galileo.mdx
+++ b/docs/edge/pt-BR/observability/galileo.mdx
@@ -22,14 +22,14 @@ transparência e melhoria contínua em todo o ciclo de vida da IA.
 
 ## Primeiros passos
 
-Este tutorial segue o [CrewAI Quickstart](pt-BR/quickstart) e mostra como adicionar
+Este tutorial segue o [CrewAI Quickstart](/pt-BR/quickstart) e mostra como adicionar
 [CrewAIEventListener] do Galileo(https://v2docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
 um manipulador de eventos.
 Para mais informações, consulte Galileu
 [Adicionar Galileo a um aplicativo CrewAI](https://v2docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
 guia prático.
 
-> **Observação**Este tutorial pressupõe que você concluiu o [CrewAI Quickstart](pt-BR/quickstart).
+> **Observação**Este tutorial pressupõe que você concluiu o [CrewAI Quickstart](/pt-BR/quickstart).
 Se você quiser um exemplo completo e abrangente, consulte o Galileo
 [Repositório de exemplo SDK da CrewAI](https://github.com/rungalileo/sdk-examples/tree/main/python/agent/crew-ai).
 


### PR DESCRIPTION
`docs/edge/pt-BR/observability/galileo.mdx` links `[CrewAI Quickstart](pt-BR/quickstart)` twice. Relative to the `observability/` directory that resolves to `docs/edge/pt-BR/observability/pt-BR/quickstart`, which doesn't exist. The link now uses the site-root path (`/pt-BR/quickstart`).

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)