### PR TITLE
docs(events): drop stale params from handle_llm_stream_chunk docstring

### DIFF
--- a/lib/crewai/src/crewai/events/utils/console_formatter.py
+++ b/lib/crewai/src/crewai/events/utils/console_formatter.py
@@ -589,9 +589,7 @@ To enable tracing, do any one of these:
         """Handle LLM stream chunk event - display streaming text in a panel.
 
         Args:
-            chunk: The new chunk of text received.
             accumulated_text: All text accumulated so far.
-            crew_tree: Unused (kept for API compatibility).
             call_type: The type of LLM call (LLM_CALL or TOOL_CALL).
         """
         if not self.verbose:


### PR DESCRIPTION
`ConsoleFormatter.handle_llm_stream_chunk(self, accumulated_text, call_type=None)`'s Args block documents `chunk` and `crew_tree` — neither is a parameter. The block now matches the signature.

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)