### PR TITLE
fix(brightdata): drop stray $ in f-string search URLs

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/brightdata_tool/brightdata_serp.py
@@ -131,10 +131,10 @@ class BrightDataSearchTool(BaseTool):
 
     def get_search_url(self, engine: str, query: str) -> str:
         if engine == "yandex":
-            return f"https://yandex.com/search/?text=${query}"
+            return f"https://yandex.com/search/?text={query}"
         if engine == "bing":
-            return f"https://www.bing.com/search?q=${query}"
-        return f"https://www.google.com/search?q=${query}"
+            return f"https://www.bing.com/search?q={query}"
+        return f"https://www.google.com/search?q={query}"
 
     def _run(
         self,


### PR DESCRIPTION
Fixes #7325

`BrightDataSERPTool.get_search_url` interpolated `${query}` inside f-strings, so the three engine URLs (yandex/bing/google) carried a literal `$` before the query — and the URL goes straight to the SERP request, so every search was malformed. Now interpolates `{query}` normally, verified by calling `get_search_url` directly.

(Note: this PR was prepared with AI assistance — happy to see it labeled `llm-generated` per the contributing guidelines.)