### PR TITLE
chore(oxylabs): allow the 3.x oxylabs SDK

### DIFF
--- a/lib/crewai-tools/pyproject.toml
+++ b/lib/crewai-tools/pyproject.toml
@@ -141,7 +141,9 @@ xml = [
     "nltk>=3.10.3",
 ]
 oxylabs = [
-    "oxylabs==2.0.0"
+    # 3.x keeps the RealtimeClient surface these tools use and adds sources;
+    # allow it rather than pinning consumers to a single release.
+    "oxylabs>=2.0.0,<4",
 ]
 mongodb = [
     "pymongo>=4.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1878,7 +1878,7 @@ requires-dist = [
     { name = "nest-asyncio", marker = "extra == 'bedrock'", specifier = ">=1.6.0" },
     { name = "nest-asyncio", marker = "extra == 'contextual'", specifier = ">=1.6.0" },
     { name = "nltk", marker = "extra == 'xml'", specifier = ">=3.10.3" },
-    { name = "oxylabs", marker = "extra == 'oxylabs'", specifier = "==2.0.0" },
+    { name = "oxylabs", marker = "extra == 'oxylabs'", specifier = ">=2.0.0,<4" },
     { name = "patronus", marker = "extra == 'patronus'", specifier = ">=0.0.16" },
     { name = "playwright", marker = "extra == 'bedrock'", specifier = ">=1.52.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgresql'", specifier = ">=2.9.10" },


### PR DESCRIPTION
Related to #7306.

Stacked on #7044, as requested in review — the failure-handling and base-tool work
stays there, this carries only the dependency bump.

## Summary

`oxylabs` is pinned to exactly `2.0.0` in `lib/crewai-tools/pyproject.toml`, so
consumers can't take 3.0.0, released in March. This relaxes it to
`oxylabs>=2.0.0,<4`.

3.x keeps the `RealtimeClient` surface these tools use (`RealtimeClient(username,
password, **kwargs)` with `sdk_type`, `results[0].content`, `results[0].status_code`,
and the `universal` / `google` / `amazon` namespaces), and adds sources rather than
removing any.

The lockfile keeps `oxylabs` at 2.0.0, so this **permits** the upgrade without forcing
it on anyone.

## Testing

All four Oxylabs tools were verified against the **live** Oxylabs API on `oxylabs`
2.0.0 and 3.0.0, along with each failure path from #7044 (invalid credentials, a
config the source rejects, an upstream 404, and a timeout):

| Tool | 2.0.0 | 3.0.0 |
|---|---|---|
| `OxylabsUniversalScraperTool` | pass | pass |
| `OxylabsGoogleSearchScraperTool` | pass | pass |
| `OxylabsAmazonSearchScraperTool` | pass | pass |
| `OxylabsAmazonProductScraperTool` | pass | pass |

`uv lock --check` passes with uv 0.11.3, the version pinned in
`.pre-commit-config.yaml` and the CI workflows. The lockfile change is a single line —
the recorded specifier. Regenerating it wholesale also rewrote ~60 lines of unrelated
platform-marker churn and re-stamped the relative `exclude-newer` cutoff, so I applied
only the specifier change and verified the result is consistent.

## Note on the diff

Rebased onto `main` now that #7044 has merged, so this is down to a single commit
touching `pyproject.toml` and `uv.lock` only.

## AI-generated contribution

Per `CONTRIBUTING.md`, this was authored with an AI coding assistant (Claude Code) and
needs the `llm-generated` label, which I can't apply from a fork — could a maintainer
add it?

---

*(Supersedes #7330, which the first-time-contributor bot closed because its body referenced PR #7044 rather than an open issue. Same branch, now with the issue reference in place.)*