### PR TITLE
fix(agent): give each async task its own executor

### DIFF
--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -151,6 +151,11 @@ _EXECUTOR_CLASS_MAP: dict[str, type] = {
 }
 
 
+_dedicated_executor: contextvars.ContextVar[Any | None] = contextvars.ContextVar(
+    "crewai_dedicated_agent_executor", default=None
+)
+
+
 def _is_resuming_agent_executor(
     executor: CrewAgentExecutor | AgentExecutor | None,
 ) -> TypeIs[AgentExecutor]:
@@ -965,6 +970,15 @@ class Agent(BaseAgent):
                 future.cancel()
                 raise RuntimeError(f"Task execution failed: {e!s}") from e
 
+    def _active_executor(self) -> CrewAgentExecutor | AgentExecutor | None:
+        """Return the executor for the current execution.
+
+        Async tasks bind their own executor to the running thread so siblings
+        sharing this agent do not reuse one instance concurrently; every other
+        path uses the agent's own executor.
+        """
+        return _dedicated_executor.get() or self.agent_executor
+
     def _execute_without_timeout(self, task_prompt: str, task: Task) -> Any:
         """Execute a task without a timeout.
 
@@ -975,14 +989,15 @@ class Agent(BaseAgent):
         Returns:
             The output of the agent.
         """
-        if not self.agent_executor:
+        executor = self._active_executor()
+        if not executor:
             raise RuntimeError("Agent executor is not initialized.")
 
-        invoke_result = self.agent_executor.invoke(
+        invoke_result = executor.invoke(
             {
                 "input": task_prompt,
-                "tool_names": self.agent_executor.tools_names,
-                "tools": self.agent_executor.tools_description,
+                "tool_names": executor.tools_names,
+                "tools": executor.tools_description,
                 "ask_for_human_input": task.human_input,
             }
         )
@@ -1168,6 +1183,20 @@ class Agent(BaseAgent):
 
         prompt, stop_words, rpm_limit_fn = self._build_execution_prompt(raw_tools)
 
+        # An async task runs concurrently with its siblings, and every agent
+        # holds a single executor whose state is reset on each invoke. Sharing
+        # one across concurrent tasks corrupts that state, so give each async
+        # task its own executor, bound to the thread running it.
+        if task is not None and task.async_execution:
+            _dedicated_executor.set(
+                self._build_executor(
+                    task, parsed_tools, raw_tools, prompt, stop_words, rpm_limit_fn
+                )
+            )
+            return
+
+        _dedicated_executor.set(None)
+
         if self.agent_executor is not None:
             self._update_executor_parameters(
                 task=task,
@@ -1178,34 +1207,46 @@ class Agent(BaseAgent):
                 rpm_limit_fn=rpm_limit_fn,
             )
         else:
-            if not isinstance(self.llm, BaseLLM):
-                raise RuntimeError(
-                    "LLM must be resolved before creating agent executor."
-                )
-            self.agent_executor = self.executor_class(
-                llm=self.llm,
-                task=task,
-                agent=self,
-                crew=self.crew,
-                tools=parsed_tools,
-                prompt=prompt,
-                original_tools=raw_tools,
-                stop_words=stop_words,
-                max_iter=self.max_iter,
-                tools_handler=self.tools_handler,
-                tools_names=get_tool_names(parsed_tools),
-                tools_description=render_text_description_and_args(parsed_tools),
-                step_callback=self.step_callback,
-                function_calling_llm=self.function_calling_llm,
-                respect_context_window=self.respect_context_window,
-                request_within_rpm_limit=rpm_limit_fn,
-                callbacks=[TokenCalcHandler(self._token_process)],
-                response_model=(
-                    task.response_model or task.output_pydantic or task.output_json
-                )
-                if task
-                else None,
+            self.agent_executor = self._build_executor(
+                task, parsed_tools, raw_tools, prompt, stop_words, rpm_limit_fn
             )
+
+    def _build_executor(
+        self,
+        task: Task | None,
+        parsed_tools: list[CrewStructuredTool],
+        raw_tools: list[BaseTool],
+        prompt: SystemPromptResult | StandardPromptResult,
+        stop_words: list[str],
+        rpm_limit_fn: Any,
+    ) -> CrewAgentExecutor | AgentExecutor:
+        """Construct a new executor for this agent without storing it."""
+        if not isinstance(self.llm, BaseLLM):
+            raise RuntimeError("LLM must be resolved before creating agent executor.")
+        return self.executor_class(
+            llm=self.llm,
+            task=task,
+            agent=self,
+            crew=self.crew,
+            tools=parsed_tools,
+            prompt=prompt,
+            original_tools=raw_tools,
+            stop_words=stop_words,
+            max_iter=self.max_iter,
+            tools_handler=self.tools_handler,
+            tools_names=get_tool_names(parsed_tools),
+            tools_description=render_text_description_and_args(parsed_tools),
+            step_callback=self.step_callback,
+            function_calling_llm=self.function_calling_llm,
+            respect_context_window=self.respect_context_window,
+            request_within_rpm_limit=rpm_limit_fn,
+            callbacks=[TokenCalcHandler(self._token_process)],
+            response_model=(
+                task.response_model or task.output_pydantic or task.output_json
+            )
+            if task
+            else None,
+        )
 
     def _update_executor_parameters(
         self,

--- a/lib/crewai/src/crewai/agent/core.py
+++ b/lib/crewai/src/crewai/agent/core.py
@@ -1113,14 +1113,15 @@ class Agent(BaseAgent):
         Returns:
             The output of the agent.
         """
-        if not self.agent_executor:
+        executor = self._active_executor()
+        if not executor:
             raise RuntimeError("Agent executor is not initialized.")
 
-        result = await self.agent_executor.ainvoke(
+        result = await executor.ainvoke(
             {
                 "input": task_prompt,
-                "tool_names": self.agent_executor.tools_names,
-                "tools": self.agent_executor.tools_description,
+                "tool_names": executor.tools_names,
+                "tools": executor.tools_description,
                 "ask_for_human_input": task.human_input,
             }
         )

--- a/lib/crewai/tests/test_async_tasks_same_agent.py
+++ b/lib/crewai/tests/test_async_tasks_same_agent.py
@@ -6,26 +6,44 @@ run concurrently, so sharing one executor between them corrupted that state and
 the executor's own guard rejected the second invocation with
 ``RuntimeError: Executor is already running``.
 
-Each async task now gets an executor bound to the thread running it. A stub LLM
-keeps these offline; no provider is required.
+Each async task now gets an executor bound to the context running it, on both
+``kickoff`` and ``akickoff``. A stub LLM keeps these offline; no provider is
+required.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 import threading
 from typing import Any
 
+import pytest
+
 from crewai import Agent, Crew, Task
 from crewai.llms.base_llm import BaseLLM
+from crewai.tools import BaseTool
+
+
+FINAL_ANSWER = "Thought: I know the answer.\nFinal Answer: done"
 
 
 class _StubLLM(BaseLLM):
-    """Offline LLM that answers immediately and records concurrency."""
+    """Offline LLM that answers immediately and records concurrency.
 
-    def __init__(self) -> None:
+    With ``overlap`` set, the first ``overlap`` calls wait for one another
+    before answering, so they are guaranteed to be in flight together. A call
+    that never gets company times out, failing its task.
+    """
+
+    def __init__(self, overlap: int = 0) -> None:
         super().__init__(model="stub-model")
         self.concurrent = 0
         self.max_concurrent = 0
+        self.prompts: list[str] = []
+        self._calls = 0
+        self._overlap = overlap
+        self._barrier = threading.Barrier(overlap, timeout=5) if overlap else None
         self._lock = threading.Lock()
 
     def call(
@@ -39,10 +57,15 @@ class _StubLLM(BaseLLM):
         response_model: Any = None,
     ) -> str:
         with self._lock:
+            self.prompts.append(_text(messages))
+            barrier = self._barrier if self._calls < self._overlap else None
+            self._calls += 1
             self.concurrent += 1
             self.max_concurrent = max(self.max_concurrent, self.concurrent)
         try:
-            return "Thought: I know the answer.\nFinal Answer: done"
+            if barrier is not None:
+                barrier.wait()
+            return FINAL_ANSWER
         finally:
             with self._lock:
                 self.concurrent -= 1
@@ -57,37 +80,42 @@ class _StubLLM(BaseLLM):
         return 4096
 
 
+class _ProbeTool(BaseTool):
+    name: str = "probe_tool"
+    description: str = "Given only to the async task."
+
+    def _run(self, **kwargs: Any) -> str:
+        return "probe"
+
+
+Runner = Callable[[Crew], Any]
+
+
+def _kickoff(crew: Crew) -> Any:
+    return crew.kickoff()
+
+
+def _akickoff(crew: Crew) -> Any:
+    return asyncio.run(crew.akickoff())
+
+
+both_paths = pytest.mark.parametrize(
+    "run", [_kickoff, _akickoff], ids=["kickoff", "akickoff"]
+)
+
+
+def _text(messages: Any) -> str:
+    if isinstance(messages, str):
+        return messages
+    return "\n".join(str(message.get("content", "")) for message in messages)
+
+
 def _agent(llm: _StubLLM, role: str = "Worker") -> Agent:
     return Agent(role=role, goal="Answer briefly.", backstory="Brief.", llm=llm)
 
 
-def test_two_async_tasks_on_one_agent_complete() -> None:
-    """Two concurrent async tasks may share an agent without colliding."""
-    llm = _StubLLM()
-    agent = _agent(llm)
-    tasks = [
-        Task(
-            description=f"say {word}",
-            expected_output="one word",
-            agent=agent,
-            async_execution=True,
-        )
-        for word in ("alpha", "beta")
-    ]
-    tasks.append(
-        Task(description="say done", expected_output="one word", agent=agent)
-    )
-
-    result = Crew(agents=[agent], tasks=tasks).kickoff()
-
-    assert len(result.tasks_output) == 3
-    assert all(output.raw for output in result.tasks_output)
-
-
-def test_three_async_tasks_on_one_agent_complete() -> None:
-    """The limit is not two: any number of async tasks may share an agent."""
-    llm = _StubLLM()
-    agent = _agent(llm)
+def _async_tasks(agent: Agent, count: int) -> list[Task]:
+    """``count`` async tasks, then the sync task that waits for them."""
     tasks = [
         Task(
             description=f"say w{index}",
@@ -95,24 +123,16 @@ def test_three_async_tasks_on_one_agent_complete() -> None:
             agent=agent,
             async_execution=True,
         )
-        for index in range(3)
+        for index in range(count)
     ]
-    tasks.append(
-        Task(description="say done", expected_output="one word", agent=agent)
-    )
-
-    result = Crew(agents=[agent], tasks=tasks).kickoff()
-
-    assert len(result.tasks_output) == 4
+    tasks.append(Task(description="say done", expected_output="one word", agent=agent))
+    return tasks
 
 
-def test_async_tasks_do_not_reuse_one_executor() -> None:
-    """Concurrent tasks on one agent must not share an executor instance."""
-    llm = _StubLLM()
-    agent = _agent(llm)
+def _record_executors(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record the id of the executor each task execution runs on."""
     seen: list[int] = []
     lock = threading.Lock()
-
     original = Agent._active_executor
 
     def record(self: Agent) -> Any:
@@ -121,37 +141,85 @@ def test_async_tasks_do_not_reuse_one_executor() -> None:
             seen.append(id(executor))
         return executor
 
-    Agent._active_executor = record  # type: ignore[method-assign]
-    try:
-        tasks = [
-            Task(
-                description=f"say w{index}",
-                expected_output="one word",
-                agent=agent,
-                async_execution=True,
-            )
-            for index in range(2)
-        ]
-        tasks.append(
-            Task(description="say done", expected_output="one word", agent=agent)
-        )
-        Crew(agents=[agent], tasks=tasks).kickoff()
-    finally:
-        Agent._active_executor = original  # type: ignore[method-assign]
+    monkeypatch.setattr(Agent, "_active_executor", record)
+    return seen
+
+
+@both_paths
+def test_two_async_tasks_on_one_agent_overlap_and_complete(run: Runner) -> None:
+    """Two async tasks may share an agent and run at the same time."""
+    llm = _StubLLM(overlap=2)
+    agent = _agent(llm)
+
+    result = run(Crew(agents=[agent], tasks=_async_tasks(agent, 2)))
+
+    assert llm.max_concurrent == 2
+    assert len(result.tasks_output) == 3
+    assert all(output.raw for output in result.tasks_output)
+
+
+@both_paths
+def test_three_async_tasks_on_one_agent_overlap_and_complete(run: Runner) -> None:
+    """The limit is not two: any number of async tasks may share an agent."""
+    llm = _StubLLM(overlap=3)
+    agent = _agent(llm)
+
+    result = run(Crew(agents=[agent], tasks=_async_tasks(agent, 3)))
+
+    assert llm.max_concurrent == 3
+    assert len(result.tasks_output) == 4
+
+
+@both_paths
+def test_async_tasks_do_not_reuse_one_executor(
+    run: Runner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent tasks on one agent must not share an executor instance."""
+    seen = _record_executors(monkeypatch)
+    agent = _agent(_StubLLM())
+
+    run(Crew(agents=[agent], tasks=_async_tasks(agent, 2)))
 
     # two async tasks plus one sync task, each with a distinct executor
     assert len(set(seen)) == len(seen) == 3
 
 
-def test_sequential_tasks_still_reuse_the_agent_executor() -> None:
-    """Non-async tasks keep reusing the agent's own executor."""
+@both_paths
+def test_async_task_runs_with_its_own_tools(run: Runner) -> None:
+    """An async task's executor is built for that task, its tools included."""
     llm = _StubLLM()
     agent = _agent(llm)
+    tasks = [
+        Task(
+            description="say w0",
+            expected_output="one word",
+            agent=agent,
+            async_execution=True,
+            tools=[_ProbeTool()],
+        ),
+        Task(description="say done", expected_output="one word", agent=agent),
+    ]
+
+    run(Crew(agents=[agent], tasks=tasks))
+
+    async_prompts = [prompt for prompt in llm.prompts if "say w0" in prompt]
+    assert async_prompts
+    assert all("probe_tool" in prompt for prompt in async_prompts)
+
+
+@both_paths
+def test_sequential_tasks_still_reuse_the_agent_executor(
+    run: Runner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-async tasks keep reusing the agent's own executor."""
+    seen = _record_executors(monkeypatch)
+    agent = _agent(_StubLLM())
     tasks = [
         Task(description=f"say s{index}", expected_output="one word", agent=agent)
         for index in range(2)
     ]
 
-    Crew(agents=[agent], tasks=tasks).kickoff()
+    run(Crew(agents=[agent], tasks=tasks))
 
-    assert agent.agent_executor is not None
+    assert len(seen) == 2
+    assert set(seen) == {id(agent.agent_executor)}

--- a/lib/crewai/tests/test_async_tasks_same_agent.py
+++ b/lib/crewai/tests/test_async_tasks_same_agent.py
@@ -1,0 +1,157 @@
+"""Tests for concurrent async tasks assigned to one agent.
+
+An ``Agent`` holds a single ``agent_executor`` whose state is reset at the
+start of every ``invoke``. Two ``async_execution=True`` tasks on the same agent
+run concurrently, so sharing one executor between them corrupted that state and
+the executor's own guard rejected the second invocation with
+``RuntimeError: Executor is already running``.
+
+Each async task now gets an executor bound to the thread running it. A stub LLM
+keeps these offline; no provider is required.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from crewai import Agent, Crew, Task
+from crewai.llms.base_llm import BaseLLM
+
+
+class _StubLLM(BaseLLM):
+    """Offline LLM that answers immediately and records concurrency."""
+
+    def __init__(self) -> None:
+        super().__init__(model="stub-model")
+        self.concurrent = 0
+        self.max_concurrent = 0
+        self._lock = threading.Lock()
+
+    def call(
+        self,
+        messages: Any,
+        tools: Any = None,
+        callbacks: Any = None,
+        available_functions: Any = None,
+        from_task: Any = None,
+        from_agent: Any = None,
+        response_model: Any = None,
+    ) -> str:
+        with self._lock:
+            self.concurrent += 1
+            self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        try:
+            return "Thought: I know the answer.\nFinal Answer: done"
+        finally:
+            with self._lock:
+                self.concurrent -= 1
+
+    def supports_function_calling(self) -> bool:
+        return False
+
+    def supports_stop_words(self) -> bool:
+        return False
+
+    def get_context_window_size(self) -> int:
+        return 4096
+
+
+def _agent(llm: _StubLLM, role: str = "Worker") -> Agent:
+    return Agent(role=role, goal="Answer briefly.", backstory="Brief.", llm=llm)
+
+
+def test_two_async_tasks_on_one_agent_complete() -> None:
+    """Two concurrent async tasks may share an agent without colliding."""
+    llm = _StubLLM()
+    agent = _agent(llm)
+    tasks = [
+        Task(
+            description=f"say {word}",
+            expected_output="one word",
+            agent=agent,
+            async_execution=True,
+        )
+        for word in ("alpha", "beta")
+    ]
+    tasks.append(
+        Task(description="say done", expected_output="one word", agent=agent)
+    )
+
+    result = Crew(agents=[agent], tasks=tasks).kickoff()
+
+    assert len(result.tasks_output) == 3
+    assert all(output.raw for output in result.tasks_output)
+
+
+def test_three_async_tasks_on_one_agent_complete() -> None:
+    """The limit is not two: any number of async tasks may share an agent."""
+    llm = _StubLLM()
+    agent = _agent(llm)
+    tasks = [
+        Task(
+            description=f"say w{index}",
+            expected_output="one word",
+            agent=agent,
+            async_execution=True,
+        )
+        for index in range(3)
+    ]
+    tasks.append(
+        Task(description="say done", expected_output="one word", agent=agent)
+    )
+
+    result = Crew(agents=[agent], tasks=tasks).kickoff()
+
+    assert len(result.tasks_output) == 4
+
+
+def test_async_tasks_do_not_reuse_one_executor() -> None:
+    """Concurrent tasks on one agent must not share an executor instance."""
+    llm = _StubLLM()
+    agent = _agent(llm)
+    seen: list[int] = []
+    lock = threading.Lock()
+
+    original = Agent._active_executor
+
+    def record(self: Agent) -> Any:
+        executor = original(self)
+        with lock:
+            seen.append(id(executor))
+        return executor
+
+    Agent._active_executor = record  # type: ignore[method-assign]
+    try:
+        tasks = [
+            Task(
+                description=f"say w{index}",
+                expected_output="one word",
+                agent=agent,
+                async_execution=True,
+            )
+            for index in range(2)
+        ]
+        tasks.append(
+            Task(description="say done", expected_output="one word", agent=agent)
+        )
+        Crew(agents=[agent], tasks=tasks).kickoff()
+    finally:
+        Agent._active_executor = original  # type: ignore[method-assign]
+
+    # two async tasks plus one sync task, each with a distinct executor
+    assert len(set(seen)) == len(seen) == 3
+
+
+def test_sequential_tasks_still_reuse_the_agent_executor() -> None:
+    """Non-async tasks keep reusing the agent's own executor."""
+    llm = _StubLLM()
+    agent = _agent(llm)
+    tasks = [
+        Task(description=f"say s{index}", expected_output="one word", agent=agent)
+        for index in range(2)
+    ]
+
+    Crew(agents=[agent], tasks=tasks).kickoff()
+
+    assert agent.agent_executor is not None


### PR DESCRIPTION
Fixes #7332

## Problem

Two or more `async_execution=True` tasks assigned to the same agent crash the crew:

```
RuntimeError: Executor is already running. Cannot invoke the same executor instance concurrently.
```

An `Agent` holds a single `agent_executor` and `create_agent_executor()` mutates that field, so concurrent async tasks race on it and then both invoke it. `AgentExecutor.invoke()` resets shared state at entry, so its guard rejects the second caller.

This is the pattern in the async example in `docs/edge/en/concepts/tasks.mdx` — `list_ideas` and `list_important_history` are both assigned to `researcher`. That example crashes when run verbatim.

It is also a regression. Matrix on `main` @ 7e18abd:

```
default executor, 2 async, same agent          FAIL  RuntimeError
default executor, 3 async, same agent          FAIL  RuntimeError
CrewAgentExecutor, 2 async, same agent         OK
kickoff_async, 2 async, same agent             FAIL  RuntimeError
hierarchical, 2 async                          OK
CONTROL: 2 async, different agents             OK
```

The legacy `CrewAgentExecutor` handles this; `AgentExecutor` does not. The default changed in `332263462` (#5745). Setting `executor_class=CrewAgentExecutor` still works but emits a DeprecationWarning pointing users at the executor that fails.

## Fix

Split executor construction from storing it, and when a task is async bind a dedicated executor to the thread running it:

- `_build_executor(...)` constructs an executor without assigning it to the agent
- `create_agent_executor(...)` binds a dedicated executor for `task.async_execution`, leaving `agent_executor` untouched
- `_active_executor()` returns the thread-bound executor if there is one, else the agent's own

`Task.execute_async` already does `contextvars.copy_context()` per thread, so siblings are isolated without locks and without copying the agent. The sequential path is unchanged and still reuses `agent_executor`.

The guard in `AgentExecutor` is left as-is — concurrent entry would still corrupt state, so it should keep failing loudly if anything else reaches it.

## Why not copy the agent per task

Smaller diff, but `Agent.copy()` excludes `_token_process` and shallow-copies the `llm`, so async task token usage would stop being counted.

## Testing

`tests/test_async_tasks_same_agent.py`, offline with a stub LLM:

- two async tasks on one agent complete
- three async tasks on one agent complete
- concurrent tasks each get a distinct executor instance
- sequential tasks still reuse the agent's own executor

The first two fail on `main` with the `RuntimeError`.

Verified against a live model as well: the documented example from `tasks.mdx` now completes and returns the article.

Full `lib/crewai/tests/` — 5291 passed, 44 skipped. ruff, ruff-format and mypy clean. (`cli/test_version.py::test_dynamic_versioning_consistency` fails identically on clean `main` in my checkout — an installed-version mismatch, unrelated. The bedrock streaming tests are flaky under `xdist` and pass in isolation on both `main` and this branch.)

---

This PR was written with AI assistance and should carry the `llm-generated` label per CONTRIBUTING.md. I can't apply labels myself — could a maintainer add it?
