### PR TITLE
fix(mcp): remove contextvars.copy_context from ThreadPoolExecutor MCP resolver

### DIFF
--- a/lib/crewai/src/crewai/mcp/tool_resolver.py
+++ b/lib/crewai/src/crewai/mcp/tool_resolver.py
@@ -11,7 +11,7 @@ into a standalone MCPToolResolver. It handles three flavours of MCP reference:
 from __future__ import annotations
 
 import asyncio
-import contextvars
+
 import sys
 import time
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -400,10 +400,9 @@ class MCPToolResolver:
             if running_loop:
                 import concurrent.futures
 
-                ctx = contextvars.copy_context()
                 with concurrent.futures.ThreadPoolExecutor() as executor:
                     future = executor.submit(
-                        ctx.run, asyncio.run, _setup_client_and_list_tools()
+                        asyncio.run, _setup_client_and_list_tools()
                     )
                     try:
                         tools_list = future.result()


### PR DESCRIPTION
## Summary

Fixes #6843.

When a CrewAI Flow runs an agent with an MCP server configured via `streamable: true` (Streamable HTTP/SSE transport), the MCP tool resolver crashes with:

```
RuntimeError: Failed to get native MCP tools: asyncio.run() cannot be called from a running event loop
```

## Root Cause

In `_resolve_native`, when a running event loop is detected, the code uses `contextvars.copy_context()` and `ctx.run(asyncio.run, ...)` to run the MCP client in a thread pool. The copied context includes the running event loop's context var, which causes `asyncio.run()` to raise the error because it detects a running event loop (from the copied context).

## Fix

Remove `contextvars.copy_context()` and `ctx.run` from the `executor.submit` call. Submit `asyncio.run` directly to the thread pool executor. Each thread gets a fresh context with no event loop, so `asyncio.run()` creates a new event loop as intended.

## Changes

- `lib/crewai/src/crewai/mcp/tool_resolver.py`: 2 insertions, 3 deletions

<!-- crewai-require-issue-check -->