### PR TITLE
fix(project): avoid retaining crew instances in memoization cache

### DIFF
--- a/lib/crewai/src/crewai/project/utils.py
+++ b/lib/crewai/src/crewai/project/utils.py
@@ -15,16 +15,18 @@ from crewai.agents.cache.cache_handler import CacheHandler
 P = ParamSpec("P")
 R = TypeVar("R")
 cache = CacheHandler()
-_instance_caches: WeakKeyDictionary[Any, CacheHandler] = WeakKeyDictionary()
+_INSTANCE_CACHE_ATTR = "__crewai_memoization_cache__"
+_instance_caches: WeakKeyDictionary[Any, None] = WeakKeyDictionary()
 _instance_caches_lock = threading.Lock()
 
 
 def _get_cache(args: tuple[Any, ...]) -> CacheHandler:
     """Return an instance-scoped cache when memoizing a bound method.
 
-    Instance caches are held by weak keys so cached Agent/Task/Crew results do
-    not keep discarded CrewBase instances alive. Functions without an instance
-    argument continue using the process-wide cache.
+    Instance caches live on their owner so cached Agent/Task/Crew results can
+    form a collectable cycle with the owner without being rooted by a global
+    registry. Functions without an instance argument continue using the
+    process-wide cache.
     """
     if not args:
         return cache
@@ -35,9 +37,14 @@ def _get_cache(args: tuple[Any, ...]) -> CacheHandler:
 
     try:
         with _instance_caches_lock:
-            return _instance_caches.setdefault(instance, CacheHandler())
-    except TypeError:
-        # Some callable objects are unhashable or cannot be weakly referenced.
+            instance_cache = instance.__dict__.get(_INSTANCE_CACHE_ATTR)
+            if instance_cache is None:
+                instance_cache = CacheHandler()
+                instance.__dict__[_INSTANCE_CACHE_ATTR] = instance_cache
+            _instance_caches[instance] = None
+            return instance_cache
+    except (AttributeError, TypeError):
+        # Some callable objects cannot expose a mutable dict or weak reference.
         return cache
 
 

--- a/lib/crewai/src/crewai/project/utils.py
+++ b/lib/crewai/src/crewai/project/utils.py
@@ -3,7 +3,9 @@
 from collections.abc import Callable, Coroutine
 from functools import wraps
 import inspect
+import threading
 from typing import Any, ParamSpec, TypeVar, cast
+from weakref import WeakKeyDictionary
 
 from pydantic import BaseModel
 
@@ -13,6 +15,30 @@ from crewai.agents.cache.cache_handler import CacheHandler
 P = ParamSpec("P")
 R = TypeVar("R")
 cache = CacheHandler()
+_instance_caches: WeakKeyDictionary[Any, CacheHandler] = WeakKeyDictionary()
+_instance_caches_lock = threading.Lock()
+
+
+def _get_cache(args: tuple[Any, ...]) -> CacheHandler:
+    """Return an instance-scoped cache when memoizing a bound method.
+
+    Instance caches are held by weak keys so cached Agent/Task/Crew results do
+    not keep discarded CrewBase instances alive. Functions without an instance
+    argument continue using the process-wide cache.
+    """
+    if not args:
+        return cache
+
+    instance = args[0]
+    if not hasattr(instance, "__dict__"):
+        return cache
+
+    try:
+        with _instance_caches_lock:
+            return _instance_caches.setdefault(instance, CacheHandler())
+    except TypeError:
+        # Some callable objects are unhashable or cannot be weakly referenced.
+        return cache
 
 
 def _make_hashable(arg: Any) -> Any:
@@ -63,12 +89,15 @@ def _memoize_sync(meth: Callable[P, R]) -> Callable[P, R]:
         )
         cache_key = str((hashable_args, hashable_kwargs))
 
-        cached_result: R | None = cache.read(tool=meth.__name__, input=cache_key)
+        instance_cache = _get_cache(tuple(args))
+        cached_result: R | None = instance_cache.read(
+            tool=meth.__name__, input=cache_key
+        )
         if cached_result is not None:
             return cached_result
 
         result = meth(*args, **kwargs)
-        cache.add(tool=meth.__name__, input=cache_key, output=result)
+        instance_cache.add(tool=meth.__name__, input=cache_key, output=result)
         return result
 
     return cast(Callable[P, R], wrapper)
@@ -87,12 +116,15 @@ def _memoize_async(
         )
         cache_key = str((hashable_args, hashable_kwargs))
 
-        cached_result: R | None = cache.read(tool=meth.__name__, input=cache_key)
+        instance_cache = _get_cache(tuple(args))
+        cached_result: R | None = instance_cache.read(
+            tool=meth.__name__, input=cache_key
+        )
         if cached_result is not None:
             return cached_result
 
         result = await meth(*args, **kwargs)
-        cache.add(tool=meth.__name__, input=cache_key, output=result)
+        instance_cache.add(tool=meth.__name__, input=cache_key, output=result)
         return result
 
     return wrapper

--- a/lib/crewai/tests/test_project.py
+++ b/lib/crewai/tests/test_project.py
@@ -1,3 +1,4 @@
+import gc
 from typing import Any, ClassVar, cast
 from unittest.mock import Mock, create_autospec, patch
 
@@ -16,6 +17,7 @@ from crewai.project import (
     llm,
     task,
 )
+from crewai.project import utils as project_utils
 from crewai.task import Task
 from crewai.tools import tool
 
@@ -135,6 +137,30 @@ def test_crew_memoization():
     assert first_call_result is second_call_result, (
         "Crew references should point to the same object"
     )
+
+
+def test_instance_memoization_cache_does_not_retain_discarded_crews():
+    """Memoized CrewBase results should be released with their owner instance."""
+    project_utils._instance_caches.clear()
+
+    class CrewFactory:
+        @agent
+        def simple_agent(self):
+            return Agent(
+                role="Simple Agent", goal="Simple Goal", backstory="Simple Backstory"
+            )
+
+    factories = [CrewFactory() for _ in range(10)]
+    results = [factory.simple_agent() for factory in factories]
+
+    assert len(project_utils._instance_caches) == len(factories)
+    assert len({id(result) for result in results}) == len(factories)
+
+    del results
+    del factories
+    gc.collect()
+
+    assert len(project_utils._instance_caches) == 0
 
 
 def test_task_name():

--- a/lib/crewai/tests/test_project.py
+++ b/lib/crewai/tests/test_project.py
@@ -1,6 +1,7 @@
 import gc
 from typing import Any, ClassVar, cast
 from unittest.mock import Mock, create_autospec, patch
+from weakref import ref
 
 import pytest
 from crewai.agent import Agent
@@ -13,6 +14,7 @@ from crewai.project import (
     after_kickoff,
     agent,
     before_kickoff,
+    callback,
     crew,
     llm,
     task,
@@ -144,14 +146,23 @@ def test_instance_memoization_cache_does_not_retain_discarded_crews():
     project_utils._instance_caches.clear()
 
     class CrewFactory:
+        @callback
+        def step_callback(self, _):
+            return None
+
         @agent
         def simple_agent(self):
             return Agent(
-                role="Simple Agent", goal="Simple Goal", backstory="Simple Backstory"
+                role="Simple Agent",
+                goal="Simple Goal",
+                backstory="Simple Backstory",
+                step_callback=self.step_callback,
             )
 
     factories = [CrewFactory() for _ in range(10)]
     results = [factory.simple_agent() for factory in factories]
+    factory_refs = [ref(factory) for factory in factories]
+    result_refs = [ref(result) for result in results]
 
     assert len(project_utils._instance_caches) == len(factories)
     assert len({id(result) for result in results}) == len(factories)
@@ -160,6 +171,8 @@ def test_instance_memoization_cache_does_not_retain_discarded_crews():
     del factories
     gc.collect()
 
+    assert all(factory_ref() is None for factory_ref in factory_refs)
+    assert all(result_ref() is None for result_ref in result_refs)
     assert len(project_utils._instance_caches) == 0
 
 


### PR DESCRIPTION
## Related issue

Fixes #7338

## Summary

- Use weakly referenced, instance-scoped caches for memoized bound CrewBase methods.
- Preserve the process-wide cache for functions without an instance receiver.
- Add a regression test verifying discarded CrewBase instances can be garbage-collected.

## Verification

- Ruff check passed.
- Ruff format passed.
- Memoization-focused tests passed: 4 tests.
- `git diff --check` passed.

## Additional context

The full target test file also exercises environment-sensitive async and Windows SQLite teardown paths; those failures were unrelated to this change.

<!-- crewai-require-issue-check -->