### PR TITLE
docs(tools): fix parallel search reference link

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/parallel_tools/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/parallel_tools/README.md
@@ -30,7 +30,7 @@ Optional (for the agent example):
 Notes:
 - API is in beta; default rate limit is 600 RPM. Contact support for production capacity.
 
-## Direct usage (when published)
+## Direct usage
 
 ```python
 from crewai_tools import ParallelSearchTool
@@ -150,4 +150,4 @@ Tips:
 ## References
 
 - Search API Quickstart: https://docs.parallel.ai/search-api/search-quickstart
-- Processors: https://docs.parallel.ai/search-api/processors
+- Search API (v1beta) reference: https://docs.parallel.ai/api-reference/legacy/search-beta/search


### PR DESCRIPTION
## Related issue

Fixes #7343

## Summary

Fix the broken processors link in the ParallelSearchTool README's References section by linking to the legacy Search API reference. That reference matches the wrapper's `/v1beta/search` endpoint and `base`/`pro` processor values. Remove “when published” from the Direct usage heading now that the tool ships in `crewai-tools` 1.15.20.

This complements #6255, which changes the introductory occurrence. This PR leaves that occurrence untouched.

## Verification

- Confirmed the old destination returns HTTP 404 and the legacy reference returns HTTP 200.
- Checked the legacy schema against the wrapper's endpoint and processor values.
- Inspected the published 1.15.20 wheel to confirm the tool is included and exported.
- `git diff --check` and targeted scope assertions passed.
- No runtime tests run for this README-only change.

## Additional context

The legacy processor field is deprecated. This change does not add support for GA API modes or alter tool behavior.


AI-assisted contribution. The contributing guide requires the `llm-generated` label; I requested it on creation, but this account cannot apply repository labels (HTTP 403). A maintainer will need to add it.
