### PR TITLE
Fix/agent executor async llm path

### DIFF
--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -86,13 +86,13 @@ from crewai.tools.tool_failure import (
 )
 from crewai.utilities.agent_utils import (
     _llm_stop_words_applied,
+    aget_llm_response_with_fallback,
     build_text_tool_calling_fallback_message,
     check_native_tool_support,
     enforce_rpm_limit,
     extract_tool_call_info,
     format_message_for_llm,
     format_native_tool_output_for_agent,
-    get_llm_response,
     handle_agent_action_core,
     handle_context_length,
     handle_max_iterations_exceeded,
@@ -1453,7 +1453,9 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
         return "agent_finished"
 
     @router("continue_reasoning")
-    def call_llm_and_parse(self) -> Literal["parsed", "parser_error", "context_error"]:
+    async def call_llm_and_parse(
+        self,
+    ) -> Literal["parsed", "parser_error", "context_error"]:
         """Execute LLM call with hooks and parse the response.
 
         Returns routing decision based on parsing result.
@@ -1468,7 +1470,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 None if self.original_tools else self.response_model
             )
 
-            answer = get_llm_response(
+            answer = await aget_llm_response_with_fallback(
                 llm=self.llm,
                 messages=list(self.state.messages),
                 callbacks=self.callbacks,
@@ -1526,7 +1528,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             raise
 
     @router("continue_reasoning_native")
-    def call_llm_native_tools(
+    async def call_llm_native_tools(
         self,
     ) -> Literal[
         "native_tool_calls",
@@ -1558,7 +1560,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             enforce_rpm_limit(self.request_within_rpm_limit)
 
             # Call LLM with native tools
-            answer = get_llm_response(
+            answer = await aget_llm_response_with_fallback(
                 llm=self.llm,
                 messages=list(self.state.messages),
                 callbacks=self.callbacks,

--- a/lib/crewai/src/crewai/experimental/agent_executor.py
+++ b/lib/crewai/src/crewai/experimental/agent_executor.py
@@ -86,7 +86,7 @@ from crewai.tools.tool_failure import (
 )
 from crewai.utilities.agent_utils import (
     _llm_stop_words_applied,
-    aget_llm_response_with_fallback,
+    aget_llm_response,
     build_text_tool_calling_fallback_message,
     check_native_tool_support,
     enforce_rpm_limit,
@@ -1470,7 +1470,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
                 None if self.original_tools else self.response_model
             )
 
-            answer = await aget_llm_response_with_fallback(
+            answer = await aget_llm_response(
                 llm=self.llm,
                 messages=list(self.state.messages),
                 callbacks=self.callbacks,
@@ -1560,7 +1560,7 @@ class AgentExecutor(Flow[AgentExecutorState], BaseAgentExecutor):
             enforce_rpm_limit(self.request_within_rpm_limit)
 
             # Call LLM with native tools
-            answer = await aget_llm_response_with_fallback(
+            answer = await aget_llm_response(
                 llm=self.llm,
                 messages=list(self.state.messages),
                 callbacks=self.callbacks,

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -618,7 +618,7 @@ async def aget_llm_response(
     executor_context: CrewAgentExecutor | AgentExecutor | None = None,
     verbose: bool = True,
 ) -> str | BaseModel | Any:
-    """Call the LLM asynchronously and return the response.
+    """Call the LLM asynchronously, fall back to sync-call and return the response.
 
     Args:
         llm: The LLM instance to call.
@@ -644,75 +644,31 @@ async def aget_llm_response(
     with _prepare_llm_call(
         executor_context, messages, printer, verbose=verbose
     ) as prepared_messages:
-        answer = await llm.acall(
-            prepared_messages,
-            tools=tools,
-            callbacks=callbacks,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+        try:
+            answer = await llm.acall(
+                prepared_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
+        except NotImplementedError:
+            answer = await asyncio.to_thread(
+                llm.call,
+                prepared_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
 
     return _validate_and_finalize_llm_response(
         answer, executor_context, printer, verbose=verbose
     )
-
-
-async def aget_llm_response_with_fallback(
-    llm: LLM | BaseLLM,
-    messages: list[LLMMessage],
-    callbacks: list[TokenCalcHandler],
-    printer: Printer,
-    tools: list[dict[str, Any]] | None = None,
-    available_functions: dict[str, Callable[..., Any]] | None = None,
-    from_task: Task | None = None,
-    from_agent: BaseAgent | None = None,
-    response_model: type[BaseModel] | None = None,
-    executor_context: CrewAgentExecutor | AgentExecutor | None = None,
-    verbose: bool = True,
-) -> str | BaseModel | Any:
-    """Call aget_llm_response, fall back to get_llm_response and return the response.
-
-    Args:
-        llm: The LLM instance to call.
-        messages: The messages to send to the LLM.
-        callbacks: List of callbacks for the LLM call.
-        printer: Printer instance for output.
-        tools: Optional list of tool schemas for native function calling.
-        available_functions: Optional dict mapping function names to callables.
-        from_task: Optional task context for the LLM call.
-        from_agent: Optional agent context for the LLM call.
-        response_model: Optional Pydantic model for structured outputs.
-        executor_context: Optional executor context for hook invocation.
-        verbose: Whether to print output.
-
-    Returns:
-        The response from the LLM as a string, Pydantic model (when response_model is provided),
-        or tool call results if native function calling is used.
-
-    Raises:
-        Exception: If an error occurs.
-        ValueError: If the response is None or empty.
-    """
-    call_kwargs = {
-        "llm": llm,
-        "messages": messages,
-        "callbacks": callbacks,
-        "printer": printer,
-        "tools": tools,
-        "available_functions": available_functions,
-        "from_task": from_task,
-        "from_agent": from_agent,
-        "response_model": response_model,
-        "executor_context": executor_context,
-        "verbose": verbose,
-    }
-
-    try:
-        return await aget_llm_response(**call_kwargs)
-    except NotImplementedError:
-        return await asyncio.to_thread(get_llm_response, **call_kwargs)
 
 
 def process_llm_response(

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -659,6 +659,62 @@ async def aget_llm_response(
     )
 
 
+async def aget_llm_response_with_fallback(
+    llm: LLM | BaseLLM,
+    messages: list[LLMMessage],
+    callbacks: list[TokenCalcHandler],
+    printer: Printer,
+    tools: list[dict[str, Any]] | None = None,
+    available_functions: dict[str, Callable[..., Any]] | None = None,
+    from_task: Task | None = None,
+    from_agent: BaseAgent | None = None,
+    response_model: type[BaseModel] | None = None,
+    executor_context: CrewAgentExecutor | AgentExecutor | None = None,
+    verbose: bool = True,
+) -> str | BaseModel | Any:
+    """Call aget_llm_response, fall back to get_llm_response and return the response.
+
+    Args:
+        llm: The LLM instance to call.
+        messages: The messages to send to the LLM.
+        callbacks: List of callbacks for the LLM call.
+        printer: Printer instance for output.
+        tools: Optional list of tool schemas for native function calling.
+        available_functions: Optional dict mapping function names to callables.
+        from_task: Optional task context for the LLM call.
+        from_agent: Optional agent context for the LLM call.
+        response_model: Optional Pydantic model for structured outputs.
+        executor_context: Optional executor context for hook invocation.
+        verbose: Whether to print output.
+
+    Returns:
+        The response from the LLM as a string, Pydantic model (when response_model is provided),
+        or tool call results if native function calling is used.
+
+    Raises:
+        Exception: If an error occurs.
+        ValueError: If the response is None or empty.
+    """
+    call_kwargs = {
+        "llm": llm,
+        "messages": messages,
+        "callbacks": callbacks,
+        "printer": printer,
+        "tools": tools,
+        "available_functions": available_functions,
+        "from_task": from_task,
+        "from_agent": from_agent,
+        "response_model": response_model,
+        "executor_context": executor_context,
+        "verbose": verbose,
+    }
+
+    try:
+        return await aget_llm_response(**call_kwargs)
+    except NotImplementedError:
+        return await asyncio.to_thread(get_llm_response, **call_kwargs)
+
+
 def process_llm_response(
     answer: str, use_stop_words: bool
 ) -> AgentAction | AgentFinish:

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -484,10 +484,10 @@ class TestAgentExecutor:
         executor.state.messages = [{"role": "user", "content": "Use a tool"}]
 
         with patch(
-            "crewai.experimental.agent_executor.get_llm_response",
+            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
             return_value="Thought: done\nFinal Answer: complete",
         ) as get_llm_response_mock:
-            result = executor.call_llm_and_parse()
+            result = asyncio.run(executor.call_llm_and_parse())
 
         assert result == "parsed"
         assert get_llm_response_mock.call_args.kwargs["response_model"] is None
@@ -506,10 +506,10 @@ class TestAgentExecutor:
         executor.state.messages = [{"role": "user", "content": "Use a tool"}]
 
         with patch(
-            "crewai.experimental.agent_executor.get_llm_response",
+            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
             return_value="complete",
         ) as get_llm_response_mock:
-            result = executor.call_llm_native_tools()
+            result = asyncio.run(executor.call_llm_native_tools())
 
         assert result == "native_finished"
         assert get_llm_response_mock.call_args.kwargs["response_model"] is None
@@ -532,13 +532,13 @@ class TestAgentExecutor:
         executor.tools_description = "lookup: search for information"
 
         with patch(
-            "crewai.experimental.agent_executor.get_llm_response",
+            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
             side_effect=RuntimeError(
                 "Error code: 400 - registry.ollama.ai/library/mariner:latest "
                 "does not support tools"
             ),
         ):
-            result = executor.call_llm_native_tools()
+            result = asyncio.run(executor.call_llm_native_tools())
 
         assert result == "continue_reasoning"
         assert executor.state.use_native_tools is False
@@ -1108,7 +1108,7 @@ class TestFlowErrorHandling:
             "tools_handler": Mock(),
         }
 
-    @patch("crewai.experimental.agent_executor.get_llm_response")
+    @patch("crewai.experimental.agent_executor.aget_llm_response_with_fallback")
     @patch("crewai.experimental.agent_executor.enforce_rpm_limit")
     def test_call_llm_parser_error(
         self, mock_enforce_rpm, mock_get_llm, mock_dependencies
@@ -1120,12 +1120,12 @@ class TestFlowErrorHandling:
         mock_get_llm.side_effect = OutputParserError("parse failed")
 
         executor = _build_executor(**mock_dependencies)
-        result = executor.call_llm_and_parse()
+        result = asyncio.run(executor.call_llm_and_parse())
 
         assert result == "parser_error"
         assert executor._last_parser_error is not None
 
-    @patch("crewai.experimental.agent_executor.get_llm_response")
+    @patch("crewai.experimental.agent_executor.aget_llm_response_with_fallback")
     @patch("crewai.experimental.agent_executor.enforce_rpm_limit")
     @patch("crewai.experimental.agent_executor.is_context_length_exceeded")
     def test_call_llm_context_error(
@@ -1141,7 +1141,7 @@ class TestFlowErrorHandling:
         mock_is_context_exceeded.return_value = True
 
         executor = _build_executor(**mock_dependencies)
-        result = executor.call_llm_and_parse()
+        result = asyncio.run(executor.call_llm_and_parse())
 
         assert result == "context_error"
         assert executor._last_context_error is not None

--- a/lib/crewai/tests/agents/test_agent_executor.py
+++ b/lib/crewai/tests/agents/test_agent_executor.py
@@ -484,7 +484,7 @@ class TestAgentExecutor:
         executor.state.messages = [{"role": "user", "content": "Use a tool"}]
 
         with patch(
-            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
+            "crewai.experimental.agent_executor.aget_llm_response",
             return_value="Thought: done\nFinal Answer: complete",
         ) as get_llm_response_mock:
             result = asyncio.run(executor.call_llm_and_parse())
@@ -506,7 +506,7 @@ class TestAgentExecutor:
         executor.state.messages = [{"role": "user", "content": "Use a tool"}]
 
         with patch(
-            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
+            "crewai.experimental.agent_executor.aget_llm_response",
             return_value="complete",
         ) as get_llm_response_mock:
             result = asyncio.run(executor.call_llm_native_tools())
@@ -532,7 +532,7 @@ class TestAgentExecutor:
         executor.tools_description = "lookup: search for information"
 
         with patch(
-            "crewai.experimental.agent_executor.aget_llm_response_with_fallback",
+            "crewai.experimental.agent_executor.aget_llm_response",
             side_effect=RuntimeError(
                 "Error code: 400 - registry.ollama.ai/library/mariner:latest "
                 "does not support tools"
@@ -1108,7 +1108,7 @@ class TestFlowErrorHandling:
             "tools_handler": Mock(),
         }
 
-    @patch("crewai.experimental.agent_executor.aget_llm_response_with_fallback")
+    @patch("crewai.experimental.agent_executor.aget_llm_response")
     @patch("crewai.experimental.agent_executor.enforce_rpm_limit")
     def test_call_llm_parser_error(
         self, mock_enforce_rpm, mock_get_llm, mock_dependencies
@@ -1125,7 +1125,7 @@ class TestFlowErrorHandling:
         assert result == "parser_error"
         assert executor._last_parser_error is not None
 
-    @patch("crewai.experimental.agent_executor.aget_llm_response_with_fallback")
+    @patch("crewai.experimental.agent_executor.aget_llm_response")
     @patch("crewai.experimental.agent_executor.enforce_rpm_limit")
     @patch("crewai.experimental.agent_executor.is_context_length_exceeded")
     def test_call_llm_context_error(

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -17,6 +17,7 @@ from crewai.hooks.tool_hooks import (
     register_after_tool_call_hook,
 )
 from crewai.tools.base_tool import BaseTool
+from crewai.llms.base_llm import BaseLLM
 from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO
 from crewai.utilities.agent_utils import (
     _asummarize_chunks,
@@ -36,6 +37,7 @@ from crewai.utilities.agent_utils import (
     NativeToolCallResult,
     parse_tool_call_args,
     summarize_messages,
+    aget_llm_response_with_fallback,
 )
 from crewai.utilities.i18n import I18N_DEFAULT
 
@@ -1652,3 +1654,77 @@ class TestResolvePlusResponse:
                 resolve_plus_response(future)
 
         asyncio.run(main())
+
+
+class TestAgetLlmResponseWithFallback:
+    class _AsyncLLM(BaseLLM):
+          calls: list[str] = Field(default_factory=list)
+
+          def call(self, messages, **kw):
+              self.calls.append("call")
+              return "Final Answer: ok"
+
+          async def acall(self, messages, **kw):
+              self.calls.append("acall")
+              return "Final Answer: ok"
+
+    class _SyncOnlyLLM(BaseLLM):
+        calls: list[str] = Field(default_factory=list)
+
+        def call(self, messages, **kw):
+            self.calls.append("call")
+            return "Final Answer: ok"
+
+        # no acall override -> inherits BaseLLM.acall, which raises NotImplementedError
+
+    class _BrokenAsyncLLM(_SyncOnlyLLM):
+        async def acall(self, messages, **kw):
+            raise NotImplementedError("no aiobotocore")
+
+    class _RaisingAsyncLLM(_SyncOnlyLLM):
+        async def acall(self, messages, **kw):
+            raise RuntimeError("boom")
+
+    @pytest.mark.asyncio
+    async def test_awaits_acall_when_available(self):
+        llm = self._AsyncLLM(model="x/y")
+
+        out = await aget_llm_response_with_fallback(
+            llm, [{"role": "user", "content": "hi"}], [], MagicMock()
+        )
+
+        assert llm.calls == ["acall"]
+        assert out == "Final Answer: ok"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_acall_not_implemented(self):
+        llm = self._SyncOnlyLLM(model="x/y")
+
+        out = await aget_llm_response_with_fallback(
+            llm, [{"role": "user", "content": "hi"}], [], MagicMock()
+        )
+
+        assert llm.calls == ["call"]
+        assert out == "Final Answer: ok"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_acall_raises_not_implemented(self):
+        llm = self._BrokenAsyncLLM(model="x/y")
+
+        out = await aget_llm_response_with_fallback(
+            llm, [{"role": "user", "content": "hi"}], [], MagicMock()
+        )
+
+        assert llm.calls == ["call"]
+        assert out == "Final Answer: ok"
+
+    @pytest.mark.asyncio
+    async def test_propagates_non_not_implemented_errors(self):
+        llm = self._RaisingAsyncLLM(model="x/y")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await aget_llm_response_with_fallback(
+                llm, [{"role": "user", "content": "hi"}], [], MagicMock()
+            )
+
+        assert llm.calls == []

--- a/lib/crewai/tests/utilities/test_agent_utils.py
+++ b/lib/crewai/tests/utilities/test_agent_utils.py
@@ -37,7 +37,7 @@ from crewai.utilities.agent_utils import (
     NativeToolCallResult,
     parse_tool_call_args,
     summarize_messages,
-    aget_llm_response_with_fallback,
+    aget_llm_response,
 )
 from crewai.utilities.i18n import I18N_DEFAULT
 
@@ -1658,15 +1658,15 @@ class TestResolvePlusResponse:
 
 class TestAgetLlmResponseWithFallback:
     class _AsyncLLM(BaseLLM):
-          calls: list[str] = Field(default_factory=list)
+        calls: list[str] = Field(default_factory=list)
 
-          def call(self, messages, **kw):
-              self.calls.append("call")
-              return "Final Answer: ok"
+        def call(self, messages, **kw):
+            self.calls.append("call")
+            return "Final Answer: ok"
 
-          async def acall(self, messages, **kw):
-              self.calls.append("acall")
-              return "Final Answer: ok"
+        async def acall(self, messages, **kw):
+            self.calls.append("acall")
+            return "Final Answer: ok"
 
     class _SyncOnlyLLM(BaseLLM):
         calls: list[str] = Field(default_factory=list)
@@ -1689,7 +1689,7 @@ class TestAgetLlmResponseWithFallback:
     async def test_awaits_acall_when_available(self):
         llm = self._AsyncLLM(model="x/y")
 
-        out = await aget_llm_response_with_fallback(
+        out = await aget_llm_response(
             llm, [{"role": "user", "content": "hi"}], [], MagicMock()
         )
 
@@ -1700,7 +1700,7 @@ class TestAgetLlmResponseWithFallback:
     async def test_falls_back_when_acall_not_implemented(self):
         llm = self._SyncOnlyLLM(model="x/y")
 
-        out = await aget_llm_response_with_fallback(
+        out = await aget_llm_response(
             llm, [{"role": "user", "content": "hi"}], [], MagicMock()
         )
 
@@ -1711,7 +1711,7 @@ class TestAgetLlmResponseWithFallback:
     async def test_falls_back_when_acall_raises_not_implemented(self):
         llm = self._BrokenAsyncLLM(model="x/y")
 
-        out = await aget_llm_response_with_fallback(
+        out = await aget_llm_response(
             llm, [{"role": "user", "content": "hi"}], [], MagicMock()
         )
 
@@ -1723,7 +1723,7 @@ class TestAgetLlmResponseWithFallback:
         llm = self._RaisingAsyncLLM(model="x/y")
 
         with pytest.raises(RuntimeError, match="boom"):
-            await aget_llm_response_with_fallback(
+            await aget_llm_response(
                 llm, [{"role": "user", "content": "hi"}], [], MagicMock()
             )
 


### PR DESCRIPTION
## Related issue

Fixes #7339

## Summary

The experimental AgentExecutor ran every LLM turn through the synchronous get_llm_response() → LLM.call(), even under  ainvoke()/kickoff_async(). Because the router methods were sync, the Flow runtime offloaded each one to a worker thread, so async pipelines were bounded by thread-pool capacity and providers' native async clients (LLM.acall()) were never used. The fix makes call_llm_and_parse and call_llm_native_tools async and has them await a new aget_llm_response_with_fallback() helper, which calls aget_llm_response() (LLM.acall()) and only drops to a threaded get_llm_response() on NotImplementedError, so custom sync-only BaseLLM subclasses keep working.

## Verification

<!-- List the automated and manual checks used to verify the change. -->

- Added in tests/utilities/test_agent_utils.py, 
  - class TestAgetLlmResponseWithFallback:

  - test_awaits_acall_when_available: LLM double implementing both
    call and acall; asserts the helper awaits acall and never touches
    call. The core behavior of the change.
  - test_falls_back_when_acall_not_implemented: LLM double with only
    call (inherits BaseLLM.acall, which raises NotImplementedError);
    asserts the helper runs call and returns the result.
  - test_falls_back_when_acall_raises_not_implemented: LLM double
    that defines acall but raises NotImplementedError inside it
    (Bedrock-without-aiobotocore shape); asserts it still falls back
    to call. This is the case that justifies try/except over an
    up-front capability check.
  - test_propagates_non_not_implemented_errors: LLM double whose
    acall raises RuntimeError; asserts the error propagates and
    there's no fallback to call (the except is intentionally narrow to
    NotImplementedError).

- Updated in tests/agents/test_agent_executor.py:

  - test_call_llm_and_parse_does_not_pass_response_model_with_tools: 
     router is now async; wrapped call in asyncio.run, patch target moved to aget_llm_response_with_fallback.
  - test_call_llm_native_tools_does_not_pass_response_model_with_tools: downgrades to text tool-calling.
  - test_call_llm_parser_error: same; still asserts OutputParserError
    → "parser_error".
  - test_call_llm_context_error: same; still asserts context-length
    error → "context_error".

- `ruff check` on the two changed source files → no new violations; error count identical with and without the diff (all pre-existing).
- `ruff format --check` on the changed files → clean.


- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

## Additional context

<!-- Include screenshots, compatibility notes, follow-up work, or "None". -->


<!-- crewai-require-issue-check -->