### PR TITLE
ci: ignore unpatched accelerate GHSA-4j2p-28q2-5m79

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -107,6 +107,16 @@ jobs:
             # TODO: drop this ignore when bumping nltk past 3.10.3 to a patched
             # release; keep the ignore list in sync with .pre-commit-config.yaml.
             --ignore-vuln GHSA-8mgp-746c-j5xp
+            # accelerate <=1.14.0: GHSA-4j2p-28q2-5m79 (CVE-2026-69112): path
+            # traversal / FIFO DoS via unsanitized sharded-checkpoint weight_map
+            # entries. No patched PyPI release yet (fix is huggingface/accelerate
+            # #4138, not shipped). Transitive via docling extras
+            # (docling-ibm-models / docling-slim[standard]); CrewAI does not load
+            # untrusted checkpoints through those APIs.
+            # TODO: drop this ignore when bumping accelerate past 1.14.0 to a
+            # patched release; keep the ignore list in sync with
+            # .pre-commit-config.yaml.
+            --ignore-vuln GHSA-4j2p-28q2-5m79
           )
           uv run pip-audit "${pip_audit_args[@]}"
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
         name: pip-audit
         # Keep this ignore list in sync with .github/workflows/vulnerability-scan.yml.
         # TODO: drop --ignore-vuln GHSA-8mgp-746c-j5xp when bumping nltk past 3.10.3.
+        # TODO: drop --ignore-vuln GHSA-4j2p-28q2-5m79 when bumping accelerate past 1.14.0.
         entry: >-
           bash -c 'source .venv/bin/activate && uv run pip-audit --skip-editable
           --ignore-vuln PYSEC-2024-277
@@ -61,7 +62,8 @@ repos:
           --ignore-vuln GHSA-2wm9-hf6c-p5cr
           --ignore-vuln GHSA-36p7-vc44-83pf
           --ignore-vuln GHSA-xph7-9rjv-w5fr
-          --ignore-vuln GHSA-8mgp-746c-j5xp' --
+          --ignore-vuln GHSA-8mgp-746c-j5xp
+          --ignore-vuln GHSA-4j2p-28q2-5m79' --
         language: system
         pass_filenames: false
         stages: [pre-push, manual]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,12 @@ exclude-newer-package = { msgpack = "2026-06-20T00:00:00Z", pydantic-settings = 
 # ships. TODO: drop --ignore-vuln GHSA-8mgp-746c-j5xp when bumping nltk
 # past 3.10.3. Transitive via
 # crewai-tools[xml] -> unstructured.
+# accelerate <=1.14.0 has GHSA-4j2p-28q2-5m79 (CVE-2026-69112): path traversal
+# and FIFO DoS via unsanitized sharded-checkpoint weight_map entries. Latest
+# PyPI is still 1.14.0; the fix is huggingface/accelerate#4138 and is not
+# released. Ignored in pip-audit until a patched release ships. TODO: drop
+# --ignore-vuln GHSA-4j2p-28q2-5m79 when bumping accelerate past 1.14.0.
+# Transitive via docling extras (docling-ibm-models / docling-slim[standard]).
 # pydantic-settings <2.14.2 has GHSA-4xgf-cpjx-pc3j.
 # h2 <=4.4.0 has GHSA-6hr6-w5qg-qmwg (CVE-2026-71554): duplicate Host headers
 # can facilitate request smuggling; fixed in 4.4.1. Transitive via


### PR DESCRIPTION
## Related issue

n/a — unblocks `pip-audit` on main; Hugging Face has not shipped a patched `accelerate` release.

## Summary

- `accelerate==1.13.0` fails `uv run pip-audit` with [GHSA-4j2p-28q2-5m79](https://github.com/advisories/GHSA-4j2p-28q2-5m79) (CVE-2026-69112): path traversal / FIFO DoS via unsanitized sharded-checkpoint `weight_map` entries.
- Latest PyPI is still `1.14.0`, which OSV lists as last affected. The upstream fix is [huggingface/accelerate#4138](https://github.com/huggingface/accelerate/pull/4138) and is not released.
- Ignore the advisory in the vulnerability-scan workflow and pre-commit hook (same pattern as nltk `GHSA-8mgp-746c-j5xp`), with a TODO to drop it when a patched release ships.
- Transitive via docling extras; CrewAI does not load untrusted checkpoints through those APIs.

## Test plan

- [x] Confirm no patched `accelerate` release exists on PyPI (`1.14.0` is latest and still in the affected range)
- [ ] CI `pip-audit` job passes on this PR
- [ ] After merge, scheduled/main `pip-audit` no longer fails on GHSA-4j2p-28q2-5m79