### PR TITLE
fix(tasks): clean up execution_spans on async CancelledError

### DIFF
--- a/lib/crewai/src/crewai/task.py
+++ b/lib/crewai/src/crewai/task.py
@@ -795,6 +795,16 @@ class Task(BaseModel):
                 TaskCompletedEvent(output=task_output, task=self),
             )
             return task_output
+        except asyncio.CancelledError as e:
+            # CancelledError inherits from BaseException, not Exception, so it bypasses
+            # the ordinary failure path. Emit a terminal event so EventListener can pop
+            # execution_spans and release the retained task graph, then re-raise.
+            self.end_time = datetime.datetime.now()
+            crewai_event_bus.emit(
+                self,
+                TaskFailedEvent(error=str(e) or "CancelledError", error_type=type(e), task=self),
+            )
+            raise
         except Exception as e:
             self.end_time = datetime.datetime.now()
             crewai_event_bus.emit(

--- a/lib/crewai/tests/telemetry/test_task_cancellation_span_cleanup.py
+++ b/lib/crewai/tests/telemetry/test_task_cancellation_span_cleanup.py
@@ -1,0 +1,121 @@
+"""Cancelled async tasks must leave no execution_spans entries.
+
+TaskStartedEvent registers the Task in EventListener.execution_spans. Completed and
+ordinary-failure paths emit terminal events that pop that entry. asyncio.CancelledError
+inherits from BaseException, not Exception, so it used to bypass TaskFailedEvent and
+leak a strong reference to the Task (and its Agent/Crew graph).
+
+See https://github.com/crewAIInc/crewAI/issues/7351
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import threading
+import weakref
+from unittest.mock import patch
+
+import pytest
+
+from crewai import Agent, Crew, Task
+from crewai.events.event_bus import crewai_event_bus
+from crewai.events.event_listener import EventListener
+from crewai.telemetry import Telemetry
+
+
+@pytest.fixture
+def clean_event_listener():
+    """Reset bus and listener singletons so span map state does not leak across tests."""
+
+    def _reset() -> None:
+        with crewai_event_bus._rwlock.w_locked():
+            crewai_event_bus._sync_handlers.clear()
+            crewai_event_bus._async_handlers.clear()
+        Telemetry._instance = None
+        EventListener._instance = None
+        if hasattr(Telemetry, "_lock"):
+            Telemetry._lock = threading.Lock()
+
+    _reset()
+    listener = EventListener()
+    yield listener
+    _reset()
+
+
+async def _cancelled_aexecute(self, *args, **kwargs):
+    raise asyncio.CancelledError()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_async_task_clears_execution_spans(clean_event_listener):
+    """Cancellation must emit a terminal path and release retained task graphs."""
+    listener = clean_event_listener
+    listener.execution_spans.clear()
+
+    task_refs: list[weakref.ref] = []
+    agent_refs: list[weakref.ref] = []
+    crew_refs: list[weakref.ref] = []
+
+    with patch.object(Agent, "aexecute_task", _cancelled_aexecute):
+        for _ in range(5):
+            agent = Agent(
+                role="test",
+                goal="test",
+                backstory="test",
+                llm="gpt-4o-mini",
+            )
+            task = Task(
+                description="test",
+                expected_output="test",
+                agent=agent,
+            )
+            crew = Crew(agents=[agent], tasks=[task], tracing=False)
+            task_refs.append(weakref.ref(task))
+            agent_refs.append(weakref.ref(agent))
+            crew_refs.append(weakref.ref(crew))
+
+            with pytest.raises(asyncio.CancelledError):
+                await crew.akickoff()
+
+            del crew, task, agent
+
+    gc.collect()
+
+    assert len(listener.execution_spans) == 0
+    assert sum(ref() is not None for ref in task_refs) == 0
+    assert sum(ref() is not None for ref in agent_refs) == 0
+    assert sum(ref() is not None for ref in crew_refs) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_cancelled_error_emits_task_failed_event(clean_event_listener):
+    """Producer must emit TaskFailedEvent for CancelledError so the listener can pop."""
+    from crewai.events.types.task_events import TaskFailedEvent
+
+    agent = Agent(
+        role="tester",
+        goal="cancel",
+        backstory="exists only to raise CancelledError",
+        llm="gpt-4o-mini",
+    )
+    task = Task(
+        description="a task that is cancelled",
+        expected_output="nothing",
+        agent=agent,
+    )
+
+    captured: list[TaskFailedEvent] = []
+
+    def _record(_source, event):
+        if isinstance(event, TaskFailedEvent):
+            captured.append(event)
+        return None
+
+    with patch.object(crewai_event_bus, "emit", side_effect=_record):
+        with patch.object(Agent, "aexecute_task", _cancelled_aexecute):
+            with pytest.raises(asyncio.CancelledError):
+                await task._aexecute_core(None, None, None)
+
+    assert len(captured) == 1
+    assert captured[0].error_type is asyncio.CancelledError


### PR DESCRIPTION
## Summary

Fixes #7351.

When an async task is cancelled after `TaskStartedEvent`, `asyncio.CancelledError` was skipping the `except Exception` path in `_aexecute_core()`. That meant no terminal event was emitted, so `EventListener.execution_spans` kept a strong reference to the `Task` (and through it the Agent / Crew graph).

This change catches `CancelledError` explicitly, emits `TaskFailedEvent` so the existing listener can pop the span entry and close telemetry the same way ordinary failures do, then re-raises to preserve cancellation semantics.

## Changes

- `lib/crewai/src/crewai/task.py`: handle `asyncio.CancelledError` before `except Exception` in `_aexecute_core()`
- `lib/crewai/tests/telemetry/test_task_cancellation_span_cleanup.py`: regression tests for span cleanup and `TaskFailedEvent` emission on cancel

## Why TaskFailedEvent

Reusing `TaskFailedEvent` is the smallest behavior change. The listener already pops `execution_spans` and routes failures through `task_failed`. A dedicated cancellation event would be nicer for telemetry consumers later, but it is not required to close the leak.

## Test plan

- [x] Added async regression covering repeated cancellations + weakref GC
- [x] Added producer-level check that `CancelledError` emits `TaskFailedEvent`
- [ ] CI: `uv run pytest lib/crewai/tests/telemetry/test_task_cancellation_span_cleanup.py -x -q`

## Notes for maintainers

Happy to adjust if you would rather introduce a dedicated cancellation event instead of reusing `TaskFailedEvent`.

I do not have permission to apply labels here - please add `llm-generated` when you can (required by the contributing guide).

Thanks for reviewing.

<!-- crewai-require-issue-check -->