### PR TITLE
fix(memory): honor read_only on update and recall access times

### DIFF
--- a/lib/crewai/src/crewai/memory/unified_memory.py
+++ b/lib/crewai/src/crewai/memory/unified_memory.py
@@ -147,7 +147,12 @@ class Memory(BaseModel):
     )
     read_only: bool = Field(
         default=False,
-        description="If True, remember() and remember_many() are silent no-ops.",
+        description=(
+            "If True, stored records are left unchanged: remember() and "
+            "remember_many() store nothing, update() leaves the record "
+            "untouched, and recall() does not refresh access times. Explicit "
+            "deletion through forget()/reset() is unaffected."
+        ),
     )
     root_scope: str | None = Field(
         default=None,
@@ -781,7 +786,7 @@ class Memory(BaseModel):
                 )
                 results = flow.state.final_results
 
-            if results:
+            if results and not self.read_only:
                 try:
                     touch = getattr(self._storage, "touch_records", None)
                     if touch is not None:
@@ -869,7 +874,8 @@ class Memory(BaseModel):
             importance: New importance score.
 
         Returns:
-            The updated MemoryRecord.
+            The updated MemoryRecord, or the unchanged record when ``read_only``
+            is set.
 
         Raises:
             ValueError: If the record is not found.
@@ -877,6 +883,8 @@ class Memory(BaseModel):
         existing = self._storage.get_record(record_id)
         if existing is None:
             raise ValueError(f"Record not found: {record_id}")
+        if self.read_only:
+            return existing
         now = datetime.utcnow()
         updates: dict[str, Any] = {"last_accessed": now}
         if content is not None:

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -335,6 +335,65 @@ def test_memory_slice_remember_is_noop_when_read_only(tmp_path: Path, mock_embed
     assert mem.list_records() == []
 
 
+def test_update_is_noop_when_read_only(tmp_path: Path, mock_embedder: MagicMock) -> None:
+    """A read-only Memory leaves stored records untouched when update() is called."""
+    from crewai.memory.unified_memory import Memory
+
+    mem = Memory(storage=str(tmp_path / "db8"), llm=MagicMock(), embedder=mock_embedder)
+    record = mem.remember(
+        "original", scope="/a", categories=[], importance=0.5, metadata={}
+    )
+    assert record is not None
+
+    mem.read_only = True
+    returned = mem.update(record.id, content="rewritten", importance=0.9)
+
+    assert returned.content == "original"
+    assert returned.importance == 0.5
+    stored = mem.list_records()
+    assert [(r.content, r.importance) for r in stored] == [("original", 0.5)]
+
+
+def test_update_still_writes_when_not_read_only(
+    tmp_path: Path, mock_embedder: MagicMock
+) -> None:
+    """The read-only guard does not change update() for a writable Memory."""
+    from crewai.memory.unified_memory import Memory
+
+    mem = Memory(storage=str(tmp_path / "db9"), llm=MagicMock(), embedder=mock_embedder)
+    record = mem.remember(
+        "original", scope="/a", categories=[], importance=0.5, metadata={}
+    )
+    assert record is not None
+
+    returned = mem.update(record.id, content="rewritten", importance=0.9)
+
+    assert returned.content == "rewritten"
+    assert returned.importance == 0.9
+    stored = mem.list_records()
+    assert [(r.content, r.importance) for r in stored] == [("rewritten", 0.9)]
+
+
+def test_recall_does_not_refresh_access_time_when_read_only(
+    tmp_path: Path, mock_embedder: MagicMock
+) -> None:
+    """Recall against a read-only Memory leaves last_accessed untouched."""
+    from crewai.memory.unified_memory import Memory
+
+    mem = Memory(storage=str(tmp_path / "db10"), llm=MagicMock(), embedder=mock_embedder)
+    mem.remember("alpha", scope="/a", categories=[], importance=0.5, metadata={})
+    before = mem.list_records()[0].last_accessed
+
+    mem.read_only = True
+    assert mem.recall("alpha", scope="/a", limit=5, depth="shallow")
+    assert mem.list_records()[0].last_accessed == before
+
+    # Positive control: a writable Memory still refreshes the access time.
+    mem.read_only = False
+    assert mem.recall("alpha", scope="/a", limit=5, depth="shallow")
+    assert mem.list_records()[0].last_accessed > before
+
+
 
 
 def test_flow_has_default_memory() -> None:


### PR DESCRIPTION
Fixes #7368.

## Summary

Memory.read_only currently blocks remember and remember_many, but update still rewrites records and recall still persists last_accessed via touch_records. This change makes those two implicit mutation paths honor read_only while leaving explicit deletion through forget and reset unchanged.

## Why

A caller using Memory as a read-only retrieval surface should not leave a persistent trace merely by reading. The existing read barrier and reset guards show that the omitted checks were inconsistent with the flag rather than an intentional latency exemption.

## Tests

- Added regression coverage proving update is a no-op in read-only mode.
- Added positive coverage that writable update still works.
- Added regression coverage proving read-only recall does not refresh last_accessed, with a writable positive control.
- pytest lib/crewai/tests/memory: 134 passed, 19 skipped.
- ruff: clean.
- hermes-gate fast and review: PASS, zero findings.