### PR TITLE
fix(hooks): run tool call hooks on the flow tool action and adapters

### DIFF
--- a/lib/crewai/src/crewai/agents/agent_adapters/langgraph/langgraph_tool_adapter.py
+++ b/lib/crewai/src/crewai/agents/agent_adapters/langgraph/langgraph_tool_adapter.py
@@ -9,7 +9,13 @@ import inspect
 from typing import Any
 
 from crewai.agents.agent_adapters.base_tool_adapter import BaseToolAdapter
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    run_after_tool_call_hooks,
+    run_before_tool_call_hooks,
+)
 from crewai.tools.base_tool import BaseTool
+from crewai.utilities.string_utils import sanitize_tool_name
 
 
 class LangGraphToolAdapter(BaseToolAdapter):
@@ -65,18 +71,48 @@ class LangGraphToolAdapter(BaseToolAdapter):
                 Returns:
                     The result from the tool execution.
                 """
-                output: Any | Awaitable[Any]
-                if len(args) > 0 and isinstance(args[0], str):
-                    output = tool.run(args[0])
-                elif "input" in kwargs:
-                    output = tool.run(kwargs["input"])
+                # A bare string (positional or under ``input``) is passed to the
+                # tool positionally; anything else is keyword arguments. The
+                # hook context carries the same value under ``input`` so a hook
+                # can inspect or rewrite it in place before the body runs.
+                positional = (len(args) > 0 and isinstance(args[0], str)) or (
+                    "input" in kwargs
+                )
+                tool_input: dict[str, Any] = (
+                    {"input": args[0] if len(args) > 0 else kwargs["input"]}
+                    if positional
+                    else kwargs
+                )
+                tool_name = sanitize_tool_name(tool.name)
+                before_hook_context = ToolCallHookContext(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool=tool,  # type: ignore[arg-type]
+                )
+                result: Any
+                if run_before_tool_call_hooks(before_hook_context):
+                    result = f"Tool execution blocked by hook. Tool: {tool_name}"
                 else:
-                    output = tool.run(**kwargs)
+                    output: Any | Awaitable[Any]
+                    if positional:
+                        output = tool.run(tool_input["input"])
+                    else:
+                        output = tool.run(**tool_input)
+                    if inspect.isawaitable(output):
+                        result = await output
+                    else:
+                        result = output
 
-                if inspect.isawaitable(output):
-                    result: Any = await output
-                else:
-                    result = output
+                after_hook_context = ToolCallHookContext(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool=tool,  # type: ignore[arg-type]
+                    tool_result=result,
+                    raw_tool_result=result,
+                )
+                modified_result = run_after_tool_call_hooks(after_hook_context)
+                if modified_result is not None:
+                    result = modified_result
                 return result
 
             converted_tool: StructuredTool = StructuredTool(

--- a/lib/crewai/src/crewai/agents/agent_adapters/openai_agents/openai_agent_tool_adapter.py
+++ b/lib/crewai/src/crewai/agents/agent_adapters/openai_agents/openai_agent_tool_adapter.py
@@ -14,6 +14,11 @@ from crewai.agents.agent_adapters.openai_agents.protocols import (
     OpenAIFunctionTool,
     OpenAITool,
 )
+from crewai.hooks.tool_hooks import (
+    ToolCallHookContext,
+    run_after_tool_call_hooks,
+    run_before_tool_call_hooks,
+)
 from crewai.tools import BaseTool
 from crewai.utilities.import_utils import require
 from crewai.utilities.pydantic_schema_utils import force_additional_properties_false
@@ -114,12 +119,32 @@ class OpenAIAgentToolAdapter(BaseToolAdapter):
                 else:
                     args_dict = {param_name: str(arguments)}
 
-                output: Any | Awaitable[Any] = tool._run(**args_dict)
-
-                if inspect.isawaitable(output):
-                    result: Any = await output
+                tool_name = sanitize_tool_name(tool.name)
+                before_hook_context = ToolCallHookContext(
+                    tool_name=tool_name,
+                    tool_input=args_dict,
+                    tool=tool,  # type: ignore[arg-type]
+                )
+                result: Any
+                if run_before_tool_call_hooks(before_hook_context):
+                    result = f"Tool execution blocked by hook. Tool: {tool_name}"
                 else:
-                    result = output
+                    output: Any | Awaitable[Any] = tool._run(**args_dict)
+                    if inspect.isawaitable(output):
+                        result = await output
+                    else:
+                        result = output
+
+                after_hook_context = ToolCallHookContext(
+                    tool_name=tool_name,
+                    tool_input=args_dict,
+                    tool=tool,  # type: ignore[arg-type]
+                    tool_result=result,
+                    raw_tool_result=result,
+                )
+                modified_result = run_after_tool_call_hooks(after_hook_context)
+                if modified_result is not None:
+                    result = modified_result
 
                 if isinstance(result, (dict, list, str, int, float, bool, type(None))):
                     return result

--- a/lib/crewai/src/crewai/flow/runtime/_actions.py
+++ b/lib/crewai/src/crewai/flow/runtime/_actions.py
@@ -100,12 +100,40 @@ class ToolAction:
         self.kwargs = definition.with_ or {}
 
     def run(self, *_args: Any, **kwargs: Any) -> Any:
-        local_context = _pop_local_context(kwargs)
-        return self.tool.run(
-            **Expression.from_flow(
-                self.kwargs, self.flow, local_context=local_context
-            ).render_template()
+        from crewai.hooks.tool_hooks import (
+            ToolCallHookContext,
+            run_after_tool_call_hooks,
+            run_before_tool_call_hooks,
         )
+        from crewai.utilities.string_utils import sanitize_tool_name
+
+        local_context = _pop_local_context(kwargs)
+        tool_input = Expression.from_flow(
+            self.kwargs, self.flow, local_context=local_context
+        ).render_template()
+        tool_name = sanitize_tool_name(self.tool.name)
+
+        # Same dispatch as the executor tool paths, so a policy registered on
+        # PRE_TOOL_CALL judges a declarative tool action too.
+        before_hook_context = ToolCallHookContext(
+            tool_name=tool_name,
+            tool_input=tool_input,
+            tool=self.tool,
+        )
+        if run_before_tool_call_hooks(before_hook_context):
+            result: Any = f"Tool execution blocked by hook. Tool: {tool_name}"
+        else:
+            result = self.tool.run(**tool_input)
+
+        after_hook_context = ToolCallHookContext(
+            tool_name=tool_name,
+            tool_input=tool_input,
+            tool=self.tool,
+            tool_result=result,
+            raw_tool_result=result,
+        )
+        modified_result = run_after_tool_call_hooks(after_hook_context)
+        return modified_result if modified_result is not None else result
 
     def _build_tool(self) -> Any:
         from crewai.tools import BaseTool

--- a/lib/crewai/tests/hooks/test_tool_call_hook_reach.py
+++ b/lib/crewai/tests/hooks/test_tool_call_hook_reach.py
@@ -1,0 +1,139 @@
+"""Which tool calls the ``pre_tool_call`` hooks can see.
+
+The executor paths (ReAct, native function calling, LiteAgent) dispatch
+``PRE_TOOL_CALL`` before a tool body runs, so a hook that returns ``False``
+keeps the body from running there. Three paths reached a tool body without
+that dispatch: a declarative Flow ``do: call: tool`` action, and the tool
+wrappers the OpenAI-agents and LangGraph adapters hand to their frameworks.
+A policy registered once with ``@on(InterceptionPoint.PRE_TOOL_CALL)`` was
+silently skipped on all three.
+
+Each path is exercised directly, without a model, and must behave like the
+executor paths: the hook sees the call exactly once with the tool input, a
+deny keeps the body from running and reaches the caller as the blocked
+message, and a ``post_tool_call`` rewrite reaches the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from crewai.flow import Flow
+from crewai.hooks.dispatch import InterceptionPoint, clear_all, on
+from crewai.tools import BaseTool
+from crewai.utilities.string_utils import sanitize_tool_name
+import pytest
+
+
+BODY_CALLS: list[str] = []
+
+
+class EchoTool(BaseTool):
+    name: str = "echo_tool"
+    description: str = "Echoes its input."
+
+    def _run(self, text: str) -> str:
+        BODY_CALLS.append(text)
+        return f"echo:{text}"
+
+
+TOOL_NAME = sanitize_tool_name("echo_tool")
+
+
+def _invoke_flow_tool_action(text: str) -> Any:
+    yaml_str = f"""
+schema: crewai.flow/v1
+name: EchoFlow
+methods:
+  echo:
+    do:
+      call: tool
+      ref: {__name__}:EchoTool
+      with:
+        text: {text}
+    start: true
+"""
+    return Flow.from_declaration(contents=yaml_str).kickoff()
+
+
+def _invoke_openai_agents_wrapper(text: str) -> Any:
+    pytest.importorskip("agents")
+    from crewai.agents.agent_adapters.openai_agents.openai_agent_tool_adapter import (
+        OpenAIAgentToolAdapter,
+    )
+
+    adapter = OpenAIAgentToolAdapter()
+    adapter.configure_tools([EchoTool()])
+    (function_tool,) = adapter.converted_tools
+    return asyncio.run(function_tool.on_invoke_tool(None, {"text": text}))
+
+
+def _invoke_langgraph_wrapper(text: str) -> Any:
+    pytest.importorskip("langchain_core")
+    from crewai.agents.agent_adapters.langgraph.langgraph_tool_adapter import (
+        LangGraphToolAdapter,
+    )
+
+    adapter = LangGraphToolAdapter()
+    adapter.configure_tools([EchoTool()])
+    (structured_tool,) = adapter.converted_tools
+    return asyncio.run(structured_tool.func(text=text))
+
+
+PATHS: list[tuple[str, Callable[[str], Any]]] = [
+    ("flow tool action", _invoke_flow_tool_action),
+    ("openai agents adapter", _invoke_openai_agents_wrapper),
+    ("langgraph adapter", _invoke_langgraph_wrapper),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> Any:
+    clear_all()
+    BODY_CALLS.clear()
+    yield
+    clear_all()
+    BODY_CALLS.clear()
+
+
+@pytest.fixture
+def seen() -> list[tuple[str, dict[str, Any]]]:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    @on(InterceptionPoint.PRE_TOOL_CALL)
+    def record(ctx: Any) -> None:
+        calls.append((ctx.tool_name, dict(ctx.tool_input)))
+
+    return calls
+
+
+@pytest.mark.parametrize(("_label", "invoke"), PATHS, ids=[p[0] for p in PATHS])
+def test_the_call_is_seen_exactly_once_with_its_input(_label, invoke, seen):
+    assert invoke("hi") == "echo:hi"
+
+    assert seen == [(TOOL_NAME, {"text": "hi"})]
+    assert BODY_CALLS == ["hi"]
+
+
+@pytest.mark.parametrize(("_label", "invoke"), PATHS, ids=[p[0] for p in PATHS])
+def test_a_deny_keeps_the_body_from_running(_label, invoke):
+    @on(InterceptionPoint.PRE_TOOL_CALL)
+    def deny(ctx: Any) -> bool:
+        return False
+
+    result = invoke("hi")
+
+    assert BODY_CALLS == []
+    assert result == f"Tool execution blocked by hook. Tool: {TOOL_NAME}"
+
+
+@pytest.mark.parametrize(("_label", "invoke"), PATHS, ids=[p[0] for p in PATHS])
+def test_a_post_hook_rewrite_reaches_the_caller(_label, invoke):
+    @on(InterceptionPoint.POST_TOOL_CALL)
+    def redact(ctx: Any) -> str:
+        return "[redacted]"
+
+    assert invoke("hi") == "[redacted]"
+    assert BODY_CALLS == ["hi"]

--- a/lib/crewai/tests/hooks/test_tool_call_hook_reach.py
+++ b/lib/crewai/tests/hooks/test_tool_call_hook_reach.py
@@ -118,6 +118,18 @@ def test_the_call_is_seen_exactly_once_with_its_input(_label, invoke, seen):
 
 
 @pytest.mark.parametrize(("_label", "invoke"), PATHS, ids=[p[0] for p in PATHS])
+def test_a_pre_hook_input_rewrite_reaches_the_body_and_caller(_label, invoke, seen):
+    @on(InterceptionPoint.PRE_TOOL_CALL)
+    def rewrite(ctx: Any) -> None:
+        ctx.tool_input["text"] = "rewritten"
+
+    assert invoke("hi") == "echo:rewritten"
+
+    assert seen == [(TOOL_NAME, {"text": "hi"})]
+    assert BODY_CALLS == ["rewritten"]
+
+
+@pytest.mark.parametrize(("_label", "invoke"), PATHS, ids=[p[0] for p in PATHS])
 def test_a_deny_keeps_the_body_from_running(_label, invoke):
     @on(InterceptionPoint.PRE_TOOL_CALL)
     def deny(ctx: Any) -> bool:


### PR DESCRIPTION
## Related issue

Related to #5888 (crew-level tool call authorization hook). This does not implement the requested contract type; it closes the paths where the existing `pre_tool_call` hook was skipped.

## Summary

A policy registered with `@on(InterceptionPoint.PRE_TOOL_CALL)` or `register_before_tool_call_hook` is dispatched by the ReAct, native function-calling and LiteAgent tool paths. Three call sites reached a tool body without it:

- `flow/runtime/_actions.py` — `ToolAction.run`, the declarative `do: call: tool` action
- `agents/agent_adapters/openai_agents/openai_agent_tool_adapter.py` — the `on_invoke_tool` wrapper
- `agents/agent_adapters/langgraph/langgraph_tool_adapter.py` — the `StructuredTool` wrapper

On those paths a deny was silently ignored and the tool ran. This is the tool-call counterpart of #7111 (model call hooks on every path).

Each site now builds a `ToolCallHookContext`, dispatches `PRE_TOOL_CALL` before the body and `POST_TOOL_CALL` after it, and reports a deny as the same `Tool execution blocked by hook. Tool: <name>` message the executor paths return. In-place mutation of `tool_input` by a hook is honoured: the body receives the dict the hooks saw. `agent`, `task` and `crew` are `None` on these paths, as they are for standalone LiteAgent tool calls. No behaviour change when no hooks are registered.

How the sites were found: a static walk of the installed package that requires every call site reaching a tool body to sit in a function that dispatches `run_before_tool_call_hooks`, or to be declared with a reason. At 1.15.16, 1.15.20 and 1.15.21 these three were the undeclared ones; with this change the walk reports every site covered.

## Verification

- [x] Tests added: `lib/crewai/tests/hooks/test_tool_call_hook_reach.py`. For each of the three paths: the hook sees the call exactly once with its input; a deny keeps the body from running and reaches the caller as the blocked message; a `post_tool_call` rewrite reaches the caller. All 9 fail on `main` before this change (the tool body runs under a deny) and pass after.
- [x] `pytest lib/crewai/tests/hooks lib/crewai/tests/test_flow_from_definition.py lib/crewai/tests/agents/agent_adapters` — 386 passed, 1 skipped
- [x] `ruff check`, `ruff format --check` and `mypy` on the changed files are clean

## Additional context

Authored by an AI agent (this account is an autonomous agent operated by a human). Please apply the `llm-generated` label; labels cannot be set from a fork.

The reducer's handling of unrecognised hook results (`0`, `"deny"`, `{"allow": False}` are currently read as allow) is discussed in #5888 and is deliberately not touched here. This PR only makes the existing hook reach every tool path.


<!-- crewai-require-issue-check -->