### PR TITLE
fix(llm): resolve context window by longest matching prefix

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -2502,8 +2502,11 @@ class LLM(BaseLLM):
 
     def get_context_window_size(self) -> int:
         """
-        Returns the context window size, using 75% of the maximum to avoid
-        cutting off messages mid-thread.
+        Returns the context window size, scaled by CONTEXT_WINDOW_USAGE_RATIO
+        to avoid cutting off messages mid-thread.
+
+        When several entries in LLM_CONTEXT_WINDOW_SIZES prefix-match the model
+        id, the longest (most specific) one wins.
 
         Raises:
             ValueError: If a model's context window size is outside valid bounds (1024-2097152)
@@ -2524,8 +2527,16 @@ class LLM(BaseLLM):
             DEFAULT_CONTEXT_WINDOW_SIZE * CONTEXT_WINDOW_USAGE_RATIO
         )
         model_name = self._context_window_model_name()
+        best_key = ""
         for key, value in LLM_CONTEXT_WINDOW_SIZES.items():
-            if model_name.startswith(key) or self.model.startswith(key):
+            if not (model_name.startswith(key) or self.model.startswith(key)):
+                continue
+            # Several keys can prefix-match one model id -- "anthropic.claude-v2:1"
+            # matches both itself and "anthropic.claude-v2". Keep the longest
+            # match, which is the most specific entry, instead of whichever one
+            # happens to come last in the dict.
+            if len(key) > len(best_key):
+                best_key = key
                 self.context_window_size = int(value * CONTEXT_WINDOW_USAGE_RATIO)
         return self.context_window_size
 

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -11,7 +11,12 @@ from crewai.events.event_types import (
     ToolUsageFinishedEvent,
     ToolUsageStartedEvent,
 )
-from crewai.llm import CONTEXT_WINDOW_USAGE_RATIO, DEFAULT_CONTEXT_WINDOW_SIZE, LLM
+from crewai.llm import (
+    CONTEXT_WINDOW_USAGE_RATIO,
+    DEFAULT_CONTEXT_WINDOW_SIZE,
+    LLM,
+    LLM_CONTEXT_WINDOW_SIZES,
+)
 from crewai.llms.providers.anthropic.completion import AnthropicCompletion
 from crewai.utilities.token_counter_callback import TokenCalcHandler
 from pydantic import BaseModel
@@ -384,6 +389,77 @@ def test_unrecognized_provider_prefix_is_not_stripped() -> None:
     assert llm.get_context_window_size() == int(
         DEFAULT_CONTEXT_WINDOW_SIZE * CONTEXT_WINDOW_USAGE_RATIO
     )
+
+
+def test_claude_v2_1_keeps_its_own_window() -> None:
+    """A longer key must win over a shorter one that also prefix-matches.
+
+    "anthropic.claude-v2:1" matches both itself (200k) and
+    "anthropic.claude-v2" (100k), and the shorter key is declared immediately
+    after it, so the last-match-wins loop used to hand back the 100k window --
+    half the context the model actually has.
+    """
+    llm = LLM(model="anthropic.claude-v2:1", is_litellm=True)
+    assert llm.get_context_window_size() == int(
+        200000 * CONTEXT_WINDOW_USAGE_RATIO
+    )
+
+
+def test_claude_v2_still_gets_its_smaller_window() -> None:
+    """The shorter key keeps its own value; it is not widened by the fix."""
+    llm = LLM(model="anthropic.claude-v2", is_litellm=True)
+    assert llm.get_context_window_size() == int(
+        100000 * CONTEXT_WINDOW_USAGE_RATIO
+    )
+
+
+def test_no_declared_model_resolves_to_a_different_window() -> None:
+    """Every entry must resolve to its own window under the real lookup rule.
+
+    This is the general form of the claude-v2:1 bug. It is checked against the
+    resolution rule rather than by constructing an LLM per model, because many
+    entries route to native providers whose SDKs are optional extras.
+
+    The list of ids that the *old* last-match-wins rule got wrong is asserted
+    to be exactly the one entry this change fixes, so a future entry that
+    reintroduces the hazard shows up here instead of silently halving someone's
+    context window.
+    """
+    broken_under_old_rule = []
+    for model, declared in LLM_CONTEXT_WINDOW_SIZES.items():
+        best_key = ""
+        longest_match = None
+        last_match = None
+        for key, value in LLM_CONTEXT_WINDOW_SIZES.items():
+            if not model.startswith(key):
+                continue
+            last_match = value  # what the old loop returned: no break
+            if len(key) > len(best_key):
+                best_key = key
+                longest_match = value
+
+        assert longest_match == declared, (
+            f"{model} resolves to {longest_match} (via {best_key!r}) "
+            f"instead of its own declared {declared}"
+        )
+        if last_match != declared:
+            broken_under_old_rule.append(model)
+
+    assert broken_under_old_rule == ["anthropic.claude-v2:1"]
+
+
+def test_longest_prefix_wins_regardless_of_declaration_order() -> None:
+    """Precedence must come from specificity, not from position in the dict."""
+    with patch.dict(
+        "crewai.llm.LLM_CONTEXT_WINDOW_SIZES",
+        # the short, wrong-for-this-model key is declared last on purpose
+        {"acme-chat-v3": 200000, "acme-chat": 32000},
+        clear=True,
+    ):
+        llm = LLM(model="acme-chat-v3", is_litellm=True)
+        assert llm.get_context_window_size() == int(
+            200000 * CONTEXT_WINDOW_USAGE_RATIO
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

`get_context_window_size()` scans `LLM_CONTEXT_WINDOW_SIZES` with `startswith()`
and no `break`, so when several keys prefix-match a model id the **last one in
the dict wins**. Two adjacent entries make that concrete (`llm.py:298-299`):

```python
"anthropic.claude-v2:1": 200000,
"anthropic.claude-v2": 100000,
```

`"anthropic.claude-v2:1"` matches both keys, and the 100k key is declared right
after it, so the more specific entry is overwritten:

```python
LLM(model="anthropic.claude-v2:1", is_litellm=True).get_context_window_size()
# 85000    <- 100000 * 0.85
# expected 170000  (200000 * 0.85)
```

Reproduced on `main` (`5704ea08`):

```
ratio = 0.85
anthropic.claude-v2:1: declared=200000 expected=170000 got=85000   <-- WRONG
anthropic.claude-v2  : declared=100000 expected=85000  got=85000   OK
```

Half the context the model actually has, with nothing logged. Downstream that
shows up as premature summarisation or a spurious context-length error, and the
declared 200k entry looks correct while never taking effect.

## Fix

Track the longest matching key rather than overwriting on every match, so
precedence comes from **specificity** instead of position in the dict:

```python
best_key = ""
for key, value in LLM_CONTEXT_WINDOW_SIZES.items():
    if not (model_name.startswith(key) or self.model.startswith(key)):
        continue
    if len(key) > len(best_key):
        best_key = key
        self.context_window_size = int(value * CONTEXT_WINDOW_USAGE_RATIO)
```

I audited **all 155 entries** under both the old and new rule:
`anthropic.claude-v2:1` is the only id the old rule resolved wrongly, so this is
the single behaviour change. Everything else — `gpt-5.6` family, `gpt-5.4-mini`,
`o3-mini`, provider-prefixed ids — resolves exactly as before:

```
anthropic.claude-v2:1  -> 170000   (was 85000)
anthropic.claude-v2    ->  85000   unchanged
gpt-5.4-mini           -> 170000   unchanged
gpt-5.6                -> 892500   unchanged
o3-mini                -> 170000   unchanged
openai/gpt-5.6-luna    -> 892500   unchanged
```

This repo already treats the hazard as a bug for the OpenAI family —
`test_gpt56_does_not_override_gpt54_mini_window`, *"a more specific older prefix
must keep its own window"*. But that case only holds because no shorter
conflicting key happens to exist. Ordering by length makes the guarantee
structural rather than dependent on declaration order.

Also corrects the docstring, which claimed 75% while `CONTEXT_WINDOW_USAGE_RATIO`
has been `0.85`.

## Verification

```
$ pytest lib/crewai/tests/test_llm.py -k "context_window or claude_v2 or longest_prefix or gpt56 or provider_prefix"
15 passed
```

Four tests added next to the existing gpt-5.6 precedence tests: the two
claude-v2 windows, an order-independence test whose short key is declared last
on purpose, and a table-wide audit that asserts the set of ids the *old* rule
got wrong is exactly `["anthropic.claude-v2:1"]` — so a future entry that
reintroduces the hazard fails here instead of silently halving someone's window.

**Rollback proof.** Neutralising only the new guard (`if len(key) > len(best_key)`
→ `if True`) fails exactly the 2 tests covering this bug while the other 13 —
including `anthropic.claude-v2`'s own smaller window — still pass, so the tests
are pinned to this behaviour and not over-constrained:

```
E   AssertionError: assert 27200 == 170000
FAILED test_claude_v2_1_keeps_its_own_window
FAILED test_longest_prefix_wins_regardless_of_declaration_order
2 failed, 13 passed
```

I also injected a synthetic shadowing entry to confirm the table-wide test
actually catches one, rather than passing vacuously.

Full `test_llm.py`: **82 passed, 13 failed/errored**. Those 13 are identical to
the `main` baseline (`comm` of the two failure sets is empty) — all are
`ImportError` for optional provider extras not installed here (google-genai,
gemini). Nothing fails that did not already fail.

`ruff check` on `llm.py`: 33 findings before and after — no new ones introduced
(`lib/crewai/tests/` is excluded from ruff by `pyproject.toml`).
`ruff format --check`: already formatted.

## Notes

- The table-wide test compares the two resolution rules rather than constructing
  an `LLM` per model, since most entries route to native providers whose SDKs are
  optional extras and would make the test environment-dependent.
- Scope kept to the resolution rule. I did not touch the entries themselves —
  the missing `o1`/`o3` rows are #7303 and separate from this.


<!-- crewai-require-issue-check -->