### PR TITLE
test(bedrock): verify environment credentials

### DIFF
--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -602,19 +602,23 @@ def test_bedrock_tool_conversion():
     assert "inputSchema" in bedrock_tools[0]["toolSpec"]
 
 
-def test_bedrock_environment_variable_credentials(bedrock_mocks):
+def test_bedrock_environment_variable_credentials():
     """Pass AWS credentials and region from the environment to boto3."""
-    mock_session_class, _ = bedrock_mocks
-
-    with patch.dict(
-        os.environ,
-        {
-            "AWS_ACCESS_KEY_ID": "test-access-key-123",
-            "AWS_SECRET_ACCESS_KEY": "test-secret-key-456",
-            "AWS_DEFAULT_REGION": "eu-west-1",
-        },
-        clear=False,
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "AWS_ACCESS_KEY_ID": "test-access-key-123",
+                "AWS_SECRET_ACCESS_KEY": "test-secret-key-456",
+                "AWS_DEFAULT_REGION": "eu-west-1",
+            },
+            clear=False,
+        ),
+        patch(
+            "crewai.llms.providers.bedrock.completion.Session"
+        ) as mock_session_class,
     ):
+        mock_session_class.return_value.client.return_value = MagicMock()
         LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
 
     mock_session_class.assert_called_once_with(

--- a/lib/crewai/tests/llms/bedrock/test_bedrock.py
+++ b/lib/crewai/tests/llms/bedrock/test_bedrock.py
@@ -603,23 +603,26 @@ def test_bedrock_tool_conversion():
 
 
 def test_bedrock_environment_variable_credentials(bedrock_mocks):
-    """
-    Test that AWS credentials are properly loaded from environment
-    """
+    """Pass AWS credentials and region from the environment to boto3."""
     mock_session_class, _ = bedrock_mocks
 
-    mock_session_class.reset_mock()
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-access-key-123",
+            "AWS_SECRET_ACCESS_KEY": "test-secret-key-456",
+            "AWS_DEFAULT_REGION": "eu-west-1",
+        },
+        clear=False,
+    ):
+        LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
 
-    with patch.dict(os.environ, {
-        "AWS_ACCESS_KEY_ID": "test-access-key-123",
-        "AWS_SECRET_ACCESS_KEY": "test-secret-key-456"
-    }):
-        llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
-
-        assert mock_session_class.called
-        call_kwargs = mock_session_class.call_args[1] if mock_session_class.call_args else {}
-        assert call_kwargs.get('aws_access_key_id') == "test-access-key-123"
-        assert call_kwargs.get('aws_secret_access_key') == "test-secret-key-456"
+    mock_session_class.assert_called_once_with(
+        aws_access_key_id="test-access-key-123",
+        aws_secret_access_key="test-secret-key-456",
+        aws_session_token=None,
+        region_name="eu-west-1",
+    )
 
 
 def test_bedrock_token_usage_tracking():


### PR DESCRIPTION
## Summary
- rewrite the Bedrock environment credential test to assert the exact boto3 Session arguments
- verify credentials, session token handling, and AWS region propagation

## Tests
- `UV_CACHE_DIR=/private/tmp/crewai-uv-cache uv run pytest -q lib/crewai/tests/llms/bedrock/test_bedrock.py::test_bedrock_environment_variable_credentials -s`
- 1 passed