### PR TITLE
fix(openai): handle empty terminal responses after tool calls

### DIFF
--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -7,7 +7,7 @@ in CrewAI, including common functionality for native SDK implementations.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 import contextvars
 from datetime import datetime
@@ -79,6 +79,37 @@ class LLMCallBlockedError(ValueError):
     absorbing it, and its own type so a provider can report it as the decision
     it is instead of letting it read as a provider outage.
     """
+
+
+class LLMEmptyResponseError(ValueError):
+    """A provider returned neither text nor tool calls.
+
+    ``finish_reason`` is a provider generation status, not proof that an agent
+    completed its task. Callers may use it together with their own tool/turn
+    state to handle an intentional empty turn without swallowing real failures.
+    Missing usage fields remain missing; in particular, absent reasoning usage
+    must not be interpreted as zero. Existing ``ValueError`` handlers still work.
+
+    Attributes:
+        finish_reason: Raw provider finish reason, or None when unavailable.
+        response_id: Provider response identifier, or None when unavailable.
+        usage: Per-response token usage, rather than the model's cumulative usage.
+    """
+
+    def __init__(
+        self,
+        *,
+        finish_reason: str | None,
+        response_id: str | None,
+        usage: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.finish_reason = finish_reason
+        self.response_id = response_id
+        self.usage = dict(usage) if usage is not None else {}
+        super().__init__(
+            "Invalid response from LLM call - None or empty. "
+            f"finish_reason={finish_reason!r}, response_id={response_id!r}"
+        )
 
 
 DEFAULT_CONTEXT_WINDOW_SIZE: Final[int] = 4096

--- a/lib/crewai/src/crewai/llms/base_llm.py
+++ b/lib/crewai/src/crewai/llms/base_llm.py
@@ -103,6 +103,7 @@ class LLMEmptyResponseError(ValueError):
         response_id: str | None,
         usage: Mapping[str, Any] | None = None,
     ) -> None:
+        """Capture per-response diagnostics while retaining ValueError compatibility."""
         self.finish_reason = finish_reason
         self.response_id = response_id
         self.usage = dict(usage) if usage is not None else {}

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -50,6 +50,7 @@ from crewai.llms.base_llm import (
     BaseLLM,
     JsonResponseFormat,
     LLMCallBlockedError,
+    LLMEmptyResponseError,
     llm_call_context,
 )
 from crewai.llms.hooks.base import BaseInterceptor
@@ -589,6 +590,8 @@ class OpenAICompletion(BaseLLM):
             except (HookAborted, LLMCallBlockedError) as e:
                 self._emit_call_denied_event(e, from_task, from_agent)
                 raise
+            except LLMEmptyResponseError:
+                raise
             except Exception as e:
                 error_msg = f"OpenAI API call failed: {e!s}"
                 logging.error(error_msg)
@@ -726,6 +729,8 @@ class OpenAICompletion(BaseLLM):
 
             except (HookAborted, LLMCallBlockedError) as e:
                 self._emit_call_denied_event(e, from_task, from_agent)
+                raise
+            except LLMEmptyResponseError:
                 raise
             except Exception as e:
                 error_msg = f"OpenAI API call failed: {e!s}"
@@ -2097,6 +2102,23 @@ class OpenAICompletion(BaseLLM):
 
             content = message.content or ""
 
+            if not content and not message.tool_calls:
+                self._emit_call_completed_event(
+                    response=content,
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params["messages"],
+                    usage=usage,
+                    finish_reason=finish_reason,
+                    response_id=response_id,
+                )
+                raise LLMEmptyResponseError(
+                    finish_reason=finish_reason,
+                    response_id=response_id,
+                    usage=usage,
+                )
+
             if self.response_format and isinstance(self.response_format, type):
                 try:
                     structured_result = self._validate_structured_output(
@@ -2156,6 +2178,8 @@ class OpenAICompletion(BaseLLM):
 
             # `_call_completions` retries this one, so reporting a failed call
             # here would surface an error the caller never experiences.
+            if isinstance(e, LLMEmptyResponseError):
+                raise
             if self._rejects_reasoning_effort_with_tools(e):
                 raise
 
@@ -2257,6 +2281,23 @@ class OpenAICompletion(BaseLLM):
 
                 if result is not None:
                     return result
+
+        if not full_response and not tool_calls:
+            self._emit_call_completed_event(
+                response=full_response,
+                call_type=LLMCallType.LLM_CALL,
+                from_task=from_task,
+                from_agent=from_agent,
+                messages=params["messages"],
+                usage=usage_data,
+                finish_reason=finish_reason,
+                response_id=response_id,
+            )
+            raise LLMEmptyResponseError(
+                finish_reason=finish_reason,
+                response_id=response_id,
+                usage=usage_data,
+            )
 
         full_response = self._apply_stop_words(full_response)
 
@@ -2539,6 +2580,23 @@ class OpenAICompletion(BaseLLM):
 
             content = message.content or ""
 
+            if not content and not message.tool_calls:
+                self._emit_call_completed_event(
+                    response=content,
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params["messages"],
+                    usage=usage,
+                    finish_reason=finish_reason,
+                    response_id=response_id,
+                )
+                raise LLMEmptyResponseError(
+                    finish_reason=finish_reason,
+                    response_id=response_id,
+                    usage=usage,
+                )
+
             if self.response_format and isinstance(self.response_format, type):
                 try:
                     structured_result = self._validate_structured_output(
@@ -2594,6 +2652,8 @@ class OpenAICompletion(BaseLLM):
 
             # `_call_completions` retries this one, so reporting a failed call
             # here would surface an error the caller never experiences.
+            if isinstance(e, LLMEmptyResponseError):
+                raise
             if self._rejects_reasoning_effort_with_tools(e):
                 raise
 

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -2353,12 +2353,33 @@ class OpenAICompletion(BaseLLM):
                 final_completion = stream.get_final_completion()
                 if final_completion:
                     usage = self._extract_openai_token_usage(final_completion)
-                    self._track_token_usage_internal(usage)
                     parsed_finish_reason, parsed_response_id = (
                         self._extract_chat_finish_reason_and_id(final_completion)
                     )
                     if final_completion.choices:
                         message = final_completion.choices[0].message
+                        if message.tool_calls:
+                            return self._finalize_streaming_response(
+                                full_response=message.content or "",
+                                tool_calls={
+                                    index: {
+                                        "id": call.id,
+                                        "name": call.function.name,
+                                        "arguments": call.function.arguments,
+                                        "index": index,
+                                    }
+                                    for index, call in enumerate(message.tool_calls)
+                                    if call.type == "function"
+                                },
+                                usage_data=usage,
+                                params=params,
+                                available_functions=available_functions,
+                                from_task=from_task,
+                                from_agent=from_agent,
+                                finish_reason=parsed_finish_reason,
+                                response_id=parsed_response_id,
+                            )
+                        self._track_token_usage_internal(usage)
                         if not message.content and not message.tool_calls:
                             self._emit_call_completed_event(
                                 response="",
@@ -2695,96 +2716,11 @@ class OpenAICompletion(BaseLLM):
         full_response = ""
         tool_calls: dict[int, dict[str, Any]] = {}
 
-        if response_model:
-            completion_stream: AsyncIterator[
-                ChatCompletionChunk
-            ] = await self._get_async_client().chat.completions.create(**params)
-
-            accumulated_content = ""
-            usage_data: dict[str, Any] | None = None
-            parsed_stream_finish_reason: str | None = None
-            parsed_stream_response_id: str | None = None
-            async for chunk in completion_stream:
-                response_id_stream = chunk.id if hasattr(chunk, "id") else None
-                if response_id_stream:
-                    parsed_stream_response_id = response_id_stream
-
-                if hasattr(chunk, "usage") and chunk.usage:
-                    usage_data = self._extract_openai_token_usage(chunk)
-                    continue
-
-                if not chunk.choices:
-                    continue
-
-                choice = chunk.choices[0]
-                delta: ChoiceDelta = choice.delta
-                chunk_finish = getattr(choice, "finish_reason", None)
-                if chunk_finish:
-                    parsed_stream_finish_reason = chunk_finish
-
-                if delta.content:
-                    accumulated_content += delta.content
-                    self._emit_stream_chunk_event(
-                        chunk=delta.content,
-                        from_task=from_task,
-                        from_agent=from_agent,
-                        response_id=response_id_stream,
-                    )
-
-            if usage_data:
-                self._track_token_usage_internal(usage_data)
-
-            if not accumulated_content:
-                self._emit_call_completed_event(
-                    response="",
-                    call_type=LLMCallType.LLM_CALL,
-                    from_task=from_task,
-                    from_agent=from_agent,
-                    messages=params["messages"],
-                    usage=usage_data,
-                    finish_reason=parsed_stream_finish_reason,
-                    response_id=parsed_stream_response_id,
-                )
-                raise LLMEmptyResponseError(
-                    finish_reason=parsed_stream_finish_reason,
-                    response_id=parsed_stream_response_id,
-                    usage=usage_data,
-                )
-
-            try:
-                parsed_object = response_model.model_validate_json(accumulated_content)
-
-                self._emit_call_completed_event(
-                    response=parsed_object.model_dump_json(),
-                    call_type=LLMCallType.LLM_CALL,
-                    from_task=from_task,
-                    from_agent=from_agent,
-                    messages=params["messages"],
-                    usage=usage_data,
-                    finish_reason=parsed_stream_finish_reason,
-                    response_id=parsed_stream_response_id,
-                )
-
-                return parsed_object
-            except Exception as e:
-                logging.error(f"Failed to parse structured output from stream: {e}")
-                self._emit_call_completed_event(
-                    response=accumulated_content,
-                    call_type=LLMCallType.LLM_CALL,
-                    from_task=from_task,
-                    from_agent=from_agent,
-                    messages=params["messages"],
-                    usage=usage_data,
-                    finish_reason=parsed_stream_finish_reason,
-                    response_id=parsed_stream_response_id,
-                )
-                return accumulated_content
-
         stream: AsyncIterator[
             ChatCompletionChunk
         ] = await self._get_async_client().chat.completions.create(**params)
 
-        usage_data = None
+        usage_data: dict[str, Any] | None = None
         stream_finish_reason: str | None = None
         stream_response_id: str | None = None
 
@@ -2853,6 +2789,39 @@ class OpenAICompletion(BaseLLM):
                         call_type=LLMCallType.TOOL_CALL,
                         response_id=response_id_stream,
                     )
+
+        if response_model and full_response and not tool_calls:
+            if usage_data:
+                self._track_token_usage_internal(usage_data)
+
+            try:
+                parsed_object = response_model.model_validate_json(full_response)
+
+                self._emit_call_completed_event(
+                    response=parsed_object.model_dump_json(),
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params["messages"],
+                    usage=usage_data,
+                    finish_reason=stream_finish_reason,
+                    response_id=stream_response_id,
+                )
+
+                return parsed_object
+            except Exception as e:
+                logging.error(f"Failed to parse structured output from stream: {e}")
+                self._emit_call_completed_event(
+                    response=full_response,
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params["messages"],
+                    usage=usage_data,
+                    finish_reason=stream_finish_reason,
+                    response_id=stream_response_id,
+                )
+                return full_response
 
         return self._finalize_streaming_response(
             full_response=full_response,

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -2358,7 +2358,24 @@ class OpenAICompletion(BaseLLM):
                         self._extract_chat_finish_reason_and_id(final_completion)
                     )
                     if final_completion.choices:
-                        parsed_result = final_completion.choices[0].message.parsed
+                        message = final_completion.choices[0].message
+                        if not message.content and not message.tool_calls:
+                            self._emit_call_completed_event(
+                                response="",
+                                call_type=LLMCallType.LLM_CALL,
+                                from_task=from_task,
+                                from_agent=from_agent,
+                                messages=params["messages"],
+                                usage=usage,
+                                finish_reason=parsed_finish_reason,
+                                response_id=parsed_response_id,
+                            )
+                            raise LLMEmptyResponseError(
+                                finish_reason=parsed_finish_reason,
+                                response_id=parsed_response_id,
+                                usage=usage,
+                            )
+                        parsed_result = message.parsed
                         if parsed_result:
                             self._emit_call_completed_event(
                                 response=parsed_result.model_dump_json(),
@@ -2716,6 +2733,23 @@ class OpenAICompletion(BaseLLM):
 
             if usage_data:
                 self._track_token_usage_internal(usage_data)
+
+            if not accumulated_content:
+                self._emit_call_completed_event(
+                    response="",
+                    call_type=LLMCallType.LLM_CALL,
+                    from_task=from_task,
+                    from_agent=from_agent,
+                    messages=params["messages"],
+                    usage=usage_data,
+                    finish_reason=parsed_stream_finish_reason,
+                    response_id=parsed_stream_response_id,
+                )
+                raise LLMEmptyResponseError(
+                    finish_reason=parsed_stream_finish_reason,
+                    response_id=parsed_stream_response_id,
+                    usage=usage_data,
+                )
 
             try:
                 parsed_object = response_model.model_validate_json(accumulated_content)

--- a/lib/crewai/src/crewai/utilities/agent_utils.py
+++ b/lib/crewai/src/crewai/utilities/agent_utils.py
@@ -24,7 +24,12 @@ from crewai.agents.parser import (
     OutputParserError,
     parse,
 )
-from crewai.llms.base_llm import BaseLLM, LLMCallBlockedError, call_stop_override
+from crewai.llms.base_llm import (
+    BaseLLM,
+    LLMCallBlockedError,
+    LLMEmptyResponseError,
+    call_stop_override,
+)
 from crewai.tools import BaseTool as CrewAITool
 from crewai.tools.base_tool import BaseTool
 from crewai.tools.structured_tool import (
@@ -523,6 +528,7 @@ def _validate_and_finalize_llm_response(
     executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
     printer: Printer,
     verbose: bool = True,
+    allow_empty: bool = False,
 ) -> str | BaseModel | Any:
     """Shared post-call logic: validate response and run after hooks.
 
@@ -531,6 +537,7 @@ def _validate_and_finalize_llm_response(
         executor_context: Optional executor context for hook invocation.
         printer: Printer instance for output.
         verbose: Whether to print output.
+        allow_empty: Whether an intentional empty terminal turn is valid.
 
     Returns:
         The potentially modified response.
@@ -538,7 +545,7 @@ def _validate_and_finalize_llm_response(
     Raises:
         ValueError: If the response is None or empty.
     """
-    if not answer:
+    if not answer and not allow_empty:
         if verbose:
             printer.print(
                 content="Received None or empty response from LLM call.",
@@ -548,6 +555,50 @@ def _validate_and_finalize_llm_response(
 
     return _setup_after_llm_call_hooks(
         executor_context, answer, printer, verbose=verbose
+    )
+
+
+def _can_accept_empty_llm_response(
+    error: LLMEmptyResponseError,
+    messages: list[LLMMessage],
+    executor_context: CrewAgentExecutor | AgentExecutor | LiteAgent | None,
+) -> bool:
+    """Recognize an intentional empty terminal turn after a tool result.
+
+    Native tool execution appends a synthetic ``post_tool_reasoning`` user
+    message after each tool result. That prompt is still part of the next
+    provider request, so the tool message is not necessarily the final item.
+    """
+    if executor_context is None or error.finish_reason != "stop":
+        return False
+
+    post_tool_reasoning = I18N_DEFAULT.slice("post_tool_reasoning")
+    last_tool_index = next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if messages[index].get("role") == "tool"
+        ),
+        None,
+    )
+    if last_tool_index is None:
+        return False
+
+    last_user_index = next(
+        (
+            index
+            for index in range(last_tool_index - 1, -1, -1)
+            if messages[index].get("role") == "user"
+            and messages[index].get("content") != post_tool_reasoning
+        ),
+        -1,
+    )
+    if last_tool_index <= last_user_index:
+        return False
+
+    return all(
+        message.get("role") == "user" and message.get("content") == post_tool_reasoning
+        for message in messages[last_tool_index + 1 :]
     )
 
 
@@ -587,21 +638,30 @@ def get_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
+    allow_empty = False
     with _prepare_llm_call(
         executor_context, messages, printer, verbose=verbose
     ) as prepared_messages:
-        answer = llm.call(
-            prepared_messages,
-            tools=tools,
-            callbacks=callbacks,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+        try:
+            answer = llm.call(
+                prepared_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
+        except LLMEmptyResponseError as error:
+            if not _can_accept_empty_llm_response(
+                error, prepared_messages, executor_context
+            ):
+                raise
+            answer = ""
+            allow_empty = True
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, verbose=verbose, allow_empty=allow_empty
     )
 
 
@@ -641,21 +701,30 @@ async def aget_llm_response(
         Exception: If an error occurs.
         ValueError: If the response is None or empty.
     """
+    allow_empty = False
     with _prepare_llm_call(
         executor_context, messages, printer, verbose=verbose
     ) as prepared_messages:
-        answer = await llm.acall(
-            prepared_messages,
-            tools=tools,
-            callbacks=callbacks,
-            available_functions=available_functions,
-            from_task=from_task,
-            from_agent=from_agent,
-            response_model=response_model,
-        )
+        try:
+            answer = await llm.acall(
+                prepared_messages,
+                tools=tools,
+                callbacks=callbacks,
+                available_functions=available_functions,
+                from_task=from_task,
+                from_agent=from_agent,
+                response_model=response_model,
+            )
+        except LLMEmptyResponseError as error:
+            if not _can_accept_empty_llm_response(
+                error, prepared_messages, executor_context
+            ):
+                raise
+            answer = ""
+            allow_empty = True
 
     return _validate_and_finalize_llm_response(
-        answer, executor_context, printer, verbose=verbose
+        answer, executor_context, printer, verbose=verbose, allow_empty=allow_empty
     )
 
 

--- a/lib/crewai/tests/llms/openai/test_empty_response.py
+++ b/lib/crewai/tests/llms/openai/test_empty_response.py
@@ -52,6 +52,7 @@ def make_llm(
     content: str | None = "",
     with_usage: bool = True,
     tool_calls: list[dict[str, Any]] | None = None,
+    stream_deltas: list[dict[str, Any]] | None = None,
 ) -> tuple[OpenAICompletion, list[httpx.Request]]:
     """Build a real OpenAI SDK client backed by deterministic HTTP responses."""
     requests: list[httpx.Request] = []
@@ -94,6 +95,23 @@ def make_llm(
                 ],
             }
         ]
+        if stream_deltas is not None:
+            chunks = [
+                {
+                    **common,
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": part,
+                            "finish_reason": finish_reason
+                            if index == len(stream_deltas) - 1
+                            else None,
+                        }
+                    ],
+                }
+                for index, part in enumerate(stream_deltas)
+            ]
         if with_usage:
             chunks.append(
                 {
@@ -474,3 +492,69 @@ async def test_structured_stream_tool_turn_finishes(is_async: bool) -> None:
     )
     assert result == ""
     assert len(requests) == 1
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("execute", [False, True])
+@pytest.mark.parametrize("with_text", [False, True])
+@pytest.mark.asyncio
+async def test_structured_stream_preserves_tool_calls(
+    is_async: bool, execute: bool, with_text: bool
+) -> None:
+    """Fragmented tool calls take precedence over structured text and run once."""
+    llm, requests = make_llm(
+        stream=True,
+        finish_reason="tool_calls",
+        stream_deltas=[
+            {
+                "content": '{"text":"planning"}' if with_text else None,
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_reply",
+                        "type": "function",
+                        "function": {"name": "reply", "arguments": '{"text":'},
+                    }
+                ],
+            },
+            {"tool_calls": [{"index": 0, "function": {"arguments": '"hello"}'}}]},
+        ],
+    )
+    reply = Mock(return_value="delivered")
+    kwargs = {
+        "response_model": StructuredReply,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "reply",
+                    "description": "Send a reply",
+                    "strict": True,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ],
+        "available_functions": {"reply": reply} if execute else None,
+    }
+    result = (
+        await llm.acall("hello", **kwargs) if is_async else llm.call("hello", **kwargs)
+    )
+    if execute:
+        assert result == "delivered"
+        reply.assert_called_once_with(text="hello")
+    else:
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "call_reply"
+        assert result[0]["function"] == {
+            "name": "reply",
+            "arguments": '{"text":"hello"}',
+        }
+        reply.assert_not_called()
+    assert len(requests) == 1
+    assert llm.get_token_usage_summary().total_tokens == USAGE["total_tokens"]

--- a/lib/crewai/tests/llms/openai/test_empty_response.py
+++ b/lib/crewai/tests/llms/openai/test_empty_response.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 import httpx
 import openai
 import pytest
+from pydantic import BaseModel
 
 from crewai.llms.base_llm import LLMEmptyResponseError
 from crewai.llms.providers.openai.completion import OpenAICompletion
@@ -52,9 +53,11 @@ def make_llm(
     with_usage: bool = True,
     tool_calls: list[dict[str, Any]] | None = None,
 ) -> tuple[OpenAICompletion, list[httpx.Request]]:
+    """Build a real OpenAI SDK client backed by deterministic HTTP responses."""
     requests: list[httpx.Request] = []
 
     def respond(request: httpx.Request) -> httpx.Response:
+        """Return completion JSON or SSE chunks without network access."""
         requests.append(request)
         common = {"id": "chatcmpl-empty", "created": 1, "model": "gpt-4o-mini"}
         if not stream:
@@ -127,6 +130,7 @@ def make_llm(
 async def test_empty_response_exposes_provider_metadata(
     stream: bool, is_async: bool, finish_reason: str | None
 ) -> None:
+    """Preserve termination metadata across sync, async, and streaming calls."""
     llm, requests = make_llm(stream=stream, finish_reason=finish_reason)
     with pytest.raises(LLMEmptyResponseError) as caught:
         if is_async:
@@ -147,6 +151,7 @@ async def test_empty_response_exposes_provider_metadata(
 async def test_tool_loop_accepts_stop_after_tool_result(
     stream: bool, is_async: bool, with_post_tool_reasoning: bool
 ) -> None:
+    """Accept an empty stop after a tool, including the synthetic follow-up."""
     llm, requests = make_llm(stream=stream)
     messages = list(MESSAGES)
     if with_post_tool_reasoning:
@@ -179,6 +184,7 @@ async def test_tool_loop_accepts_stop_after_tool_result(
 def test_empty_turn_is_only_accepted_after_a_stop_tool_result(
     finish_reason: str, last_role: str
 ) -> None:
+    """Reject truncation and empty responses without a qualifying tool result."""
     llm, requests = make_llm(stream=False, finish_reason=finish_reason)
     messages = list(MESSAGES)
     if last_role == "user":
@@ -202,6 +208,7 @@ def test_empty_turn_is_only_accepted_after_a_stop_tool_result(
 
 
 def test_native_executor_finishes_after_tool_result_empty_turn() -> None:
+    """Finish the native executor after a successful tool and empty stop."""
     from crewai.agents.crew_agent_executor import CrewAgentExecutor
     from crewai.tools.base_tool import BaseTool, to_langchain
 
@@ -210,6 +217,7 @@ def test_native_executor_finishes_after_tool_result_empty_turn() -> None:
         description: str = "Send a reply"
 
         def _run(self, text: str) -> str:
+            """Simulate delivery of a reply and return a successful tool result."""
             return '{"status":"success"}'
 
     llm = Mock()
@@ -265,6 +273,7 @@ def test_native_executor_finishes_after_tool_result_empty_turn() -> None:
 
 
 def test_experimental_native_executor_finishes_after_tool_result_empty_turn() -> None:
+    """Finish the experimental executor after a tool and empty stop."""
     from crewai.experimental.agent_executor import AgentExecutor
     from crewai.tools.base_tool import BaseTool, to_langchain
 
@@ -273,6 +282,7 @@ def test_experimental_native_executor_finishes_after_tool_result_empty_turn() ->
         description: str = "Send a reply"
 
         def _run(self, text: str) -> str:
+            """Simulate delivery of a reply and return a successful tool result."""
             return '{"status":"success"}'
 
     llm = Mock()
@@ -331,6 +341,7 @@ def test_experimental_native_executor_finishes_after_tool_result_empty_turn() ->
 async def test_first_turn_empty_response_remains_an_error(
     stream: bool, is_async: bool
 ) -> None:
+    """Keep first-call empty responses distinguishable from successful output."""
     llm, requests = make_llm(stream=stream, content=None, with_usage=False)
     with pytest.raises(LLMEmptyResponseError) as caught:
         if is_async:
@@ -349,6 +360,7 @@ async def test_first_turn_empty_response_remains_an_error(
 async def test_nonempty_text_and_tool_calls_are_unchanged(
     stream: bool, is_async: bool, tool_call: bool
 ) -> None:
+    """Preserve normal text and tool-call responses."""
     calls = MESSAGES[1]["tool_calls"] if tool_call else None
     llm, requests = make_llm(
         stream=stream,
@@ -362,4 +374,103 @@ async def test_nonempty_text_and_tool_calls_are_unchanged(
         if tool_call
         else result == "hello"
     )
+    assert len(requests) == 1
+
+
+class StructuredReply(BaseModel):
+    """A structured response used to exercise the SDK parsing paths."""
+
+    text: str
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("with_usage", [False, True])
+@pytest.mark.parametrize("content", [None, ""])
+@pytest.mark.asyncio
+async def test_structured_stream_empty_response(
+    is_async: bool, with_usage: bool, content: str | None
+) -> None:
+    """Empty structured streams must expose metadata on the first call."""
+    llm, requests = make_llm(stream=True, with_usage=with_usage, content=content)
+    with pytest.raises(LLMEmptyResponseError) as caught:
+        if is_async:
+            await llm.acall("hello", response_model=StructuredReply)
+        else:
+            llm.call("hello", response_model=StructuredReply)
+    assert caught.value.finish_reason == "stop"
+    assert caught.value.response_id == "chatcmpl-empty"
+    if with_usage:
+        assert caught.value.usage["completion_tokens"] == 3
+    else:
+        assert "reasoning_tokens" not in caught.value.usage
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_structured_stream_valid_response(is_async: bool) -> None:
+    """Valid structured streams continue returning the requested model."""
+    llm, requests = make_llm(stream=True, content='{"text":"hello"}')
+    result = (
+        await llm.acall("hello", response_model=StructuredReply)
+        if is_async
+        else llm.call("hello", response_model=StructuredReply)
+    )
+    assert result == StructuredReply(text="hello")
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter", None])
+@pytest.mark.asyncio
+async def test_async_structured_empty_termination_metadata(
+    finish_reason: str | None,
+) -> None:
+    """Structured async failures retain non-stop and absent finish reasons."""
+    llm, requests = make_llm(stream=True, finish_reason=finish_reason)
+    with pytest.raises(LLMEmptyResponseError) as caught:
+        await llm.acall("hello", response_model=StructuredReply)
+    assert caught.value.finish_reason == finish_reason
+    assert caught.value.response_id == "chatcmpl-empty"
+    assert caught.value.usage["completion_tokens"] == 3
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "error_type"),
+    [
+        ("length", openai.LengthFinishReasonError),
+        ("content_filter", openai.ContentFilterFinishReasonError),
+    ],
+)
+def test_sync_structured_sdk_failures_remain_errors(
+    finish_reason: str, error_type: type[Exception]
+) -> None:
+    """Preserve the SDK's explicit truncation and content-filter exceptions."""
+    llm, requests = make_llm(stream=True, finish_reason=finish_reason)
+    with pytest.raises(error_type):
+        llm.call("hello", response_model=StructuredReply)
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_structured_stream_tool_turn_finishes(is_async: bool) -> None:
+    """The structured path accepts an empty terminal turn after tool execution."""
+    llm, requests = make_llm(stream=True)
+    messages = list(MESSAGES)
+    kwargs = {
+        "llm": llm,
+        "messages": messages,
+        "callbacks": [],
+        "printer": Printer(),
+        "executor_context": SimpleNamespace(
+            before_llm_call_hooks=[], after_llm_call_hooks=[], messages=messages
+        ),
+        "response_model": StructuredReply,
+        "verbose": False,
+    }
+    result = (
+        await aget_llm_response(**kwargs) if is_async else get_llm_response(**kwargs)
+    )
+    assert result == ""
     assert len(requests) == 1

--- a/lib/crewai/tests/llms/openai/test_empty_response.py
+++ b/lib/crewai/tests/llms/openai/test_empty_response.py
@@ -1,0 +1,365 @@
+"""Empty Chat Completions must retain the provider's termination metadata.
+
+Drive the real SDK over a mock HTTP transport; no API keys or network are needed.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import openai
+import pytest
+
+from crewai.llms.base_llm import LLMEmptyResponseError
+from crewai.llms.providers.openai.completion import OpenAICompletion
+from crewai.utilities.agent_utils import aget_llm_response, get_llm_response
+from crewai.utilities.i18n import I18N_DEFAULT
+from crewai_core.printer import Printer
+
+
+USAGE = {
+    "prompt_tokens": 10,
+    "completion_tokens": 3,
+    "total_tokens": 13,
+    "completion_tokens_details": {"reasoning_tokens": 0},
+}
+MESSAGES = [
+    {"role": "user", "content": "Say hello using reply."},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_reply",
+                "type": "function",
+                "function": {"name": "reply", "arguments": '{"text":"hello"}'},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "call_reply", "content": '{"status":"success"}'},
+]
+
+
+def make_llm(
+    *,
+    stream: bool,
+    finish_reason: str | None = "stop",
+    content: str | None = "",
+    with_usage: bool = True,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> tuple[OpenAICompletion, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        common = {"id": "chatcmpl-empty", "created": 1, "model": "gpt-4o-mini"}
+        if not stream:
+            return httpx.Response(
+                200,
+                json={
+                    **common,
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "finish_reason": finish_reason,
+                            "message": {
+                                "role": "assistant",
+                                "content": content,
+                                "tool_calls": tool_calls,
+                            },
+                        }
+                    ],
+                    "usage": USAGE if with_usage else None,
+                },
+            )
+        delta: dict[str, Any] = {"role": "assistant", "content": content}
+        if tool_calls:
+            delta["tool_calls"] = [
+                {"index": i, **call} for i, call in enumerate(tool_calls)
+            ]
+        chunks = [
+            {
+                **common,
+                "object": "chat.completion.chunk",
+                "choices": [
+                    {"index": 0, "delta": delta, "finish_reason": finish_reason}
+                ],
+            }
+        ]
+        if with_usage:
+            chunks.append(
+                {
+                    **common,
+                    "object": "chat.completion.chunk",
+                    "choices": [],
+                    "usage": USAGE,
+                }
+            )
+        data = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        return httpx.Response(
+            200,
+            content=(data + "data: [DONE]\n\n").encode(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(respond)
+    llm = OpenAICompletion(model="gpt-4o-mini", api_key="sk-test", stream=stream)
+    llm._client = openai.OpenAI(
+        api_key="sk-test", max_retries=0, http_client=httpx.Client(transport=transport)
+    )
+    llm._async_client = openai.AsyncOpenAI(
+        api_key="sk-test",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+    return llm, requests
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("finish_reason", ["stop", "length", "content_filter", None])
+@pytest.mark.asyncio
+async def test_empty_response_exposes_provider_metadata(
+    stream: bool, is_async: bool, finish_reason: str | None
+) -> None:
+    llm, requests = make_llm(stream=stream, finish_reason=finish_reason)
+    with pytest.raises(LLMEmptyResponseError) as caught:
+        if is_async:
+            await llm.acall(MESSAGES)
+        else:
+            llm.call(MESSAGES)
+    assert caught.value.finish_reason == finish_reason
+    assert caught.value.response_id == "chatcmpl-empty"
+    assert caught.value.usage["reasoning_tokens"] == 0
+    assert caught.value.usage["completion_tokens"] == 3
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("with_post_tool_reasoning", [False, True])
+@pytest.mark.asyncio
+async def test_tool_loop_accepts_stop_after_tool_result(
+    stream: bool, is_async: bool, with_post_tool_reasoning: bool
+) -> None:
+    llm, requests = make_llm(stream=stream)
+    messages = list(MESSAGES)
+    if with_post_tool_reasoning:
+        messages.append(
+            {"role": "user", "content": I18N_DEFAULT.slice("post_tool_reasoning")}
+        )
+    kwargs = {
+        "llm": llm,
+        "messages": messages,
+        "callbacks": [],
+        "printer": Printer(),
+        "executor_context": SimpleNamespace(
+            before_llm_call_hooks=[],
+            after_llm_call_hooks=[],
+            messages=messages,
+        ),
+        "verbose": False,
+    }
+    result = (
+        await aget_llm_response(**kwargs) if is_async else get_llm_response(**kwargs)
+    )
+    assert result == ""
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "last_role"),
+    [("length", "tool"), ("stop", "user")],
+)
+def test_empty_turn_is_only_accepted_after_a_stop_tool_result(
+    finish_reason: str, last_role: str
+) -> None:
+    llm, requests = make_llm(stream=False, finish_reason=finish_reason)
+    messages = list(MESSAGES)
+    if last_role == "user":
+        messages[-1] = {"role": "user", "content": "continue"}
+    context = SimpleNamespace(
+        before_llm_call_hooks=[],
+        after_llm_call_hooks=[],
+        messages=messages,
+    )
+
+    with pytest.raises(LLMEmptyResponseError):
+        get_llm_response(
+            llm=llm,
+            messages=messages,
+            callbacks=[],
+            printer=Printer(),
+            executor_context=context,
+            verbose=False,
+        )
+    assert len(requests) == 1
+
+
+def test_native_executor_finishes_after_tool_result_empty_turn() -> None:
+    from crewai.agents.crew_agent_executor import CrewAgentExecutor
+    from crewai.tools.base_tool import BaseTool, to_langchain
+
+    class ReplyTool(BaseTool):
+        name: str = "reply"
+        description: str = "Send a reply"
+
+        def _run(self, text: str) -> str:
+            return '{"status":"success"}'
+
+    llm = Mock()
+    llm.call.side_effect = [
+        [
+            {
+                "id": "call_reply",
+                "type": "function",
+                "function": {"name": "reply", "arguments": '{"text":"hello"}'},
+            }
+        ],
+        LLMEmptyResponseError(
+            finish_reason="stop",
+            response_id="chatcmpl-empty",
+            usage={"total_tokens": 3},
+        ),
+    ]
+    tool = ReplyTool()
+    executor = CrewAgentExecutor(
+        tools=to_langchain([tool]),
+        original_tools=[tool],
+    )
+    executor.llm = llm
+    executor.agent = SimpleNamespace(
+        id="agent-id",
+        key="test-agent",
+        role="tester",
+        verbose=False,
+        fingerprint=None,
+        tools_results=[],
+    )
+    executor.task = SimpleNamespace(name="test-task", description="test", id="task-id")
+    executor.messages = [{"role": "user", "content": "Say hello"}]
+    executor.callbacks = []
+    executor.iterations = 0
+    executor.max_iter = 3
+    executor.request_within_rpm_limit = None
+    executor.respect_context_window = False
+
+    result = executor._invoke_loop_native_tools()
+
+    assert type(result).__name__ == "AgentFinish"
+    assert result.output == ""
+    assert result.text == ""
+    assert llm.call.call_count == 2
+    assert [message["role"] for message in executor.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+        "assistant",
+    ]
+
+
+def test_experimental_native_executor_finishes_after_tool_result_empty_turn() -> None:
+    from crewai.experimental.agent_executor import AgentExecutor
+    from crewai.tools.base_tool import BaseTool, to_langchain
+
+    class ReplyTool(BaseTool):
+        name: str = "reply"
+        description: str = "Send a reply"
+
+        def _run(self, text: str) -> str:
+            return '{"status":"success"}'
+
+    llm = Mock()
+    llm.call.side_effect = [
+        [
+            {
+                "id": "call_reply",
+                "type": "function",
+                "function": {"name": "reply", "arguments": '{"text":"hello"}'},
+            }
+        ],
+        LLMEmptyResponseError(
+            finish_reason="stop",
+            response_id="chatcmpl-empty",
+            usage={"total_tokens": 3},
+        ),
+    ]
+    tool = ReplyTool()
+    executor = AgentExecutor()
+    executor.agent = SimpleNamespace(
+        id="agent-id",
+        key="test-agent",
+        role="tester",
+        verbose=False,
+        planning_enabled=False,
+        tools_results=[],
+    )
+    executor.task = SimpleNamespace(name="test-task", description="test", id="task-id")
+    executor.llm = llm
+    executor.original_tools = [tool]
+    executor.tools = to_langchain([tool])
+    executor._setup_native_tools()
+    executor.messages = [{"role": "user", "content": "Say hello"}]
+    executor.state.use_native_tools = True
+    executor.callbacks = []
+    executor.request_within_rpm_limit = None
+
+    assert executor.call_llm_native_tools() == "native_tool_calls"
+    assert executor.execute_native_tool() == "native_tool_completed"
+    assert executor.call_llm_native_tools() == "native_finished"
+    assert type(executor.state.current_answer).__name__ == "AgentFinish"
+    assert executor.state.current_answer.output == ""
+    assert executor.state.current_answer.text == ""
+    assert llm.call.call_count == 2
+    assert [message["role"] for message in executor.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_first_turn_empty_response_remains_an_error(
+    stream: bool, is_async: bool
+) -> None:
+    llm, requests = make_llm(stream=stream, content=None, with_usage=False)
+    with pytest.raises(LLMEmptyResponseError) as caught:
+        if is_async:
+            await llm.acall("hello")
+        else:
+            llm.call("hello")
+    assert type(caught.value).__name__ == "LLMEmptyResponseError"
+    assert "reasoning_tokens" not in caught.value.usage
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("tool_call", [False, True])
+@pytest.mark.asyncio
+async def test_nonempty_text_and_tool_calls_are_unchanged(
+    stream: bool, is_async: bool, tool_call: bool
+) -> None:
+    calls = MESSAGES[1]["tool_calls"] if tool_call else None
+    llm, requests = make_llm(
+        stream=stream,
+        content=None if tool_call else "hello",
+        tool_calls=calls,
+        finish_reason="tool_calls" if tool_call else "stop",
+    )
+    result = await llm.acall("hello") if is_async else llm.call("hello")
+    assert (
+        isinstance(result, list) and len(result) == 1
+        if tool_call
+        else result == "hello"
+    )
+    assert len(requests) == 1

--- a/lib/crewai/tests/llms/openai/test_openai.py
+++ b/lib/crewai/tests/llms/openai/test_openai.py
@@ -664,6 +664,8 @@ def test_openai_streaming_with_response_model():
         mock_parsed = TestResponse(answer="test", confidence=0.95)
         mock_message = MagicMock()
         mock_message.parsed = mock_parsed
+        mock_message.content = mock_parsed.model_dump_json()
+        mock_message.tool_calls = None
         mock_choice = MagicMock()
         mock_choice.message = mock_message
         mock_final_completion = MagicMock()


### PR DESCRIPTION
## Related issue

Fixes #7349

## Summary

Preserve finish reason, response ID, and usage in a dedicated
ValueError subclass for empty OpenAI Chat Completions.

Allow native agent execution to finish with empty text after a tool
result when finish_reason is stop. First-call empty responses and
other termination reasons remain errors with inspectable metadata.

## Verification

- 40 new regression tests passed.
- 162 related regression tests passed.
- Ruff checks passed for changed production files.
- git diff --check passed.
- Full test suite and live OpenAI calls were not run.

## Additional context

AI-assisted contribution.

<!-- crewai-require-issue-check -->