### PR TITLE
feat: validate platform integrations during crew setup

### DIFF
--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import re
 import sys
 from typing import Any
+import warnings
 
 import click
 from crewai_core.telemetry import Telemetry
@@ -619,6 +621,10 @@ def _wizard_agents_and_tasks(
         "inputs": {},
     }
 
+    # Platform authentication belongs to the final wizard step, after the
+    # user has finished configuring agents, tasks, and crew settings.
+    _setup_platform_auth(agents)
+
     return agents, tasks, crew_settings
 
 
@@ -871,6 +877,131 @@ def _setup_env(folder_path: Path, llm_model: str) -> None:
         click.secho("  API keys and model saved to .env file", fg="green")
 
 
+def _platform_apps_from_agents(agents: list[dict[str, Any]]) -> list[str]:
+    """Return unique platform applications selected across all agents."""
+    apps: list[str] = []
+    for agent in agents:
+        for tool in agent.get("tools", []):
+            if isinstance(tool, str) and tool.startswith("platform:"):
+                app = tool.removeprefix("platform:")
+                if app and app not in apps:
+                    apps.append(app)
+    return apps
+
+
+def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
+    """Get and validate AMP authentication for selected platform applications."""
+    apps = _platform_apps_from_agents(agents)
+    if not apps:
+        return None
+
+    click.echo()
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message='Field name "validate" in "UploadSarifAnalysisRequest"',
+                category=UserWarning,
+            )
+            from crewai_tools import CrewaiPlatformTools
+    except ImportError as error:
+        raise click.ClickException(
+            "Platform tools require the 'crewai-tools' package. "
+            "Install it with `uv add crewai-tools` or "
+            "`pip install 'crewai[tools]'`."
+        ) from error
+
+    while True:
+        token = os.environ.get("CREWAI_PLATFORM_INTEGRATION_TOKEN", "")
+        if not token:
+            click.secho(
+                "  To use CrewAI Platform tools, you need a CrewAI Platform "
+                "Integration Token.",
+                fg="yellow",
+            )
+            click.secho(
+                "  Get your token from CrewAI AMP: https://app.crewai.com "
+                "→ Settings → Integration Tokens.",
+                fg="cyan",
+            )
+            token = click.prompt(
+                click.style("  CREWAI_PLATFORM_INTEGRATION_TOKEN", fg="cyan"),
+                hide_input=True,
+                prompt_suffix=click.style(" > ", fg="bright_white"),
+            ).strip()
+        if not token:
+            click.secho(
+                "  A CrewAI Platform Integration Token is required to validate "
+                "the selected integrations.",
+                fg="yellow",
+            )
+            continue
+
+        os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = token
+        failed: list[str] = []
+        for app in apps:
+            app_name = (
+                dict(PLATFORM_TOOLS)
+                .get(f"platform:{app}", app.replace("_", " ").title())
+                .removesuffix(" Integration")
+            )
+            click.secho(
+                "  Checking CrewAI Platform Integration Token and "
+                f"{app_name} integration on AMP...",
+                fg="cyan",
+            )
+            try:
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message='Field name "validate" in "UploadSarifAnalysisRequest"',
+                        category=UserWarning,
+                    )
+                    app_tools = CrewaiPlatformTools(apps=[app])
+                if not app_tools:
+                    failed.append(app)
+                else:
+                    _success(f"{app_name} integration is connected on CrewAI Platform")
+            except Exception as error:
+                click.secho(f"  Could not connect to {app}: {error}", fg="yellow")
+                failed.append(app)
+
+        if not failed:
+            _success("CrewAI Platform integration token set", bold=True)
+            _success(
+                f"{len(apps)} CrewAI Platform integration"
+                f"{'s' if len(apps) != 1 else ''} connected"
+            )
+            return token
+
+        failed_app_names = [
+            dict(PLATFORM_TOOLS)
+            .get(f"platform:{app}", app.replace("_", " ").title())
+            .removesuffix(" Integration")
+            for app in failed
+        ]
+        click.secho(
+            "  Check the "
+            f"{', '.join(failed_app_names)} integration"
+            f"{'s' if len(failed_app_names) != 1 else ''} and your CrewAI "
+            "Platform Integration Token in AMP.",
+            fg="yellow",
+        )
+        replacement_token = click.prompt(
+            click.style(
+                "  Press Enter to revalidate, or enter a replacement token",
+                fg="cyan",
+            ),
+            default="",
+            show_default=False,
+            hide_input=True,
+            prompt_suffix=click.style(" > ", fg="bright_white"),
+        ).strip()
+        if replacement_token:
+            token = replacement_token
+            os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = token
+
+
 # ── Main ────────────────────────────────────────────────────────
 
 
@@ -923,12 +1054,24 @@ def create_json_crew(
             default_llm=default_llm,
         )
 
-    # Create directories
+    platform_token = (
+        os.environ.get("CREWAI_PLATFORM_INTEGRATION_TOKEN")
+        if _platform_apps_from_agents(agents) and not dmn_mode
+        else None
+    )
+
+    # Create directories only after platform authentication succeeds.
     folder_path.mkdir(parents=True)
     (folder_path / "agents").mkdir()
     (folder_path / "tools").mkdir()
     (folder_path / "skills").mkdir()
     (folder_path / "knowledge").mkdir()
+
+    if platform_token:
+        os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = platform_token
+        env_vars = load_env_vars(folder_path)
+        env_vars["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = platform_token
+        write_env_file(folder_path, env_vars)
 
     for agent in agents:
         _write_jsonc(

--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import re
 import sys
 from typing import Any
-import warnings
 
 import click
 from crewai_core.telemetry import Telemetry
@@ -897,13 +896,10 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
 
     click.echo()
     try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message='Field name "validate" in "UploadSarifAnalysisRequest"',
-                category=UserWarning,
-            )
-            from crewai_tools import CrewaiPlatformTools
+        from crewai_tools.tools.crewai_platform_tools.integrations_client import (
+            ApplicationSelector,
+            client_for_selector,
+        )
     except ImportError as error:
         raise click.ClickException(
             "Platform tools require the 'crewai-tools' package. "
@@ -939,34 +935,51 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
 
         os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = token
         failed: list[str] = []
+        token_invalid = False
         for app in apps:
             app_name = (
                 dict(PLATFORM_TOOLS)
                 .get(f"platform:{app}", app.replace("_", " ").title())
                 .removesuffix(" Integration")
             )
+            click.echo()
             click.secho(
                 "  Checking CrewAI Platform Integration Token and "
                 f"{app_name} integration on AMP...",
                 fg="cyan",
             )
             try:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message='Field name "validate" in "UploadSarifAnalysisRequest"',
-                        category=UserWarning,
-                    )
-                    app_tools = CrewaiPlatformTools(apps=[app])
-                if not app_tools:
+                selector = ApplicationSelector.from_string(app)
+                actions = client_for_selector(selector).get_actions([selector])
+                if not actions:
                     failed.append(app)
+                    click.secho(
+                        f"  ✘ {app_name} integration is not connected on CrewAI Platform",
+                        fg="red",
+                    )
                 else:
-                    _success(f"{app_name} integration is connected on CrewAI Platform")
+                    click.secho(
+                        f"  ✔ {app_name} integration is connected on CrewAI Platform",
+                        fg="green",
+                    )
             except Exception as error:
-                click.secho(f"  Could not connect to {app}: {error}", fg="yellow")
+                status_code = getattr(
+                    getattr(error, "response", None), "status_code", None
+                )
+                if status_code in {401, 403}:
+                    click.secho(
+                        "  ✘ CrewAI Platform Integration Token is invalid or expired",
+                        fg="red",
+                    )
+                    token_invalid = True
+                    break
+                click.secho(
+                    f"  ✘ {app_name} integration could not be validated: {error}",
+                    fg="red",
+                )
                 failed.append(app)
 
-        if not failed:
+        if not failed and not token_invalid:
             _success("CrewAI Platform integration token set", bold=True)
             _success(
                 f"{len(apps)} CrewAI Platform integration"
@@ -974,19 +987,27 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
             )
             return token
 
-        failed_app_names = [
-            dict(PLATFORM_TOOLS)
-            .get(f"platform:{app}", app.replace("_", " ").title())
-            .removesuffix(" Integration")
-            for app in failed
-        ]
-        click.secho(
-            "  Check the "
-            f"{', '.join(failed_app_names)} integration"
-            f"{'s' if len(failed_app_names) != 1 else ''} and your CrewAI "
-            "Platform Integration Token in AMP.",
-            fg="yellow",
-        )
+        click.echo()
+        if token_invalid:
+            click.secho(
+                "  Check your CrewAI Platform Integration Token in AMP.",
+                fg="yellow",
+            )
+        else:
+            failed_app_names = [
+                dict(PLATFORM_TOOLS)
+                .get(f"platform:{app}", app.replace("_", " ").title())
+                .removesuffix(" Integration")
+                for app in failed
+            ]
+            click.secho(
+                "  Check the "
+                f"{', '.join(failed_app_names)} integration"
+                f"{'s' if len(failed_app_names) != 1 else ''} and your CrewAI "
+                "Platform Integration Token in AMP.",
+                fg="yellow",
+            )
+        click.echo()
         replacement_token = click.prompt(
             click.style(
                 "  Press Enter to revalidate, or enter a replacement token",

--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -1039,8 +1039,8 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
         if not failed_apps and not token_invalid:
             _success("CrewAI Platform integration token set", bold=True)
             _success(
-                f"{len(apps)} CrewAI Platform integration"
-                f"{'s' if len(apps) != 1 else ''} connected"
+                "CrewAI Platform integrations connected: "
+                f"{', '.join(_platform_app_name(app) for app in apps)}"
             )
             return token
 

--- a/lib/cli/src/crewai_cli/create_json_crew.py
+++ b/lib/cli/src/crewai_cli/create_json_crew.py
@@ -888,6 +888,119 @@ def _platform_apps_from_agents(agents: list[dict[str, Any]]) -> list[str]:
     return apps
 
 
+def _platform_app_name(app: str) -> str:
+    """Return the display name for a platform application slug."""
+    return (
+        dict(PLATFORM_TOOLS)
+        .get(f"platform:{app}", app.replace("_", " ").title())
+        .removesuffix(" Integration")
+    )
+
+
+def _prompt_platform_token() -> str:
+    """Explain how to obtain and securely prompt for an AMP integration token."""
+    click.secho(
+        "  To use CrewAI Platform tools, you need a CrewAI Platform Integration Token.",
+        fg="yellow",
+    )
+    click.secho(
+        "  Get your token from CrewAI AMP: https://app.crewai.com "
+        "→ Settings → Integration Tokens.",
+        fg="cyan",
+    )
+    return str(
+        click.prompt(
+            click.style("  CREWAI_PLATFORM_INTEGRATION_TOKEN", fg="cyan"),
+            hide_input=True,
+            prompt_suffix=click.style(" > ", fg="bright_white"),
+        )
+    ).strip()
+
+
+def _validate_platform_apps(
+    apps: list[str], application_selector: Any, client_for_selector: Any
+) -> tuple[list[str], bool]:
+    """Check selected AMP applications and return failures and token validity."""
+    failed: list[str] = []
+    for app in apps:
+        app_name = _platform_app_name(app)
+        click.echo()
+        click.secho(
+            "  Checking CrewAI Platform Integration Token and "
+            f"{app_name} integration on AMP...",
+            fg="cyan",
+        )
+        try:
+            selector = application_selector.from_string(app)
+            actions = client_for_selector(selector).get_actions([selector])
+        except Exception as error:
+            status_code = getattr(getattr(error, "response", None), "status_code", None)
+            if status_code in {401, 403}:
+                click.secho(
+                    "  ✘ CrewAI Platform Integration Token is invalid or expired",
+                    fg="red",
+                )
+                return failed, True
+            click.secho(
+                f"  ✘ {app_name} integration could not be validated: {error}",
+                fg="red",
+            )
+            failed.append(app)
+            continue
+
+        if not actions:
+            click.secho(
+                f"  ✘ {app_name} integration is not connected on CrewAI Platform",
+                fg="red",
+            )
+            failed.append(app)
+        else:
+            click.secho(
+                f"  ✔ {app_name} integration is connected on CrewAI Platform",
+                fg="green",
+            )
+    return failed, False
+
+
+def _show_platform_validation_guidance(
+    failed_apps: list[str], token_invalid: bool
+) -> None:
+    """Tell the user what to fix before revalidating AMP integrations."""
+    click.echo()
+    if token_invalid:
+        click.secho(
+            "  Check your CrewAI Platform Integration Token in AMP.",
+            fg="yellow",
+        )
+        return
+
+    failed_app_names = [_platform_app_name(app) for app in failed_apps]
+    click.secho(
+        "  Check the "
+        f"{', '.join(failed_app_names)} integration"
+        f"{'s' if len(failed_app_names) != 1 else ''} and your CrewAI "
+        "Platform Integration Token in AMP.",
+        fg="yellow",
+    )
+
+
+def _prompt_platform_revalidation_token() -> str:
+    """Prompt for an optional replacement token before the next validation pass."""
+    click.echo()
+    return str(
+        click.prompt(
+            click.style(
+                "  Press Enter to revalidate, or enter a replacement token",
+                fg="cyan",
+            ),
+            default="",
+            show_default=False,
+            hide_input=True,
+            prompt_suffix=click.style(" > ", fg="bright_white"),
+        )
+    ).strip()
+
+
 def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
     """Get and validate AMP authentication for selected platform applications."""
     apps = _platform_apps_from_agents(agents)
@@ -907,24 +1020,10 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
             "`pip install 'crewai[tools]'`."
         ) from error
 
+    token = os.environ.get("CREWAI_PLATFORM_INTEGRATION_TOKEN", "")
     while True:
-        token = os.environ.get("CREWAI_PLATFORM_INTEGRATION_TOKEN", "")
         if not token:
-            click.secho(
-                "  To use CrewAI Platform tools, you need a CrewAI Platform "
-                "Integration Token.",
-                fg="yellow",
-            )
-            click.secho(
-                "  Get your token from CrewAI AMP: https://app.crewai.com "
-                "→ Settings → Integration Tokens.",
-                fg="cyan",
-            )
-            token = click.prompt(
-                click.style("  CREWAI_PLATFORM_INTEGRATION_TOKEN", fg="cyan"),
-                hide_input=True,
-                prompt_suffix=click.style(" > ", fg="bright_white"),
-            ).strip()
+            token = _prompt_platform_token()
         if not token:
             click.secho(
                 "  A CrewAI Platform Integration Token is required to validate "
@@ -934,52 +1033,10 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
             continue
 
         os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = token
-        failed: list[str] = []
-        token_invalid = False
-        for app in apps:
-            app_name = (
-                dict(PLATFORM_TOOLS)
-                .get(f"platform:{app}", app.replace("_", " ").title())
-                .removesuffix(" Integration")
-            )
-            click.echo()
-            click.secho(
-                "  Checking CrewAI Platform Integration Token and "
-                f"{app_name} integration on AMP...",
-                fg="cyan",
-            )
-            try:
-                selector = ApplicationSelector.from_string(app)
-                actions = client_for_selector(selector).get_actions([selector])
-                if not actions:
-                    failed.append(app)
-                    click.secho(
-                        f"  ✘ {app_name} integration is not connected on CrewAI Platform",
-                        fg="red",
-                    )
-                else:
-                    click.secho(
-                        f"  ✔ {app_name} integration is connected on CrewAI Platform",
-                        fg="green",
-                    )
-            except Exception as error:
-                status_code = getattr(
-                    getattr(error, "response", None), "status_code", None
-                )
-                if status_code in {401, 403}:
-                    click.secho(
-                        "  ✘ CrewAI Platform Integration Token is invalid or expired",
-                        fg="red",
-                    )
-                    token_invalid = True
-                    break
-                click.secho(
-                    f"  ✘ {app_name} integration could not be validated: {error}",
-                    fg="red",
-                )
-                failed.append(app)
-
-        if not failed and not token_invalid:
+        failed_apps, token_invalid = _validate_platform_apps(
+            apps, ApplicationSelector, client_for_selector
+        )
+        if not failed_apps and not token_invalid:
             _success("CrewAI Platform integration token set", bold=True)
             _success(
                 f"{len(apps)} CrewAI Platform integration"
@@ -987,37 +1044,8 @@ def _setup_platform_auth(agents: list[dict[str, Any]]) -> str | None:
             )
             return token
 
-        click.echo()
-        if token_invalid:
-            click.secho(
-                "  Check your CrewAI Platform Integration Token in AMP.",
-                fg="yellow",
-            )
-        else:
-            failed_app_names = [
-                dict(PLATFORM_TOOLS)
-                .get(f"platform:{app}", app.replace("_", " ").title())
-                .removesuffix(" Integration")
-                for app in failed
-            ]
-            click.secho(
-                "  Check the "
-                f"{', '.join(failed_app_names)} integration"
-                f"{'s' if len(failed_app_names) != 1 else ''} and your CrewAI "
-                "Platform Integration Token in AMP.",
-                fg="yellow",
-            )
-        click.echo()
-        replacement_token = click.prompt(
-            click.style(
-                "  Press Enter to revalidate, or enter a replacement token",
-                fg="cyan",
-            ),
-            default="",
-            show_default=False,
-            hide_input=True,
-            prompt_suffix=click.style(" > ", fg="bright_white"),
-        ).strip()
+        _show_platform_validation_guidance(failed_apps, token_invalid)
+        replacement_token = _prompt_platform_revalidation_token()
         if replacement_token:
             token = replacement_token
             os.environ["CREWAI_PLATFORM_INTEGRATION_TOKEN"] = token


### PR DESCRIPTION
## Related issue

OSS-164: https://linear.app/crewai/issue/OSS-164/enable-amp-crewai-platform-tools-for-oss-users

## Summary

Prompt for the CrewAI Platform Integration Token during JSON crew setup and validate each selected AMP integration with actionable retry guidance.

## Verification

- [x] Targeted platform picker tests pass locally
- [x] Ruff, formatting, and mypy pass locally

## Additional context

Stacked on #7384.