### PR TITLE
Add TrustedRouter as an OpenAI-compatible native provider

### DIFF
--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -959,6 +959,29 @@ mode: "wide"
     ```
   </Accordion>
 
+  <Accordion title="TrustedRouter">
+    TrustedRouter هو موجّه متوافق مع OpenAI ومُصدَّق (attested) مخصص لأعمال الوكلاء الحساسة للخصوصية، مع اختيار تلقائي للنماذج، ومسارات بدون احتفاظ بالبيانات، ومسارات مشفّرة من طرف إلى طرف.
+
+    عيّن متغيرات البيئة التالية في ملف `.env`:
+    ```toml Code
+    TRUSTEDROUTER_API_KEY=<your-api-key>
+    ```
+
+    مثال الاستخدام في مشروع CrewAI:
+    ```python Code
+    llm = LLM(
+        model="trustedrouter/auto",
+    )
+    ```
+
+    <Info>
+      أسماء التوجيه المستعارة:
+      - trustedrouter/auto (المسارات السليمة، يتم اختيارها تلقائيًا)
+      - trustedrouter/zdr (مسارات بدون احتفاظ بالبيانات)
+      - trustedrouter/e2e (مسارات مشفّرة من طرف إلى طرف)
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     عيّن متغيرات البيئة التالية في ملف `.env`:
     ```toml Code

--- a/docs/edge/ar/concepts/llms.mdx
+++ b/docs/edge/ar/concepts/llms.mdx
@@ -965,6 +965,9 @@ mode: "wide"
     عيّن متغيرات البيئة التالية في ملف `.env`:
     ```toml Code
     TRUSTEDROUTER_API_KEY=<your-api-key>
+
+    # Optional
+    TRUSTEDROUTER_BASE_URL=<custom-base-url>
     ```
 
     مثال الاستخدام في مشروع CrewAI:

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1108,6 +1108,9 @@ In this section, you'll find detailed examples that help you select, configure, 
     Set the following environment variables in your `.env` file:
     ```toml Code
     TRUSTEDROUTER_API_KEY=<your-api-key>
+
+    # Optional
+    TRUSTEDROUTER_BASE_URL=<custom-base-url>
     ```
 
     Example usage in your CrewAI project:

--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -1102,6 +1102,29 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="TrustedRouter">
+    TrustedRouter is an attested OpenAI-compatible router for privacy-sensitive agent work, with automatic model selection, zero-data-retention routes, and end-to-end encrypted routes.
+
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    TRUSTEDROUTER_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="trustedrouter/auto",
+    )
+    ```
+
+    <Info>
+      Routing aliases:
+      - trustedrouter/auto (healthy routes, chosen automatically)
+      - trustedrouter/zdr (zero-data-retention routes)
+      - trustedrouter/e2e (end-to-end encrypted routes)
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     Set the following environment variables in your `.env` file:
     ```toml Code

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -708,6 +708,9 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     `.env` 파일에 다음 환경 변수를 설정하십시오:
     ```toml Code
     TRUSTEDROUTER_API_KEY=<your-api-key>
+
+    # Optional
+    TRUSTEDROUTER_BASE_URL=<custom-base-url>
     ```
 
     CrewAI 프로젝트에서의 예시 사용법:

--- a/docs/edge/ko/concepts/llms.mdx
+++ b/docs/edge/ko/concepts/llms.mdx
@@ -702,6 +702,29 @@ CrewAI는 고유한 기능, 인증 방법, 모델 역량을 제공하는 다양�
     ```
   </Accordion>
 
+  <Accordion title="TrustedRouter">
+    TrustedRouter는 프라이버시가 중요한 에이전트 작업을 위한 어테스테이션 기반 OpenAI 호환 라우터로, 자동 모델 선택, 데이터 미보존 경로, 종단 간 암호화 경로를 제공합니다.
+
+    `.env` 파일에 다음 환경 변수를 설정하십시오:
+    ```toml Code
+    TRUSTEDROUTER_API_KEY=<your-api-key>
+    ```
+
+    CrewAI 프로젝트에서의 예시 사용법:
+    ```python Code
+    llm = LLM(
+        model="trustedrouter/auto",
+    )
+    ```
+
+    <Info>
+      라우팅 별칭:
+      - trustedrouter/auto (정상 경로를 자동으로 선택)
+      - trustedrouter/zdr (데이터 미보존 경로)
+      - trustedrouter/e2e (종단 간 암호화 경로)
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     `.env` 파일에 다음 환경 변수를 설정하십시오:
     ```toml Code

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -708,6 +708,9 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
     ```toml Code
     TRUSTEDROUTER_API_KEY=<your-api-key>
+
+    # Optional
+    TRUSTEDROUTER_BASE_URL=<custom-base-url>
     ```
 
     Exemplo de uso em seu projeto CrewAI:

--- a/docs/edge/pt-BR/concepts/llms.mdx
+++ b/docs/edge/pt-BR/concepts/llms.mdx
@@ -702,6 +702,29 @@ Nesta seção, você encontrará exemplos detalhados que ajudam a selecionar, co
     ```
   </Accordion>
 
+  <Accordion title="TrustedRouter">
+    O TrustedRouter é um roteador compatível com OpenAI e atestado para trabalhos de agentes sensíveis à privacidade, com seleção automática de modelos, rotas sem retenção de dados e rotas criptografadas de ponta a ponta.
+
+    Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
+    ```toml Code
+    TRUSTEDROUTER_API_KEY=<your-api-key>
+    ```
+
+    Exemplo de uso em seu projeto CrewAI:
+    ```python Code
+    llm = LLM(
+        model="trustedrouter/auto",
+    )
+    ```
+
+    <Info>
+      Aliases de roteamento:
+      - trustedrouter/auto (rotas saudáveis, escolhidas automaticamente)
+      - trustedrouter/zdr (rotas sem retenção de dados)
+      - trustedrouter/e2e (rotas criptografadas de ponta a ponta)
+    </Info>
+  </Accordion>
+
   <Accordion title="Open Router">
     Defina as seguintes variáveis de ambiente no seu arquivo `.env`:
     ```toml Code

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -338,6 +338,7 @@ SUPPORTED_NATIVE_PROVIDERS: Final[list[str]] = [
     "bedrock",
     "aws",
     "openrouter",
+    "trustedrouter",
     "deepseek",
     "ollama",
     "ollama_chat",
@@ -443,6 +444,7 @@ class LLM(BaseLLM):
                 "bedrock": "bedrock",
                 "aws": "bedrock",
                 "openrouter": "openrouter",
+                "trustedrouter": "trustedrouter",
                 "deepseek": "deepseek",
                 "ollama": "ollama",
                 "ollama_chat": "ollama_chat",
@@ -580,6 +582,10 @@ class LLM(BaseLLM):
             # OpenRouter uses org/model format but accepts anything
             return True
 
+        if provider == "trustedrouter":
+            # TrustedRouter routes provider-prefixed ids and router aliases
+            return True
+
         if provider == "snowflake":
             return True
 
@@ -715,6 +721,7 @@ class LLM(BaseLLM):
 
         openai_compatible_providers = {
             "openrouter",
+            "trustedrouter",
             "deepseek",
             "ollama",
             "ollama_chat",

--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -469,7 +469,14 @@ class LLM(BaseLLM):
             if canonical_provider and (valid_native_model or custom_openai_route):
                 provider = canonical_provider
                 use_native = True
-                model_string = model_part
+                # Every TrustedRouter model id is namespaced. "trustedrouter/auto"
+                # names a router alias whose id keeps the prefix, while
+                # "trustedrouter/moonshotai/kimi-k3" prefixes an upstream id that
+                # must be stripped. A bare remainder means the former.
+                if canonical_provider == "trustedrouter" and "/" not in model_part:
+                    model_string = model
+                else:
+                    model_string = model_part
             else:
                 provider = prefix
                 use_native = False

--- a/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai_compatible/completion.py
@@ -51,6 +51,12 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderConfig] = {
         default_headers={"HTTP-Referer": "https://crewai.com"},
         api_key_required=True,
     ),
+    "trustedrouter": ProviderConfig(
+        base_url="https://api.trustedrouter.com/v1",
+        api_key_env="TRUSTEDROUTER_API_KEY",
+        base_url_env="TRUSTEDROUTER_BASE_URL",
+        api_key_required=True,
+    ),
     "deepseek": ProviderConfig(
         base_url="https://api.deepseek.com/v1",
         api_key_env="DEEPSEEK_API_KEY",
@@ -136,6 +142,7 @@ class OpenAICompatibleCompletion(OpenAICompletion):
 
     Supported providers:
         - openrouter: OpenRouter (https://openrouter.ai)
+        - trustedrouter: TrustedRouter (https://trustedrouter.com)
         - deepseek: DeepSeek (https://deepseek.com)
         - ollama: Ollama local server (https://ollama.ai)
         - ollama_chat: Alias for ollama

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -50,6 +50,14 @@ class TestProviderRegistry:
         assert "HTTP-Referer" in config.default_headers
         assert config.api_key_required is True
 
+    def test_trustedrouter_config(self):
+        """Test TrustedRouter provider configuration."""
+        config = OPENAI_COMPATIBLE_PROVIDERS["trustedrouter"]
+        assert config.base_url == "https://api.trustedrouter.com/v1"
+        assert config.api_key_env == "TRUSTEDROUTER_API_KEY"
+        assert config.base_url_env == "TRUSTEDROUTER_BASE_URL"
+        assert config.api_key_required is True
+
     def test_deepseek_config(self):
         """Test DeepSeek provider configuration."""
         config = OPENAI_COMPATIBLE_PROVIDERS["deepseek"]

--- a/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
+++ b/lib/crewai/tests/llms/openai_compatible/test_openai_compatible.py
@@ -340,6 +340,63 @@ class TestLLMIntegration:
             assert llm.max_tokens == 1000
 
 
+class TestTrustedRouter:
+    """Tests for TrustedRouter model resolution and construction."""
+
+    def test_llm_creates_openai_compatible_for_trustedrouter(self):
+        """Test LLM factory creates OpenAICompatibleCompletion for TrustedRouter."""
+        with patch.dict(os.environ, {"TRUSTEDROUTER_API_KEY": "test-key"}):
+            llm = LLM(model="trustedrouter/moonshotai/kimi-k3")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "trustedrouter"
+            # Upstream ids keep their vendor namespace, minus the routing prefix
+            assert llm.model == "moonshotai/kimi-k3"
+
+    @pytest.mark.parametrize("alias", ["auto", "zdr", "e2e"])
+    def test_router_aliases_keep_their_prefix(self, alias):
+        """Test router aliases reach the API with the trustedrouter/ prefix intact."""
+        with patch.dict(os.environ, {"TRUSTEDROUTER_API_KEY": "test-key"}):
+            llm = LLM(model=f"trustedrouter/{alias}")
+            assert isinstance(llm, OpenAICompatibleCompletion)
+            assert llm.provider == "trustedrouter"
+            assert llm.model == f"trustedrouter/{alias}"
+
+    def test_missing_api_key_raises_error(self):
+        """Test that a missing TrustedRouter API key raises ValueError."""
+        original = os.environ.pop("TRUSTEDROUTER_API_KEY", None)
+        try:
+            with pytest.raises(ValueError, match="API key required"):
+                OpenAICompatibleCompletion(
+                    model="trustedrouter/auto", provider="trustedrouter"
+                )
+        finally:
+            if original is not None:
+                os.environ["TRUSTEDROUTER_API_KEY"] = original
+
+    def test_base_url_from_env(self):
+        """Test TRUSTEDROUTER_BASE_URL overrides the default base URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "TRUSTEDROUTER_API_KEY": "test-key",
+                "TRUSTEDROUTER_BASE_URL": "https://eu.trustedrouter.com/v1",
+            },
+        ):
+            completion = OpenAICompatibleCompletion(
+                model="trustedrouter/auto", provider="trustedrouter"
+            )
+            assert completion.base_url == "https://eu.trustedrouter.com/v1"
+
+    def test_default_base_url(self):
+        """Test the default base URL is used when no override is set."""
+        with patch.dict(os.environ, {"TRUSTEDROUTER_API_KEY": "test-key"}, clear=False):
+            os.environ.pop("TRUSTEDROUTER_BASE_URL", None)
+            completion = OpenAICompatibleCompletion(
+                model="trustedrouter/auto", provider="trustedrouter"
+            )
+            assert completion.base_url == "https://api.trustedrouter.com/v1"
+
+
 class TestCallMocking:
     """Tests for mocking the call method."""
 


### PR DESCRIPTION
Closes #7395.

Adds TrustedRouter (attested OpenAI-compatible router) as a native provider, following the same shape as the existing `openrouter` entry:

- `OPENAI_COMPATIBLE_PROVIDERS["trustedrouter"]` with `https://api.trustedrouter.com/v1`, `TRUSTEDROUTER_API_KEY`, and `TRUSTEDROUTER_BASE_URL` override
- provider constant, prefix mapping, model validation, and openai-compatible dispatch in `llm.py`
- registry test in `tests/llms/openai_compatible/test_openai_compatible.py`
- docs accordion in `docs/edge/en/concepts/llms.mdx` (native usage — no LiteLLM dependency needed)

Verified locally: 36/36 openai_compatible tests and 19/19 provider/prefix tests in `test_llm.py` pass.

This reworks the earlier docs-only version of this PR into a code integration.

Localized guides (`ar`, `ko`, `pt-BR`) carry the same accordion, and the optional `TRUSTEDROUTER_BASE_URL` entry is present in all four.

Reopened as a new PR because #6143 was auto-closed for not referencing an issue and the reopen was refused; the branch is unchanged apart from a rebase onto current `main`.


<!-- crewai-require-issue-check -->