### PR TITLE
fix(memory): preserve newest-first LanceDB pagination

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -504,7 +504,7 @@ class LanceDBStorage:
         Returns:
             List of MemoryRecord, ordered by created_at descending.
         """
-        rows = self._scan_rows(scope_prefix, limit=limit + offset)
+        rows = self._scan_rows(scope_prefix)
         records = [self._row_to_record(r) for r in rows]
         records.sort(key=lambda r: r.created_at, reverse=True)
         return records[offset : offset + limit]

--- a/lib/crewai/tests/memory/test_lancedb_storage.py
+++ b/lib/crewai/tests/memory/test_lancedb_storage.py
@@ -1,0 +1,64 @@
+"""Tests for LanceDBStorage backend."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import pytest
+
+from crewai.memory.storage.lancedb_storage import LanceDBStorage
+from crewai.memory.types import MemoryRecord
+
+
+def test_list_records_returns_newest_first_with_limit(tmp_path: Path) -> None:
+    """list_records(limit=N) should return the N newest records, not the N oldest."""
+    storage = LanceDBStorage(path=str(tmp_path), vector_dim=4)
+    base_time = datetime.now(timezone.utc)
+
+    # Insert 10 records with sequential created_at timestamps:
+    # rec_0 is oldest, rec_9 is newest
+    records = [
+        MemoryRecord(
+            id=f"rec_{i}",
+            content=f"Record {i}",
+            scope="/test",
+            created_at=base_time + timedelta(minutes=i),
+            updated_at=base_time + timedelta(minutes=i),
+            vector=[0.1, 0.2, 0.3, 0.4],
+        )
+        for i in range(10)
+    ]
+    storage.save(records)
+
+    # Request the 3 newest records
+    results = storage.list_records(scope_prefix="/test", limit=3)
+    result_ids = [r.id for r in results]
+
+    assert result_ids == ["rec_9", "rec_8", "rec_7"], (
+        f"Expected newest records ['rec_9', 'rec_8', 'rec_7'], but got {result_ids}"
+    )
+
+
+def test_list_records_pagination_with_offset(tmp_path: Path) -> None:
+    """list_records with limit and offset should paginate over newest records first."""
+    storage = LanceDBStorage(path=str(tmp_path), vector_dim=4)
+    base_time = datetime.now(timezone.utc)
+
+    records = [
+        MemoryRecord(
+            id=f"rec_{i}",
+            content=f"Record {i}",
+            scope="/test",
+            created_at=base_time + timedelta(minutes=i),
+            updated_at=base_time + timedelta(minutes=i),
+            vector=[0.1, 0.2, 0.3, 0.4],
+        )
+        for i in range(10)
+    ]
+    storage.save(records)
+
+    # First page: newest 3
+    page1 = storage.list_records(scope_prefix="/test", limit=3, offset=0)
+    assert [r.id for r in page1] == ["rec_9", "rec_8", "rec_7"]
+
+    # Second page: next 3
+    page2 = storage.list_records(scope_prefix="/test", limit=3, offset=3)
+    assert [r.id for r in page2] == ["rec_6", "rec_5", "rec_4"]


### PR DESCRIPTION
## Related issue

Fixes #7394

## Summary

`LanceDBStorage.list_records()` is documented to return records ordered by `created_at` descending ("newest first").

- **Root cause:** `list_records()` passed `limit=limit + offset` directly to `self._scan_rows()`. Because LanceDB table scans read in insertion order, the query was truncated before `list_records()` could sort by timestamp, returning the oldest records instead of the newest.
- **Fix:** Retrieve the scoped rows via `self._scan_rows(scope_prefix)` (bounded by `_SCAN_ROWS_LIMIT = 50_000`), sort the records by `created_at` descending, and then slice `[offset : offset + limit]`.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

- Added regression tests in `lib/crewai/tests/memory/test_lancedb_storage.py`:
  - `test_list_records_returns_newest_first_with_limit`: confirms requesting `limit=3` from 10 items returns the 3 newest records.
  - `test_list_records_pagination_with_offset`: confirms pagination offsets correctly advance through newest records.
- Both tests failed on the unpatched code (`AssertionError: Expected newest records [rec_9, rec_8, rec_7], but got [rec_2, rec_1, rec_0]`) and pass with this fix.
- Targeted memory test suite passed (15 passed).

## Additional context

None.