### PR TITLE
fix: use sys.platform guards so mypy passes on Windows

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import sys
 import threading
 import time
 from typing import Any
@@ -77,14 +78,15 @@ class LanceDBStorage:
         self._table_name = table_name
         self._db = lancedb.connect(str(self._path))
 
-        try:
-            import resource
+        if sys.platform != "win32":
+            try:
+                import resource
 
-            soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-            if soft < 4096:
-                resource.setrlimit(resource.RLIMIT_NOFILE, (min(hard, 4096), hard))
-        except Exception:  # noqa: S110
-            pass  # Windows or already at the max hard limit — safe to ignore
+                soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+                if soft < 4096:
+                    resource.setrlimit(resource.RLIMIT_NOFILE, (min(hard, 4096), hard))
+            except Exception:  # noqa: S110
+                pass  # Already at the max hard limit — safe to ignore
 
         self._compact_every = compact_every
         self._save_count = 0

--- a/lib/crewai/src/crewai/utilities/crew_chat.py
+++ b/lib/crewai/src/crewai/utilities/crew_chat.py
@@ -3,7 +3,6 @@
 import contextvars
 import json
 from pathlib import Path
-import platform
 import re
 import sys
 import threading
@@ -175,11 +174,11 @@ def create_tool_function(crew: Crew, messages: list[LLMMessage]) -> Any:
 
 def flush_input() -> None:
     """Flush any pending input from the user."""
-    if platform.system() == "Windows":
+    if sys.platform == "win32":
         import msvcrt
 
-        while msvcrt.kbhit():  # type: ignore[attr-defined]
-            msvcrt.getch()  # type: ignore[attr-defined]
+        while msvcrt.kbhit():
+            msvcrt.getch()
     else:
         import termios
 


### PR DESCRIPTION
Fixes #7400

## What

Two minimal changes so `mypy` passes under Windows platform semantics. Runtime behavior is unchanged.

- `lib/crewai/src/crewai/utilities/crew_chat.py`: replace `platform.system() == "Windows"` with `sys.platform == "win32"`, which mypy natively understands for branch pruning. The two `# type: ignore[attr-defined]` comments on the `msvcrt` calls were flagged as unused under win32 semantics and are removed. `import platform` was only used here and is dropped.
- `lib/crewai/src/crewai/memory/storage/lancedb_storage.py`: wrap the existing try/except around `resource` in `if sys.platform != "win32":` so mypy skips it under win32 semantics. Runtime behavior is unchanged — the `resource` import already failed on Windows and was swallowed by the `except`.

## Verification

- `uv run mypy lib/crewai/src/crewai/` on Windows: 8 errors → 0 (`Success: no issues found in 515 source files`)
- `uv run mypy --platform linux lib/crewai/src/crewai/`: still clean (no regression)
- `uv run ruff check lib/`: clean; pre-commit hooks pass
- `lib/crewai/tests/cli/test_crew_chat.py`: 6 passed
- memory/knowledge tests pass except pre-existing `qdrant_edge` DLL load failures on this Windows machine, which also occur on `main` and are unrelated to this change

---

This PR was drafted with AI assistance (Claude Code) and should receive the `llm-generated` label per CONTRIBUTING.md.
