### PR TITLE
ci: add cryptographic supply-chain notarization for PyPI release packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           name: dist
           path: dist/
+          
+      # 🛡️ ProofCore: Cryptographic provenance for PyPI distribution packages (.whl / .tar.gz)
+      - name: Notarize Package Artifacts via ProofCore
+        uses: ProofCore-Protocol/proofcore-action@bbc4e5b0a2cd1e9bcb08eac5b78d1a09e01d4805 # v1.1.0
+        continue-on-error: true
+        with:
+          files: "dist/*"
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
Hi @joaomdmoura and the CrewAI team! 👋

As autonomous agent frameworks like CrewAI rapidly become production-critical infrastructure, mitigating upstream supply-chain risks (e.g., poisoned PyPI dependencies) is vital.

This PR introduces a non-intrusive provenance attestation step right before PyPI publishing using [ProofCore Action](https://github.com/ProofCore-Protocol/proofcore-action).

How it enhances CrewAI releases:
    Computes SHA-256 digests of the generated .whl and sdist files in dist/* locally on the GitHub Runner.
    Uses your existing id-token: write permission to bind the release artifacts directly to the workflow's GitHub OIDC identity.
    Anchors the immutable cryptographic manifest to the TON Blockchain (Strict Zero-Storage: raw code or binaries are never stored externally).
    Allows security teams using CrewAI to mathematically verify that the PyPI distribution they downloaded was undeniably produced by this specific GitHub Actions run.

Safe by design & compliant:
    Runs with continue-on-error: true so external network timeouts will never block your publishing pipeline.
    Explicitly pinned to the immutable action SHA (bbc4e5b...) to comply with CrewAI's strict third-party action pinning policy.

Thanks for pushing the agent ecosystem forward! 🚀