### PR TITLE
fix(tools): support JSON checkpoint serialization for function tools

### DIFF
--- a/lib/crewai/src/crewai/tools/base_tool.py
+++ b/lib/crewai/src/crewai/tools/base_tool.py
@@ -6,7 +6,9 @@ from collections.abc import Awaitable, Callable
 import importlib
 from inspect import Parameter, signature
 import threading
+import warnings
 from typing import (
+    Annotated,
     Any,
     Generic,
     ParamSpec,
@@ -17,6 +19,7 @@ from typing import (
 from pydantic import (
     BaseModel,
     BaseModel as PydanticBaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     GetCoreSchemaHandler,
@@ -26,6 +29,7 @@ from pydantic import (
     field_serializer,
     field_validator,
 )
+from pydantic.functional_serializers import PlainSerializer
 from pydantic_core import CoreSchema, core_schema
 from typing_extensions import TypeIs
 
@@ -39,7 +43,12 @@ from crewai.tools.structured_tool import (
     format_description_for_llm,
 )
 from crewai.tools.tool_failure import ToolFailure, ToolFailurePolicy, ToolFailureReason
-from crewai.types.callback import SerializableCallable, _resolve_dotted_path
+from crewai.types.callback import (
+    SerializableCallable,
+    _resolve_dotted_path,
+    callable_to_string,
+    string_to_callable,
+)
 from crewai.utilities.string_utils import sanitize_tool_name
 
 
@@ -67,7 +76,7 @@ def _resolve_tool_dict(value: dict[str, Any]) -> Any:
     # Pre-resolve serialized callback strings so SerializableCallable's
     # BeforeValidator sees a callable and skips the env-var guard.
     data = dict(value)
-    for key in ("cache_function",):
+    for key in ("cache_function", "func"):
         val = data.get(key)
         if isinstance(val, str):
             try:
@@ -91,6 +100,32 @@ def _is_async_callable(func: Callable[..., Any]) -> bool:
 def _is_awaitable(value: R | Awaitable[R]) -> TypeIs[Awaitable[R]]:
     """Type narrowing check for awaitable values."""
     return asyncio.iscoroutine(value) or asyncio.isfuture(value)
+
+
+def _serialize_tool_func_for_json(fn: Any) -> str | None:
+    """Serialize a Tool func for JSON checkpointing.
+
+    Module-level functions become dotted-path strings so checkpoints can
+    restore them. Anything else (lambdas, partials, callable objects)
+    cannot round-trip and is dropped with a warning instead of raising,
+    so auto-checkpointing still writes the rest of the snapshot.
+    """
+    if fn is None:
+        return None
+    try:
+        dotted = callable_to_string(fn)
+    except ValueError:
+        dotted = None
+    if dotted is None:
+        warnings.warn(
+            "Tool func cannot be JSON-serialized and will be dropped "
+            "during checkpointing; restored checkpoints will not run this tool. "
+            "Use a module-level named function for checkpointable tools.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+    return dotted
 
 
 class EnvVar(BaseModel):
@@ -527,7 +562,15 @@ class Tool(BaseTool, Generic[P, R]):
         R: The return type of the function.
     """
 
-    func: Callable[P, R | Awaitable[R]]
+    func: Annotated[
+        Callable[P, R | Awaitable[R]],
+        BeforeValidator(string_to_callable),
+        PlainSerializer(
+            _serialize_tool_func_for_json,
+            return_type=str | None,
+            when_used="json",
+        ),
+    ]
 
     def run(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Executes the tool synchronously.

--- a/lib/crewai/tests/tools/test_tool_checkpoint.py
+++ b/lib/crewai/tests/tools/test_tool_checkpoint.py
@@ -1,0 +1,32 @@
+from typing import Any
+import warnings
+
+from crewai import Agent, Crew, Task
+from crewai.state.checkpoint_config import CheckpointConfig
+from crewai.state.checkpoint_listener import _do_checkpoint
+from crewai.state.runtime import RuntimeState
+from crewai.tools import tool as tool_decorator
+
+
+def sample_top_level_tool_func(text: str) -> str:
+    """A top level named tool function."""
+    return text
+
+
+def test_tool_checkpoint_json_serialization(tmp_path):
+    @tool_decorator("echo_tool")
+    def echo_tool(text: str) -> str:
+        return text
+
+    agent = Agent(role="researcher", goal="research", backstory="backstory", tools=[echo_tool])
+    task = Task(description="task desc", expected_output="output", agent=agent)
+    crew = Crew(agents=[agent], tasks=[task])
+    state = RuntimeState([crew])
+
+    cfg = CheckpointConfig(location=str(tmp_path))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _do_checkpoint(state, cfg, event=None)
+
+    # Should checkpoint cleanly without raising an exception
+    assert any("Tool func" in str(w.message) or "guardrail" in str(w.message).lower() for w in caught)


### PR DESCRIPTION
### Summary
When an Agent is created using @tool-decorated function tools (instance of Tool), state checkpointing (_do_checkpoint) attempts to serialize the Tool instance to JSON. Without a custom serializer on Tool.func, Pydantic raises a serialization error when dumping raw Python callables to JSON.

### Fix
- Add _serialize_tool_func_for_json serializer to Tool.func in crewai.tools.base_tool.
- Convert module-level function callables to dotted path strings for JSON checkpointing.
- For local lambdas/closures that cannot be resolved via dotted paths, emit a warning and serialize as None rather than raising a hard exception, allowing checkpointing to complete safely.
- Include func in _resolve_tool_dict pre-resolution key list so restored serialized tools resolve back to callables.