### PR TITLE
fix(llm): register official 200k context windows for o1, o1-pro and o3

### DIFF
--- a/lib/crewai/src/crewai/llm.py
+++ b/lib/crewai/src/crewai/llm.py
@@ -177,6 +177,12 @@ LLM_CONTEXT_WINDOW_SIZES: Final[dict[str, int]] = {
     "gpt-4.1": 1047576,  # Based on official docs
     "gpt-4.1-mini-2025-04-14": 1047576,
     "gpt-4.1-nano-2025-04-14": 1047576,
+    # Shorter o-series prefixes must precede longer ones: lookup iterates the
+    # whole table and the last startswith match wins, so "o1-preview"/"o1-mini"
+    # can still override the shared "o1" entry with their 128k windows.
+    "o1": 200000,
+    "o1-pro": 200000,
+    "o3": 200000,
     "o1-preview": 128000,
     "o1-mini": 128000,
     "o3-mini": 200000,

--- a/lib/crewai/src/crewai/llms/providers/azure/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/azure/completion.py
@@ -1325,6 +1325,16 @@ class AzureCompletion(BaseLLM):
             "gpt-5.6": 1050000,
             "gpt-4o": 128000,
             "gpt-4": 8192,
+            # Longer o-series prefixes must come first: lookup returns on the
+            # first startswith match, so "o1-preview"/"o1-mini" keep their 128k
+            # windows instead of being swallowed by the shared "o1" entry.
+            "o1-preview": 128000,
+            "o1-mini": 128000,
+            "o3-mini": 200000,
+            "o4-mini": 200000,
+            "o1-pro": 200000,
+            "o1": 200000,
+            "o3": 200000,
         }
 
         for model_prefix, size in context_windows.items():

--- a/lib/crewai/src/crewai/llms/providers/openai/completion.py
+++ b/lib/crewai/src/crewai/llms/providers/openai/completion.py
@@ -2815,6 +2815,12 @@ class OpenAICompletion(BaseLLM):
             "gpt-4o": 128000,
             "gpt-5": 1047576,
             "gpt-4": 8192,
+            # Longer o-series prefixes must come first: lookup returns on the
+            # first startswith match, so "o1-preview"/"o1-mini" keep their 128k
+            # windows instead of being swallowed by the shared "o1" entry.
+            "o1-pro": 200000,
+            "o1": 200000,
+            "o3": 200000,
         }
 
         for model_prefix, size in context_windows.items():

--- a/lib/crewai/tests/llms/azure/test_azure.py
+++ b/lib/crewai/tests/llms/azure/test_azure.py
@@ -673,6 +673,23 @@ def test_azure_gpt54_mini_keeps_its_window() -> None:
     assert llm.get_context_window_size() == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["azure/o1", "azure/o1-pro", "azure/o3", "azure/o3-mini", "azure/o4-mini"],
+)
+def test_azure_o_series_reasoning_models_use_official_context_window(model: str) -> None:
+    """Azure o-series deployments must not fall back to the 8k default."""
+    llm = LLM(model=model)
+    assert llm.get_context_window_size() == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
+@pytest.mark.parametrize("model", ["azure/o1-preview", "azure/o1-mini"])
+def test_azure_o1_preview_and_mini_keep_128k_context_window(model: str) -> None:
+    """The shared "o1" entry must not swallow the longer 128k prefixes."""
+    llm = LLM(model=model)
+    assert llm.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
 def test_azure_message_formatting():
     """
     Test that messages are properly formatted for Azure API

--- a/lib/crewai/tests/llms/openai/test_openai.py
+++ b/lib/crewai/tests/llms/openai/test_openai.py
@@ -1867,6 +1867,20 @@ def test_openai_gpt56_family_uses_official_context_window(model: str) -> None:
     assert llm.get_context_window_size() == int(1_050_000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
+@pytest.mark.parametrize("model", ["o1", "o1-pro", "o3", "o1-2024-12-17"])
+def test_openai_o_series_reasoning_models_use_official_context_window(model: str) -> None:
+    """Native OpenAI o1/o1-pro/o3 have a 200k window, not the 8k default."""
+    llm = OpenAICompletion(model=model)
+    assert llm.get_context_window_size() == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
+@pytest.mark.parametrize("model", ["o1-preview", "o1-mini"])
+def test_openai_o1_preview_and_mini_keep_128k_context_window(model: str) -> None:
+    """The shared "o1" entry must not swallow the longer 128k prefixes."""
+    llm = OpenAICompletion(model=model)
+    assert llm.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
 def test_openai_prefixed_gpt56_luna_uses_official_context_window() -> None:
     llm = LLM(model="openai/gpt-5.6-luna")
     assert isinstance(llm, OpenAICompletion)

--- a/lib/crewai/tests/test_llm.py
+++ b/lib/crewai/tests/test_llm.py
@@ -353,6 +353,23 @@ def test_gpt56_family_uses_official_context_window(model: str) -> None:
     assert llm.get_context_window_size() == int(1_050_000 * CONTEXT_WINDOW_USAGE_RATIO)
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["o1", "o1-pro", "o3", "o1-2024-12-17", "o3-2025-04-16"],
+)
+def test_o_series_reasoning_models_use_official_context_window(model: str) -> None:
+    """o1/o1-pro/o3 (and dated snapshots) have a 200k window, not the 8k default."""
+    llm = LLM(model=model, is_litellm=True)
+    assert llm.get_context_window_size() == int(200000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
+@pytest.mark.parametrize("model", ["o1-preview", "o1-mini"])
+def test_o1_preview_and_mini_keep_128k_context_window(model: str) -> None:
+    """The shared "o1" entry must not swallow the longer 128k o1-preview/o1-mini prefixes."""
+    llm = LLM(model=model, is_litellm=True)
+    assert llm.get_context_window_size() == int(128000 * CONTEXT_WINDOW_USAGE_RATIO)
+
+
 def test_gpt56_does_not_override_gpt54_mini_window() -> None:
     """A more specific older prefix must keep its own window."""
     llm = LLM(model="gpt-5.4-mini", is_litellm=True)


### PR DESCRIPTION
Fixes #7303

`o1`, `o1-pro` and `o3` were missing from the context window tables, so lookups fell through to the 8k default (`LLMContextLengthExceededError` false positives, premature truncation).

Registers 200k for the three models in `LLM_CONTEXT_WINDOW_SIZES` (llm.py) and in the native OpenAI and Azure provider tables, while keeping the 128k windows for `o1-preview` and `o1-mini`. Prefix ordering follows each lookup's own semantics: llm.py iterates the whole table with last-match-wins, so the shorter `o1` entry goes *before* the longer prefixes; the provider tables return on the first startswith match, so the new entries go *after* them.

Tests: parametrized regression cases for o1 / o1-pro / o3 / dated snapshots (200k) and o1-preview / o1-mini (still 128k) at all three layers (`tests/test_llm.py`, `tests/llms/openai/test_openai.py`, `tests/llms/azure/test_azure.py`).

<!-- crewai-require-issue-check -->