### PR TITLE
fix(tools): list OPENAI_API_KEY in mongodb vector search env metadata

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
@@ -92,14 +92,9 @@ class MongoDBVectorSearchTool(BaseTool):
     env_vars: list[EnvVar] = Field(
         default_factory=lambda: [
             EnvVar(
-                name="BROWSERBASE_API_KEY",
-                description="API key for Browserbase services",
-                required=False,
-            ),
-            EnvVar(
-                name="BROWSERBASE_PROJECT_ID",
-                description="Project ID for Browserbase services",
-                required=False,
+                name="OPENAI_API_KEY",
+                description="OpenAI API key for embeddings",
+                required=True,
             ),
         ]
     )

--- a/lib/crewai-tools/tests/tools/test_mongodb_vector_search_tool.py
+++ b/lib/crewai-tools/tests/tools/test_mongodb_vector_search_tool.py
@@ -68,3 +68,9 @@ def test_add_texts(mongodb_vector_search_tool):
         args = bulk_write.mock_calls[0].args
         assert "ReplaceOne" in str(args[0][0])
         assert "foo" in str(args[0][0])
+
+
+def test_env_vars_metadata_lists_openai_credentials():
+    env_vars = MongoDBVectorSearchTool.model_fields["env_vars"].default_factory()
+
+    assert [env_var.name for env_var in env_vars] == ["OPENAI_API_KEY"]


### PR DESCRIPTION
## Related issue

None — found by code inspection while reviewing tool metadata; happy to open a tracking issue if maintainers prefer.

## Summary

`MongoDBVectorSearchTool` declared `BROWSERBASE_API_KEY` / `BROWSERBASE_PROJECT_ID` in its `env_vars` metadata, which looks like a copy-paste from `BrowserbaseLoadTool`. The tool never touches Browserbase: embeddings require `OPENAI_API_KEY` (or an Azure OpenAI endpoint), and `__init__` raises `ValueError` without it.

This replaces the two Browserbase entries with a single required `OPENAI_API_KEY` entry, matching the tool's own error message and the convention used by `QdrantVectorSearchTool`.

## Verification

- Added `test_env_vars_metadata_lists_openai_credentials`, asserting the metadata lists exactly `OPENAI_API_KEY`; it fails on the old metadata and passes with this change.
- `uv run pytest lib/crewai-tools/tests/tools/test_mongodb_vector_search_tool.py` — 6 passed locally.
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean on the touched files.

## Additional context

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

This PR was authored with AI assistance; per [CONTRIBUTING](https://github.com/crewAIInc/crewAI/blob/main/.github/CONTRIBUTING.md) it should carry the `llm-generated` label — please apply it, as I don't have permission to add labels myself.
