### PR TITLE
fix(tools): honor api_key and project_id params in BrowserbaseLoadTool

### DIFF
--- a/lib/crewai-tools/src/crewai_tools/tools/browserbase_load_tool/browserbase_load_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/browserbase_load_tool/browserbase_load_tool.py
@@ -45,6 +45,8 @@ class BrowserbaseLoadTool(BaseTool):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        self.api_key = api_key or os.getenv("BROWSERBASE_API_KEY")
+        self.project_id = project_id or os.getenv("BROWSERBASE_PROJECT_ID")
         if not self.api_key:
             raise EnvironmentError(
                 "BROWSERBASE_API_KEY environment variable is required for initialization"

--- a/lib/crewai-tools/tests/tools/test_browserbase_load_tool.py
+++ b/lib/crewai-tools/tests/tools/test_browserbase_load_tool.py
@@ -1,0 +1,47 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from crewai_tools.tools.browserbase_load_tool.browserbase_load_tool import (
+    BrowserbaseLoadTool,
+)
+
+
+def _build_tool(monkeypatch, **credentials):
+    monkeypatch.delenv("BROWSERBASE_API_KEY", raising=False)
+    monkeypatch.delenv("BROWSERBASE_PROJECT_ID", raising=False)
+    fake_browserbase_module = MagicMock()
+    with patch.dict(sys.modules, {"browserbase": fake_browserbase_module}):
+        tool = BrowserbaseLoadTool(**credentials)
+    return tool, fake_browserbase_module
+
+
+def test_explicit_credentials_honored_when_env_missing(monkeypatch):
+    tool, fake_browserbase_module = _build_tool(
+        monkeypatch, api_key="bb-test-key", project_id="proj-1"
+    )
+
+    assert tool.api_key == "bb-test-key"
+    assert tool.project_id == "proj-1"
+    fake_browserbase_module.Browserbase.assert_called_once_with(api_key="bb-test-key")
+
+
+def test_explicit_credentials_override_environment(monkeypatch):
+    monkeypatch.setenv("BROWSERBASE_API_KEY", "env-key")
+    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "env-project")
+    fake_browserbase_module = MagicMock()
+    with patch.dict(sys.modules, {"browserbase": fake_browserbase_module}):
+        tool = BrowserbaseLoadTool(api_key="bb-test-key", project_id="proj-1")
+
+    assert tool.api_key == "bb-test-key"
+    assert tool.project_id == "proj-1"
+
+
+def test_environment_fallback_when_no_credentials_passed(monkeypatch):
+    monkeypatch.setenv("BROWSERBASE_API_KEY", "env-key")
+    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "env-project")
+    fake_browserbase_module = MagicMock()
+    with patch.dict(sys.modules, {"browserbase": fake_browserbase_module}):
+        tool = BrowserbaseLoadTool()
+
+    assert tool.api_key == "env-key"
+    assert tool.project_id == "env-project"


### PR DESCRIPTION
## Related issue

None — found by code inspection; happy to open a tracking issue if maintainers prefer.

## Summary

`BrowserbaseLoadTool.__init__` accepts `api_key` and `project_id` parameters but never uses them: the pydantic field defaults are `os.getenv(...)` evaluated once at class-definition time, so

- `BrowserbaseLoadTool(api_key="bb-...")` raises `EnvironmentError` when `BROWSERBASE_API_KEY` was not set at import time, even though a key was passed, and
- when the env var *was* set at import, a caller-supplied key is silently ignored.

Two lines after `super().__init__(**kwargs)` assign `api_key or os.getenv("BROWSERBASE_API_KEY")` and the same for `project_id`, mirroring the existing pattern in `HyperbrowserLoadTool`. Environment-variable behavior is unchanged.

## Verification

- Added `lib/crewai-tools/tests/tools/test_browserbase_load_tool.py` with three tests (explicit credentials when env missing, explicit credentials overriding env, env fallback when nothing passed). The `browserbase` SDK is stubbed via `sys.modules`, so no network or extra install is needed. All three fail on the old code and pass with this change.
- `uv run pytest lib/crewai-tools/tests/tools/test_browserbase_load_tool.py` — 3 passed locally.
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean on the touched files.

## Additional context

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

This PR was authored with AI assistance; per [CONTRIBUTING](https://github.com/crewAIInc/crewAI/blob/main/.github/CONTRIBUTING.md) it should carry the `llm-generated` label — please apply it, as I don't have permission to add labels myself.
