### PR TITLE
fix(memory): normalize tz-aware recall time filter to naive utc

### DIFF
--- a/lib/crewai/src/crewai/memory/recall_flow.py
+++ b/lib/crewai/src/crewai/memory/recall_flow.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any, ClassVar
 from uuid import uuid4
@@ -221,11 +221,16 @@ class RecallFlow(Flow[RecallState]):
 
             if analysis.time_filter:
                 try:
-                    self.state.time_cutoff = datetime.fromisoformat(
-                        analysis.time_filter
-                    )
+                    cutoff = datetime.fromisoformat(analysis.time_filter)
                 except ValueError:
-                    pass
+                    cutoff = None
+                if cutoff is not None:
+                    # MemoryRecord.created_at is naive; comparing against a
+                    # tz-aware cutoff would raise TypeError and silently drop
+                    # every scope's results.
+                    if cutoff.tzinfo is not None:
+                        cutoff = cutoff.astimezone(timezone.utc).replace(tzinfo=None)
+                    self.state.time_cutoff = cutoff
 
         queries = (
             analysis.recall_queries if analysis.recall_queries else [self.state.query]

--- a/lib/crewai/src/crewai/memory/recall_flow.py
+++ b/lib/crewai/src/crewai/memory/recall_flow.py
@@ -221,7 +221,10 @@ class RecallFlow(Flow[RecallState]):
 
             if analysis.time_filter:
                 try:
-                    cutoff = datetime.fromisoformat(analysis.time_filter)
+                    # Python 3.10's fromisoformat rejects the "Z" suffix.
+                    cutoff = datetime.fromisoformat(
+                        analysis.time_filter.replace("Z", "+00:00")
+                    )
                 except ValueError:
                     cutoff = None
                 if cutoff is not None:

--- a/lib/crewai/tests/memory/test_recall_flow.py
+++ b/lib/crewai/tests/memory/test_recall_flow.py
@@ -1,0 +1,55 @@
+"""Regression tests for time-filter handling in the recall flow."""
+
+import json
+from datetime import datetime
+
+from crewai.memory.recall_flow import RecallFlow
+from crewai.memory.types import MemoryRecord
+
+
+class _FakeStorage:
+    def __init__(self, record: MemoryRecord) -> None:
+        self._record = record
+
+    def list_scopes(self, _prefix: str) -> list[str]:
+        return ["/"]
+
+    def get_scope_info(self, _prefix: str) -> None:
+        return None
+
+    def search(
+        self, *_args: object, **_kwargs: object
+    ) -> list[tuple[MemoryRecord, float]]:
+        return [(self._record, 0.9)]
+
+
+class _FakeLLM:
+    def call(self, *_args: object, **_kwargs: object) -> str:
+        return json.dumps(
+            {
+                "keywords": [],
+                "suggested_scopes": [],
+                "complexity": "simple",
+                "recall_queries": ["dummy query"],
+                "time_filter": "2026-01-01T00:00:00Z",
+            }
+        )
+
+
+def _recall_flow(record: MemoryRecord) -> RecallFlow:
+    return RecallFlow(
+        storage=_FakeStorage(record),
+        llm=_FakeLLM(),
+        embedder=lambda texts: [[0.1] for _ in texts],
+    )
+
+
+def test_tz_aware_time_filter_is_normalized_to_naive_utc():
+    record = MemoryRecord(content="remembered fact", created_at=datetime(2026, 2, 1))
+    flow = _recall_flow(record)
+
+    results = flow.kickoff(inputs={"query": "what happened since january? " * 10})
+
+    assert flow.state.time_cutoff is not None
+    assert flow.state.time_cutoff.tzinfo is None
+    assert [match.record.content for match in results] == ["remembered fact"]


### PR DESCRIPTION
## Related issue

None — found by code inspection; happy to open a tracking issue if maintainers prefer.

## Summary

In the deep-recall flow, `analyze_query_step` parses the LLM's `time_filter` (documented as "an ISO 8601 date string") with `datetime.fromisoformat`. Models routinely emit offset-suffixed values such as `2026-01-01T00:00:00Z`, which parse to a **tz-aware** datetime on Python 3.11+. `MemoryRecord.created_at` is naive (`datetime.utcnow`), so the comparison in `_search_one` raises `TypeError: can't compare offset-naive and offset-aware datetimes`.

That exception is swallowed by the `except Exception` around each scope search, so every scope is skipped, confidence drops to 0, and recall silently returns an empty result set — exactly for the time-constrained queries the filter exists for.

The fix normalizes an aware cutoff to naive UTC at the single write point (`analyze_query_step`), before it reaches the comparison. Date-only and offset-free strings are unaffected.

## Verification

- Added `lib/crewai/tests/memory/test_recall_flow.py`: a fake-storage/fake-LLM kickoff with `time_filter: "2026-01-01T00:00:00Z"`. On the old code it fails with the naive/aware `TypeError` (and the record is dropped); with the fix the cutoff is naive UTC and the record is returned.
- `uv run pytest lib/crewai/tests/memory/` — same result as `main` baseline locally on Windows (pre-existing environment failures unchanged), plus the new passing test.
- Verified on Python 3.13 and 3.10 locally; a follow-up commit translates the `Z` suffix to `+00:00` before parsing because `datetime.fromisoformat` rejects it on Python 3.10 (where such filters were silently dropped).
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean on the touched files.

## Additional context

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

This PR was authored with AI assistance; per [CONTRIBUTING](https://github.com/crewAIInc/crewAI/blob/main/.github/CONTRIBUTING.md) it should carry the `llm-generated` label — please apply it, as I don't have permission to add labels myself.

