### PR TITLE
fix(knowledge): raise when knowledge_sources fail to initialize

### DIFF
--- a/lib/crewai/src/crewai/crew.py
+++ b/lib/crewai/src/crewai/crew.py
@@ -716,9 +716,13 @@ class Crew(FlowTrackable, BaseModel):
                     self.knowledge.add_sources()
 
             except Exception as e:
-                self._logger.log(
-                    "warning", f"Failed to init knowledge: {e}", color="yellow"
-                )
+                self._logger.log("error", f"Failed to init knowledge: {e}", color="red")
+                raise ValueError(
+                    "Failed to initialize crew knowledge_sources. "
+                    "Check your embedder configuration (CrewAI defaults to OpenAI "
+                    "embeddings and requires OPENAI_API_KEY unless you set a local "
+                    "embedder such as provider='ollama' or provider='onnx')."
+                ) from e
         return self
 
     @model_validator(mode="after")

--- a/lib/crewai/src/crewai/rag/chromadb/config.py
+++ b/lib/crewai/src/crewai/rag/chromadb/config.py
@@ -49,7 +49,9 @@ def _default_embedding_function() -> ChromaEmbeddingFunctionWrapper:
     """Create default ChromaDB embedding function.
 
     Returns:
-        Default embedding function using all-MiniLM-L6-v2 via ONNX.
+        Default embedding function using OpenAI ``text-embedding-3-small``.
+        Requires ``OPENAI_API_KEY``. For local setups, pass an explicit
+        embedder (for example ``provider="onnx"`` or ``provider="ollama"``).
     """
     from chromadb.utils.embedding_functions.openai_embedding_function import (
         OpenAIEmbeddingFunction,

--- a/lib/crewai/tests/knowledge/test_crew_knowledge_init_failure.py
+++ b/lib/crewai/tests/knowledge/test_crew_knowledge_init_failure.py
@@ -1,0 +1,71 @@
+"""Crew knowledge_sources must fail loudly when initialization fails."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from crewai import Agent, Crew, Process, Task
+from crewai.knowledge.source.string_knowledge_source import StringKnowledgeSource
+from crewai.llms.base_llm import BaseLLM
+
+
+class _StubLLM(BaseLLM):
+    def call(
+        self,
+        messages,
+        tools=None,
+        callbacks=None,
+        available_functions=None,
+        from_task=None,
+        from_agent=None,
+        response_model=None,
+    ):
+        return "Thought: ok.\nFinal Answer: stub"
+
+    def supports_function_calling(self) -> bool:
+        return False
+
+
+def test_crew_raises_when_knowledge_sources_fail_without_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit knowledge_sources must not silently degrade to empty knowledge."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    knowledge = StringKnowledgeSource(content="Secret fact: the vault code is 42.")
+    agent = Agent(
+        role="tester",
+        goal="answer from knowledge",
+        backstory="bg",
+        llm=_StubLLM(model="stub"),
+        verbose=False,
+    )
+    task = Task(
+        description="What is the vault code?",
+        expected_output="the code",
+        agent=agent,
+    )
+
+    with pytest.raises(ValueError, match="Failed to initialize crew knowledge_sources"):
+        Crew(
+            agents=[agent],
+            tasks=[task],
+            knowledge_sources=[knowledge],
+            process=Process.sequential,
+            verbose=False,
+        )
+
+
+def test_chromadb_default_embedder_docstring_mentions_openai() -> None:
+    from crewai.rag.chromadb import config as chroma_config
+
+    doc = chroma_config._default_embedding_function.__doc__ or ""
+    assert "OpenAI" in doc
+    assert "all-MiniLM-L6-v2" not in doc
+    # Construction still requires an API key when env is empty.
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            chroma_config._default_embedding_function()


### PR DESCRIPTION
## Summary
- Re-raise when explicit `knowledge_sources` fail during crew knowledge init instead of logging a warning and continuing with empty retrieval
- Correct `ChromaDBConfig._default_embedding_function` docstring (OpenAI default, not ONNX MiniLM)
- Add regression tests for missing `OPENAI_API_KEY` + explicit knowledge sources

Fixes #7415

## Test plan
- [x] `uv run pytest lib/crewai/tests/knowledge/test_crew_knowledge_init_failure.py -q`
- [x] Pre-commit (ruff, ruff-format, mypy) passed on commit
- [ ] CI green on this PR

<!-- crewai-require-issue-check -->