### PR TITLE
fix(memory): return newest records first in LanceDBStorage list_records

### DIFF
--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -504,10 +504,25 @@ class LanceDBStorage:
         Returns:
             List of MemoryRecord, ordered by created_at descending.
         """
-        rows = self._scan_rows(scope_prefix, limit=limit + offset)
-        records = [self._row_to_record(r) for r in rows]
-        records.sort(key=lambda r: r.created_at, reverse=True)
-        return records[offset : offset + limit]
+        rows = self._scan_rows(scope_prefix)
+
+        def _get_created_at(row: dict[str, Any]) -> datetime:
+            val = row.get("created_at")
+            if val is None:
+                return datetime.min.replace(tzinfo=timezone.utc)
+            if isinstance(val, datetime):
+                dt = val
+            else:
+                try:
+                    dt = datetime.fromisoformat(str(val).replace("Z", "+00:00"))
+                except Exception:
+                    return datetime.min.replace(tzinfo=timezone.utc)
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+
+        rows.sort(key=_get_created_at, reverse=True)
+        return [self._row_to_record(r) for r in rows[offset : offset + limit]]
 
     def get_scope_info(self, scope: str) -> ScopeInfo:
         scope = scope.rstrip("/") or "/"

--- a/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
+++ b/lib/crewai/src/crewai/memory/storage/lancedb_storage.py
@@ -507,6 +507,7 @@ class LanceDBStorage:
         rows = self._scan_rows(scope_prefix)
 
         def _get_created_at(row: dict[str, Any]) -> datetime:
+            """Extract and parse created_at into a timezone-aware UTC datetime."""
             val = row.get("created_at")
             if val is None:
                 return datetime.min.replace(tzinfo=timezone.utc)

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -180,6 +180,7 @@ def test_lancedb_list_scopes_get_scope_info(lancedb_path: Path) -> None:
 
 
 def test_lancedb_list_records_order_and_pagination(lancedb_path: Path) -> None:
+    """Test that LanceDBStorage.list_records returns newest records first with correct pagination."""
     from crewai.memory.storage.lancedb_storage import LanceDBStorage
 
     storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)

--- a/lib/crewai/tests/memory/test_unified_memory.py
+++ b/lib/crewai/tests/memory/test_unified_memory.py
@@ -179,6 +179,65 @@ def test_lancedb_list_scopes_get_scope_info(lancedb_path: Path) -> None:
     assert info.path == "/"
 
 
+def test_lancedb_list_records_order_and_pagination(lancedb_path: Path) -> None:
+    from crewai.memory.storage.lancedb_storage import LanceDBStorage
+
+    storage = LanceDBStorage(path=str(lancedb_path), vector_dim=4)
+    base_time = datetime(2025, 1, 1, 12, 0, 0)
+    records = [
+        MemoryRecord(
+            id=f"rec_{i}",
+            content=f"content {i}",
+            scope="/test",
+            created_at=base_time + timedelta(minutes=i),
+            embedding=[0.0] * 4,
+        )
+        for i in range(10)
+    ]
+    other_records = [
+        MemoryRecord(
+            id=f"other_{i}",
+            content=f"other content {i}",
+            scope="/other",
+            created_at=base_time + timedelta(minutes=i),
+            embedding=[0.0] * 4,
+        )
+        for i in range(5)
+    ]
+    storage.save(records + other_records)
+
+    # 1. Page 1: limit=3, offset=0 returns 3 newest records (rec_9, rec_8, rec_7)
+    page1 = storage.list_records(scope_prefix="/test", limit=3, offset=0)
+    assert [r.id for r in page1] == ["rec_9", "rec_8", "rec_7"]
+    assert page1[0].created_at > page1[1].created_at > page1[2].created_at
+
+    # 2. Page 2: limit=3, offset=3 returns next 3 newest (rec_6, rec_5, rec_4)
+    page2 = storage.list_records(scope_prefix="/test", limit=3, offset=3)
+    assert [r.id for r in page2] == ["rec_6", "rec_5", "rec_4"]
+
+    # 3. Page 3: limit=3, offset=6 returns next 3 newest (rec_3, rec_2, rec_1)
+    page3 = storage.list_records(scope_prefix="/test", limit=3, offset=6)
+    assert [r.id for r in page3] == ["rec_3", "rec_2", "rec_1"]
+
+    # 4. Page 4: limit=3, offset=9 returns last 1 record (rec_0)
+    page4 = storage.list_records(scope_prefix="/test", limit=3, offset=9)
+    assert [r.id for r in page4] == ["rec_0"]
+
+    # 5. Page 5: offset beyond total count returns empty list
+    page5 = storage.list_records(scope_prefix="/test", limit=3, offset=10)
+    assert page5 == []
+
+    # 6. Global listing without scope_prefix returns newest across all scopes
+    all_newest = storage.list_records(limit=4, offset=0)
+    assert len(all_newest) == 4
+    assert (
+        all_newest[0].created_at
+        >= all_newest[1].created_at
+        >= all_newest[2].created_at
+        >= all_newest[3].created_at
+    )
+
+
 
 
 @pytest.fixture


### PR DESCRIPTION
## Related issue

Fixes #7394

## Summary

`LanceDBStorage.list_records(scope_prefix, limit, offset)` is documented to return memory records ordered by `created_at` descending ("newest first").

### Root Cause
Previously, `list_records()` called `self._scan_rows(scope_prefix, limit=limit + offset)` before sorting in Python. Because LanceDB table scans return records in storage append order (oldest first) and LanceDB does not support descending ordering on search queries, passing `limit=limit + offset` to the table scan truncated the result set to the oldest records in storage. Any records newer than `limit + offset` were omitted from the query results.

### Solution
1. In `list_records()`, call `self._scan_rows(scope_prefix)` without premature `limit` truncation, relying on `_SCAN_ROWS_LIMIT = 50_000` default.
2. Sort the raw row dictionaries directly descending by `created_at` using timezone-safe datetime parsing.
3. Lazily deserialize only the sliced records `[offset : offset + limit]` into `MemoryRecord` models, avoiding expensive JSON decoding and Pydantic model construction for unreturned records.

## Verification

- [x] Tests added or updated for the changed behavior
- [x] Relevant tests and quality checks pass locally

- Added `test_lancedb_list_records_order_and_pagination` in `lib/crewai/tests/memory/test_unified_memory.py` testing newest-first ordering across pagination pages (`limit`, `offset`), out-of-bounds offsets, and scope prefix filtering.
- Ran all memory tests: `132 passed, 19 skipped`.
- Code quality checks passed cleanly (`ruff check`, `ruff format --check`, `mypy`).

## Additional context

None