### PR TITLE
docs: add EmpirioLabs LLM provider configuration (#7551)

### DIFF
--- a/docs/edge/en/concepts/llms.mdx
+++ b/docs/edge/en/concepts/llms.mdx
@@ -249,6 +249,32 @@ In this section, you'll find detailed examples that help you select, configure, 
     ```
   </Accordion>
 
+  <Accordion title="EmpirioLabs AI">
+    Set the following environment variables in your `.env` file:
+    ```toml Code
+    EMPIRIOLABS_API_KEY=<your-api-key>
+    ```
+
+    Example usage in your CrewAI project:
+    ```python Code
+    llm = LLM(
+        model="empiriolabs/qwen3-7-plus"
+    )
+    ```
+
+    <Info>
+      EmpirioLabs features:
+      - Open and proprietary models (Qwen, DeepSeek, GLM, Kimi, MiniMax, Gemma, and more) behind one OpenAI-compatible API
+      - Pay-as-you-go pricing with per-model rates
+      - Model catalog with context windows at [empiriolabs.ai/models](https://empiriolabs.ai/models)
+    </Info>
+
+    **Note:** This provider uses LiteLLM. Add it as a dependency to your project:
+    ```bash
+    uv add 'crewai[litellm]'
+    ```
+  </Accordion>
+
   <Accordion title="Meta-Llama">
     Meta's Llama API provides access to Meta's family of large language models.
     The API is available through the [Meta Llama API](https://llama.developer.meta.com?utm_source=partner-crewai&utm_medium=website).


### PR DESCRIPTION
Closes #7551.

Adds an EmpirioLabs accordion to the Provider Configuration Examples in `docs/en/concepts/llms.mdx`, following the same structure as the Nebius AI Studio entry: env var, `LLM(model=empiriolabs/<model>)` example, feature notes, and the LiteLLM dependency note.

EmpirioLabs is a registered LiteLLM provider, so `LLM(model="empiriolabs/qwen3-7-plus")` routes through the standard LiteLLM fallback path in `crewai.llm` exactly as the Nebius example does. No code changes, English docs only, matching the merged Nebius and SambaNova provider additions.

This replaces #6142, which the first-time-contributor bot closed for having no linked issue.
