### PR TITLE
feat(crewai-tools): add Live Tennis API tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -274,7 +274,8 @@
                           "edge/en/tools/search-research/serpapi-googlesearchtool",
                           "edge/en/tools/search-research/serpapi-googleshoppingtool",
                           "edge/en/tools/search-research/databricks-query-tool",
-                          "edge/en/tools/search-research/youai-search"
+                          "edge/en/tools/search-research/youai-search",
+                          "edge/en/tools/search-research/livetennistool"
                         ]
                       },
                       {

--- a/docs/edge/en/tools/search-research/livetennistool.mdx
+++ b/docs/edge/en/tools/search-research/livetennistool.mdx
@@ -24,12 +24,17 @@ LIVETENNIS_API_KEY=your_api_key   # Free key at livetennisapi.com
 | `action` | What it returns | Plan |
 |---|---|---|
 | `live_matches` | Matches in play with current scores (optional `tour` filter) | Free |
-| `upcoming_matches` | Matches starting soon | Free |
-| `fixtures` | Scheduled matches | Free |
+| `upcoming_matches` | Matches starting soon (optional `tour` filter) | Free |
+| `fixtures` | Scheduled matches (optional `tour` filter) | Free |
 | `search_players` | Player search by name (requires `search`) | Free |
-| `player_profile` | Single player detail, including current ranking (requires `player_id`) | Free |
-| `rankings` | Published ranking table (requires `system`: `atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`, `utr`) | PRO |
+| `player_profile` | Single player detail, including current ranking (requires `player_id`, the numeric id from `search_players`) | Free |
+| `rankings` | Published ranking table (requires `system`: `atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`; UTR has no listing — it is a rating, not a ranking) | PRO |
 | `usage` | Your API quota vs. consumption | Free |
+
+### Parameters
+
+- `tour` — optional filter for `live_matches`, `upcoming_matches` and `fixtures`: one of `atp`, `wta`, `challenger`, `itf`, `juniors`. Omit for all tours.
+- `limit` / `offset` — pagination for the list actions (`live_matches`, `upcoming_matches`, `fixtures`, `search_players`, `rankings`). The API default is 50 results.
 
 ## Basic Usage
 
@@ -59,7 +64,7 @@ print(tool.run(action="live_matches", tour="atp"))
 
 # Find a player, then load their profile
 players = tool.run(action="search_players", search="alcaraz")
-profile = tool.run(action="player_profile", player_id="<id from search>")
+profile = tool.run(action="player_profile", player_id=12345)  # numeric id from the search result
 ```
 
 ## Error Handling

--- a/docs/edge/en/tools/search-research/livetennistool.mdx
+++ b/docs/edge/en/tools/search-research/livetennistool.mdx
@@ -1,0 +1,69 @@
+---
+title: Live Tennis Tool
+description: Live tennis scores, fixtures, player profiles and rankings for CrewAI agents via the Live Tennis API.
+icon: trophy
+mode: "wide"
+---
+
+# `LiveTennisTool`
+
+## Description
+
+Query professional tennis data from the [Live Tennis API](https://livetennisapi.com): matches currently in play with live scores, upcoming matches, scheduled fixtures, player search and profiles (including current ranking), published ranking tables, and your API quota usage.
+
+The tool is scoped to REST endpoints, most of which are available on the API's free tier (keyed, 30 requests/minute, 100 requests/day), so it can be tried without payment. Completed-match history is a paid feature of the API and is not part of this tool.
+
+## Environment Variables
+
+```bash
+LIVETENNIS_API_KEY=your_api_key   # Free key at livetennisapi.com
+```
+
+## Actions
+
+| `action` | What it returns | Plan |
+|---|---|---|
+| `live_matches` | Matches in play with current scores (optional `tour` filter) | Free |
+| `upcoming_matches` | Matches starting soon | Free |
+| `fixtures` | Scheduled matches | Free |
+| `search_players` | Player search by name (requires `search`) | Free |
+| `player_profile` | Single player detail, including current ranking (requires `player_id`) | Free |
+| `rankings` | Published ranking table (requires `system`: `atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`, `utr`) | PRO |
+| `usage` | Your API quota vs. consumption | Free |
+
+## Basic Usage
+
+```python
+from crewai import Agent
+from crewai_tools import LiveTennisTool
+
+tool = LiveTennisTool()
+
+reporter = Agent(
+    role="Tennis Reporter",
+    goal="Summarise what is happening on tour right now",
+    backstory="You follow professional tennis and report live developments.",
+    tools=[tool],
+)
+```
+
+## Direct Invocation
+
+```python
+from crewai_tools import LiveTennisTool
+
+tool = LiveTennisTool()
+
+# Matches in play right now
+print(tool.run(action="live_matches", tour="atp"))
+
+# Find a player, then load their profile
+players = tool.run(action="search_players", search="alcaraz")
+profile = tool.run(action="player_profile", player_id="<id from search>")
+```
+
+## Error Handling
+
+The tool returns readable messages (rather than raising) when the API key is missing, invalid (401), the endpoint needs a higher plan (403), or the rate limit is hit (429), so an agent can recover or report the problem.
+
+Full API documentation: [docs.livetennisapi.com](https://docs.livetennisapi.com).

--- a/docs/edge/en/tools/search-research/livetennistool.mdx
+++ b/docs/edge/en/tools/search-research/livetennistool.mdx
@@ -65,9 +65,10 @@ tool = LiveTennisTool()
 print(tool.run(action="live_matches", tour="atp"))
 
 # Find a player, then load their profile using the id from the search result
-players = json.loads(tool.run(action="search_players", search="alcaraz"))
-player_id = players["data"][0]["id"]
-profile = tool.run(action="player_profile", player_id=player_id)
+result = tool.run(action="search_players", search="alcaraz")
+players = json.loads(result).get("data", []) if result.startswith("{") else []
+if players:  # result is a readable error string when the call fails
+    profile = tool.run(action="player_profile", player_id=players[0]["id"])
 ```
 
 ## Error Handling

--- a/docs/edge/en/tools/search-research/livetennistool.mdx
+++ b/docs/edge/en/tools/search-research/livetennistool.mdx
@@ -55,6 +55,8 @@ reporter = Agent(
 ## Direct Invocation
 
 ```python
+import json
+
 from crewai_tools import LiveTennisTool
 
 tool = LiveTennisTool()
@@ -62,9 +64,10 @@ tool = LiveTennisTool()
 # Matches in play right now
 print(tool.run(action="live_matches", tour="atp"))
 
-# Find a player, then load their profile
-players = tool.run(action="search_players", search="alcaraz")
-profile = tool.run(action="player_profile", player_id=12345)  # numeric id from the search result
+# Find a player, then load their profile using the id from the search result
+players = json.loads(tool.run(action="search_players", search="alcaraz"))
+player_id = players["data"][0]["id"]
+profile = tool.run(action="player_profile", player_id=player_id)
 ```
 
 ## Error Handling

--- a/lib/crewai-tools/src/crewai_tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/__init__.py
@@ -110,6 +110,7 @@ from crewai_tools.tools.jina_scrape_website_tool.jina_scrape_website_tool import
 )
 from crewai_tools.tools.json_search_tool.json_search_tool import JSONSearchTool
 from crewai_tools.tools.linkup.linkup_search_tool import LinkupSearchTool
+from crewai_tools.tools.live_tennis_tool.live_tennis_tool import LiveTennisTool
 from crewai_tools.tools.llamaindex_tool.llamaindex_tool import LlamaIndexTool
 from crewai_tools.tools.mdx_search_tool.mdx_search_tool import MDXSearchTool
 from crewai_tools.tools.merge_agent_handler_tool.merge_agent_handler_tool import (
@@ -280,6 +281,7 @@ __all__ = [
     "JSONSearchTool",
     "JinaScrapeWebsiteTool",
     "LinkupSearchTool",
+    "LiveTennisTool",
     "LlamaIndexTool",
     "MCPServerAdapter",
     "MDXSearchTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/__init__.py
@@ -99,6 +99,7 @@ from crewai_tools.tools.jina_scrape_website_tool.jina_scrape_website_tool import
 )
 from crewai_tools.tools.json_search_tool.json_search_tool import JSONSearchTool
 from crewai_tools.tools.linkup.linkup_search_tool import LinkupSearchTool
+from crewai_tools.tools.live_tennis_tool.live_tennis_tool import LiveTennisTool
 from crewai_tools.tools.llamaindex_tool.llamaindex_tool import LlamaIndexTool
 from crewai_tools.tools.mdx_search_tool.mdx_search_tool import MDXSearchTool
 from crewai_tools.tools.merge_agent_handler_tool.merge_agent_handler_tool import (
@@ -264,6 +265,7 @@ __all__ = [
     "JSONSearchTool",
     "JinaScrapeWebsiteTool",
     "LinkupSearchTool",
+    "LiveTennisTool",
     "LlamaIndexTool",
     "MDXSearchTool",
     "MergeAgentHandlerTool",

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
@@ -34,6 +34,8 @@ Get a free key at [livetennisapi.com](https://livetennisapi.com). Full API docum
 ## Example Usage
 
 ```python
+import json
+
 from crewai_tools import LiveTennisTool
 
 tool = LiveTennisTool()
@@ -41,9 +43,10 @@ tool = LiveTennisTool()
 # Matches in play right now
 print(tool.run(action="live_matches", tour="atp"))
 
-# Find a player, then load their profile
-players = tool.run(action="search_players", search="alcaraz")
-profile = tool.run(action="player_profile", player_id=12345)  # numeric id from the search result
+# Find a player, then load their profile using the id from the search result
+players = json.loads(tool.run(action="search_players", search="alcaraz"))
+player_id = players["data"][0]["id"]
+profile = tool.run(action="player_profile", player_id=player_id)
 ```
 
 ## With an Agent

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
@@ -8,13 +8,18 @@ The tool is scoped to REST endpoints, most of which are available on the free ti
 
 | `action` | Endpoint | Plan | Notes |
 |---|---|---|---|
-| `live_matches` | `GET /matches?status=live` | Free | Matches in play with current scores |
-| `upcoming_matches` | `GET /matches?status=upcoming` | Free | Matches starting soon |
-| `fixtures` | `GET /fixtures` | Free | Scheduled matches |
+| `live_matches` | `GET /matches?status=live` | Free | Matches in play with current scores; optional `tour` |
+| `upcoming_matches` | `GET /matches?status=upcoming` | Free | Matches starting soon; optional `tour` |
+| `fixtures` | `GET /fixtures` | Free | Scheduled matches; optional `tour` |
 | `search_players` | `GET /players?search=` | Free | Requires `search` |
-| `player_profile` | `GET /players/{id}` | Free | Requires `player_id`; includes current ranking |
-| `rankings` | `GET /rankings?system=` | PRO | Requires `system` (`atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`, `utr`) |
+| `player_profile` | `GET /players/{id}` | Free | Requires `player_id` (numeric id from `search_players`); includes current ranking |
+| `rankings` | `GET /rankings?system=` | PRO | Requires `system` (`atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`); UTR has no listing (it is a rating, not a ranking) |
 | `usage` | `GET /usage` | Free | Your quota vs. consumption; exempt from quota |
+
+### Parameters
+
+- `tour` — optional filter for `live_matches`, `upcoming_matches` and `fixtures`: one of `atp`, `wta`, `challenger`, `itf`, `juniors`. Omit for all tours.
+- `limit` / `offset` — pagination for the list actions (`live_matches`, `upcoming_matches`, `fixtures`, `search_players`, `rankings`). The API default is 50 results.
 
 The free tier is keyed and rate-limited to 30 requests/minute and 100 requests/day. Completed-match history is a paid feature and is not part of this tool. The API also offers a WebSocket push feed and model win probability on its top tier; this tool intentionally sticks to the polling REST surface.
 
@@ -38,7 +43,7 @@ print(tool.run(action="live_matches", tour="atp"))
 
 # Find a player, then load their profile
 players = tool.run(action="search_players", search="alcaraz")
-profile = tool.run(action="player_profile", player_id="<id from search>")
+profile = tool.run(action="player_profile", player_id=12345)  # numeric id from the search result
 ```
 
 ## With an Agent

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
@@ -44,9 +44,10 @@ tool = LiveTennisTool()
 print(tool.run(action="live_matches", tour="atp"))
 
 # Find a player, then load their profile using the id from the search result
-players = json.loads(tool.run(action="search_players", search="alcaraz"))
-player_id = players["data"][0]["id"]
-profile = tool.run(action="player_profile", player_id=player_id)
+result = tool.run(action="search_players", search="alcaraz")
+players = json.loads(result).get("data", []) if result.startswith("{") else []
+if players:  # result is a readable error string when the call fails
+    profile = tool.run(action="player_profile", player_id=players[0]["id"])
 ```
 
 ## With an Agent

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/README.md
@@ -1,0 +1,60 @@
+# Live Tennis Tool
+
+Query professional tennis data from the [Live Tennis API](https://livetennisapi.com) — live match scores, upcoming matches, scheduled fixtures, player search and profiles, ranking tables, and API usage.
+
+The tool is scoped to REST endpoints, most of which are available on the free tier, so it can be tried without payment.
+
+## Actions
+
+| `action` | Endpoint | Plan | Notes |
+|---|---|---|---|
+| `live_matches` | `GET /matches?status=live` | Free | Matches in play with current scores |
+| `upcoming_matches` | `GET /matches?status=upcoming` | Free | Matches starting soon |
+| `fixtures` | `GET /fixtures` | Free | Scheduled matches |
+| `search_players` | `GET /players?search=` | Free | Requires `search` |
+| `player_profile` | `GET /players/{id}` | Free | Requires `player_id`; includes current ranking |
+| `rankings` | `GET /rankings?system=` | PRO | Requires `system` (`atp`, `wta`, `itf_jt`, `itf_mt`, `itf_wt`, `utr`) |
+| `usage` | `GET /usage` | Free | Your quota vs. consumption; exempt from quota |
+
+The free tier is keyed and rate-limited to 30 requests/minute and 100 requests/day. Completed-match history is a paid feature and is not part of this tool. The API also offers a WebSocket push feed and model win probability on its top tier; this tool intentionally sticks to the polling REST surface.
+
+## Environment Variables
+
+```env
+LIVETENNIS_API_KEY=your_api_key
+```
+
+Get a free key at [livetennisapi.com](https://livetennisapi.com). Full API documentation: [docs.livetennisapi.com](https://docs.livetennisapi.com).
+
+## Example Usage
+
+```python
+from crewai_tools import LiveTennisTool
+
+tool = LiveTennisTool()
+
+# Matches in play right now
+print(tool.run(action="live_matches", tour="atp"))
+
+# Find a player, then load their profile
+players = tool.run(action="search_players", search="alcaraz")
+profile = tool.run(action="player_profile", player_id="<id from search>")
+```
+
+## With an Agent
+
+```python
+from crewai import Agent
+from crewai_tools import LiveTennisTool
+
+reporter = Agent(
+    role="Tennis Reporter",
+    goal="Summarise what is happening on tour right now",
+    backstory="You follow professional tennis and report live developments.",
+    tools=[LiveTennisTool()],
+)
+```
+
+## Error Handling
+
+The tool returns readable messages (rather than raising) when the API key is missing, invalid (401), the endpoint needs a higher plan (403), or the rate limit is hit (429), so an agent can recover or report the problem.

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/__init__.py
@@ -1,0 +1,8 @@
+from crewai_tools.tools.live_tennis_tool.live_tennis_tool import LiveTennisTool
+from crewai_tools.tools.live_tennis_tool.schemas import LiveTennisToolSchema
+
+
+__all__ = [
+    "LiveTennisTool",
+    "LiveTennisToolSchema",
+]

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/__init__.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/__init__.py
@@ -1,3 +1,5 @@
+"""Live Tennis API tool package: live scores, fixtures, players, rankings."""
+
 from crewai_tools.tools.live_tennis_tool.live_tennis_tool import LiveTennisTool
 from crewai_tools.tools.live_tennis_tool.schemas import LiveTennisToolSchema
 

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/live_tennis_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/live_tennis_tool.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 from typing import Any
-from urllib.parse import quote
 
 from crewai.tools import BaseTool, EnvVar
 from pydantic import BaseModel, Field, ValidationError
@@ -48,6 +47,12 @@ class LiveTennisTool(BaseTool):
     )
 
     def _run(self, **kwargs: Any) -> str:
+        """Validate the arguments, call the API, and return the response.
+
+        Returns the endpoint's JSON as a string on success, or a readable
+        error message (missing key, invalid arguments, 401/403/429/other
+        HTTP errors, network failure) so an agent can recover.
+        """
         api_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
         if not api_key:
             return (
@@ -116,7 +121,7 @@ class LiveTennisTool(BaseTool):
             query["search"] = params.search
             return "/players", query
         if params.action == "player_profile":
-            return f"/players/{quote(str(params.player_id), safe='')}", {}
+            return f"/players/{params.player_id}", {}
         if params.action == "rankings":
             query["system"] = params.system
             return "/rankings", query

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/live_tennis_tool.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/live_tennis_tool.py
@@ -1,0 +1,123 @@
+"""Tool for querying professional tennis data from the Live Tennis API."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.parse import quote
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field, ValidationError
+import requests
+
+from crewai_tools.tools.live_tennis_tool.schemas import LiveTennisToolSchema
+
+
+API_KEY_ENV_VAR = "LIVETENNIS_API_KEY"
+
+
+class LiveTennisTool(BaseTool):
+    """Query the Live Tennis API (https://livetennisapi.com).
+
+    Covers the endpoints available on the free tier: live match scores,
+    upcoming matches, scheduled fixtures, player search and profiles
+    (including current ranking), and API usage. The 'rankings' action
+    (full published ranking tables) requires a paid plan.
+    """
+
+    name: str = "Live Tennis API"
+    description: str = (
+        "Fetches professional tennis data from the Live Tennis API: matches "
+        "currently in play with live scores, upcoming matches, scheduled "
+        "fixtures, player search and profiles (including current ranking and "
+        "ranking points), published ranking tables, and your API quota usage. "
+        "Results are returned as JSON."
+    )
+    args_schema: type[BaseModel] = LiveTennisToolSchema
+    base_url: str = "https://api.livetennisapi.com/api/public/v1"
+    request_timeout: float = 30.0
+    env_vars: list[EnvVar] = Field(
+        default_factory=lambda: [
+            EnvVar(
+                name=API_KEY_ENV_VAR,
+                description="API key for the Live Tennis API (free tier available)",
+                required=True,
+            ),
+        ]
+    )
+
+    def _run(self, **kwargs: Any) -> str:
+        api_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
+        if not api_key:
+            return (
+                f"The {API_KEY_ENV_VAR} environment variable is not set. "
+                "Get a free API key at https://livetennisapi.com and set "
+                f"{API_KEY_ENV_VAR} to use this tool."
+            )
+
+        try:
+            params = LiveTennisToolSchema(**kwargs)
+        except ValidationError as e:
+            return f"Invalid arguments for the Live Tennis API tool: {e}"
+
+        path, query = self._build_request(params)
+        try:
+            response = requests.get(
+                f"{self.base_url}{path}",
+                headers={"Authorization": f"Bearer {api_key}"},
+                params=query,
+                timeout=self.request_timeout,
+            )
+        except requests.RequestException as e:
+            return f"Live Tennis API request failed: {e}"
+
+        if response.status_code == 401:
+            return (
+                "Live Tennis API rejected the request (401): the "
+                f"{API_KEY_ENV_VAR} key is missing, unknown, or disabled."
+            )
+        if response.status_code == 403:
+            return (
+                "Live Tennis API returned 403: this endpoint requires a higher "
+                f"subscription tier than the current key provides. {response.text}"
+            )
+        if response.status_code == 429:
+            return f"Live Tennis API rate limit exceeded (429): {response.text}"
+        if not response.ok:
+            return (
+                f"Live Tennis API returned HTTP {response.status_code}: {response.text}"
+            )
+
+        try:
+            return json.dumps(response.json())
+        except ValueError:
+            return response.text
+
+    @staticmethod
+    def _build_request(params: LiveTennisToolSchema) -> tuple[str, dict[str, Any]]:
+        """Map a validated action to its endpoint path and query parameters."""
+        query: dict[str, Any] = {}
+        if params.limit is not None:
+            query["limit"] = params.limit
+        if params.offset is not None:
+            query["offset"] = params.offset
+
+        if params.action in ("live_matches", "upcoming_matches"):
+            query["status"] = "live" if params.action == "live_matches" else "upcoming"
+            if params.tour:
+                query["tour"] = params.tour
+            return "/matches", query
+        if params.action == "fixtures":
+            if params.tour:
+                query["tour"] = params.tour
+            return "/fixtures", query
+        if params.action == "search_players":
+            query["search"] = params.search
+            return "/players", query
+        if params.action == "player_profile":
+            return f"/players/{quote(str(params.player_id), safe='')}", {}
+        if params.action == "rankings":
+            query["system"] = params.system
+            return "/rankings", query
+        return "/usage", {}

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/schemas.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/schemas.py
@@ -16,8 +16,17 @@ LiveTennisAction = Literal[
     "rankings",
     "usage",
 ]
+"""Operations the tool can perform, each mapping to one REST endpoint."""
 
-RankingSystem = Literal["atp", "wta", "itf_jt", "itf_mt", "itf_wt", "utr"]
+RankingSystem = Literal["atp", "wta", "itf_jt", "itf_mt", "itf_wt"]
+"""Ranking systems with a published rank-ordered listing.
+
+UTR is intentionally absent: the API's ``/rankings`` listing mode does not
+serve it ("`utr` has no listing — it is a rating, not a ranking").
+"""
+
+Tour = Literal["atp", "wta", "challenger", "itf", "juniors"]
+"""Valid ``tour`` filter values; an unrecognised value is a 400 from the API."""
 
 
 class LiveTennisToolSchema(BaseModel):
@@ -31,14 +40,15 @@ class LiveTennisToolSchema(BaseModel):
             "'fixtures' (scheduled matches), 'search_players' (find players by "
             "name, requires 'search'), 'player_profile' (single player detail "
             "including current ranking, requires 'player_id'), 'rankings' "
-            "(published ranking table, requires 'system'), 'usage' (your API "
-            "quota and consumption)."
+            "(published ranking table, requires 'system'; needs a PRO-plan "
+            "API key), 'usage' (your API quota and consumption)."
         ),
     )
-    tour: str | None = Field(
+    tour: Tour | None = Field(
         default=None,
         description=(
-            "Optional tour filter for match and fixture actions, e.g. 'atp' or 'wta'."
+            "Optional tour filter for match and fixture actions: 'atp', 'wta', "
+            "'challenger', 'itf' or 'juniors'. Omit for all tours."
         ),
     )
     search: str | None = Field(
@@ -48,18 +58,18 @@ class LiveTennisToolSchema(BaseModel):
             "'search_players' action."
         ),
     )
-    player_id: str | None = Field(
+    player_id: int | None = Field(
         default=None,
         description=(
-            "Player id as returned by 'search_players'. Required for the "
-            "'player_profile' action."
+            "Numeric player id as returned by 'search_players'. Required for "
+            "the 'player_profile' action."
         ),
     )
     system: RankingSystem | None = Field(
         default=None,
         description=(
             "Ranking system for the 'rankings' action: 'atp', 'wta', 'itf_jt', "
-            "'itf_mt', 'itf_wt' or 'utr'."
+            "'itf_mt' or 'itf_wt'. The rankings listing needs a PRO-plan key."
         ),
     )
     limit: int | None = Field(
@@ -75,13 +85,12 @@ class LiveTennisToolSchema(BaseModel):
 
     @model_validator(mode="after")
     def _validate_action_arguments(self) -> LiveTennisToolSchema:
+        """Ensure the arguments each action depends on are present."""
         if self.action == "search_players" and not (
             self.search and self.search.strip()
         ):
             raise ValueError("'search' is required for the 'search_players' action.")
-        if self.action == "player_profile" and not (
-            self.player_id and self.player_id.strip()
-        ):
+        if self.action == "player_profile" and self.player_id is None:
             raise ValueError("'player_id' is required for the 'player_profile' action.")
         if self.action == "rankings" and self.system is None:
             raise ValueError("'system' is required for the 'rankings' action.")

--- a/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/schemas.py
+++ b/lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/schemas.py
@@ -1,0 +1,88 @@
+"""Pydantic input schemas for the Live Tennis API tool."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+LiveTennisAction = Literal[
+    "live_matches",
+    "upcoming_matches",
+    "fixtures",
+    "search_players",
+    "player_profile",
+    "rankings",
+    "usage",
+]
+
+RankingSystem = Literal["atp", "wta", "itf_jt", "itf_mt", "itf_wt", "utr"]
+
+
+class LiveTennisToolSchema(BaseModel):
+    """Input schema for LiveTennisTool."""
+
+    action: LiveTennisAction = Field(
+        ...,
+        description=(
+            "Operation to perform: 'live_matches' (matches in play right now, "
+            "with current scores), 'upcoming_matches' (matches starting soon), "
+            "'fixtures' (scheduled matches), 'search_players' (find players by "
+            "name, requires 'search'), 'player_profile' (single player detail "
+            "including current ranking, requires 'player_id'), 'rankings' "
+            "(published ranking table, requires 'system'), 'usage' (your API "
+            "quota and consumption)."
+        ),
+    )
+    tour: str | None = Field(
+        default=None,
+        description=(
+            "Optional tour filter for match and fixture actions, e.g. 'atp' or 'wta'."
+        ),
+    )
+    search: str | None = Field(
+        default=None,
+        description=(
+            "Player name (or name fragment) to look up. Required for the "
+            "'search_players' action."
+        ),
+    )
+    player_id: str | None = Field(
+        default=None,
+        description=(
+            "Player id as returned by 'search_players'. Required for the "
+            "'player_profile' action."
+        ),
+    )
+    system: RankingSystem | None = Field(
+        default=None,
+        description=(
+            "Ranking system for the 'rankings' action: 'atp', 'wta', 'itf_jt', "
+            "'itf_mt', 'itf_wt' or 'utr'."
+        ),
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of results to return (API default: 50).",
+    )
+    offset: int | None = Field(
+        default=None,
+        ge=0,
+        description="Pagination offset into the result list.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_action_arguments(self) -> LiveTennisToolSchema:
+        if self.action == "search_players" and not (
+            self.search and self.search.strip()
+        ):
+            raise ValueError("'search' is required for the 'search_players' action.")
+        if self.action == "player_profile" and not (
+            self.player_id and self.player_id.strip()
+        ):
+            raise ValueError("'player_id' is required for the 'player_profile' action.")
+        if self.action == "rankings" and self.system is None:
+            raise ValueError("'system' is required for the 'rankings' action.")
+        return self

--- a/lib/crewai-tools/tests/tools/test_live_tennis_tool.py
+++ b/lib/crewai-tools/tests/tools/test_live_tennis_tool.py
@@ -1,0 +1,189 @@
+"""Tests for LiveTennisTool.
+
+All HTTP traffic is mocked — no test touches the network and no real
+Live Tennis API key is required.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from crewai_tools.tools.live_tennis_tool.live_tennis_tool import (
+    API_KEY_ENV_VAR,
+    LiveTennisTool,
+)
+from crewai_tools.tools.live_tennis_tool.schemas import LiveTennisToolSchema
+
+
+REQUESTS_GET = "crewai_tools.tools.live_tennis_tool.live_tennis_tool.requests.get"
+
+
+def _response(status_code=200, payload=None, text=""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    if payload is not None:
+        response.json.return_value = payload
+        response.text = json.dumps(payload)
+    else:
+        response.json.side_effect = ValueError("no json")
+        response.text = text
+    return response
+
+
+@pytest.fixture
+def tool(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV_VAR, "test-key")
+    return LiveTennisTool()
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_requires_search_for_player_search():
+    with pytest.raises(ValidationError, match="search"):
+        LiveTennisToolSchema(action="search_players")
+
+
+def test_schema_requires_player_id_for_profile():
+    with pytest.raises(ValidationError, match="player_id"):
+        LiveTennisToolSchema(action="player_profile")
+
+
+def test_schema_requires_system_for_rankings():
+    with pytest.raises(ValidationError, match="system"):
+        LiveTennisToolSchema(action="rankings")
+
+
+def test_schema_rejects_unknown_action():
+    with pytest.raises(ValidationError):
+        LiveTennisToolSchema(action="win_probability")
+
+
+# ---------------------------------------------------------------------------
+# Missing / invalid credentials
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_returns_helpful_message(monkeypatch):
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    result = LiveTennisTool()._run(action="live_matches")
+    assert API_KEY_ENV_VAR in result
+    assert "livetennisapi.com" in result
+
+
+def test_invalid_key_maps_401_to_message(tool):
+    with patch(REQUESTS_GET, return_value=_response(401, text="unauthorized")):
+        result = tool._run(action="live_matches")
+    assert "401" in result
+
+
+def test_upgrade_required_maps_403_to_message(tool):
+    body = {"error": "upgrade_required"}
+    with patch(REQUESTS_GET, return_value=_response(403, payload=body)):
+        result = tool._run(action="rankings", system="atp")
+    assert "403" in result
+    assert "upgrade_required" in result
+
+
+def test_rate_limit_maps_429_to_message(tool):
+    body = {"error": "rate_limited"}
+    with patch(REQUESTS_GET, return_value=_response(429, payload=body)):
+        result = tool._run(action="live_matches")
+    assert "429" in result
+    assert "rate_limited" in result
+
+
+def test_request_exception_is_caught(tool):
+    import requests
+
+    with patch(REQUESTS_GET, side_effect=requests.ConnectionError("boom")):
+        result = tool._run(action="live_matches")
+    assert "request failed" in result
+    assert "boom" in result
+
+
+# ---------------------------------------------------------------------------
+# Request construction
+# ---------------------------------------------------------------------------
+
+
+def test_live_matches_request(tool):
+    payload = {"data": [], "meta": {"count": 0}}
+    with patch(REQUESTS_GET, return_value=_response(200, payload=payload)) as mock_get:
+        result = tool._run(action="live_matches", tour="atp", limit=5)
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.livetennisapi.com/api/public/v1/matches"
+    assert kwargs["params"] == {"limit": 5, "status": "live", "tour": "atp"}
+    assert kwargs["headers"] == {"Authorization": "Bearer test-key"}
+    assert kwargs["timeout"] == tool.request_timeout
+    assert json.loads(result) == payload
+
+
+def test_upcoming_matches_request(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+        tool._run(action="upcoming_matches")
+    assert mock_get.call_args.kwargs["params"] == {"status": "upcoming"}
+
+
+def test_fixtures_request(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+        tool._run(action="fixtures", tour="wta", offset=10)
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith("/fixtures")
+    assert kwargs["params"] == {"offset": 10, "tour": "wta"}
+
+
+def test_search_players_request(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+        tool._run(action="search_players", search="alcaraz")
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith("/players")
+    assert kwargs["params"] == {"search": "alcaraz"}
+
+
+def test_player_profile_request_quotes_id(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"id": "p 1"})) as mock_get:
+        tool._run(action="player_profile", player_id="p 1")
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith("/players/p%201")
+    assert kwargs["params"] == {}
+
+
+def test_rankings_request(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+        tool._run(action="rankings", system="wta", limit=10)
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith("/rankings")
+    assert kwargs["params"] == {"limit": 10, "system": "wta"}
+
+
+def test_usage_request(tool):
+    with patch(REQUESTS_GET, return_value=_response(200, payload={"tier": "FREE"})) as mock_get:
+        result = tool._run(action="usage")
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith("/usage")
+    assert kwargs["params"] == {}
+    assert json.loads(result) == {"tier": "FREE"}
+
+
+def test_invalid_arguments_return_message_not_raise(tool):
+    with patch(REQUESTS_GET) as mock_get:
+        result = tool._run(action="search_players")
+    mock_get.assert_not_called()
+    assert "Invalid arguments" in result
+
+
+def test_unexpected_status_is_reported(tool):
+    with patch(REQUESTS_GET, return_value=_response(500, text="server error")):
+        result = tool._run(action="live_matches")
+    assert "500" in result
+    assert "server error" in result

--- a/lib/crewai-tools/tests/tools/test_live_tennis_tool.py
+++ b/lib/crewai-tools/tests/tools/test_live_tennis_tool.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from crewai_tools.tools.live_tennis_tool.live_tennis_tool import (
     API_KEY_ENV_VAR,
@@ -23,6 +23,7 @@ REQUESTS_GET = "crewai_tools.tools.live_tennis_tool.live_tennis_tool.requests.ge
 
 
 def _response(status_code=200, payload=None, text=""):
+    """Build a mock requests.Response with the given status and body."""
     response = MagicMock()
     response.status_code = status_code
     response.ok = 200 <= status_code < 300
@@ -37,6 +38,7 @@ def _response(status_code=200, payload=None, text=""):
 
 @pytest.fixture
 def tool(monkeypatch):
+    """A LiveTennisTool with a dummy API key set in the environment."""
     monkeypatch.setenv(API_KEY_ENV_VAR, "test-key")
     return LiveTennisTool()
 
@@ -47,31 +49,54 @@ def tool(monkeypatch):
 
 
 def test_schema_requires_search_for_player_search():
+    """'search_players' without a 'search' term is rejected."""
     with pytest.raises(ValidationError, match="search"):
         LiveTennisToolSchema(action="search_players")
 
 
 def test_schema_requires_player_id_for_profile():
+    """'player_profile' without a 'player_id' is rejected."""
     with pytest.raises(ValidationError, match="player_id"):
         LiveTennisToolSchema(action="player_profile")
 
 
+def test_schema_accepts_numeric_string_player_id():
+    """A numeric string player_id is coerced to int (lax mode)."""
+    params = LiveTennisToolSchema(action="player_profile", player_id="12345")
+    assert params.player_id == 12345
+
+
 def test_schema_requires_system_for_rankings():
+    """'rankings' without a 'system' is rejected."""
     with pytest.raises(ValidationError, match="system"):
         LiveTennisToolSchema(action="rankings")
 
 
+def test_schema_rejects_utr_rankings_system():
+    """UTR has no rankings listing in the API, so 'utr' is not accepted."""
+    with pytest.raises(ValidationError):
+        LiveTennisToolSchema(action="rankings", system="utr")
+
+
+def test_schema_rejects_unknown_tour():
+    """A tour outside the API's enum (atp/wta/challenger/itf/juniors) is rejected."""
+    with pytest.raises(ValidationError):
+        LiveTennisToolSchema(action="live_matches", tour="exhibition")
+
+
 def test_schema_rejects_unknown_action():
+    """An action not in the supported set is rejected."""
     with pytest.raises(ValidationError):
         LiveTennisToolSchema(action="win_probability")
 
 
 # ---------------------------------------------------------------------------
-# Missing / invalid credentials
+# Missing / invalid credentials and error mapping
 # ---------------------------------------------------------------------------
 
 
 def test_missing_api_key_returns_helpful_message(monkeypatch):
+    """Without the env var the tool explains how to get a key, not raise."""
     monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
     result = LiveTennisTool()._run(action="live_matches")
     assert API_KEY_ENV_VAR in result
@@ -79,12 +104,14 @@ def test_missing_api_key_returns_helpful_message(monkeypatch):
 
 
 def test_invalid_key_maps_401_to_message(tool):
+    """A 401 becomes a readable bad-credentials message."""
     with patch(REQUESTS_GET, return_value=_response(401, text="unauthorized")):
         result = tool._run(action="live_matches")
     assert "401" in result
 
 
 def test_upgrade_required_maps_403_to_message(tool):
+    """A 403 (tier too low) is surfaced with the API's error body."""
     body = {"error": "upgrade_required"}
     with patch(REQUESTS_GET, return_value=_response(403, payload=body)):
         result = tool._run(action="rankings", system="atp")
@@ -93,6 +120,7 @@ def test_upgrade_required_maps_403_to_message(tool):
 
 
 def test_rate_limit_maps_429_to_message(tool):
+    """A 429 is surfaced with the API's rate-limit body."""
     body = {"error": "rate_limited"}
     with patch(REQUESTS_GET, return_value=_response(429, payload=body)):
         result = tool._run(action="live_matches")
@@ -101,6 +129,7 @@ def test_rate_limit_maps_429_to_message(tool):
 
 
 def test_request_exception_is_caught(tool):
+    """Network failures come back as a message, not an exception."""
     import requests
 
     with patch(REQUESTS_GET, side_effect=requests.ConnectionError("boom")):
@@ -109,12 +138,29 @@ def test_request_exception_is_caught(tool):
     assert "boom" in result
 
 
+def test_invalid_arguments_return_message_not_raise(tool):
+    """Schema violations inside _run return a message and skip the HTTP call."""
+    with patch(REQUESTS_GET) as mock_get:
+        result = tool._run(action="search_players")
+    mock_get.assert_not_called()
+    assert "Invalid arguments" in result
+
+
+def test_unexpected_status_is_reported(tool):
+    """Any other non-2xx status is reported with its code and body."""
+    with patch(REQUESTS_GET, return_value=_response(500, text="server error")):
+        result = tool._run(action="live_matches")
+    assert "500" in result
+    assert "server error" in result
+
+
 # ---------------------------------------------------------------------------
 # Request construction
 # ---------------------------------------------------------------------------
 
 
 def test_live_matches_request(tool):
+    """live_matches hits /matches with status=live, auth header and timeout."""
     payload = {"data": [], "meta": {"count": 0}}
     with patch(REQUESTS_GET, return_value=_response(200, payload=payload)) as mock_get:
         result = tool._run(action="live_matches", tour="atp", limit=5)
@@ -129,13 +175,19 @@ def test_live_matches_request(tool):
 
 
 def test_upcoming_matches_request(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+    """upcoming_matches hits /matches with status=upcoming."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"data": []})
+    ) as mock_get:
         tool._run(action="upcoming_matches")
     assert mock_get.call_args.kwargs["params"] == {"status": "upcoming"}
 
 
 def test_fixtures_request(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+    """fixtures hits /fixtures and forwards tour and offset."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"data": []})
+    ) as mock_get:
         tool._run(action="fixtures", tour="wta", offset=10)
     args, kwargs = mock_get.call_args
     assert args[0].endswith("/fixtures")
@@ -143,23 +195,32 @@ def test_fixtures_request(tool):
 
 
 def test_search_players_request(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+    """search_players hits /players with the search term."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"data": []})
+    ) as mock_get:
         tool._run(action="search_players", search="alcaraz")
     args, kwargs = mock_get.call_args
     assert args[0].endswith("/players")
     assert kwargs["params"] == {"search": "alcaraz"}
 
 
-def test_player_profile_request_quotes_id(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"id": "p 1"})) as mock_get:
-        tool._run(action="player_profile", player_id="p 1")
+def test_player_profile_request(tool):
+    """player_profile hits /players/{id} with the numeric id in the path."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"id": 12345})
+    ) as mock_get:
+        tool._run(action="player_profile", player_id=12345)
     args, kwargs = mock_get.call_args
-    assert args[0].endswith("/players/p%201")
+    assert args[0].endswith("/players/12345")
     assert kwargs["params"] == {}
 
 
 def test_rankings_request(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"data": []})) as mock_get:
+    """rankings hits /rankings with the system and pagination."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"data": []})
+    ) as mock_get:
         tool._run(action="rankings", system="wta", limit=10)
     args, kwargs = mock_get.call_args
     assert args[0].endswith("/rankings")
@@ -167,23 +228,12 @@ def test_rankings_request(tool):
 
 
 def test_usage_request(tool):
-    with patch(REQUESTS_GET, return_value=_response(200, payload={"tier": "FREE"})) as mock_get:
+    """usage hits /usage with no query parameters."""
+    with patch(
+        REQUESTS_GET, return_value=_response(200, payload={"tier": "FREE"})
+    ) as mock_get:
         result = tool._run(action="usage")
     args, kwargs = mock_get.call_args
     assert args[0].endswith("/usage")
     assert kwargs["params"] == {}
     assert json.loads(result) == {"tier": "FREE"}
-
-
-def test_invalid_arguments_return_message_not_raise(tool):
-    with patch(REQUESTS_GET) as mock_get:
-        result = tool._run(action="search_players")
-    mock_get.assert_not_called()
-    assert "Invalid arguments" in result
-
-
-def test_unexpected_status_is_reported(tool):
-    with patch(REQUESTS_GET, return_value=_response(500, text="server error")):
-        result = tool._run(action="live_matches")
-    assert "500" in result
-    assert "server error" in result


### PR DESCRIPTION
Closes #7659

Supersedes #7000, which was closed automatically before a linked issue existed; same branch and content, CodeRabbit findings there were all addressed and resolved.

## What this PR does

Adds `LiveTennisTool`, a vendor tool for the [Live Tennis API](https://livetennisapi.com) — professional tennis data over REST. One tool with an `action` parameter covering:

- `live_matches` — matches in play with current scores (`GET /matches?status=live`)
- `upcoming_matches` / `fixtures` — scheduled matches
- `search_players` / `player_profile` — player lookup and detail (includes current ranking)
- `rankings` — published ranking tables (PRO plan; documented as such)
- `usage` — the key's quota vs. consumption

Auth is a Bearer key read from the `LIVETENNIS_API_KEY` env var (declared via `EnvVar` on the tool). Requests use a timeout, and missing-key / 401 / 403 / 429 all come back as readable messages instead of raising, so an agent can recover.

## Testability

The API has a free keyed tier (30 req/min, 100 req/day) that covers everything in this tool except `rankings`, so maintainers can exercise it end to end without payment.

## Structure

Mirrors existing vendor tools (`brave_search_tool`, `db2_search_tool` from #5885): package under `lib/crewai-tools/src/crewai_tools/tools/live_tennis_tool/` (README, `__init__.py`, `schemas.py`, tool module), exported from both `crewai_tools/__init__.py` and `crewai_tools/tools/__init__.py`, plus an edge docs page registered in `docs/docs.json`.

## Tests

`lib/crewai-tools/tests/tools/test_live_tennis_tool.py` — 18 tests, all HTTP mocked (no network, no key needed): schema validation per action, request construction (URL, params, Bearer header, timeout, path quoting), and error mapping (missing key, 401/403/429/500, connection failure). All pass locally; `ruff check` / `ruff format` (pinned 0.15.1) clean.

Disclosure: I maintain the Live Tennis API.


<!-- crewai-require-issue-check -->
